### PR TITLE
Remove the "Cannot measure text in a removed node" error

### DIFF
--- a/src/utils/textUtils.ts
+++ b/src/utils/textUtils.ts
@@ -19,9 +19,6 @@ export module Util {
         if (s.trim() === "") {
           return [0, 0];
         }
-        if (DOM.isSelectionRemovedFromSVG(selection)) {
-          throw new Error("Cannot measure text in a removed node");
-        }
         var bb: SVGRect;
         if (selection.node().nodeName === "text") {
           var originalText = selection.text();

--- a/test/domUtilsTests.ts
+++ b/test/domUtilsTests.ts
@@ -69,14 +69,4 @@ describe("Util.DOM", () => {
       child.remove();
     });
   });
-
-  it("isSelectionRemovedFromSVG works", () => {
-    var svg = generateSVG();
-    var g = svg.append("g");
-    assert.isFalse(Plottable.Util.DOM.isSelectionRemovedFromSVG(g), "g is in svg");
-    g.remove();
-    assert.isTrue(Plottable.Util.DOM.isSelectionRemovedFromSVG(g), "g is no longer in svg");
-    assert.isFalse(Plottable.Util.DOM.isSelectionRemovedFromSVG(svg), "svg is not considered removed");
-    svg.remove();
-    });
 });


### PR DESCRIPTION
Measuring text in a removed node produces erroneous results. Currently
we throw an error if this is attempted. However, erroring out plottable is
much worse than getting a bad text measurement on a removed node, since
probably when you add the node back in it will re-measure appropriately.
