### PR TITLE
Numeric Axis no longer forces 10 ticks.

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -5001,7 +5001,7 @@ var Plottable;
             };
 
             Numeric.prototype._getTickValues = function () {
-                return this._scale.ticks(10);
+                return this._scale.ticks();
             };
 
             Numeric.prototype._doRender = function () {

--- a/src/components/numericAxis.ts
+++ b/src/components/numericAxis.ts
@@ -62,7 +62,7 @@ export module Axis {
     }
 
     public _getTickValues(): any[] {
-      return this._scale.ticks(10);
+      return this._scale.ticks();
     }
 
     public _doRender() {


### PR DESCRIPTION
Unless the user has tried to change the number of ticks using
Quantitive Scale's ticks() call, there shouldn't be a visual difference.
