### PR TITLE
Refactor Interaction so constructors have no side effects and inheritanc...

### DIFF
--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -15,8 +15,8 @@ module Demo {
   basicTable.anchor(svg1);
   basicTable.computeLayout();
   basicTable.render();
-  new Plottable.PanZoomInteraction(renderAreaD1, xScale, yScale);
-
+  var pzi = new Plottable.PanZoomInteraction(renderAreaD1, xScale, yScale);
+  pzi.registerWithComponent();
   // make a table with four nested tables
   var svg2 = d3.select("#svg2");
 
@@ -82,6 +82,7 @@ module Demo {
     var toggleClass = function() {return !d3.select(this).classed("selected-point")};
     var cb = (s) => s.classed("selected-point", toggleClass);
     var areaInteraction = new Plottable.AreaInteraction(renderer2);
+    areaInteraction.registerWithComponent();
     var row2: Plottable.Component[] = [leftAxis, renderer2, null];
     var bottomAxis = new Plottable.XAxis(xScale1, "bottom");
     var row3: Plottable.Component[] = [null, bottomAxis, null];
@@ -92,6 +93,7 @@ module Demo {
     var zoomCallback = new Plottable.ZoomCallbackGenerator().addXScale(xScaleSpark, xScale1).addYScale(yScaleSpark, yScale2).getCallback();
 
     var zoomInteraction = new Plottable.AreaInteraction(sparkline).callback(zoomCallback);
+    zoomInteraction.registerWithComponent();
     var multiChart = new Plottable.Table([row1, row2, row3, row4]);
     multiChart.rowWeight(3, 0.25);
     return multiChart;

--- a/examples/demoDay.ts
+++ b/examples/demoDay.ts
@@ -111,6 +111,7 @@ module DemoDay {
     }
 
     var areaInteraction = new Plottable.AreaInteraction(scatterplot.renderer).callback(firstCallback);
+    areaInteraction.registerWithComponent();
     var zoomCallback = new Plottable.ZoomCallbackGenerator().addXScale(scatterplot.xSpark, scatterplot.xScale)
                                                   .addYScale(scatterplot.ySpark, scatterplot.yScale)
                                                   .getCallback();
@@ -126,6 +127,7 @@ module DemoDay {
     };
 
     chart.c.zoom = new Plottable.AreaInteraction(scatterplot.sparkline).callback(secondCallback);
+    chart.c.zoom.registerWithComponent();
   }
 
   function grabIndices(itemsToGrab: any[], indices: number[]) {

--- a/examples/sparklineDemo.ts
+++ b/examples/sparklineDemo.ts
@@ -23,6 +23,7 @@ module SparklineDemo {
                       .addYScale(ySpark, yScale)
                       .getCallback();
   var zoomInteraction = new Plottable.AreaInteraction(sparkline).callback(zoomCallback);
+  zoomInteraction.registerWithComponent();
 
   // var toggleClass = function() {return !d3.select(this).classed("selected-point")};
   // var cb = (s) => s.classed("selected-point", toggleClass);

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -303,7 +303,7 @@ declare module Plottable {
         public anchor(hitBox: D3.Selection): void;
         /**
         * Registers the Interaction on the Component it's listening to.
-        * Should not be invoked externally; To be called only at the end of subclassing constructors.
+        * This needs to be called to activate the interaction.
         */
         public registerWithComponent(): Interaction;
     }

--- a/plottable.js
+++ b/plottable.js
@@ -4,12 +4,6 @@ Copyright 2014 Palantir Technologies
 Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
 */
 
-/*!
-Plottable v0.2.2 (https://github.com/palantir/plottable)
-Copyright 2014 Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
-
 ///<reference path="reference.ts" />
 var Plottable;
 (function (Plottable) {
@@ -612,14 +606,10 @@ var Plottable;
 
         /**
         * Registers the Interaction on the Component it's listening to.
-        * Should not be invoked externally; To be called only at the end of subclassing constructors.
+        * This needs to be called to activate the interaction.
         */
         Interaction.prototype.registerWithComponent = function () {
             this.componentToListenTo.registerInteraction(this);
-
-            // It would be nice to have a call to this in the Interaction constructor, but
-            // can't do this right now because that depends on listenToHitBox being callable, which depends on the subclass
-            // constructor finishing first.
             return this;
         };
         return Interaction;
@@ -647,8 +637,6 @@ var Plottable;
             this.zoom.on("zoom", function () {
                 return _this.rerenderZoomed();
             });
-
-            this.registerWithComponent();
         }
         PanZoomInteraction.prototype.anchor = function (hitBox) {
             _super.prototype.anchor.call(this, hitBox);
@@ -690,7 +678,6 @@ var Plottable;
             this.dragBehavior.on("dragend", function () {
                 return _this.dragend();
             });
-            this.registerWithComponent();
         }
         /**
         * Adds a callback to be called when the AreaInteraction triggers.
@@ -868,7 +855,6 @@ var Plottable;
         function CrosshairsInteraction(renderer) {
             _super.call(this, renderer);
             this.renderer = renderer;
-            this.registerWithComponent();
         }
         CrosshairsInteraction.prototype.anchor = function (hitBox) {
             _super.prototype.anchor.call(this, hitBox);

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -27,13 +27,10 @@ module Plottable {
 
     /**
      * Registers the Interaction on the Component it's listening to.
-     * Should not be invoked externally; To be called only at the end of subclassing constructors.
+     * This needs to be called to activate the interaction.
      */
     public registerWithComponent(): Interaction {
       this.componentToListenTo.registerInteraction(this);
-      // It would be nice to have a call to this in the Interaction constructor, but
-      // can't do this right now because that depends on listenToHitBox being callable, which depends on the subclass
-      // constructor finishing first.
       return this;
     }
   }
@@ -64,8 +61,6 @@ module Plottable {
       this.zoom.x(this.xScale.scale);
       this.zoom.y(this.yScale.scale);
       this.zoom.on("zoom", () => this.rerenderZoomed());
-
-      this.registerWithComponent();
     }
 
     public anchor(hitBox: D3.Selection) {
@@ -105,7 +100,6 @@ module Plottable {
       this.dragBehavior.on("dragstart", () => this.dragstart());
       this.dragBehavior.on("drag",      () => this.drag     ());
       this.dragBehavior.on("dragend",   () => this.dragend  ());
-      this.registerWithComponent();
     }
 
     /**
@@ -272,7 +266,6 @@ module Plottable {
     constructor(renderer: XYRenderer) {
       super(renderer);
       this.renderer = renderer;
-      this.registerWithComponent();
     }
 
     public anchor(hitBox: D3.Selection) {

--- a/test/interactionTests.ts
+++ b/test/interactionTests.ts
@@ -45,6 +45,7 @@ describe("Interactions", () => {
       var yDomainBefore = yScale.domain();
 
       var interaction = new Plottable.PanZoomInteraction(renderer, xScale, yScale);
+      interaction.registerWithComponent();
 
       var hb = renderer.element.select(".hit-box").node();
       var dragDistancePixelX = 10;
@@ -99,6 +100,7 @@ describe("Interactions", () => {
       renderer = new Plottable.CircleRenderer(dataset, xScale, yScale);
       renderer.renderTo(svg);
       interaction = new Plottable.AreaInteraction(renderer);
+      interaction.registerWithComponent();
     });
 
     afterEach(() => {
@@ -186,6 +188,8 @@ describe("Interactions", () => {
         zoomCallback(a);
       };
       interaction = new Plottable.AreaInteraction(renderer).callback(callback);
+      interaction.registerWithComponent();
+
       fakeDragSequence((<any> interaction), dragstartX, dragstartY, dragendX, dragendY);
       assert.isTrue(indicesCallbackCalled, "indicesCallback was called");
       assert.deepEqual(xScale.domain(), expectedXDomain, "X scale domain was updated correctly");
@@ -205,6 +209,7 @@ describe("Interactions", () => {
       var yScale = new Plottable.LinearScale();
       var circleRenderer = new Plottable.CircleRenderer(dataset, xScale, yScale);
       var crosshairs = new Plottable.CrosshairsInteraction(circleRenderer);
+      crosshairs.registerWithComponent();
       circleRenderer.renderTo(svg);
 
       var crosshairsG = circleRenderer.foregroundContainer.select(".crosshairs");


### PR DESCRIPTION
...e works better.

Achieved by removing all internal calls to registerWithComponent() in constructor.
Now external caller must call this function to activate the interaction.
Fixes #155.
