### PR TITLE
fix ie bug on categoryAxis.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 build
 plottable_multifile.js
 test/tests_multifile.js
+local/
 
 # Emacs
 .#*

--- a/plottable.js
+++ b/plottable.js
@@ -5187,7 +5187,7 @@ var Plottable;
             };
 
             Category.prototype.measureTicks = function (axisWidth, axisHeight, scale, dataOrTicks) {
-                var draw = dataOrTicks instanceof d3.selection;
+                var draw = typeof dataOrTicks[0] !== "string";
                 var self = this;
                 var textWriteResults = [];
                 var tm = function (s) {

--- a/src/components/categoryAxis.ts
+++ b/src/components/categoryAxis.ts
@@ -87,7 +87,7 @@ export module Axis {
      */
     private measureTicks(axisWidth: number, axisHeight: number, scale: Scale.Ordinal, ticks: D3.Selection): Util.Text.IWriteTextResult;
     private measureTicks(axisWidth: number, axisHeight: number, scale: Scale.Ordinal, dataOrTicks: any): Util.Text.IWriteTextResult {
-      var draw = dataOrTicks instanceof d3.selection;
+      var draw = typeof dataOrTicks[0] !== "string";
       var self = this;
       var textWriteResults: Util.Text.IWriteTextResult[] = [];
       var tm = (s: string) => self.measurer.measure(s);


### PR DESCRIPTION
IE 9 was failing on category axes. This branch fixes the bug.

Specifically, it was failing http://jsfiddle.net/DDwz8/23/ because IE 9 doesn't support `instanceof` on "arrays that are actually objects", like d3 selections or jQuery selections.

Note that cramped category axes still look ugly, but that's a separate issue.
