### PR TITLE
OrdinalScale.rangeType() broadcasts (issue #440)

### DIFF
--- a/src/scales/ordinalScale.ts
+++ b/src/scales/ordinalScale.ts
@@ -105,6 +105,7 @@ module Plottable {
         if (innerPadding != null) {
           this._innerPadding = innerPadding;
         }
+        this._broadcast();
         return this;
       }
     }

--- a/test/scaleTests.ts
+++ b/test/scaleTests.ts
@@ -124,6 +124,18 @@ describe("Scales", () => {
       scale.domain([1,2,3,4,5]);
       assert.deepEqual(scale.rangeBand(), 329);
     });
+
+    it("rangeType triggers broadcast", () => {
+      var scale = new Plottable.OrdinalScale();
+      var callbackWasCalled = false;
+      var testCallback: Plottable.IBroadcasterCallback = (broadcaster: Plottable.Broadcaster) => {
+        assert.equal(broadcaster, scale, "Callback received the calling scale as the first argument");
+        callbackWasCalled = true;
+      };
+      scale.registerListener(null, testCallback);
+      scale.rangeType("points");
+      assert.isTrue(callbackWasCalled, "The registered callback was called");
+    });
   });
 
   describe("Color Scales", () => {


### PR DESCRIPTION
`OrdinalScale.rangeType()` broadcasts to all listeners, as it always should have. This fix also adds a test ensuring this.
