### PR TITLE
Refactor truncateTextToLength out of Label and into Utils.

### DIFF
--- a/src/label.ts
+++ b/src/label.ts
@@ -47,29 +47,10 @@ class Label extends Component {
     }
   }
 
-  private truncateTextToLength(availableLength: number) {
-    if (this.textLength <= availableLength) {
-      return;
-    }
-
-    this.textElement.text(this.text + "...");
-    var textNode = <SVGTextElement> this.textElement.node();
-    var dotLength = textNode.getSubStringLength(textNode.textContent.length-3, 3);
-    if (dotLength > availableLength) {
-      this.textElement.text(""); // no room even for ellipsis
-      this.measureAndSetTextSize();
-      return;
-    }
-
-    var numChars = this.text.length;
-    for (var i=1; i<numChars; i++) {
-      var testLength = textNode.getSubStringLength(0, i);
-      if ((testLength + dotLength) > availableLength) {
-        this.textElement.text(this.text.substr(0, i-1).trim() + "...");
-        this.measureAndSetTextSize();
-        return;
-      }
-    }
+  private truncateTextAndRemeasure(availableLength: number) {
+    var shortText = Utils.truncateTextToLength(this.text, availableLength, this.textElement);
+    this.textElement.text(shortText);
+    this.measureAndSetTextSize();
   }
 
   public computeLayout(xOffset?: number, yOffset?: number, availableWidth?: number, availableHeight?: number) {
@@ -83,10 +64,10 @@ class Label extends Component {
     var yShift = 0;
 
     if (this.orientation === "horizontal") {
-      this.truncateTextToLength(this.availableWidth);
+      this.truncateTextAndRemeasure(this.availableWidth);
       xShift = (this.availableWidth  - this.textLength) * this.xAlignProportion;
     } else {
-      this.truncateTextToLength(this.availableHeight);
+      this.truncateTextAndRemeasure(this.availableHeight);
       xShift = (this.availableHeight - this.textLength) * this.yAlignProportion;
 
       if (this.orientation === "vertical-right") {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,4 +8,37 @@ module Utils {
   export function getBBox(element: D3.Selection): SVGRect {
     return (<any> element.node()).getBBox();
   }
+
+  /** Truncates a text string to a max length, given the element in which to draw the text
+   * @param {string} text: The string to put in the text element, and truncate
+   * @param {D3.Selection} element: The element in which to measure and place the text
+   * @param {number} length: How much space to truncate text into
+   * @returns {string} text - the shortened text
+   */
+  export function truncateTextToLength(text: string, length: number, element: D3.Selection) {
+    var originalText = element.text();
+    element.text(text);
+    var bbox = Utils.getBBox(element);
+    var textLength = bbox.width;
+    if (textLength < length) {
+      element.text(originalText);
+      return text;
+    }
+    element.text(text + "...");
+    var textNode = <SVGTextElement> element.node();
+    var dotLength = textNode.getSubStringLength(textNode.textContent.length-3, 3);
+    if (dotLength > length) {
+      element.text(originalText);
+      return ""; // no room even for ellipsis
+    }
+
+    var numChars = text.length;
+    for (var i=1; i<numChars; i++) {
+      var testLength = textNode.getSubStringLength(0, i);
+      if (testLength + dotLength > length) {
+        element.text(originalText);
+        return text.substr(0, i-1).trim() + "...";
+      }
+    }
+  }
 }

--- a/test/utilsTests.ts
+++ b/test/utilsTests.ts
@@ -17,4 +17,20 @@ describe("Utils", () => {
     assert.deepEqual(bb1, bb2);
     svg.remove();
   });
+
+  it("truncateTextToLength works properly", () => {
+    var svg = generateSVG();
+    var textEl = svg.append("text").attr("x", 20).attr("y", 50);
+    textEl.text("foobar");
+
+    var fullText = Utils.truncateTextToLength("hello, world!", 200, textEl);
+    assert.equal(fullText, "hello, world!", "text untruncated");
+    var partialText = Utils.truncateTextToLength("hello, world!", 70, textEl);
+    assert.equal(partialText, "hello,...", "text truncated");
+    var tinyText = Utils.truncateTextToLength("hello, world!", 5, textEl);
+    assert.equal(tinyText, "", "empty string for tiny text");
+
+    assert.equal(textEl.text(), "foobar", "truncate had no side effect on textEl");
+    svg.remove();
+  });
 });


### PR DESCRIPTION
Add better unit testing.
Change API so it no longer modifies the element as a side-effect, but instead
takes the text, element, and length, measures the text in the element, returns
shorter text, and returns the textElement to its original state.

I think this is a better API so that it can be called multiple times without
getting into weird states, and its easier to reason about functions without
side effects.
