### PR TITLE
Tables now guess rowWeight and colWeight, although this can be overwritt...

### DIFF
--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -53,7 +53,6 @@ module Demo {
     var yScale = new LinearScale();
     var rightAxes = [new YAxis(yScale, "right"), new YAxis(yScale, "right")];
     var rightAxesTable = new Table([rightAxes]);
-    rightAxesTable.colWeight(0);
     var xAxis = new XAxis(xScale, "bottom");
     var data = makeRandomData(30);
     var renderArea = new LineRenderer(data, xScale, yScale);
@@ -75,10 +74,8 @@ module Demo {
     var yScale1 = new LinearScale();
     var leftAxes = [new YAxis(yScale1, "left"), new YAxis(yScale1, "left")];
     var leftAxesTable = new Table([leftAxes]);
-    leftAxesTable.colWeight(0);
     var rightAxes = [new YAxis(yScale1, "right"), new YAxis(yScale1, "right")];
     var rightAxesTable = new Table([rightAxes]);
-    rightAxesTable.colWeight(0);
     var data1 = makeRandomData(30, .0005);
     var renderer1 = new LineRenderer(data1, xScale1, yScale1);
     var row1: Component[] = [leftAxesTable, renderer1, rightAxesTable];
@@ -131,12 +128,10 @@ module Demo {
   var yAxisRight = new YAxis(yScale, "right");
   var yAxisRightLabel = new AxisLabel("bp y right qd", "vertical-right");
   var yAxisRightTable = new Table([[yAxisRight, yAxisRightLabel]]);
-  yAxisRightTable.colWeight(0);
 
   var yAxisLeft = new YAxis(yScale, "left");
   var yAxisLeftLabel = new AxisLabel("bp y left qd", "vertical-left");
   var yAxisLeftTable = new Table([[yAxisLeftLabel, yAxisLeft]]);
-  yAxisLeftTable.colWeight(0);
 
   var data = makeRandomData(30);
   var renderArea = new LineRenderer(data, xScale, yScale);

--- a/examples/demoDay.ts
+++ b/examples/demoDay.ts
@@ -8,10 +8,8 @@ module DemoDay {
     s.yScale = new LinearScale();
     s.leftAxis = new YAxis(s.yScale, "left");
     var leftAxisTable = new Table([[new AxisLabel("y", "vertical-left"), s.leftAxis]]);
-    leftAxisTable.colWeight(0);
     s.xAxis = new XAxis(s.xScale, "bottom");
     var xAxisTable = new Table([[s.xAxis], [new AxisLabel("x")]]);
-    xAxisTable.rowWeight(0);
 
     s.renderer = new CircleRenderer(data, s.xScale, s.yScale, null, null, 1.5);
     s.xSpark = new LinearScale();
@@ -37,9 +35,7 @@ module DemoDay {
     h.xAxis1 = new XAxis(h.xScale1, "bottom");
     h.yAxis1 = new YAxis(h.yScale1, "right");
     var labelX1Table = new Table([[h.xAxis1], [new AxisLabel("X values")]]);
-    labelX1Table.rowWeight(0);
     var labelY1Table = new Table([[h.yAxis1, new AxisLabel("Counts", "vertical-right")]]);
-    labelY1Table.colWeight(0);
     var table1 = new Table([[h.renderer1, labelY1Table], [labelX1Table, null]]);
 
     var yExtent = d3.extent(data, (d) => d.y);
@@ -52,9 +48,7 @@ module DemoDay {
     h.xAxis2 = new XAxis(h.xScale2, "bottom");
     h.yAxis2 = new YAxis(h.yScale2, "right");
     var labelX2Table = new Table([[h.xAxis2], [new AxisLabel("Y values")]]);
-    labelX2Table.rowWeight(0);
     var labelY2Table = new Table([[h.yAxis2, new AxisLabel("Counts", "vertical-right")]]);
-    labelY2Table.colWeight(0);
     var table2 = new Table([[h.renderer2, labelY2Table], [labelX2Table, null]]);
 
     h.table = new Table([[table1], [table2]]);

--- a/src/component.ts
+++ b/src/component.ts
@@ -84,11 +84,11 @@ class Component {
     }
     if (this.rowWeight() === 0 && this.rowMinimum() !== 0) {
       yOffset += (availableHeight - this.rowMinimum()) * this.yAlignProportion;
-      availableHeight = this.rowMinimum();
+      availableHeight = availableHeight > this.rowMinimum() ? this.rowMinimum() : availableHeight;
     }
     if (this.colWeight() === 0 && this.colMinimum() !== 0) {
       xOffset += (availableWidth - this.colMinimum()) * this.xAlignProportion;
-      availableWidth = this.colMinimum();
+      availableWidth = availableWidth > this.colMinimum() ? this.colMinimum() : availableWidth;
     }
     this.xOffset = xOffset;
     this.yOffset = yOffset;

--- a/src/table.ts
+++ b/src/table.ts
@@ -18,7 +18,10 @@ class Table extends Component {
   private rowWeightSum: number;
   private colWeightSum: number;
 
-  constructor(rows: Component[][], rowWeightVal=1, colWeightVal=1) {
+  private guessRowWeight = true;
+  private guessColWeight = true;
+
+  constructor(rows: Component[][]) {
     super();
     this.classed(Table.CSS_CLASS, true);
     // Clean out any null components and replace them with base Components
@@ -28,7 +31,6 @@ class Table extends Component {
     this.cols = d3.transpose(rows);
     this.nRows = this.rows.length;
     this.nCols = this.cols.length;
-    super.rowWeight(rowWeightVal).colWeight(colWeightVal);
   }
 
   public anchor(element: D3.Selection) {
@@ -49,7 +51,7 @@ class Table extends Component {
     var freeWidth = this.availableWidth - this.colMinimum();
     var freeHeight = this.availableHeight - this.rowMinimum();
     if (freeWidth < 0 || freeHeight < 0) {
-      throw new Error("InsufficientSpaceError");
+      throw new Error("Insufficient Space");
     }
 
     // distribute remaining height to rows
@@ -101,6 +103,33 @@ class Table extends Component {
   }
 
   /* Getters */
+
+  public rowWeight(): number;
+  public rowWeight(newVal: number): Table;
+  public rowWeight(newVal?: number): any {
+    if (newVal != null || !this.guessRowWeight) {
+      this.guessRowWeight = false;
+      return super.rowWeight(newVal);
+    } else {
+      var componentWeights: number[][] = this.rows.map((r) => r.map((c) => c.rowWeight()));
+      var biggestWeight = d3.max(componentWeights.map((ws) => d3.max(ws)));
+      return biggestWeight > 0 ? 1 : 0;
+    }
+  }
+
+  public colWeight(): number;
+  public colWeight(newVal: number): Table;
+  public colWeight(newVal?: number): any {
+    if (newVal != null || !this.guessColWeight) {
+      this.guessColWeight = false;
+      return super.colWeight(newVal);
+    } else {
+      var componentWeights: number[][] = this.rows.map((r) => r.map((c) => c.colWeight()));
+      var biggestWeight = d3.max(componentWeights.map((ws) => d3.max(ws)));
+      return biggestWeight > 0 ? 1 : 0;
+    }
+  }
+
   public rowMinimum(): number;
   public rowMinimum(newVal: number): Component;
   public rowMinimum(newVal?: number): any {

--- a/test/tableTests.ts
+++ b/test/tableTests.ts
@@ -5,13 +5,12 @@ var assert = chai.assert;
 function generateBasicTable(nRows, nCols) {
   // makes a table with exactly nRows * nCols children in a regular grid, with each
   // child being a basic component
-  var emptyDataset: IDataset = {data: [], seriesName: "blah"};
   var rows: Component[][] = [];
   var components: Component[] = [];
   for(var i=0; i<nRows; i++) {
     var cols = [];
     for(var j=0; j<nCols; j++) {
-      var r = new Component();
+      var r = new Component().rowWeight(1).colWeight(1);
       cols.push(r);
       components.push(r);
     }
@@ -34,13 +33,12 @@ describe("Tables", () => {
     assert.equal(component.constructor.name, "Component", "the component is a base Component");
   });
 
-  it("tables with insufficient space throw InsufficientSpaceError", () => {
+  it("tables with insufficient space throw Insufficient Space", () => {
     var svg = generateSVG(200, 200);
-    var c = new Component();
-    c.rowMinimum(300).colMinimum(300);
+    var c = new Component().rowMinimum(300).colMinimum(300);
     var t = new Table([[c]]);
     t.anchor(svg);
-    assert.throws(() => t.computeLayout(), Error, "InsufficientSpaceError");
+    assert.throws(() => t.computeLayout(), Error, "Insufficient Space");
     svg.remove();
   });
 
@@ -132,5 +130,22 @@ describe("Tables", () => {
     var table = new Table([[]]);
     assert.throws(() => table.rowMinimum(3), Error, "cannot be directly set");
     assert.throws(() => table.colMinimum(3), Error, "cannot be directly set");
+  });
+
+  it("tables guess weights intelligently", () => {
+    var c1 = new Component().rowWeight(0).colWeight(0);
+    var c2 = new Component().rowWeight(0).colWeight(0);
+    var table = new Table([[c1], [c2]]);
+    assert.equal(table.rowWeight(), 0, "the first table guessed 0 for rowWeight");
+    assert.equal(table.colWeight(), 0, "the first table guessed 0 for rowWeight");
+
+    c1.rowWeight(0);
+    c2.rowWeight(3);
+
+    assert.equal(table.rowWeight(), 1, "the table now guesses 1 for rowWeight");
+    assert.equal(table.colWeight(), 0, "the table still guesses 0 for colWeight");
+
+    assert.equal(table.rowWeight(2), table, "rowWeight returned the table");
+    assert.equal(table.rowWeight(), 2, "the rowWeight was overridden explicitly");
   });
 });


### PR DESCRIPTION
...en. Close #106.

There was a slight annoyance in that Component tries to align itself in computeLayout,
and sets its size to the rowMinimum() if the rowWeight = 0 and minimum != 0. However
this interacted poorly with the table guessing 0 as its weight, which caused the table
to not throw insufficientSpaceError. I tried moving the error into the component but this
didn't work as it now caused textLabel to throw insufficientSpaceError rather than truncating text
as intended.

Fixed this by having the component.computeLayout only change availableWidth or availableHeight
if it has extra width or height to spare, which is logically a better behavior.
