### PR TITLE
better exceptions for testing.html

### DIFF
--- a/quicktests/quicktest.js
+++ b/quicktests/quicktest.js
@@ -37,12 +37,7 @@ var data2 = makeRandomData(50);
 function runSingleQuicktest(container, quickTest, data, Plottable) {
   container.append("p").text(quickTest.name);
   var div = container.append("div");
-  try {
-    quickTest.run(div, data, Plottable);
-  } catch (e) {
-    console.log(e.stack);
-    throw e;
-  }
+  quickTest.run(div, data, Plottable);
 }
 
 function runQuicktest(tableSelection, quickTest, Plottable1, Plottable2) {
@@ -133,9 +128,17 @@ function main() {
         });
       })
       .then(function(qts) {
-        qts.forEach(function(q) {
-          runQuicktest(table, q, Plottables[firstBranch], Plottables[secondBranch]);
-        });
+        return Promise.all(qts.map(function(q) {
+          return new Promise(function() {
+            runQuicktest(table, q, Plottables[firstBranch], Plottables[secondBranch]);
+          });
+        }));
+      }).catch(function(error) {
+        // errors in Promises are swallowed into the abyss by default, we must
+        // throw the error in a non-promise callback to get a stack trace
+        setTimeout(function() {
+          throw error;
+        }, 0);
       });
 }
 


### PR DESCRIPTION
Now, exceptions are throw properly as angry red text with a stack trace rather than black text with a stack trace whose links don't always work.
## Before

![screen shot 2014-07-14 at 4 30 07 pm](https://cloud.githubusercontent.com/assets/3344958/3578747/51e897c8-0bb0-11e4-96e8-2daefa8ce549.png)
## After

![screen shot 2014-07-14 at 4 28 08 pm](https://cloud.githubusercontent.com/assets/3344958/3578744/48ea8ab4-0bb0-11e4-9454-efc8da6b6fbf.png)

Also, errors don't stop all rendering: other tests after the failing one will continue to render.
