### PR TITLE
Set xAlign and yAlign on component with setters rather than variable acc...

### DIFF
--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -83,8 +83,7 @@ module Demo {
     var renderer1 = new LineRenderer(data1, xScale1, yScale1);
     var row1: Component[] = [leftAxesTable, renderer1, rightAxesTable];
     var yScale2 = new LinearScale();
-    var leftAxis = new YAxis(yScale2, "left");
-    leftAxis.xAlignment = "RIGHT";
+    var leftAxis = new YAxis(yScale2, "left").xAlign("RIGHT");
     var data2 = makeRandomData(1000, 100000);
     var renderer2 = new CircleRenderer(data2, xScale1, yScale2);
     var toggleClass = function() {return !d3.select(this).classed("selected-point")};

--- a/src/component.ts
+++ b/src/component.ts
@@ -20,8 +20,8 @@ class Component {
 
   private cssClasses: string[] = ["component"];
 
-  public xAlignment = "LEFT"; // LEFT, CENTER, RIGHT
-  public yAlignment = "TOP"; // TOP, CENTER, BOTTOM
+  private xAlignProportion = 0;
+  private yAlignProportion = 0;
 
   public anchor(element: D3.Selection) {
     if (element.node().childNodes.length > 0) {
@@ -42,6 +42,32 @@ class Component {
     return this;
   }
 
+  public xAlign(alignment: string): Component {
+    if (alignment === "LEFT") {
+      this.xAlignProportion = 0;
+    } else if (alignment === "CENTER") {
+      this.xAlignProportion = 0.5;
+    } else if (alignment === "RIGHT") {
+      this.xAlignProportion = 1;
+    } else {
+      throw new Error("Unsupported alignment");
+    }
+    return this;
+  }
+
+  public yAlign(alignment: string): Component {
+    if (alignment === "TOP") {
+      this.yAlignProportion = 0;
+    } else if (alignment === "CENTER") {
+      this.yAlignProportion = 0.5;
+    } else if (alignment === "BOTTOM") {
+      this.yAlignProportion = 1;
+    } else {
+      throw new Error("Unsupported alignment");
+    }
+    return this;
+  }
+
   public computeLayout(xOffset?: number, yOffset?: number, availableWidth?: number, availableHeight?: number) {
     if (xOffset == null || yOffset == null || availableWidth == null || availableHeight == null) {
       if (this.element == null) {
@@ -57,33 +83,11 @@ class Component {
       }
     }
     if (this.rowWeight() === 0 && this.rowMinimum() !== 0) {
-      switch (this.yAlignment) {
-        case "TOP":
-          break;
-        case "CENTER":
-          yOffset += (availableHeight - this.rowMinimum()) / 2;
-          break;
-        case "BOTTOM":
-          yOffset += availableHeight - this.rowMinimum();
-          break;
-        default:
-          throw new Error(this.yAlignment + " is not a supported alignment");
-      }
+      yOffset += (availableHeight - this.rowMinimum()) * this.yAlignProportion;
       availableHeight = this.rowMinimum();
     }
     if (this.colWeight() === 0 && this.colMinimum() !== 0) {
-      switch (this.xAlignment) {
-        case "LEFT":
-          break;
-        case "CENTER":
-          xOffset += (availableWidth - this.colMinimum()) / 2;
-          break;
-        case "RIGHT":
-          xOffset += availableWidth - this.colMinimum();
-          break;
-        default:
-          throw new Error(this.xAlignment + " is not a supported alignment");
-      }
+      xOffset += (availableWidth - this.colMinimum()) * this.xAlignProportion;
       availableWidth = this.colMinimum();
     }
     this.xOffset = xOffset;

--- a/test/componentTests.ts
+++ b/test/componentTests.ts
@@ -77,13 +77,11 @@ describe("Component behavior", () => {
     c.computeLayout();
     assertComponentXY(c, 0, 0, "top-left component aligns correctly");
 
-    c.xAlignment = "CENTER";
-    c.yAlignment = "CENTER";
+    c.xAlign("CENTER").yAlign("CENTER");
     c.computeLayout();
     assertComponentXY(c, 150, 100, "center component aligns correctly");
 
-    c.xAlignment = "RIGHT";
-    c.yAlignment = "BOTTOM";
+    c.xAlign("RIGHT").yAlign("BOTTOM");
     c.computeLayout();
     assertComponentXY(c, 300, 200, "bottom-right component aligns correctly");
     svg.remove();
@@ -94,8 +92,8 @@ describe("Component behavior", () => {
     assert.equal(c.colMinimum(), 0, "colMinimum defaults to 0");
     assert.equal(c.rowWeight() , 0, "rowWeight  defaults to 0");
     assert.equal(c.colWeight() , 0, "colWeight  defaults to 0");
-    assert.equal(c.xAlignment, "LEFT", "xAlignment defaults to LEFT");
-    assert.equal(c.yAlignment, "TOP" , "yAlignment defaults to TOP");
+    assert.equal((<any> c).xAlignProportion, 0, "xAlignment defaults to LEFT");
+    assert.equal((<any> c).yAlignProportion, 0, "yAlignment defaults to TOP");
     svg.remove();
   });
 
@@ -163,16 +161,8 @@ describe("Component behavior", () => {
   });
 
   it("errors are thrown on bad alignments", () => {
-    c.rowWeight(0);
-    c.colWeight(0);
-    c.rowMinimum(10);
-    c.colMinimum(10);
-    c.xAlignment = "foo";
-    c.anchor(svg);
-    assert.throws(() => c.computeLayout(), Error, "not a supported alignment");
-    c.xAlignment = "CENTER";
-    c.yAlignment = "bar";
-    assert.throws(() => c.computeLayout(), Error, "not a supported alignment");
+    assert.throws(() => c.xAlign("foo"), Error, "Unsupported alignment");
+    assert.throws(() => c.yAlign("foo"), Error, "Unsupported alignment");
     svg.remove();
   });
 


### PR DESCRIPTION
...ess.

Store alignment internally as a proportion between 0 and 1 rather than a string. Simplified layout code. Move error handling to
the setter.
Simplified unit tests.
Close #107.
