### PR TITLE
single _doRender() error doesn't break all future _doRender()'s

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -2251,10 +2251,20 @@ var Plottable;
                     toCompute.forEach(function (c) { return c._computeLayout(); });
                     var toRender = d3.values(_componentsNeedingRender);
                     toRender.forEach(function (c) { return c._render(); });
-                    toRender = d3.values(_componentsNeedingRender);
-                    toRender.forEach(function (c) { return c._doRender(); });
+                    var failed = {};
+                    Object.keys(_componentsNeedingRender).forEach(function (k) {
+                        try {
+                            _componentsNeedingRender[k]._doRender();
+                        }
+                        catch (err) {
+                            setTimeout(function () {
+                                throw err;
+                            }, 0);
+                            failed[k] = _componentsNeedingRender[k];
+                        }
+                    });
                     _componentsNeedingComputeLayout = {};
-                    _componentsNeedingRender = {};
+                    _componentsNeedingRender = failed;
                     _animationRequested = false;
                 }
                 Core.ResizeBroadcaster.clearResizing();

--- a/quicktests/render_error.js
+++ b/quicktests/render_error.js
@@ -1,0 +1,53 @@
+function makeData() {
+  return [makeRandomData(50), makeRandomData(50)];
+}
+
+function _run(div, data, Plottable) {
+  var doAnimate = true;
+  var areaRenderer;
+  var xScale = new Plottable.Scale.Linear();
+  var xAxis = new Plottable.Axis.Numeric(xScale, "bottom");
+
+  var yScale = new Plottable.Scale.Linear();
+  var yAxis = new Plottable.Axis.Numeric(yScale, "left");
+
+  areaRenderer = new Plottable.Plot.Area(data[0].slice(0, 20), xScale, yScale);
+  areaRenderer.project("opacity", 0.75);
+  areaRenderer.animate(doAnimate);
+
+  var areaChart = new Plottable.Component.Table([[yAxis, areaRenderer],
+                                           [null,  xAxis]]);
+  var svg = div.append("svg").attr("height", 500);
+  areaChart.renderTo(svg);
+
+  cb = function(x, y){
+    d = areaRenderer.dataSource().data();
+    areaRenderer.dataSource().data(d);
+  }
+
+  window.xy = new Plottable.Interaction.Click(areaRenderer)
+    .callback(cb)
+    .registerWithComponent();
+}
+
+function foo() {
+  bar();
+}
+
+var n = 0;
+
+function bar() {
+  throw new Error("foo " + (n++));
+}
+
+function run(div, data, Plottable) {
+  var doRender = Plottable.Plot.Area._doRender;
+  var n = 0;
+  Plottable.Plot.Area.prototype._doRender = foo;
+  _run(div, data, Plottable);
+  setTimeout(function() {
+    Plottable.Plot.Area._doRender = doRender;
+    console.log("fixed it now?");
+    _run(div, data, Plottable);
+  }, 100);
+}

--- a/src/core/renderController.ts
+++ b/src/core/renderController.ts
@@ -66,12 +66,23 @@ export module Core {
         toRender.forEach((c) => c._render());
 
         // Finally, perform render of all components
-        toRender = d3.values(_componentsNeedingRender);
-        toRender.forEach((c) => c._doRender());
+        var failed: {[key: string]: Abstract.Component} = {};
+        Object.keys(_componentsNeedingRender).forEach((k) => {
+          try {
+            _componentsNeedingRender[k]._doRender();
+          } catch (err) {
+            // using setTimeout instead of console.log, we get the familiar red
+            // stack trace
+            setTimeout(() => {
+              throw err;
+            }, 0);
+            failed[k] = _componentsNeedingRender[k];
+          }
+        });
 
         // Reset queues
         _componentsNeedingComputeLayout = {};
-        _componentsNeedingRender = {};
+        _componentsNeedingRender = failed;
         _animationRequested = false;
       }
 


### PR DESCRIPTION
Before, if a single component threw an error in `_doRender`, Plottable would no longer render anything ever again. That's silly, other components should render just fine.

Now an error will not affect other components, and the component will continue to be retried until it renders without failure.

For QE, try checking out my branch and adding `render_error.js` to `list_of_quicktests.json`. I didn't want `render_error.js` to be a regular quicktest because it produces a bunch of errors. 

Close #728.
