### PR TITLE
grunt watch test/**/*.ts

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -196,7 +196,7 @@ module.exports = function(grunt) {
       },
       "tests": {
         "tasks": ["test-compile"],
-        "files": ["test/**.ts"]
+        "files": ["test/**/*.ts"]
       }
     },
     blanket_mocha: {


### PR DESCRIPTION
At some point, tests were moved from `test/` to subdirectories like `test/scales/`. This means that grunt won't re-compile when you save a test file. This branch fixed that problem.
