### PR TITLE
Sublime syntax highlighting

### DIFF
--- a/.sublimets
+++ b/.sublimets
@@ -1,3 +1,3 @@
 {
-    "root":"src/references.ts",
+    "root":"build/sublime.d.ts"
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -102,6 +102,11 @@ module.exports = function(grunt) {
       replacement: 'synchronousRequire("/build/test/$1.js");',
       path: "test/tests_multifile.js",
     },
+    sublime: {
+      pattern: "(.*\\.ts)",
+      replacement: '/// <reference path="../$1" />',
+      path: "build/sublime.d.ts",
+    }
   };
 
   // e.g. ["components/foo.ts", ...]
@@ -247,7 +252,12 @@ module.exports = function(grunt) {
       main: {
         files: {'plottable.min.js': ['plottable.js']}
       }
-    }
+    },
+    shell: {
+      sublime: {
+        command: "(echo 'src/reference.ts'; find typings -name '*.d.ts') > build/sublime.d.ts",
+      },
+    },
   };
 
 
@@ -306,4 +316,9 @@ module.exports = function(grunt) {
   grunt.registerTask("launch", ["connect", "dev-compile", "watch"]);
   grunt.registerTask("test", ["dev-compile", "blanket_mocha"]);
   grunt.registerTask("bm", ["blanket_mocha"]);
+
+  grunt.registerTask("sublime", [
+                                  "shell:sublime",
+                                  "sed:sublime",
+                                  ]);
 };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "grunt-contrib-clean": "~0.4.0",
     "grunt-bump": "0.0.13",
     "grunt-contrib-compress": "~0.9.1",
-    "grunt-contrib-uglify": "~0.4.0"
+    "grunt-contrib-uglify": "~0.4.0",
+    "grunt-shell": "0.7.0"
   }
 }


### PR DESCRIPTION
For too long we've lived with angry pink highlighting around D3 code.

![screen shot 2014-06-03 at 1 12 01 pm](https://cloud.githubusercontent.com/assets/3344958/3165988/93b701d2-eb5b-11e3-8a09-a51bad81325f.png)

Lame. This commit makes sublime recognize things in `typings/`, so it stops complaining and starts giving suggestions.

![screen shot 2014-06-03 at 1 15 09 pm](https://cloud.githubusercontent.com/assets/3344958/3166018/f17678fc-eb5b-11e3-980c-b9fee38c7c68.png)

To get this to work, run `grunt sublime`, then quit sublime and re-open.
