### PR TITLE
Fix IE test failures caused by Time Axis tests choking.

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -4990,7 +4990,7 @@ var Plottable;
                 tickLabels.attr("transform", function (d) {
                     return "translate(" + _this._scale.scale(d) + ",0)";
                 });
-                var anchor = shouldCenterText ? "middle" : "left";
+                var anchor = shouldCenterText ? "middle" : "start";
                 tickLabels.selectAll("text").text(function (d) {
                     return d3.time.format(interval.formatString)(d);
                 }).style("text-anchor", anchor);

--- a/src/components/timeAxis.ts
+++ b/src/components/timeAxis.ts
@@ -222,7 +222,7 @@ export module Axis {
       }
       tickLabels.exit().remove();
       tickLabels.attr("transform", (d: any) => "translate(" + this._scale.scale(d) + ",0)");
-      var anchor = shouldCenterText ? "middle" : "left";
+      var anchor = shouldCenterText ? "middle" : "start";
       tickLabels.selectAll("text").text((d: any) => d3.time.format(interval.formatString)(d))
                                   .style("text-anchor", anchor);
     }

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -37,6 +37,7 @@ describe("Scales", () => {
     scale.domainer(new Plottable.Domainer().pad());
     assert.isTrue(callbackWasCalled, "The registered callback was called when padDomain() is used to set the domain");
   });
+
   describe("autoranging behavior", () => {
     var data: any[];
     var dataSource: Plottable.DataSource;
@@ -147,8 +148,6 @@ describe("Scales", () => {
 
     it("domain can't include NaN or Infinity", () => {
       var scale = new Plottable.Scale.Linear();
-      var log = console.log;
-      console.log = function() {}; // stop warnings from going to console
       scale.domain([0, 1]);
       scale.domain([5, Infinity]);
       assert.deepEqual(scale.domain(), [0, 1], "Infinity containing domain was ignored");
@@ -158,7 +157,6 @@ describe("Scales", () => {
       assert.deepEqual(scale.domain(), [0, 1], "NaN containing domain was ignored");
       scale.domain([-1, 5]);
       assert.deepEqual(scale.domain(), [-1, 5], "Regular domains still accepted");
-      console.log = log; // reset console.log
     });
   });
 
@@ -226,6 +224,7 @@ describe("Scales", () => {
     assert.lengthOf(xScale.domain(), 1);
     iterateDataChanges([], [dA, dB, dC]);
     assert.lengthOf(xScale.domain(), 3);
+    svg.remove();
   });
 
   describe("Color Scales", () => {

--- a/test/tests.js
+++ b/test/tests.js
@@ -3606,6 +3606,7 @@ describe("Scales", function () {
         scale.domainer(new Plottable.Domainer().pad());
         assert.isTrue(callbackWasCalled, "The registered callback was called when padDomain() is used to set the domain");
     });
+
     describe("autoranging behavior", function () {
         var data;
         var dataSource;
@@ -3716,9 +3717,6 @@ describe("Scales", function () {
 
         it("domain can't include NaN or Infinity", function () {
             var scale = new Plottable.Scale.Linear();
-            var log = console.log;
-            console.log = function () {
-            }; // stop warnings from going to console
             scale.domain([0, 1]);
             scale.domain([5, Infinity]);
             assert.deepEqual(scale.domain(), [0, 1], "Infinity containing domain was ignored");
@@ -3728,7 +3726,6 @@ describe("Scales", function () {
             assert.deepEqual(scale.domain(), [0, 1], "NaN containing domain was ignored");
             scale.domain([-1, 5]);
             assert.deepEqual(scale.domain(), [-1, 5], "Regular domains still accepted");
-            console.log = log; // reset console.log
         });
     });
 
@@ -3800,6 +3797,7 @@ describe("Scales", function () {
         assert.lengthOf(xScale.domain(), 1);
         iterateDataChanges([], [dA, dB, dC]);
         assert.lengthOf(xScale.domain(), 3);
+        svg.remove();
     });
 
     describe("Color Scales", function () {


### PR DESCRIPTION
Time Axis tried to set text-anchor to "left", which isn't a valid
value.
