### PR TITLE
Allow axes to be resized.

### DIFF
--- a/quicktests/quicktest-horizontalCategoryRenderer.html
+++ b/quicktests/quicktest-horizontalCategoryRenderer.html
@@ -1,0 +1,59 @@
+<html>
+  <head>
+    <title>Bar Renderer Quicktest</title>
+    <link rel="stylesheet" type="text/css" href="../../plottable.css">
+    <script src="http://d3js.org/d3.v3.js" charset="utf-8"></script>
+    <script src="../../build/plottable.js"></script>
+    <script src="../../build/exampleUtil.js"></script>
+
+    <script>
+      var data = [
+          { name: "Spot", age: 8 },
+          { name: "Poptart", age: 1 },
+          { name: "Budoka", age: 3 },
+          { name: "Sugar", age: 14 },
+          { name: "Tac", age: -5 }
+        ];
+
+      var ds = new Plottable.DataSource(data);
+      var xScale = new Plottable.LinearScale();
+      var xAxis = new Plottable.XAxis(xScale, "bottom");
+      // xAxis.showEndTickLabels(true);
+
+      var yScale = new Plottable.OrdinalScale()//.rangeType("bands");
+      // Plottable.Axis.Y_WIDTH = 60;
+      var yAxis = new Plottable.YAxis(yScale, "left", function(d) { return d; } );
+      yAxis.colMinimum(60);
+
+      var barRenderer = new Plottable.CircleRenderer(ds, xScale, yScale)
+                              .project("x", "age", xScale)
+                              .project("y", "name", yScale)
+                              .project("fill", function() {return "steelblue"});
+      var chart = new Plottable.Table([
+        [yAxis, barRenderer],
+        [null, xAxis]
+      ]);
+      // barRenderer._animate = false;
+
+      window.onload = function() {
+        chart.renderTo("#meow");
+      }
+
+      function younger() {
+        var data = ds.data();
+        data.forEach(function(d) { d.age--; });
+        ds.data(data);
+      }
+      function older() {
+        var data = ds.data();
+        data.forEach(function(d) { d.age++; });
+        ds.data(data);
+      }
+    </script>
+  </head>
+  <body>
+    <svg id="meow" width="480" height="320"></svg>
+    <p />
+    <button name="minus-age" onclick="younger()">-1 year</button><button name="plus-age" onclick="older()">+1 year</button>
+  </body>
+</html>

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -38,8 +38,8 @@ module Plottable {
     }
 
     public _render() {
-      if (this.orient() === "left") {this.axisElement.attr("transform", "translate(" + Axis.Y_WIDTH + ", 0)");};
-      if (this.orient() === "top")  {this.axisElement.attr("transform", "translate(0," + Axis.X_HEIGHT + ")");};
+      if (this.orient() === "left") {this.axisElement.attr("transform", "translate(" + this.colMinimum() + ", 0)");};
+      if (this.orient() === "top")  {this.axisElement.attr("transform", "translate(0," + this.rowMinimum() + ")");};
       var domain = this.d3Axis.scale().domain();
       var extent = Math.abs(domain[1] - domain[0]);
       var min = +d3.min(domain);

--- a/test/axisTests.ts
+++ b/test/axisTests.ts
@@ -55,6 +55,31 @@ describe("Axes", () => {
     svg.remove();
   });
 
+  it("X Axis height can be changed", () => {
+    var svg = generateSVG(500, 100);
+    var xScale = new Plottable.LinearScale();
+    xScale.domain([0, 10]);
+    xScale.range([0, 500]);
+    var xAxis = new Plottable.XAxis(xScale, "top"); // not a common position, but needed to test that things get shifted
+    xAxis.renderTo(svg);
+
+    var oldHeight = xAxis.rowMinimum();
+    var axisBBoxBefore = (<any> xAxis.element.node()).getBBox();
+    var baselineClientRectBefore = xAxis.element.select("path").node().getBoundingClientRect();
+    assert.equal(axisBBoxBefore.height, oldHeight, "axis height matches minimum height (before)");
+
+    var newHeight = 60;
+    xAxis.rowMinimum(newHeight);
+    xAxis.renderTo(svg);
+    var axisBBoxAfter = (<any> xAxis.element.node()).getBBox();
+    var baselineClientRectAfter = xAxis.element.select("path").node().getBoundingClientRect();
+    assert.equal(axisBBoxAfter.height, newHeight, "axis height updated to match new minimum");
+    assert.equal( (baselineClientRectAfter.bottom - baselineClientRectBefore.bottom),
+                  (newHeight - oldHeight),
+                  "baseline has shifted down as a consequence" );
+    svg.remove();
+  });
+
   it("YAxis positions tick labels correctly", () => {
     var svg = generateSVG(100, 500);
     var yScale = new Plottable.LinearScale();
@@ -91,6 +116,31 @@ describe("Axes", () => {
       labelRect = tickLabels[i].getBoundingClientRect();
       assert.operator(markRect.bottom, "<=", labelRect.top, "tick label is below the mark");
     }
+    svg.remove();
+  });
+
+  it("Y Axis width can be changed", () => {
+    var svg = generateSVG(100, 500);
+    var yScale = new Plottable.LinearScale();
+    yScale.domain([0, 10]);
+    yScale.range([500, 0]);
+    var yAxis = new Plottable.YAxis(yScale, "left");
+    yAxis.renderTo(svg);
+
+    var oldWidth = yAxis.colMinimum();
+    var axisBBoxBefore = (<any> yAxis.element.node()).getBBox();
+    var baselineClientRectBefore = yAxis.element.select("path").node().getBoundingClientRect();
+    assert.equal(axisBBoxBefore.width, oldWidth, "axis width matches minimum width (before)");
+
+    var newWidth = 80;
+    yAxis.colMinimum(newWidth);
+    yAxis.renderTo(svg);
+    var axisBBoxAfter = (<any> yAxis.element.node()).getBBox();
+    var baselineClientRectAfter = yAxis.element.select("path").node().getBoundingClientRect();
+    assert.equal(axisBBoxAfter.width, newWidth, "axis width updated to match new minimum");
+    assert.equal( (baselineClientRectAfter.right - baselineClientRectBefore.right),
+                  (newWidth - oldWidth),
+                  "baseline has shifted over as a consequence" );
     svg.remove();
   });
 


### PR DESCRIPTION
Axis' computeLayout previously didn't depend on the minimum width/height.
Instead, it performed calculations based on the default sizes of X/Y axes.

This commit modifies computeLayout to depend on the minimum width/height.
