### PR TITLE
disable saucelabs for external pull requests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -352,12 +352,12 @@ module.exports = function(grunt) {
   grunt.registerTask("launch", ["connect", "dev-compile", "watch"]);
   grunt.registerTask("test-sauce", ["connect", "saucelabs-mocha"]);
   grunt.registerTask("test", ["dev-compile", "blanket_mocha", "tslint", "ts:verify_d_ts"]);
-  // Disable saucelabs for external pull requests. Check if we have access to environment variables
-  if (process.env.TRAVIS_SECURE_ENV_VARS) {
-    grunt.registerTask("test-travis", ["test", "test-sauce"]);
-  } else {
-    grunt.registerTask("test-travis", ["test"]);
+  // Disable saucelabs for external pull requests. Check if we can see the SAUCE_USERNAME
+  var travisTests = ["test"];
+  if (process.env.SAUCE_USERNAME) {
+    travisTests.push("test-sauce");
   }
+  grunt.registerTask("test-travis", travisTests);
   grunt.registerTask("bm", ["blanket_mocha"]);
 
   grunt.registerTask("sublime", [


### PR DESCRIPTION
Checks if we can see SAUCE_USERNAME. If we can, then run saucelabs, otherwise, don't.

Close #826
