### PR TITLE
784 - Fix clip-path with base element on the same page

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -1306,7 +1306,8 @@ var Plottable;
                 return box;
             };
             Component.prototype.generateClipPath = function () {
-                this.element.attr("clip-path", "url(#clipPath" + this._plottableID + ")");
+                var prefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
+                this.element.attr("clip-path", "url(" + prefix + "#clipPath" + this._plottableID + ")");
                 var clipPathParent = this.boxContainer.append("clipPath").attr("id", "clipPath" + this._plottableID);
                 this.addBox("clip-rect", clipPathParent);
             };

--- a/src/core/component.ts
+++ b/src/core/component.ts
@@ -332,7 +332,10 @@ export module Abstract {
 
     private generateClipPath() {
       // The clip path will prevent content from overflowing its component space.
-      this.element.attr("clip-path", "url(#clipPath" + this._plottableID + ")");
+      // HACKHACK: IE <=9 does not respect the HTML base element in SVG.
+      // They don't need the current URL in the clip path reference.
+      var prefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
+      this.element.attr("clip-path", "url(" + prefix + "#clipPath" + this._plottableID + ")");
       var clipPathParent = this.boxContainer.append("clipPath")
                                       .attr("id", "clipPath" + this._plottableID);
       this.addBox("clip-rect", clipPathParent);

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -205,7 +205,8 @@ it("components can be offset relative to their alignment, and throw errors if th
     c._anchor(svg);
     c._computeLayout(0, 0, 100, 100);
     c._render();
-    var expectedClipPathURL = "url(#clipPath" + expectedClipPathID+ ")";
+    var expectedPrefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
+    var expectedClipPathURL = "url(" + expectedPrefix + "#clipPath" + expectedClipPathID+ ")";
     // IE 9 has clipPath like 'url("#clipPath")', must accomodate
     var normalizeClipPath = (s: string) => s.replace(/"/g, "");
     assert.isTrue(normalizeClipPath(c.element.attr("clip-path")) === expectedClipPathURL,

--- a/test/tests.js
+++ b/test/tests.js
@@ -2739,7 +2739,8 @@ describe("Component behavior", function () {
         c._anchor(svg);
         c._computeLayout(0, 0, 100, 100);
         c._render();
-        var expectedClipPathURL = "url(#clipPath" + expectedClipPathID + ")";
+        var expectedPrefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
+        var expectedClipPathURL = "url(" + expectedPrefix + "#clipPath" + expectedClipPathID + ")";
         var normalizeClipPath = function (s) { return s.replace(/"/g, ""); };
         assert.isTrue(normalizeClipPath(c.element.attr("clip-path")) === expectedClipPathURL, "the element has clip-path url attached");
         var clipRect = c.boxContainer.select(".clip-rect");


### PR DESCRIPTION
This commit adds the current document's URL to the clip-path URL so `<base>` elements do not break the URL (assuming `<base href="/">` and `clip-path="url(#clipPath1)"` the URL `#clipPath1` becomes `/#clipPath1` which obviously won't work).

Close #784.

This new PR includes a browser switch that only applies the fix on non-IE≤9-browsers, because those browsers do not respect the base element in SVG context.
