### PR TITLE
guaranteed ModifiedLog.ticks().length >= 2

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -2665,7 +2665,11 @@ var Plottable;
                 var negativeLogTicks = this.logTicks(-negativeUpper, -negativeLower).map(function (x) { return -x; }).reverse();
                 var positiveLogTicks = this.logTicks(positiveLower, positiveUpper);
                 var linearTicks = this._showIntermediateTicks ? d3.scale.linear().domain([negativeUpper, positiveLower]).ticks(this.howManyTicks(negativeUpper, positiveLower)) : [-this.pivot, 0, this.pivot].filter(function (x) { return min <= x && x <= max; });
-                return negativeLogTicks.concat(linearTicks).concat(positiveLogTicks);
+                var ticks = negativeLogTicks.concat(linearTicks).concat(positiveLogTicks);
+                if (ticks.length <= 1) {
+                    ticks = d3.scale.linear().domain([min, max]).ticks(this._lastRequestedTickCount);
+                }
+                return ticks;
             };
             ModifiedLog.prototype.logTicks = function (lower, upper) {
                 var _this = this;

--- a/src/scales/modifiedLogScale.ts
+++ b/src/scales/modifiedLogScale.ts
@@ -123,7 +123,12 @@ export module Scale {
                                         .ticks(this.howManyTicks(negativeUpper, positiveLower)) :
                                 [-this.pivot, 0, this.pivot].filter((x) => min <= x && x <= max);
 
-      return negativeLogTicks.concat(linearTicks).concat(positiveLogTicks);
+      var ticks = negativeLogTicks.concat(linearTicks).concat(positiveLogTicks);
+      // If you only have 1 tick, you can't tell how big the scale is.
+      if (ticks.length <= 1) {
+        ticks = d3.scale.linear().domain([min, max]).ticks(this._lastRequestedTickCount);
+      }
+      return ticks;
     }
 
     /**

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -397,6 +397,14 @@ describe("Scales", () => {
       assert.operator(afterPivot.length, ">", 0, "should be ticks after base");
       assert.operator(betweenPivots.length, ">", 0, "should be ticks between -base and base");
     });
+
+    it("ticks() is always non-empty", () => {
+      [[2, 9], [0, 1], [1, 2], [0.001, 0.01], [-0.1, 0.1], [-3, -2]].forEach((domain) => {
+        scale.updateExtent(1, "x", domain);
+        var ticks = scale.ticks();
+        assert.operator(ticks.length, ">", 0);
+      });
+    });
   });
 
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -3352,6 +3352,13 @@ describe("Scales", function () {
             assert.operator(afterPivot.length, ">", 0, "should be ticks after base");
             assert.operator(betweenPivots.length, ">", 0, "should be ticks between -base and base");
         });
+        it("ticks() is always non-empty", function () {
+            [[2, 9], [0, 1], [1, 2], [0.001, 0.01], [-0.1, 0.1], [-3, -2]].forEach(function (domain) {
+                scale.updateExtent(1, "x", domain);
+                var ticks = scale.ticks();
+                assert.operator(ticks.length, ">", 0);
+            });
+        });
     });
 });
 


### PR DESCRIPTION
if you get <= 1 log ticks, return linear ticks. This should fix a number of bugs caused by having no ticks, and a lot of confusion when you plot your data and all you see is the "0" tick.

Close #799.
