### PR TITLE
Restore default Line Plot stylings; project() default styles

### DIFF
--- a/plottable.css
+++ b/plottable.css
@@ -70,15 +70,13 @@ svg.plottable {
   font-size: 14pt;
 }
 
-.plottable .area-renderer path.area {
-  stroke: none;
-  fill-opacity: 0.5;
+.plottable .line-renderer path.line {
+  fill: none;
+  vector-effect: non-scaling-stroke;
 }
 
-.plottable .area-renderer path.line {
-  fill: none;
-  stroke-width: 2px;
-  vector-effect: non-scaling-stroke;
+.plottable .area-renderer path.area {
+  stroke: none;
 }
 
 .plottable .legend .toggled-off circle {

--- a/plottable.js
+++ b/plottable.js
@@ -6319,10 +6319,10 @@ var Plottable;
                 this.classed("line-renderer", true);
                 this.project("stroke", function () {
                     return "steelblue";
-                });
-                this.project("fill", function () {
-                    return "none";
-                });
+                }); // default
+                this.project("stroke-width", function () {
+                    return "2px";
+                }); // default
             }
             Line.prototype._setup = function () {
                 _super.prototype._setup.call(this);
@@ -6385,6 +6385,9 @@ var Plottable;
                 this.project("y0", 0, yScale); // default
                 this.project("fill", function () {
                     return "steelblue";
+                }); // default
+                this.project("fill-opacity", function () {
+                    return 0.5;
                 }); // default
                 this.project("stroke", function () {
                     return "none";

--- a/src/components/plots/areaPlot.ts
+++ b/src/components/plots/areaPlot.ts
@@ -20,6 +20,7 @@ export module Plot {
       this.classed("area-renderer", true);
       this.project("y0", 0, yScale); // default
       this.project("fill", () => "steelblue"); // default
+      this.project("fill-opacity", () => 0.5); // default
       this.project("stroke", () => "none"); // default
       this._animators["area-reset"] = new Animator.Null();
       this._animators["area"]       = new Animator.Default()

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -23,8 +23,8 @@ export module Plot {
     constructor(dataset: any, xScale: Abstract.Scale, yScale: Abstract.Scale) {
       super(dataset, xScale, yScale);
       this.classed("line-renderer", true);
-      this.project("stroke", () => "steelblue");
-      this.project("fill", () => "none");
+      this.project("stroke", () => "steelblue"); // default
+      this.project("stroke-width", () => "2px"); // default
     }
 
     public _setup() {


### PR DESCRIPTION
By project()-ing the default styles instead of having them in the CSS,
they can be overridden by the user using project().

Downside: harder to discover default values.
