### PR TITLE
Fix bounding-box checks due to off-by-one errors on Firefox

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -3036,7 +3036,7 @@ var Plottable;
             var boundingBox = this.element.select(".bounding-box")[0][0].getBoundingClientRect();
 
             var isInsideBBox = function (tickBox) {
-                return (boundingBox.left <= tickBox.left && boundingBox.top <= tickBox.top && tickBox.right <= boundingBox.left + _this.availableWidth && tickBox.bottom <= boundingBox.top + _this.availableHeight);
+                return (Math.floor(boundingBox.left) <= Math.ceil(tickBox.left) && Math.floor(boundingBox.top) <= Math.ceil(tickBox.top) && Math.floor(tickBox.right) <= Math.ceil(boundingBox.left + _this.availableWidth) && Math.floor(tickBox.bottom) <= Math.ceil(boundingBox.top + _this.availableHeight));
             };
 
             tickLabels.each(function (d) {

--- a/src/components/axis.ts
+++ b/src/components/axis.ts
@@ -96,10 +96,12 @@ module Plottable {
       var boundingBox = this.element.select(".bounding-box")[0][0].getBoundingClientRect();
 
       var isInsideBBox = (tickBox: ClientRect) => {
-        return (boundingBox.left <= tickBox.left &&
-                boundingBox.top  <= tickBox.top  &&
-                tickBox.right  <= boundingBox.left + this.availableWidth &&
-                tickBox.bottom <= boundingBox.top  + this.availableHeight);
+        return (
+          Math.floor(boundingBox.left) <= Math.ceil(tickBox.left) &&
+          Math.floor(boundingBox.top)  <= Math.ceil(tickBox.top)  &&
+          Math.floor(tickBox.right)  <= Math.ceil(boundingBox.left + this.availableWidth) &&
+          Math.floor(tickBox.bottom) <= Math.ceil(boundingBox.top  + this.availableHeight)
+        );
       };
 
       tickLabels.each(function (d: any){

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -53,10 +53,10 @@ function assertBBoxEquivalence(bbox: SVGRect, widthAndHeightPair: number[], mess
 function assertBBoxInclusion(outerEl: D3.Selection, innerEl: D3.Selection) {
   var outerBox = outerEl.node().getBoundingClientRect();
   var innerBox = innerEl.node().getBoundingClientRect();
-  assert.operator(outerBox.left,   "<=", innerBox.left + 0.5,   "bounding rect left included"  );
-  assert.operator(outerBox.top,    "<=", innerBox.top + 0.5,    "bounding rect top included"   );
-  assert.operator(outerBox.right  + 0.5, ">=", innerBox.right,  "bounding rect right included" );
-  assert.operator(outerBox.bottom + 0.5, ">=", innerBox.bottom, "bounding rect bottom included");
+  assert.operator(Math.floor(outerBox.left), "<=", Math.ceil(innerBox.left), "bounding rect left included");
+  assert.operator(Math.floor(outerBox.top), "<=", Math.ceil(innerBox.top), "bounding rect top included");
+  assert.operator(Math.ceil(outerBox.right), ">=", Math.floor(innerBox.right), "bounding rect right included");
+  assert.operator(Math.ceil(outerBox.bottom), ">=", Math.floor(innerBox.bottom), "bounding rect bottom included");
 }
 
 function assertXY(el: D3.Selection, xExpected: number, yExpected: number, message: string) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -54,10 +54,10 @@ function assertBBoxEquivalence(bbox, widthAndHeightPair, message) {
 function assertBBoxInclusion(outerEl, innerEl) {
     var outerBox = outerEl.node().getBoundingClientRect();
     var innerBox = innerEl.node().getBoundingClientRect();
-    assert.operator(outerBox.left, "<=", innerBox.left + 0.5, "bounding rect left included");
-    assert.operator(outerBox.top, "<=", innerBox.top + 0.5, "bounding rect top included");
-    assert.operator(outerBox.right + 0.5, ">=", innerBox.right, "bounding rect right included");
-    assert.operator(outerBox.bottom + 0.5, ">=", innerBox.bottom, "bounding rect bottom included");
+    assert.operator(Math.floor(outerBox.left), "<=", Math.ceil(innerBox.left), "bounding rect left included");
+    assert.operator(Math.floor(outerBox.top), "<=", Math.ceil(innerBox.top), "bounding rect top included");
+    assert.operator(Math.ceil(outerBox.right), ">=", Math.floor(innerBox.right), "bounding rect right included");
+    assert.operator(Math.ceil(outerBox.bottom), ">=", Math.floor(innerBox.bottom), "bounding rect bottom included");
 }
 
 function assertXY(el, xExpected, yExpected, message) {


### PR DESCRIPTION
"I got 98.999999999999 problems..."

Due to rounding errors, sometimes bounds checks would fail in FF.
Solution: use `Math.floor()` and `Math.ceil()` to account for sub-pixel
errors.

Close #477.
Close #305 (no more test failures in FF!).
