### PR TITLE
Add stroke to top of AreaRenderer.

### DIFF
--- a/plottable.css
+++ b/plottable.css
@@ -51,17 +51,6 @@ svg.plottable {
   font-family: sans-serif;
 }
 
-.plottable .line {
-  fill: none;
-  stroke-width: 1.5px;
-  vector-effect: non-scaling-stroke;
-}
-
-.plottable .line-renderer .line {
-  stroke-width: 2px;
-  vector-effect: non-scaling-stroke;
-}
-
 .plottable .table-rect {
   fill: none;
   stroke: royalblue;
@@ -118,4 +107,21 @@ svg.plottable {
 
 .plottable .legend .legend-box {
   opacity: 0;
+}
+
+.plottable .line-renderer .line {
+  fill: none;
+  stroke-width: 2px;
+  vector-effect: non-scaling-stroke;
+}
+
+.plottable .area-renderer path.area {
+  stroke: none;
+  fill-opacity: 0.5;
+}
+
+.plottable .area-renderer path.line {
+  fill: none;
+  stroke-width: 2px;
+  vector-effect: non-scaling-stroke;
 }

--- a/plottable.js
+++ b/plottable.js
@@ -2140,6 +2140,7 @@ var Plottable;
 
         Renderer.prototype.project = function (attrToSet, accessor, scale) {
             var _this = this;
+            attrToSet = attrToSet.toLowerCase();
             var rendererIDAttr = this._plottableID + attrToSet;
             var currentProjection = this._projectors[attrToSet];
             var existingScale = (currentProjection != null) ? currentProjection.scale : null;
@@ -4838,10 +4839,14 @@ var Plottable;
             this.project("fill", function () {
                 return "steelblue";
             }); // default
+            this.project("stroke", function () {
+                return "steelblue";
+            }); // default
         }
         AreaRenderer.prototype._setup = function () {
             _super.prototype._setup.call(this);
-            this.path = this.renderArea.append("path").classed("area", true);
+            this.areaPath = this.renderArea.append("path").classed("area", true);
+            this.linePath = this.renderArea.append("path").classed("line", true);
             return this;
         };
 
@@ -4855,18 +4860,25 @@ var Plottable;
             delete attrToProjector["y0"];
             delete attrToProjector["y"];
 
-            this.dataSelection = this.path.datum(this._dataSource.data());
+            this.dataSelection = this.areaPath.datum(this._dataSource.data());
+            this.linePath.datum(this._dataSource.data());
             if (this._animate && this._dataChanged) {
                 var animationStartArea = d3.svg.area().x(xFunction).y0(y0Function).y1(y0Function);
-                this.path.attr("d", animationStartArea).attr(attrToProjector);
+                this.areaPath.attr("d", animationStartArea).attr(attrToProjector);
+                var animationStartLine = d3.svg.line().x(xFunction).y(y0Function);
+                this.linePath.attr("d", animationStartLine).attr(attrToProjector);
             }
 
             this.area = d3.svg.area().x(xFunction).y0(y0Function).y1(yFunction);
-            var updateSelection = this.path;
+            var areaUpdateSelection = this.areaPath;
+            var lineUpdateSelection = this.linePath;
             if (this._animate) {
-                updateSelection = this.path.transition().duration(this._ANIMATION_DURATION).ease("exp-in-out");
+                areaUpdateSelection = this.areaPath.transition().duration(this._ANIMATION_DURATION).ease("exp-in-out");
+                lineUpdateSelection = this.linePath.transition().duration(this._ANIMATION_DURATION).ease("exp-in-out");
             }
-            updateSelection.attr("d", this.area).attr(attrToProjector);
+            this.line = d3.svg.line().x(xFunction).y(yFunction);
+            areaUpdateSelection.attr("d", this.area).attr(attrToProjector);
+            lineUpdateSelection.attr("d", this.line).attr(attrToProjector);
         };
         return AreaRenderer;
     })(Plottable.XYRenderer);

--- a/quicktests/animations-quicktest.html
+++ b/quicktests/animations-quicktest.html
@@ -3,7 +3,7 @@
   <head>
     <title>Animations Quicktest</title>
     <link rel="stylesheet" type="text/css" href="../../plottable.css">
-    <script src="../bower_components/d3/d3.min.js" charset="utf-8"></script>
+    <script src="../bower_components/d3/d3.js" charset="utf-8"></script>
     <script src="../../plottable_multifile.js"></script>
     <script src="../../examples/exampleUtil.js"></script>
 

--- a/src/components/renderers/areaRenderer.ts
+++ b/src/components/renderers/areaRenderer.ts
@@ -2,8 +2,10 @@
 
 module Plottable {
   export class AreaRenderer extends XYRenderer {
-    private path: D3.Selection;
+    private areaPath: D3.Selection;
+    private linePath: D3.Selection;
     private area: D3.Svg.Area;
+    private line: D3.Svg.Line;
     public _ANIMATION_DURATION = 600; //milliseconds
 
     /**
@@ -19,11 +21,13 @@ module Plottable {
       this.classed("area-renderer", true);
       this.project("y0", 0, yScale); // default
       this.project("fill", () => "steelblue"); // default
+      this.project("stroke", () => "steelblue"); // default
     }
 
     public _setup() {
       super._setup();
-      this.path = this.renderArea.append("path").classed("area", true);
+      this.areaPath = this.renderArea.append("path").classed("area", true);
+      this.linePath = this.renderArea.append("path").classed("line", true);
       return this;
     }
 
@@ -37,24 +41,35 @@ module Plottable {
       delete attrToProjector["y0"];
       delete attrToProjector["y"];
 
-      this.dataSelection = this.path.datum(this._dataSource.data());
+      this.dataSelection = this.areaPath.datum(this._dataSource.data());
+      this.linePath.datum(this._dataSource.data());
       if (this._animate && this._dataChanged) {
          var animationStartArea = d3.svg.area()
                                         .x(xFunction)
                                         .y0(y0Function)
                                         .y1(y0Function);
-        this.path.attr("d", animationStartArea).attr(attrToProjector);
+        this.areaPath.attr("d", animationStartArea).attr(attrToProjector);
+        var animationStartLine = d3.svg.line()
+                                       .x(xFunction)
+                                       .y(y0Function);
+        this.linePath.attr("d", animationStartLine).attr(attrToProjector);
       }
 
       this.area = d3.svg.area()
-            .x(xFunction)
-            .y0(y0Function)
-            .y1(yFunction);
-      var updateSelection: any = this.path;
+                        .x(xFunction)
+                        .y0(y0Function)
+                        .y1(yFunction);
+      var areaUpdateSelection: any = this.areaPath;
+      var lineUpdateSelection: any = this.linePath;
       if (this._animate) {
-        updateSelection = this.path.transition().duration(this._ANIMATION_DURATION).ease("exp-in-out");
+        areaUpdateSelection = this.areaPath.transition().duration(this._ANIMATION_DURATION).ease("exp-in-out");
+        lineUpdateSelection = this.linePath.transition().duration(this._ANIMATION_DURATION).ease("exp-in-out");
       }
-      updateSelection.attr("d", this.area).attr(attrToProjector);
+      this.line = d3.svg.line()
+                        .x(xFunction)
+                        .y(yFunction);
+      areaUpdateSelection.attr("d", this.area).attr(attrToProjector);
+      lineUpdateSelection.attr("d", this.line).attr(attrToProjector);
     }
   }
 }

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -105,6 +105,7 @@ module Plottable {
     }
 
     public project(attrToSet: string, accessor: any, scale?: Scale) {
+      attrToSet = attrToSet.toLowerCase();
       var rendererIDAttr = this._plottableID + attrToSet;
       var currentProjection = this._projectors[attrToSet];
       var existingScale = (currentProjection != null) ? currentProjection.scale : null;

--- a/test/rendererTests.ts
+++ b/test/rendererTests.ts
@@ -257,9 +257,24 @@ describe("Renderers", () => {
         verifier.start();
       });
 
+      it("draws area and line correctly", () => {
+        var areaPath = renderArea.select(".area");
+        assert.strictEqual(areaPath.attr("d"), "M0,500L500,0L500,500L0,500Z", "area d was set correctly");
+        assert.strictEqual(areaPath.attr("fill"), "steelblue", "area fill was set correctly");
+        var areaComputedStyle = window.getComputedStyle(areaPath.node());
+        assert.strictEqual(areaComputedStyle.stroke, "none", "area stroke renders as \"none\"");
+
+        var linePath = renderArea.select(".line");
+        assert.strictEqual(linePath.attr("d"), "M0,500L500,0", "line d was set correctly");
+        assert.strictEqual(linePath.attr("stroke"), "#000000", "line stroke was set correctly");
+        var lineComputedStyle = window.getComputedStyle(linePath.node());
+        assert.strictEqual(lineComputedStyle.fill, "none", "line fill renders as \"none\"");
+        verifier.end();
+      });
+
       it("fill colors set appropriately from accessor", () => {
-        var path = renderArea.select("path");
-        assert.equal(path.attr("fill"), "steelblue", "fill set correctly");
+        var areaPath = renderArea.select(".area");
+        assert.equal(areaPath.attr("fill"), "steelblue", "fill set correctly");
         verifier.end();
       });
 
@@ -268,8 +283,8 @@ describe("Renderers", () => {
         areaRenderer.project("fill", newFillAccessor);
         areaRenderer.renderTo(svg);
         renderArea = areaRenderer.renderArea;
-        var path = renderArea.select("path");
-        assert.equal(path.attr("fill"), "pink", "fill changed correctly");
+        var areaPath = renderArea.select(".area");
+        assert.equal(areaPath.attr("fill"), "pink", "fill changed correctly");
         verifier.end();
       });
 
@@ -277,8 +292,8 @@ describe("Renderers", () => {
         areaRenderer.project("y0", (d: any) => d.bar/2);
         areaRenderer.renderTo(svg);
         renderArea = areaRenderer.renderArea;
-        var path = renderArea.select("path");
-        assert.equal(path.attr("d"), "M0,500L500,0L500,250L0,500Z");
+        var areaPath = renderArea.select(".area");
+        assert.equal(areaPath.attr("d"), "M0,500L500,0L500,250L0,500Z");
         verifier.end();
       });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -2248,9 +2248,24 @@ describe("Renderers", function () {
                 verifier.start();
             });
 
+            it("draws area and line correctly", function () {
+                var areaPath = renderArea.select(".area");
+                assert.strictEqual(areaPath.attr("d"), "M0,500L500,0L500,500L0,500Z", "area d was set correctly");
+                assert.strictEqual(areaPath.attr("fill"), "steelblue", "area fill was set correctly");
+                var areaComputedStyle = window.getComputedStyle(areaPath.node());
+                assert.strictEqual(areaComputedStyle.stroke, "none", "area stroke renders as \"none\"");
+
+                var linePath = renderArea.select(".line");
+                assert.strictEqual(linePath.attr("d"), "M0,500L500,0", "line d was set correctly");
+                assert.strictEqual(linePath.attr("stroke"), "#000000", "line stroke was set correctly");
+                var lineComputedStyle = window.getComputedStyle(linePath.node());
+                assert.strictEqual(lineComputedStyle.fill, "none", "line fill renders as \"none\"");
+                verifier.end();
+            });
+
             it("fill colors set appropriately from accessor", function () {
-                var path = renderArea.select("path");
-                assert.equal(path.attr("fill"), "steelblue", "fill set correctly");
+                var areaPath = renderArea.select(".area");
+                assert.equal(areaPath.attr("fill"), "steelblue", "fill set correctly");
                 verifier.end();
             });
 
@@ -2261,8 +2276,8 @@ describe("Renderers", function () {
                 areaRenderer.project("fill", newFillAccessor);
                 areaRenderer.renderTo(svg);
                 renderArea = areaRenderer.renderArea;
-                var path = renderArea.select("path");
-                assert.equal(path.attr("fill"), "pink", "fill changed correctly");
+                var areaPath = renderArea.select(".area");
+                assert.equal(areaPath.attr("fill"), "pink", "fill changed correctly");
                 verifier.end();
             });
 
@@ -2272,8 +2287,8 @@ describe("Renderers", function () {
                 });
                 areaRenderer.renderTo(svg);
                 renderArea = areaRenderer.renderArea;
-                var path = renderArea.select("path");
-                assert.equal(path.attr("d"), "M0,500L500,0L500,250L0,500Z");
+                var areaPath = renderArea.select(".area");
+                assert.equal(areaPath.attr("d"), "M0,500L500,0L500,250L0,500Z");
                 verifier.end();
             });
 


### PR DESCRIPTION
Since an AreaRenderer with no fill now resembles a LineRenderer,
perhaps we should consider merging the two classes.

Close #482.
