### PR TITLE
Fix animations for Line and Area Plots.

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -6384,6 +6384,26 @@ var Plottable;
                 return this;
             };
 
+            Line.prototype._getResetYFunction = function () {
+                // gets the y-value generator for the animation start point
+                var yDomain = this.yScale.domain();
+                var domainMax = Math.max(yDomain[0], yDomain[1]);
+                var domainMin = Math.min(yDomain[0], yDomain[1]);
+
+                // start from zero, or the closest domain value to zero
+                // avoids lines zooming on from offscreen.
+                var startValue = 0;
+                if (domainMax < 0) {
+                    startValue = domainMax;
+                } else if (domainMin > 0) {
+                    startValue = domainMin;
+                }
+                var scaledStartValue = this.yScale.scale(startValue);
+                return function (d, i) {
+                    return scaledStartValue;
+                };
+            };
+
             Line.prototype._paint = function () {
                 _super.prototype._paint.call(this);
                 var attrToProjector = this._generateAttrToProjector();
@@ -6395,9 +6415,7 @@ var Plottable;
                 this.linePath.datum(this._dataSource.data());
 
                 if (this._dataChanged) {
-                    attrToProjector["d"] = d3.svg.line().x(xFunction).y(function () {
-                        return 0;
-                    });
+                    attrToProjector["d"] = d3.svg.line().x(xFunction).y(this._getResetYFunction());
                     this._applyAnimatedAttributes(this.linePath, "line-reset", attrToProjector);
                 }
 
@@ -6497,6 +6515,10 @@ var Plottable;
                 return this;
             };
 
+            Area.prototype._getResetYFunction = function () {
+                return this._generateAttrToProjector()["y0"];
+            };
+
             Area.prototype._paint = function () {
                 _super.prototype._paint.call(this);
                 var attrToProjector = this._generateAttrToProjector();
@@ -6510,7 +6532,7 @@ var Plottable;
                 this.areaPath.datum(this._dataSource.data());
 
                 if (this._dataChanged) {
-                    attrToProjector["d"] = d3.svg.area().x(xFunction).y0(y0Function).y1(y0Function);
+                    attrToProjector["d"] = d3.svg.area().x(xFunction).y0(y0Function).y1(this._getResetYFunction());
                     this._applyAnimatedAttributes(this.areaPath, "area-reset", attrToProjector);
                 }
 

--- a/src/components/plots/areaPlot.ts
+++ b/src/components/plots/areaPlot.ts
@@ -76,6 +76,10 @@ export module Plot {
       return this;
     }
 
+    public _getResetYFunction() {
+      return this._generateAttrToProjector()["y0"];
+    }
+
     public _paint() {
       super._paint();
       var attrToProjector = this._generateAttrToProjector();
@@ -92,7 +96,7 @@ export module Plot {
         attrToProjector["d"] = d3.svg.area()
           .x(xFunction)
           .y0(y0Function)
-          .y1(y0Function);
+          .y1(this._getResetYFunction());
         this._applyAnimatedAttributes(this.areaPath, "area-reset", attrToProjector);
       }
 

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -33,6 +33,23 @@ export module Plot {
       return this;
     }
 
+    public _getResetYFunction() {
+      // gets the y-value generator for the animation start point
+      var yDomain = this.yScale.domain();
+      var domainMax = Math.max(yDomain[0], yDomain[1]);
+      var domainMin = Math.min(yDomain[0], yDomain[1]);
+      // start from zero, or the closest domain value to zero
+      // avoids lines zooming on from offscreen.
+      var startValue = 0;
+      if (domainMax < 0) {
+        startValue = domainMax;
+      } else if (domainMin > 0) {
+        startValue = domainMin;
+      }
+      var scaledStartValue = this.yScale.scale(startValue);
+      return (d: any, i: number) => scaledStartValue;
+    }
+
     public _paint() {
       super._paint();
       var attrToProjector = this._generateAttrToProjector();
@@ -44,9 +61,10 @@ export module Plot {
       this.linePath.datum(this._dataSource.data());
 
       if (this._dataChanged) {
+
         attrToProjector["d"] = d3.svg.line()
           .x(xFunction)
-          .y(() => 0);
+          .y(this._getResetYFunction());
         this._applyAnimatedAttributes(this.linePath, "line-reset", attrToProjector);
       }
 


### PR DESCRIPTION
Lines were animating from the top of the chart due to an oversight
(we didn't scale the zero value). They now correctly animate from 0,
or from the closest edge of the chart if zero is not in the y domain.

Area charts were updated too so that the line and area would render together.

Close #634.
