### PR TITLE
Clean up Renderers.

### DIFF
--- a/src/components/renderers/abstractBarRenderer.ts
+++ b/src/components/renderers/abstractBarRenderer.ts
@@ -2,6 +2,7 @@
 
 module Plottable {
   export class AbstractBarRenderer extends XYRenderer {
+    public _bars: D3.UpdateSelection;
     public _baseline: D3.Selection;
     public _baselineValue = 0;
     public _barAlignment: string;
@@ -65,7 +66,7 @@ module Plottable {
       var selectedBar: D3.Selection = null;
 
       // currently, linear scan the bars. If inversion is implemented on non-numeric scales we might be able to do better.
-      this.dataSelection.each(function(d: any) {
+      this._bars.each(function(d: any) {
         var bbox = this.getBBox();
         if (bbox.x <= x && x <= bbox.x + bbox.width &&
             bbox.y <= y && y <= bbox.y + bbox.height) {
@@ -85,7 +86,7 @@ module Plottable {
      * @return {AbstractBarRenderer} The calling AbstractBarRenderer.
      */
     public deselectAll() {
-      this.dataSelection.classed("selected", false);
+      this._bars.classed("selected", false);
       return this;
     }
   }

--- a/src/components/renderers/areaRenderer.ts
+++ b/src/components/renderers/areaRenderer.ts
@@ -4,8 +4,6 @@ module Plottable {
   export class AreaRenderer extends XYRenderer {
     private areaPath: D3.Selection;
     private linePath: D3.Selection;
-    private area: D3.Svg.Area;
-    private line: D3.Svg.Line;
     public _ANIMATION_DURATION = 600; //milliseconds
 
     /**
@@ -41,7 +39,7 @@ module Plottable {
       delete attrToProjector["y0"];
       delete attrToProjector["y"];
 
-      this.dataSelection = this.areaPath.datum(this._dataSource.data());
+      this.areaPath.datum(this._dataSource.data());
       this.linePath.datum(this._dataSource.data());
       if (this._animate && this._dataChanged) {
          var animationStartArea = d3.svg.area()
@@ -55,7 +53,7 @@ module Plottable {
         this.linePath.attr("d", animationStartLine).attr(attrToProjector);
       }
 
-      this.area = d3.svg.area()
+      var area = d3.svg.area()
                         .x(xFunction)
                         .y0(y0Function)
                         .y1(yFunction);
@@ -65,11 +63,11 @@ module Plottable {
         areaUpdateSelection = this.areaPath.transition().duration(this._ANIMATION_DURATION).ease("exp-in-out");
         lineUpdateSelection = this.linePath.transition().duration(this._ANIMATION_DURATION).ease("exp-in-out");
       }
-      this.line = d3.svg.line()
+      var line = d3.svg.line()
                         .x(xFunction)
                         .y(yFunction);
-      areaUpdateSelection.attr("d", this.area).attr(attrToProjector);
-      lineUpdateSelection.attr("d", this.line).attr(attrToProjector);
+      areaUpdateSelection.attr("d", area).attr(attrToProjector);
+      lineUpdateSelection.attr("d", line).attr(attrToProjector);
     }
   }
 }

--- a/src/components/renderers/barRenderer.ts
+++ b/src/components/renderers/barRenderer.ts
@@ -22,8 +22,8 @@ module Plottable {
       super._paint();
       var scaledBaseline = this.yScale.scale(this._baselineValue);
 
-      this.dataSelection = this.renderArea.selectAll("rect").data(this._dataSource.data());
-      this.dataSelection.enter().append("rect");
+      this._bars = this.renderArea.selectAll("rect").data(this._dataSource.data());
+      this._bars.enter().append("rect");
 
       var attrToProjector = this._generateAttrToProjector();
 
@@ -48,7 +48,7 @@ module Plottable {
       if (this._animate && this._dataChanged) {
         attrToProjector["y"] = () => scaledBaseline;
         attrToProjector["height"] = () => 0;
-        this.dataSelection.attr(attrToProjector);
+        this._bars.attr(attrToProjector);
       }
 
       attrToProjector["y"] = (d: any, i: number) => {
@@ -62,10 +62,10 @@ module Plottable {
       attrToProjector["height"] = heightFunction;
 
       if (attrToProjector["fill"] != null) {
-        this.dataSelection.attr("fill", attrToProjector["fill"]); // so colors don't animate
+        this._bars.attr("fill", attrToProjector["fill"]); // so colors don't animate
       }
 
-      var updateSelection: any = this.dataSelection;
+      var updateSelection: any = this._bars;
       if (this._animate) {
         var n = this.dataSource().data().length;
         updateSelection = updateSelection.transition().ease("exp-out").duration(this._ANIMATION_DURATION)
@@ -73,7 +73,7 @@ module Plottable {
       }
 
       updateSelection.attr(attrToProjector);
-      this.dataSelection.exit().remove();
+      this._bars.exit().remove();
 
       this._baseline.attr({
         "x1": 0,

--- a/src/components/renderers/circleRenderer.ts
+++ b/src/components/renderers/circleRenderer.ts
@@ -38,11 +38,11 @@ module Plottable {
       var rFunction = attrToProjector["r"];
       attrToProjector["r"] = () => 0;
 
-      this.dataSelection = this.renderArea.selectAll("circle").data(this._dataSource.data());
-      this.dataSelection.enter().append("circle");
-      this.dataSelection.attr(attrToProjector);
+      var circles = this.renderArea.selectAll("circle").data(this._dataSource.data());
+      circles.enter().append("circle");
+      circles.attr(attrToProjector);
 
-      var updateSelection: any = this.dataSelection;
+      var updateSelection: any = circles;
       if (this._animate && this._dataChanged) {
         var n = this.dataSource().data().length;
         updateSelection = updateSelection.transition().ease("exp-out").duration(this._ANIMATION_DURATION)
@@ -50,7 +50,7 @@ module Plottable {
       }
       updateSelection.attr("r", rFunction);
 
-      this.dataSelection.exit().remove();
+      circles.exit().remove();
     }
   }
 }

--- a/src/components/renderers/gridRenderer.ts
+++ b/src/components/renderers/gridRenderer.ts
@@ -39,8 +39,8 @@ module Plottable {
     public _paint() {
       super._paint();
 
-      this.dataSelection = this.renderArea.selectAll("rect").data(this._dataSource.data());
-      this.dataSelection.enter().append("rect");
+      var cells = this.renderArea.selectAll("rect").data(this._dataSource.data());
+      cells.enter().append("rect");
 
       var xStep = this.xScale.rangeBand();
       var yStep = this.yScale.rangeBand();
@@ -49,8 +49,8 @@ module Plottable {
       attrToProjector["width"]  = () => xStep;
       attrToProjector["height"] = () => yStep;
 
-      this.dataSelection.attr(attrToProjector);
-      this.dataSelection.exit().remove();
+      cells.attr(attrToProjector);
+      cells.exit().remove();
     }
   }
 }

--- a/src/components/renderers/horizontalBarRenderer.ts
+++ b/src/components/renderers/horizontalBarRenderer.ts
@@ -20,8 +20,8 @@ module Plottable {
 
     public _paint() {
       super._paint();
-      this.dataSelection = this.renderArea.selectAll("rect").data(this._dataSource.data());
-      this.dataSelection.enter().append("rect");
+      this._bars = this.renderArea.selectAll("rect").data(this._dataSource.data());
+      this._bars.enter().append("rect");
 
       var attrToProjector = this._generateAttrToProjector();
 
@@ -49,7 +49,7 @@ module Plottable {
       if (this._animate && this._dataChanged) {
         attrToProjector["x"] = () => scaledBaseline;
         attrToProjector["width"] = () => 0;
-        this.dataSelection.attr(attrToProjector);
+        this._bars.attr(attrToProjector);
       }
 
       attrToProjector["x"] = (d: any, i: number) => {
@@ -63,10 +63,10 @@ module Plottable {
       attrToProjector["width"] = widthFunction; // actual SVG rect width
 
       if (attrToProjector["fill"] != null) {
-        this.dataSelection.attr("fill", attrToProjector["fill"]); // so colors don't animate
+        this._bars.attr("fill", attrToProjector["fill"]); // so colors don't animate
       }
 
-      var updateSelection: any = this.dataSelection;
+      var updateSelection: any = this._bars;
       if (this._animate) {
         var n = this.dataSource().data().length;
         updateSelection = updateSelection.transition().ease("exp-out").duration(this._ANIMATION_DURATION)
@@ -74,7 +74,7 @@ module Plottable {
       }
 
       updateSelection.attr(attrToProjector);
-      this.dataSelection.exit().remove();
+      this._bars.exit().remove();
 
       this._baseline.attr({
         "x1": scaledBaseline,

--- a/src/components/renderers/lineRenderer.ts
+++ b/src/components/renderers/lineRenderer.ts
@@ -3,7 +3,6 @@
 module Plottable {
   export class LineRenderer extends XYRenderer {
     private path: D3.Selection;
-    private line: D3.Svg.Line;
     public _ANIMATION_DURATION = 600; //milliseconds
 
     /**
@@ -35,7 +34,7 @@ module Plottable {
       delete attrToProjector["x"];
       delete attrToProjector["y"];
 
-      this.dataSelection = this.path.datum(this._dataSource.data());
+      this.path.datum(this._dataSource.data());
       if (this._animate && this._dataChanged) {
         var animationStartLine = d3.svg.line()
                                        .x(xFunction)
@@ -43,14 +42,14 @@ module Plottable {
         this.path.attr("d", animationStartLine).attr(attrToProjector);
       }
 
-      this.line = d3.svg.line()
+      var line = d3.svg.line()
             .x(xFunction)
             .y(yFunction);
       var updateSelection: any = this.path;
       if (this._animate) {
         updateSelection = this.path.transition().duration(this._ANIMATION_DURATION).ease("exp-in-out");
       }
-      updateSelection.attr("d", this.line).attr(attrToProjector);
+      updateSelection.attr("d", line).attr(attrToProjector);
     }
   }
 }

--- a/src/components/renderers/rectRenderer.ts
+++ b/src/components/renderers/rectRenderer.ts
@@ -28,10 +28,10 @@ module Plottable {
       attrToProjector["x"] = (d: any, i: number) => xF(d, i) -  widthF(d, i) / 2;
       attrToProjector["y"] = (d: any, i: number) => yF(d, i) - heightF(d, i) / 2;
 
-      this.dataSelection = this.renderArea.selectAll("rect").data(this._dataSource.data());
-      this.dataSelection.enter().append("rect");
-      this.dataSelection.attr(attrToProjector);
-      this.dataSelection.exit().remove();
+      var rects = this.renderArea.selectAll("rect").data(this._dataSource.data());
+      rects.enter().append("rect");
+      rects.attr(attrToProjector);
+      rects.exit().remove();
     }
   }
 }

--- a/src/components/renderers/xyRenderer.ts
+++ b/src/components/renderers/xyRenderer.ts
@@ -2,7 +2,6 @@
 
 module Plottable {
   export class XYRenderer extends Renderer {
-    public dataSelection: D3.UpdateSelection;
     public xScale: Scale;
     public yScale: Scale;
     public _xAccessor: any;
@@ -40,12 +39,11 @@ module Plottable {
         this.yScale._autoPad = true;
       }
       super.project(attrToSet, accessor, scale);
-      
+
       return this;
     }
 
     public _computeLayout(xOffset?: number, yOffset?: number, availableWidth?: number, availableHeight?: number) {
-      this._hasRendered = false;
       super._computeLayout(xOffset, yOffset, availableWidth, availableHeight);
       this.xScale.range([0, this.availableWidth]);
       this.yScale.range([this.availableHeight, 0]);
@@ -53,7 +51,7 @@ module Plottable {
     }
 
     private rescale() {
-      if (this.element != null && this._hasRendered) {
+      if (this.element != null) {
         this._render();
       }
     }

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -10,15 +10,12 @@ module Plottable {
     public _dataSource: DataSource;
     public _dataChanged = false;
 
-    public dataSelection: D3.UpdateSelection;
     public renderArea: D3.Selection;
     public element: D3.Selection;
     public scales: Scale[];
     public _colorAccessor: IAccessor;
     public _animate = false;
     public _ANIMATION_DURATION = 250; // milliseconds
-    public _hasRendered = false;
-    private static DEFAULT_COLOR_ACCESSOR = (d: any) => "#1f77b4";
     public _projectors: { [attrToSet: string]: _IProjector; } = {};
 
     public _rerenderUpdateSelection = false;
@@ -140,7 +137,6 @@ module Plottable {
 
     public _doRender(): Renderer {
       if (this.element != null) {
-        this._hasRendered = true;
         this._paint();
         this._dataChanged = false;
         this._requireRerender = false;


### PR DESCRIPTION
First, removed the dataSelection property. In most cases, there
wasn't much point in hanging on to the selection. Exception: bar
renderers, which used the selection to support highlighting bars.

In addition, removed some unused fields and fields that were saved off,
but not used outside of the _paint() call.

Close #500.
