### PR TITLE
ordinalScale.extentModifier added

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1349,6 +1349,29 @@ declare module Plottable {
             * @constructor
             */
             constructor(scale?: D3.Scale.OrdinalScale);
+            public autoDomain(): Ordinal;
+            /**
+            * Return the extentModifier function.
+            *
+            * @returns {(extent: string[]) => string[]} The extentModifier function.
+            */
+            public extentModifier(): (extent: string[]) => string[];
+            /**
+            * Sets the extentModifier function.
+            *
+            * @param {(extent: string[]) => string[]} f
+            *        The extentModifier function is used to change the extent before
+            *        it is displayed. For example, it could sort the extent, or remove
+            *        certain undesired values.
+            *
+            *        It defaults to the identity function.
+            *
+            *        It serves a similar role to Plottable.Domainer, but operates on
+            *        Ordinal scales.
+            *
+            * @returns {Ordinal} The calling Ordinal Scale.
+            */
+            public extentModifier(f: (extent: string[]) => string[]): Ordinal;
             /**
             * Gets the domain.
             *

--- a/plottable.js
+++ b/plottable.js
@@ -414,19 +414,19 @@ var Plottable;
                     if (s.trim() === "") {
                         return [0, 0];
                     }
-                    if (Plottable.Util.DOM.isSelectionRemovedFromSVG(selection)) {
+                    if (Util.DOM.isSelectionRemovedFromSVG(selection)) {
                         throw new Error("Cannot measure text in a removed node");
                     }
                     var bb;
                     if (selection.node().nodeName === "text") {
                         var originalText = selection.text();
                         selection.text(s);
-                        bb = Plottable.Util.DOM.getBBox(selection);
+                        bb = Util.DOM.getBBox(selection);
                         selection.text(originalText);
                         return [bb.width, bb.height];
                     } else {
                         var t = selection.append("text").text(s);
-                        bb = Plottable.Util.DOM.getBBox(t);
+                        bb = Util.DOM.getBBox(t);
                         t.remove();
                         return [bb.width, bb.height];
                     }
@@ -501,7 +501,7 @@ var Plottable;
                 */
                 function CachingCharacterMeasurer(g) {
                     var _this = this;
-                    this.cache = new Plottable.Util.Cache(getTextMeasure(g), CANONICAL_CHR, Plottable.Util.Methods.arrayEq);
+                    this.cache = new Util.Cache(getTextMeasure(g), CANONICAL_CHR, Util.Methods.arrayEq);
                     this.measure = combineWhitespace(measureByCharacter(wrapWhitespace(function (s) {
                         return _this.cache.get(s);
                     })));
@@ -594,7 +594,7 @@ var Plottable;
                 var innerG = g.append("g");
                 var textEl = innerG.append("text");
                 textEl.text(line);
-                var bb = Plottable.Util.DOM.getBBox(textEl);
+                var bb = Util.DOM.getBBox(textEl);
                 var h = bb.height;
                 var w = bb.width;
                 if (w > width || h > height) {
@@ -607,7 +607,7 @@ var Plottable;
                 var yOff = height * yOffsetFactor[yAlign] + h * (1 - yOffsetFactor[yAlign]);
                 var ems = -0.4 * (1 - yOffsetFactor[yAlign]);
                 textEl.attr("text-anchor", anchor).attr("y", ems + "em");
-                Plottable.Util.DOM.translate(innerG, xOff, yOff);
+                Util.DOM.translate(innerG, xOff, yOff);
                 return [w, h];
             }
             Text.writeLineHorizontally = writeLineHorizontally;
@@ -642,7 +642,7 @@ var Plottable;
                 var blockG = g.append("g");
                 brokenText.forEach(function (line, i) {
                     var innerG = blockG.append("g");
-                    Plottable.Util.DOM.translate(innerG, 0, i * h);
+                    Util.DOM.translate(innerG, 0, i * h);
                     var wh = writeLineHorizontally(line, innerG, width, h, xAlign, yAlign);
                     if (wh[0] > maxWidth) {
                         maxWidth = wh[0];
@@ -651,7 +651,7 @@ var Plottable;
                 var usedSpace = h * brokenText.length;
                 var freeSpace = height - usedSpace;
                 var translator = { center: 0.5, top: 0, bottom: 1 };
-                Plottable.Util.DOM.translate(blockG, 0, freeSpace * translator[yAlign]);
+                Util.DOM.translate(blockG, 0, freeSpace * translator[yAlign]);
                 return [maxWidth, usedSpace];
             }
             Text.writeTextHorizontally = writeTextHorizontally;
@@ -665,7 +665,7 @@ var Plottable;
                 var blockG = g.append("g");
                 brokenText.forEach(function (line, i) {
                     var innerG = blockG.append("g");
-                    Plottable.Util.DOM.translate(innerG, i * h, 0);
+                    Util.DOM.translate(innerG, i * h, 0);
                     var wh = writeLineVertically(line, innerG, h, height, xAlign, yAlign, rotation);
                     if (wh[1] > maxHeight) {
                         maxHeight = wh[1];
@@ -674,7 +674,7 @@ var Plottable;
                 var usedSpace = h * brokenText.length;
                 var freeSpace = width - usedSpace;
                 var translator = { center: 0.5, left: 0, right: 1 };
-                Plottable.Util.DOM.translate(blockG, freeSpace * translator[xAlign], 0);
+                Util.DOM.translate(blockG, freeSpace * translator[xAlign], 0);
 
                 return [usedSpace, maxHeight];
             }
@@ -692,7 +692,7 @@ var Plottable;
                 var orientHorizontally = (horizontally != null) ? horizontally : width * 1.1 > height;
                 var primaryDimension = orientHorizontally ? width : height;
                 var secondaryDimension = orientHorizontally ? height : width;
-                var wrappedText = Plottable.Util.WordWrap.breakTextToFitRect(text, primaryDimension, secondaryDimension, tm);
+                var wrappedText = Util.WordWrap.breakTextToFitRect(text, primaryDimension, secondaryDimension, tm);
 
                 var usedWidth, usedHeight;
                 if (write == null) {
@@ -755,7 +755,7 @@ var Plottable;
                     lines = lines.splice(0, nLinesThatFit);
                     if (nLinesThatFit > 0) {
                         // Overwrite the last line to one that has had a ... appended to the end
-                        lines[nLinesThatFit - 1] = Plottable.Util.Text.addEllipsesToLine(lines[nLinesThatFit - 1], width, measureText);
+                        lines[nLinesThatFit - 1] = Util.Text.addEllipsesToLine(lines[nLinesThatFit - 1], width, measureText);
                     }
                 }
                 return { originalText: text, lines: lines, textFits: textFit };
@@ -1232,7 +1232,7 @@ var Plottable;
                 return formattedValue;
             };
             return Currency;
-        })(Plottable.Formatter.Fixed);
+        })(Formatter.Fixed);
         Formatter.Currency = Currency;
     })(Plottable.Formatter || (Plottable.Formatter = {}));
     var Formatter = Plottable.Formatter;
@@ -1269,7 +1269,7 @@ var Plottable;
                 return formattedValue;
             };
             return Percentage;
-        })(Plottable.Formatter.Fixed);
+        })(Formatter.Fixed);
         Formatter.Percentage = Percentage;
     })(Plottable.Formatter || (Plottable.Formatter = {}));
     var Formatter = Plottable.Formatter;
@@ -2057,7 +2057,7 @@ var Plottable;
             };
             Component.AUTORESIZE_BY_DEFAULT = true;
             return Component;
-        })(Plottable.Abstract.PlottableObject);
+        })(Abstract.PlottableObject);
         Abstract.Component = Component;
     })(Plottable.Abstract || (Plottable.Abstract = {}));
     var Abstract = Plottable.Abstract;
@@ -2159,7 +2159,7 @@ var Plottable;
                 return this;
             };
             return ComponentContainer;
-        })(Plottable.Abstract.Component);
+        })(Abstract.Component);
         Abstract.ComponentContainer = ComponentContainer;
     })(Plottable.Abstract || (Plottable.Abstract = {}));
     var Abstract = Plottable.Abstract;
@@ -2767,7 +2767,7 @@ var Plottable;
                 return this;
             };
             return Scale;
-        })(Plottable.Abstract.PlottableObject);
+        })(Abstract.PlottableObject);
         Abstract.Scale = Scale;
     })(Plottable.Abstract || (Plottable.Abstract = {}));
     var Abstract = Plottable.Abstract;
@@ -2967,7 +2967,7 @@ var Plottable;
                 }
             };
             return Plot;
-        })(Plottable.Abstract.Component);
+        })(Abstract.Component);
         Abstract.Plot = Plot;
     })(Plottable.Abstract || (Plottable.Abstract = {}));
     var Abstract = Plottable.Abstract;
@@ -2983,7 +2983,7 @@ var Plottable;
                     function Immediate() {
                     }
                     Immediate.prototype.render = function () {
-                        Plottable.Core.RenderController.flush();
+                        RenderController.flush();
                     };
                     return Immediate;
                 })();
@@ -2993,7 +2993,7 @@ var Plottable;
                     function AnimationFrame() {
                     }
                     AnimationFrame.prototype.render = function () {
-                        Plottable.Util.DOM.requestAnimationFramePolyfill(Plottable.Core.RenderController.flush);
+                        Plottable.Util.DOM.requestAnimationFramePolyfill(RenderController.flush);
                     };
                     return AnimationFrame;
                 })();
@@ -3004,7 +3004,7 @@ var Plottable;
                         this._timeoutMsec = Plottable.Util.DOM.POLYFILL_TIMEOUT_MSEC;
                     }
                     Timeout.prototype.render = function () {
-                        setTimeout(Plottable.Core.RenderController.flush, this._timeoutMsec);
+                        setTimeout(RenderController.flush, this._timeoutMsec);
                     };
                     return Timeout;
                 })();
@@ -3035,7 +3035,7 @@ var Plottable;
             var _componentsNeedingRender = {};
             var _componentsNeedingComputeLayout = {};
             var _animationRequested = false;
-            RenderController._renderPolicy = new Plottable.Core.RenderController.RenderPolicy.AnimationFrame();
+            RenderController._renderPolicy = new RenderController.RenderPolicy.AnimationFrame();
 
             function setRenderPolicy(policy) {
                 RenderController._renderPolicy = policy;
@@ -3103,7 +3103,7 @@ var Plottable;
                 }
 
                 // Reset resize flag regardless of queue'd components
-                Plottable.Core.ResizeBroadcaster.clearResizing();
+                Core.ResizeBroadcaster.clearResizing();
             }
             RenderController.flush = flush;
         })(Core.RenderController || (Core.RenderController = {}));
@@ -3132,7 +3132,7 @@ var Plottable;
 
             function _lazyInitialize() {
                 if (broadcaster === undefined) {
-                    broadcaster = new Plottable.Core.Broadcaster(ResizeBroadcaster);
+                    broadcaster = new Core.Broadcaster(ResizeBroadcaster);
                     window.addEventListener("resize", _onResize);
                 }
             }
@@ -3487,7 +3487,7 @@ var Plottable;
                 }
             };
             return QuantitiveScale;
-        })(Plottable.Abstract.Scale);
+        })(Abstract.Scale);
         Abstract.QuantitiveScale = QuantitiveScale;
     })(Plottable.Abstract || (Plottable.Abstract = {}));
     var Abstract = Plottable.Abstract;
@@ -3577,6 +3577,9 @@ var Plottable;
                 // Padding as a proportion of the spacing between domain values
                 this._innerPadding = 0.3;
                 this._outerPadding = 0.5;
+                this._extentModifier = function (extent) {
+                    return extent;
+                };
                 if (this._innerPadding > this._outerPadding) {
                     throw new Error("outerPadding must be >= innerPadding so cat axis bands work out reasonably");
                 }
@@ -3584,6 +3587,21 @@ var Plottable;
             Ordinal.prototype._getExtent = function () {
                 var extents = this._getAllExtents();
                 return Plottable.Util.Methods.uniq(Plottable.Util.Methods.flatten(extents));
+            };
+
+            Ordinal.prototype.autoDomain = function () {
+                this._setDomain(this._extentModifier(this._getExtent()));
+                return this;
+            };
+
+            Ordinal.prototype.extentModifier = function (f) {
+                if (f == null) {
+                    return this._extentModifier;
+                } else {
+                    this._extentModifier = f;
+                    this._autoDomainIfAutomaticMode();
+                    return this;
+                }
             };
 
             Ordinal.prototype.domain = function (values) {
@@ -4835,7 +4853,7 @@ var Plottable;
                     return (Math.floor(boundingBox.left) <= Math.ceil(tickBox.left) && Math.floor(boundingBox.top) <= Math.ceil(tickBox.top) && Math.floor(tickBox.right) <= Math.ceil(boundingBox.left + _this.availableWidth) && Math.floor(tickBox.bottom) <= Math.ceil(boundingBox.top + _this.availableHeight));
                 };
 
-                var tickLabels = this._tickLabelContainer.selectAll("." + Plottable.Abstract.Axis.TICK_LABEL_CLASS);
+                var tickLabels = this._tickLabelContainer.selectAll("." + Abstract.Axis.TICK_LABEL_CLASS);
                 var firstTickLabel = tickLabels[0][0];
                 if (!isInsideBBox(firstTickLabel.getBoundingClientRect())) {
                     d3.select(firstTickLabel).style("visibility", "hidden");
@@ -4847,7 +4865,7 @@ var Plottable;
             };
 
             Axis.prototype._hideOverlappingTickLabels = function () {
-                var visibleTickLabels = this._tickLabelContainer.selectAll("." + Plottable.Abstract.Axis.TICK_LABEL_CLASS).filter(function (d, i) {
+                var visibleTickLabels = this._tickLabelContainer.selectAll("." + Abstract.Axis.TICK_LABEL_CLASS).filter(function (d, i) {
                     return d3.select(this).style("visibility") === "visible";
                 });
                 var lastLabelClientRect;
@@ -4882,7 +4900,7 @@ var Plottable;
             Axis.TICK_MARK_CLASS = "tick-mark";
             Axis.TICK_LABEL_CLASS = "tick-label";
             return Axis;
-        })(Plottable.Abstract.Component);
+        })(Abstract.Component);
         Abstract.Axis = Axis;
     })(Plottable.Abstract || (Plottable.Abstract = {}));
     var Abstract = Plottable.Abstract;
@@ -5800,7 +5818,7 @@ var Plottable;
             };
 
             XYPlot.prototype._updateXDomainer = function () {
-                if (this.xScale instanceof Plottable.Abstract.QuantitiveScale) {
+                if (this.xScale instanceof Abstract.QuantitiveScale) {
                     var scale = this.xScale;
                     if (!scale._userSetDomainer) {
                         scale.domainer().pad().nice();
@@ -5810,7 +5828,7 @@ var Plottable;
             };
 
             XYPlot.prototype._updateYDomainer = function () {
-                if (this.yScale instanceof Plottable.Abstract.QuantitiveScale) {
+                if (this.yScale instanceof Abstract.QuantitiveScale) {
                     var scale = this.yScale;
                     if (!scale._userSetDomainer) {
                         scale.domainer().pad().nice();
@@ -5819,7 +5837,7 @@ var Plottable;
                 return this;
             };
             return XYPlot;
-        })(Plottable.Abstract.Plot);
+        })(Abstract.Plot);
         Abstract.XYPlot = XYPlot;
     })(Plottable.Abstract || (Plottable.Abstract = {}));
     var Abstract = Plottable.Abstract;
@@ -6143,7 +6161,7 @@ var Plottable;
             };
 
             BarPlot.prototype._updateDomainer = function (scale) {
-                if (scale instanceof Plottable.Abstract.QuantitiveScale) {
+                if (scale instanceof Abstract.QuantitiveScale) {
                     var qscale = scale;
                     if (!qscale._userSetDomainer && this._baselineValue != null) {
                         qscale.domainer().paddingException(this.previousBaselineValue, false).include(this.previousBaselineValue, false).paddingException(this._baselineValue).include(this._baselineValue);
@@ -6204,7 +6222,7 @@ var Plottable;
 
             BarPlot._BarAlignmentToFactor = {};
             return BarPlot;
-        })(Plottable.Abstract.XYPlot);
+        })(Abstract.XYPlot);
         Abstract.BarPlot = BarPlot;
     })(Plottable.Abstract || (Plottable.Abstract = {}));
     var Abstract = Plottable.Abstract;
@@ -6464,7 +6482,7 @@ var Plottable;
                 this._applyAnimatedAttributes(this.areaPath, "area", attrToProjector);
             };
             return Area;
-        })(Plottable.Plot.Line);
+        })(Plot.Line);
         Plot.Area = Area;
     })(Plottable.Plot || (Plottable.Plot = {}));
     var Plot = Plottable.Plot;
@@ -6570,7 +6588,7 @@ var Plottable;
                 }).attr(attrToProjector);
             };
             return IterativeDelay;
-        })(Plottable.Animator.Default);
+        })(Animator.Default);
         Animator.IterativeDelay = IterativeDelay;
     })(Plottable.Animator || (Plottable.Animator = {}));
     var Animator = Plottable.Animator;
@@ -7068,7 +7086,7 @@ var Plottable;
             };
             DragBox.CLASS_DRAG_BOX = "drag-box";
             return DragBox;
-        })(Plottable.Interaction.Drag);
+        })(Interaction.Drag);
         Interaction.DragBox = DragBox;
     })(Plottable.Interaction || (Plottable.Interaction = {}));
     var Interaction = Plottable.Interaction;
@@ -7109,7 +7127,7 @@ var Plottable;
                 return this;
             };
             return XDragBox;
-        })(Plottable.Interaction.DragBox);
+        })(Interaction.DragBox);
         Interaction.XDragBox = XDragBox;
     })(Plottable.Interaction || (Plottable.Interaction = {}));
     var Interaction = Plottable.Interaction;
@@ -7147,7 +7165,7 @@ var Plottable;
                 this.callbackToCall(pixelArea);
             };
             return XYDragBox;
-        })(Plottable.Interaction.DragBox);
+        })(Interaction.DragBox);
         Interaction.XYDragBox = XYDragBox;
     })(Plottable.Interaction || (Plottable.Interaction = {}));
     var Interaction = Plottable.Interaction;
@@ -7188,7 +7206,7 @@ var Plottable;
                 return this;
             };
             return YDragBox;
-        })(Plottable.Interaction.DragBox);
+        })(Interaction.DragBox);
         Interaction.YDragBox = YDragBox;
     })(Plottable.Interaction || (Plottable.Interaction = {}));
     var Interaction = Plottable.Interaction;

--- a/quicktests/ordinalExtentModifier-quicktest.html
+++ b/quicktests/ordinalExtentModifier-quicktest.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <title> - jsFiddle demo by cmorford</title>
+  
+  
+  
+  
+  
+  
+  <style type='text/css'>
+    </style> <link rel="stylesheet" type="text/css" href="../plottable.css"> <style type="text/css">
+/*-- Add custom styles after this line --*/
+ .demo-title {
+    font-size: 24 pt;
+}
+.plottable .y-axis .tick line {
+    opacity: 1
+}
+
+.plottable .x-axis .tick line {
+    opacity: 1
+}
+
+  </style>
+  
+
+
+<script type='text/javascript'>//<![CDATA[ 
+
+ var ds;
+    window.onload = function() {
+
+        var data = [
+          { name: "Spot", age: 8 },
+          { name: "Poptart", age: 1 },
+          { name: "Budoka", age: 3 },
+          { name: "Sugar", age: 14 },
+          { name: "Temporal Asynchronous Cat", age: -5 }
+        ];
+
+      var cuteFormatter = function(d) { return d + " is a pretty darn cute cat"; } ;
+
+      ds = new Plottable.DataSource(data);
+      var xScale = new Plottable.Scale.Ordinal();
+      xScale.extentModifier(function(extent) {
+        // though I can modify the given extent safely, it probably isn't
+        // part of the spec. I should copy it.
+        var a = extent.slice(0);
+        a.sort();
+        return a;
+      });
+      var xAxis = new Plottable.Axis.Category(xScale, "bottom", cuteFormatter);
+
+      var yScale = new Plottable.Scale.Linear();
+      var yAxis = new Plottable.Axis.YAxis(yScale, "left");
+      yAxis.showEndTickLabels(true);
+
+      var barRenderer = new Plottable.Plot.VerticalBar(ds, xScale, yScale)
+                              .project("x", "name", xScale)
+                              .project("y", "age", yScale)
+                              .project("fill", function() {return "steelblue"; })
+      var chart = new Plottable.Component.Table([
+                                  [yAxis, barRenderer],
+                                  [null,  xAxis]
+                                ]);
+
+      var xScale2 = new Plottable.Scale.Linear();
+      var xAxis2 = new Plottable.Axis.XAxis(xScale2, "bottom");
+
+      var yScale2 = new Plottable.Scale.Ordinal();
+      yScale2.extentModifier(function(extent) {
+        return extent.filter(function(s) {
+          // only include elements with "p" in them
+          return /p/.test(s);
+        });
+      });
+      var yAxis2 = new Plottable.Axis.Category(yScale2, "left");//, cuteFormatter);
+
+      var horizBarRenderer = new Plottable.Plot.HorizontalBar(ds, xScale2, yScale2)
+                              .project("x", "age", xScale2)
+                              .project("y", "name", yScale2)
+                              .project("fill", function() {return "steelblue"; })
+
+      var horizChart = new Plottable.Component.Table([
+        [yAxis2, horizBarRenderer],
+        [null, xAxis2]
+      ]);
+
+        chart.renderTo("#meow");
+        horizChart.renderTo("#nya");
+      }
+
+      function younger() {
+        var data = ds.data();
+        data.forEach(function(d) { d.age--; });
+        ds.data(data);
+      }
+      function older() {
+        var data = ds.data();
+        data.forEach(function(d) { d.age++; });
+        ds.data(data);
+      }
+
+//]]>  
+
+</script>
+
+
+</head>
+<body>
+  <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
+<script src="../plottable.js"></script>
+<script src="../examples/exampleUtil.js"></script>
+<div class="demo-title">Simple Chart</div>
+<br>
+
+
+<br>
+<h1>sorted</h1>
+<svg id="meow" width="480" height="320"></svg>
+    <p />
+<h1>filter("p" in s)</h1>
+    <svg id="nya" width="480" height="320"></svg>
+<p />
+  
+</body>
+
+
+</html>
+

--- a/src/scales/ordinalScale.ts
+++ b/src/scales/ordinalScale.ts
@@ -11,6 +11,8 @@ export module Scale {
     private _innerPadding: number = 0.3;
     private _outerPadding: number = 0.5;
 
+    private _extentModifier = (extent: string[]) => extent;
+
     /**
      * Creates a new OrdinalScale. Domain and Range are set later.
      *
@@ -26,6 +28,43 @@ export module Scale {
     public _getExtent(): any[] {
       var extents: string[][] = this._getAllExtents();
       return Util.Methods.uniq(Util.Methods.flatten(extents));
+    }
+
+    public autoDomain() {
+      this._setDomain(this._extentModifier(this._getExtent()));
+      return this;
+    }
+
+    /**
+     * Return the extentModifier function.
+     *
+     * @returns {(extent: string[]) => string[]} The extentModifier function.
+     */
+    public extentModifier(): (extent: string[]) => string[];
+    /**
+     * Sets the extentModifier function.
+     *
+     * @param {(extent: string[]) => string[]} f
+     *        The extentModifier function is used to change the extent before
+     *        it is displayed. For example, it could sort the extent, or remove
+     *        certain undesired values.
+     *
+     *        It defaults to the identity function.
+     *
+     *        It serves a similar role to Plottable.Domainer, but operates on
+     *        Ordinal scales.
+     *
+     * @returns {Ordinal} The calling Ordinal Scale.
+     */
+    public extentModifier(f: (extent: string[]) => string[]): Ordinal;
+    public extentModifier(f?: (extent: string[]) => string[]): any {
+      if (f == null) {
+        return this._extentModifier;
+      } else {
+        this._extentModifier = f;
+        this._autoDomainIfAutomaticMode();
+        return this;
+      }
     }
 
     /**

--- a/test/scaleTests.ts
+++ b/test/scaleTests.ts
@@ -180,6 +180,22 @@ describe("Scales", () => {
       scale.rangeType("points");
       assert.isTrue(callbackWasCalled, "The registered callback was called");
     });
+
+    it("extentModifier works as expected", () => {
+      var scale = new Plottable.Scale.Ordinal();
+      scale.updateExtent(1, "x", ["d", "e", "f"]);
+
+      scale.extentModifier(() => ["a", "b", "c"]);
+      assert.deepEqual(scale.domain(), ["a", "b", "c"]);
+
+      scale.extentModifier((extent) => extent.concat(["g"]));
+      assert.deepEqual(scale.domain(), ["d", "e", "f", "g"]);
+
+      scale.domain(["h", "i", "j"]);
+      scale.extentModifier(() => ["nope"]);
+      assert.deepEqual(scale.domain(), ["h", "i", "j"],
+                       "after scale.domain(d), extentModifier is ignored");
+    });
   });
 
   describe("Color Scales", () => {

--- a/test/tests.js
+++ b/test/tests.js
@@ -3978,6 +3978,27 @@ describe("Scales", function () {
             scale.rangeType("points");
             assert.isTrue(callbackWasCalled, "The registered callback was called");
         });
+
+        it("extentModifier works as expected", function () {
+            var scale = new Plottable.Scale.Ordinal();
+            scale.updateExtent(1, "x", ["d", "e", "f"]);
+
+            scale.extentModifier(function () {
+                return ["a", "b", "c"];
+            });
+            assert.deepEqual(scale.domain(), ["a", "b", "c"]);
+
+            scale.extentModifier(function (extent) {
+                return extent.concat(["g"]);
+            });
+            assert.deepEqual(scale.domain(), ["d", "e", "f", "g"]);
+
+            scale.domain(["h", "i", "j"]);
+            scale.extentModifier(function () {
+                return ["nope"];
+            });
+            assert.deepEqual(scale.domain(), ["h", "i", "j"], "after scale.domain(d), extentModifier is ignored");
+        });
     });
 
     describe("Color Scales", function () {


### PR DESCRIPTION
`Domainer` turns extents into domain on `Scale.Quantitive`. It would be helpful to have something similar on `Scale.Ordinal`.

While the most general form of this would be some sort of `OrdinalDomainer`, it would end up sharing almost no code with `Domainer` other than being logically similar. Therefore, it's implemented as a function of the type `(string[]) => string[]`.

Close #623.
