### PR TITLE
Use generic typing for Scales. [make-uniq-generic]

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -297,18 +297,18 @@ declare module Plottable {
 
 declare module Plottable {
     module Abstract {
-        class Scale extends PlottableObject implements Plottable.Core.IListenable {
+        class Scale<D, R> extends PlottableObject implements Plottable.Core.IListenable {
             broadcaster: any;
             constructor(scale: D3.Scale.Scale);
-            autoDomain(): Scale;
-            scale(value: any): any;
-            domain(): any[];
-            domain(values: any[]): Scale;
-            range(): any[];
-            range(values: any[]): Scale;
-            copy(): Scale;
-            updateExtent(plotProvidedKey: string, attr: string, extent: any[]): Scale;
-            removeExtent(plotProvidedKey: string, attr: string): Scale;
+            autoDomain(): Scale<D, R>;
+            scale(value: D): R;
+            domain(): D[];
+            domain(values: D[]): Scale<D, R>;
+            range(): R[];
+            range(values: R[]): Scale<D, R>;
+            copy(): Scale<D, R>;
+            updateExtent(plotProvidedKey: string, attr: string, extent: D[]): Scale<D, R>;
+            removeExtent(plotProvidedKey: string, attr: string): Scale<D, R>;
         }
     }
 }
@@ -325,7 +325,7 @@ declare module Plottable {
             remove(): void;
             dataSource(): DataSource;
             dataSource(source: DataSource): Plot;
-            project(attrToSet: string, accessor: any, scale?: Scale): Plot;
+            project(attrToSet: string, accessor: any, scale?: Scale<any, any>): Plot;
             animate(enabled: boolean): Plot;
             detach(): Plot;
             animator(animatorKey: string): Plottable.Animator.IPlotAnimator;
@@ -338,10 +338,10 @@ declare module Plottable {
 declare module Plottable {
     module Abstract {
         class XYPlot extends Plot {
-            xScale: Scale;
-            yScale: Scale;
-            constructor(dataset: any, xScale: Scale, yScale: Scale);
-            project(attrToSet: string, accessor: any, scale?: Scale): XYPlot;
+            xScale: Scale<any, number>;
+            yScale: Scale<any, number>;
+            constructor(dataset: any, xScale: Scale<any, number>, yScale: Scale<any, number>);
+            project(attrToSet: string, accessor: any, scale?: Scale<any, any>): XYPlot;
         }
     }
 }
@@ -355,7 +355,7 @@ declare module Plottable {
     }
     module Abstract {
         class NewStylePlot extends XYPlot {
-            constructor(xScale?: Scale, yScale?: Scale);
+            constructor(xScale?: Scale<any, number>, yScale?: Scale<any, number>);
             remove(): void;
             addDataset(key: string, dataset: DataSource): NewStylePlot;
             addDataset(key: string, dataset: any[]): NewStylePlot;
@@ -443,7 +443,7 @@ declare module Plottable {
     }
     interface _IProjector {
         accessor: IAccessor;
-        scale?: Plottable.Abstract.Scale;
+        scale?: Plottable.Abstract.Scale<any, any>;
         attribute: string;
     }
     interface IAttributeToProjector {
@@ -479,7 +479,7 @@ declare module Plottable {
 declare module Plottable {
     class Domainer {
         constructor(combineExtents?: (extents: any[][]) => any[]);
-        computeDomain(extents: any[][], scale: Plottable.Abstract.QuantitativeScale): any[];
+        computeDomain(extents: any[][], scale: Plottable.Abstract.QuantitativeScale<any>): any[];
         pad(padProportion?: number): Domainer;
         addPaddingException(exception: any, key?: string): Domainer;
         removePaddingException(keyOrException: any): Domainer;
@@ -492,21 +492,21 @@ declare module Plottable {
 
 declare module Plottable {
     module Abstract {
-        class QuantitativeScale extends Scale {
+        class QuantitativeScale<D> extends Scale<D, number> {
             constructor(scale: D3.Scale.QuantitativeScale);
-            invert(value: number): number;
-            copy(): QuantitativeScale;
-            domain(): any[];
-            domain(values: any[]): QuantitativeScale;
+            invert(value: number): D;
+            copy(): QuantitativeScale<D>;
+            domain(): D[];
+            domain(values: D[]): QuantitativeScale<D>;
             interpolate(): D3.Transition.Interpolate;
-            interpolate(factory: D3.Transition.Interpolate): QuantitativeScale;
-            rangeRound(values: number[]): QuantitativeScale;
+            interpolate(factory: D3.Transition.Interpolate): QuantitativeScale<D>;
+            rangeRound(values: number[]): QuantitativeScale<D>;
             clamp(): boolean;
-            clamp(clamp: boolean): QuantitativeScale;
+            clamp(clamp: boolean): QuantitativeScale<D>;
             ticks(count?: number): any[];
             tickFormat(count: number, format?: string): (n: number) => string;
             domainer(): Domainer;
-            domainer(domainer: Domainer): QuantitativeScale;
+            domainer(domainer: Domainer): QuantitativeScale<D>;
         }
     }
 }
@@ -514,7 +514,7 @@ declare module Plottable {
 
 declare module Plottable {
     module Scale {
-        class Linear extends Plottable.Abstract.QuantitativeScale {
+        class Linear extends Plottable.Abstract.QuantitativeScale<number> {
             constructor();
             constructor(scale: D3.Scale.LinearScale);
             copy(): Linear;
@@ -525,7 +525,7 @@ declare module Plottable {
 
 declare module Plottable {
     module Scale {
-        class Log extends Plottable.Abstract.QuantitativeScale {
+        class Log extends Plottable.Abstract.QuantitativeScale<number> {
             constructor();
             constructor(scale: D3.Scale.LogScale);
             copy(): Log;
@@ -536,7 +536,7 @@ declare module Plottable {
 
 declare module Plottable {
     module Scale {
-        class ModifiedLog extends Plottable.Abstract.QuantitativeScale {
+        class ModifiedLog extends Plottable.Abstract.QuantitativeScale<number> {
             constructor(base?: number);
             scale(x: number): number;
             invert(x: number): number;
@@ -551,7 +551,7 @@ declare module Plottable {
 
 declare module Plottable {
     module Scale {
-        class Ordinal extends Plottable.Abstract.Scale {
+        class Ordinal extends Plottable.Abstract.Scale<string, number> {
             constructor(scale?: D3.Scale.OrdinalScale);
             domain(): any[];
             domain(values: any[]): Ordinal;
@@ -570,7 +570,7 @@ declare module Plottable {
 
 declare module Plottable {
     module Scale {
-        class Color extends Plottable.Abstract.Scale {
+        class Color extends Plottable.Abstract.Scale<string, string> {
             constructor(scaleType?: string);
         }
     }
@@ -579,7 +579,7 @@ declare module Plottable {
 
 declare module Plottable {
     module Scale {
-        class Time extends Plottable.Abstract.QuantitativeScale {
+        class Time extends Plottable.Abstract.QuantitativeScale<any> {
             constructor();
             constructor(scale: D3.Scale.LinearScale);
             tickInterval(interval: D3.Time.Interval, step?: number): any[];
@@ -593,7 +593,7 @@ declare module Plottable {
 
 declare module Plottable {
     module Scale {
-        class InterpolatedColor extends Plottable.Abstract.QuantitativeScale {
+        class InterpolatedColor extends Plottable.Abstract.Scale<number, string> {
             constructor(colorRange?: any, scaleType?: string);
             colorRange(): string[];
             colorRange(colorRange: any): InterpolatedColor;
@@ -607,9 +607,9 @@ declare module Plottable {
 
 declare module Plottable {
     module Util {
-        class ScaleDomainCoordinator {
-            constructor(scales: Plottable.Abstract.Scale[]);
-            rescale(scale: Plottable.Abstract.Scale): void;
+        class ScaleDomainCoordinator<D, R> {
+            constructor(scales: Plottable.Abstract.Scale<D, R>[]);
+            rescale(scale: Plottable.Abstract.Scale<D, R>): void;
         }
     }
 }
@@ -643,7 +643,7 @@ declare module Plottable {
             static END_TICK_MARK_CLASS: string;
             static TICK_MARK_CLASS: string;
             static TICK_LABEL_CLASS: string;
-            constructor(scale: Scale, orientation: string, formatter?: (d: any) => string);
+            constructor(scale: Scale<any, number>, orientation: string, formatter?: (d: any) => string);
             remove(): void;
             width(): number;
             width(w: any): Axis;
@@ -687,7 +687,7 @@ declare module Plottable {
 declare module Plottable {
     module Axis {
         class Numeric extends Plottable.Abstract.Axis {
-            constructor(scale: Plottable.Abstract.QuantitativeScale, orientation: string, formatter?: (d: any) => string);
+            constructor(scale: Plottable.Abstract.QuantitativeScale<number>, orientation: string, formatter?: (d: any) => string);
             tickLabelPosition(): string;
             tickLabelPosition(position: string): Numeric;
             showEndTickLabel(orientation: string): boolean;
@@ -763,7 +763,7 @@ declare module Plottable {
 declare module Plottable {
     module Component {
         class Gridlines extends Plottable.Abstract.Component {
-            constructor(xScale: Plottable.Abstract.QuantitativeScale, yScale: Plottable.Abstract.QuantitativeScale);
+            constructor(xScale: Plottable.Abstract.QuantitativeScale<any>, yScale: Plottable.Abstract.QuantitativeScale<any>);
             remove(): Gridlines;
         }
     }
@@ -773,8 +773,8 @@ declare module Plottable {
 declare module Plottable {
     module Plot {
         class Scatter extends Plottable.Abstract.XYPlot {
-            constructor(dataset: any, xScale: Plottable.Abstract.Scale, yScale: Plottable.Abstract.Scale);
-            project(attrToSet: string, accessor: any, scale?: Plottable.Abstract.Scale): Scatter;
+            constructor(dataset: any, xScale: Plottable.Abstract.Scale<any, number>, yScale: Plottable.Abstract.Scale<any, number>);
+            project(attrToSet: string, accessor: any, scale?: Plottable.Abstract.Scale<any, any>): Scatter;
         }
     }
 }
@@ -783,11 +783,11 @@ declare module Plottable {
 declare module Plottable {
     module Plot {
         class Grid extends Plottable.Abstract.XYPlot {
-            colorScale: Plottable.Abstract.Scale;
+            colorScale: Plottable.Abstract.Scale<any, string>;
             xScale: Plottable.Scale.Ordinal;
             yScale: Plottable.Scale.Ordinal;
-            constructor(dataset: any, xScale: Plottable.Scale.Ordinal, yScale: Plottable.Scale.Ordinal, colorScale: Plottable.Abstract.Scale);
-            project(attrToSet: string, accessor: any, scale?: Plottable.Abstract.Scale): Grid;
+            constructor(dataset: any, xScale: Plottable.Scale.Ordinal, yScale: Plottable.Scale.Ordinal, colorScale: Plottable.Abstract.Scale<any, string>);
+            project(attrToSet: string, accessor: any, scale?: Plottable.Abstract.Scale<any, any>): Grid;
         }
     }
 }
@@ -796,7 +796,7 @@ declare module Plottable {
 declare module Plottable {
     module Abstract {
         class BarPlot extends XYPlot {
-            constructor(dataset: any, xScale: Scale, yScale: Scale);
+            constructor(dataset: any, xScale: Scale<any, number>, yScale: Scale<any, number>);
             baseline(value: number): BarPlot;
             barAlignment(alignment: string): BarPlot;
             selectBar(xValOrExtent: IExtent, yValOrExtent: IExtent, select?: boolean): D3.Selection;
@@ -812,7 +812,7 @@ declare module Plottable {
 declare module Plottable {
     module Plot {
         class VerticalBar extends Plottable.Abstract.BarPlot {
-            constructor(dataset: any, xScale: Plottable.Abstract.Scale, yScale: Plottable.Abstract.QuantitativeScale);
+            constructor(dataset: any, xScale: Plottable.Abstract.Scale<any, number>, yScale: Plottable.Abstract.QuantitativeScale<number>);
         }
     }
 }
@@ -822,7 +822,7 @@ declare module Plottable {
     module Plot {
         class HorizontalBar extends Plottable.Abstract.BarPlot {
             isVertical: boolean;
-            constructor(dataset: any, xScale: Plottable.Abstract.QuantitativeScale, yScale: Plottable.Abstract.Scale);
+            constructor(dataset: any, xScale: Plottable.Abstract.QuantitativeScale<number>, yScale: Plottable.Abstract.Scale<any, number>);
         }
     }
 }
@@ -831,7 +831,7 @@ declare module Plottable {
 declare module Plottable {
     module Plot {
         class Line extends Plottable.Abstract.XYPlot {
-            constructor(dataset: any, xScale: Plottable.Abstract.Scale, yScale: Plottable.Abstract.Scale);
+            constructor(dataset: any, xScale: Plottable.Abstract.QuantitativeScale<any>, yScale: Plottable.Abstract.QuantitativeScale<any>);
         }
     }
 }
@@ -840,8 +840,8 @@ declare module Plottable {
 declare module Plottable {
     module Plot {
         class Area extends Line {
-            constructor(dataset: any, xScale: Plottable.Abstract.Scale, yScale: Plottable.Abstract.Scale);
-            project(attrToSet: string, accessor: any, scale?: Plottable.Abstract.Scale): Area;
+            constructor(dataset: any, xScale: Plottable.Abstract.QuantitativeScale<any>, yScale: Plottable.Abstract.QuantitativeScale<any>);
+            project(attrToSet: string, accessor: any, scale?: Plottable.Abstract.Scale<any, any>): Area;
         }
     }
 }
@@ -851,7 +851,7 @@ declare module Plottable {
     module Abstract {
         class NewStyleBarPlot extends NewStylePlot {
             static DEFAULT_WIDTH: number;
-            constructor(xScale: Scale, yScale: Scale);
+            constructor(xScale: Scale<any, number>, yScale: Scale<any, number>);
             baseline(value: number): any;
         }
     }
@@ -862,7 +862,7 @@ declare module Plottable {
     module Plot {
         class ClusteredBar extends Plottable.Abstract.NewStyleBarPlot {
             static DEFAULT_WIDTH: number;
-            constructor(xScale: Plottable.Abstract.Scale, yScale: Plottable.Abstract.QuantitativeScale);
+            constructor(xScale: Plottable.Abstract.Scale<any, number>, yScale: Plottable.Abstract.QuantitativeScale<number>);
         }
     }
 }
@@ -872,7 +872,7 @@ declare module Plottable {
     module Plot {
         class StackedBar extends Plottable.Abstract.NewStyleBarPlot {
             stackedData: any[][];
-            constructor(xScale?: Plottable.Abstract.Scale, yScale?: Plottable.Abstract.Scale);
+            constructor(xScale?: Plottable.Abstract.Scale<any, number>, yScale?: Plottable.Abstract.QuantitativeScale<number>);
         }
     }
 }
@@ -972,9 +972,9 @@ declare module Plottable {
 declare module Plottable {
     module Interaction {
         class PanZoom extends Plottable.Abstract.Interaction {
-            xScale: Plottable.Abstract.QuantitativeScale;
-            yScale: Plottable.Abstract.QuantitativeScale;
-            constructor(componentToListenTo: Plottable.Abstract.Component, xScale?: Plottable.Abstract.QuantitativeScale, yScale?: Plottable.Abstract.QuantitativeScale);
+            xScale: Plottable.Abstract.QuantitativeScale<any>;
+            yScale: Plottable.Abstract.QuantitativeScale<any>;
+            constructor(componentToListenTo: Plottable.Abstract.Component, xScale?: Plottable.Abstract.QuantitativeScale<any>, yScale?: Plottable.Abstract.QuantitativeScale<any>);
             resetZoom(): void;
         }
     }
@@ -1007,7 +1007,7 @@ declare module Plottable {
             drag(cb: (startLocation: Point, endLocation: Point) => any): Drag;
             dragend(): (startLocation: Point, endLocation: Point) => void;
             dragend(cb: (startLocation: Point, endLocation: Point) => any): Drag;
-            setupZoomCallback(xScale?: Plottable.Abstract.QuantitativeScale, yScale?: Plottable.Abstract.QuantitativeScale): Drag;
+            setupZoomCallback(xScale?: Plottable.Abstract.QuantitativeScale<any>, yScale?: Plottable.Abstract.QuantitativeScale<any>): Drag;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -1777,7 +1777,7 @@ var Plottable;
             __extends(Scale, _super);
             function Scale(scale) {
                 _super.call(this);
-                this.autoDomainAutomatically = true;
+                this._autoDomainAutomatically = true;
                 this.broadcaster = new Plottable.Core.Broadcaster(this);
                 this._rendererAttrID2Extent = {};
                 this._d3Scale = scale;
@@ -1789,12 +1789,12 @@ var Plottable;
                 return [];
             };
             Scale.prototype.autoDomain = function () {
-                this.autoDomainAutomatically = true;
+                this._autoDomainAutomatically = true;
                 this._setDomain(this._getExtent());
                 return this;
             };
             Scale.prototype._autoDomainIfAutomaticMode = function () {
-                if (this.autoDomainAutomatically) {
+                if (this._autoDomainAutomatically) {
                     this.autoDomain();
                 }
             };
@@ -1806,7 +1806,7 @@ var Plottable;
                     return this._getDomain();
                 }
                 else {
-                    this.autoDomainAutomatically = false;
+                    this._autoDomainAutomatically = false;
                     this._setDomain(values);
                     return this;
                 }
@@ -3087,7 +3087,7 @@ var Plottable;
                 ]
             };
             return InterpolatedColor;
-        })(Plottable.Abstract.QuantitativeScale);
+        })(Plottable.Abstract.Scale);
         Scale.InterpolatedColor = InterpolatedColor;
     })(Plottable.Scale || (Plottable.Scale = {}));
     var Scale = Plottable.Scale;

--- a/src/components/baseAxis.ts
+++ b/src/components/baseAxis.ts
@@ -18,7 +18,7 @@ export module Abstract {
     public _tickMarkContainer: D3.Selection;
     public _tickLabelContainer: D3.Selection;
     public _baseline: D3.Selection;
-    public _scale: Abstract.Scale;
+    public _scale: Abstract.Scale<any, number>;
     public _formatter: Formatter;
     public _orientation: string;
     public _width: any = "auto";
@@ -31,7 +31,8 @@ export module Abstract {
     private _gutter = 15;
     private _showEndTickLabels = false;
 
-    constructor(scale: Abstract.Scale, orientation: string, formatter = Formatters.identity()) {
+    constructor(scale: Abstract.Scale<any, number>, orientation: string, formatter = Formatters.identity()) {
+      // TODO in future commit: Remove <any> typing
       super();
       if (scale == null || orientation == null) {throw new Error("Axis requires a scale and orientation");}
       this._scale = scale;

--- a/src/components/gridlines.ts
+++ b/src/components/gridlines.ts
@@ -3,8 +3,8 @@
 module Plottable {
 export module Component {
   export class Gridlines extends Abstract.Component {
-    private xScale: Abstract.QuantitativeScale;
-    private yScale: Abstract.QuantitativeScale;
+    private xScale: Abstract.QuantitativeScale<any>;
+    private yScale: Abstract.QuantitativeScale<any>;
     private xLinesContainer: D3.Selection;
     private yLinesContainer: D3.Selection;
 
@@ -15,7 +15,7 @@ export module Component {
      * @param {QuantitativeScale} xScale The scale to base the x gridlines on. Pass null if no gridlines are desired.
      * @param {QuantitativeScale} yScale The scale to base the y gridlines on. Pass null if no gridlines are desired.
      */
-    constructor(xScale: Abstract.QuantitativeScale, yScale: Abstract.QuantitativeScale) {
+    constructor(xScale: Abstract.QuantitativeScale<any>, yScale: Abstract.QuantitativeScale<any>) {
       super();
       if (xScale == null && yScale == null) {throw new Error("Gridlines must have at least one scale");}
       this.classed("gridlines", true);

--- a/src/components/numericAxis.ts
+++ b/src/components/numericAxis.ts
@@ -3,7 +3,7 @@
 module Plottable {
 export module Axis {
   export class Numeric extends Abstract.Axis {
-    public _scale: Abstract.QuantitativeScale;
+    public _scale: Abstract.QuantitativeScale<number>;
     private tickLabelPositioning = "center";
     // Whether or not first/last tick label will still be displayed even if
     // the label is cut off.
@@ -19,7 +19,7 @@ export module Axis {
      * @param {string} orientation The orientation of the QuantitativeScale (top/bottom/left/right)
      * @param {Formatter} [formatter] A function to format tick labels (default Formatters.general(3, false)).
      */
-    constructor(scale: Abstract.QuantitativeScale, orientation: string, formatter = Formatters.general(3, false)) {
+    constructor(scale: Abstract.QuantitativeScale<number>, orientation: string, formatter = Formatters.general(3, false)) {
       super(scale, orientation, formatter);
     }
 

--- a/src/components/plots/abstractBarPlot.ts
+++ b/src/components/plots/abstractBarPlot.ts
@@ -29,7 +29,7 @@ export module Abstract {
      * @param {Scale} xScale The x scale to use.
      * @param {Scale} yScale The y scale to use.
      */
-    constructor(dataset: any, xScale: Abstract.Scale, yScale: Abstract.Scale) {
+    constructor(dataset: any, xScale: Abstract.Scale<any, number>, yScale: Abstract.Scale<any, number>) {
       super(dataset, xScale, yScale);
       this.classed("bar-plot", true);
       this.project("fill", () => Core.Colors.INDIGO);
@@ -70,7 +70,7 @@ export module Abstract {
 
       this._bars.exit().remove();
 
-      var baselineAttr: IAttributeToProjector = {
+      var baselineAttr: any = {
         "x1": this._isVertical ? 0 : scaledBaseline,
         "y1": this._isVertical ? scaledBaseline : 0,
         "x2": this._isVertical ? this.availableWidth : scaledBaseline,
@@ -186,9 +186,9 @@ export module Abstract {
       return this;
     }
 
-    public _updateDomainer(scale: Scale) {
+    public _updateDomainer(scale: Scale<any, number>) {
       if (scale instanceof Abstract.QuantitativeScale) {
-        var qscale = <Abstract.QuantitativeScale> scale;
+        var qscale = <Abstract.QuantitativeScale<any>> scale;
         if (!qscale._userSetDomainer) {
           if (this._baselineValue != null) {
             qscale.domainer()
@@ -231,10 +231,10 @@ export module Abstract {
       var primaryAttr     = this._isVertical ? "y" : "x";
       var secondaryAttr   = this._isVertical ? "x" : "y";
       var bandsMode = (secondaryScale instanceof Plottable.Scale.Ordinal)
-                      && (<Plottable.Scale.Ordinal> secondaryScale).rangeType() === "bands";
+                      && (<Plottable.Scale.Ordinal> <any> secondaryScale).rangeType() === "bands";
       var scaledBaseline = primaryScale.scale(this._baselineValue);
       if (attrToProjector["width"] == null) {
-        var constantWidth = bandsMode ? (<Scale.Ordinal> secondaryScale).rangeBand() : BarPlot.DEFAULT_WIDTH;
+        var constantWidth = bandsMode ? (<Scale.Ordinal> <any> secondaryScale).rangeBand() : BarPlot.DEFAULT_WIDTH;
         attrToProjector["width"] = (d: any, i: number) => constantWidth;
       }
 
@@ -243,7 +243,7 @@ export module Abstract {
       if (!bandsMode) {
         attrToProjector[secondaryAttr] = (d: any, i: number) => positionF(d, i) - widthF(d, i) * this._barAlignmentFactor;
       } else {
-        var bandWidth = (<Plottable.Scale.Ordinal> secondaryScale).rangeBand();
+        var bandWidth = (<Plottable.Scale.Ordinal> <any> secondaryScale).rangeBand();
         attrToProjector[secondaryAttr] = (d: any, i: number) => positionF(d, i) - widthF(d, i) / 2 + bandWidth / 2;
       }
 

--- a/src/components/plots/areaPlot.ts
+++ b/src/components/plots/areaPlot.ts
@@ -13,10 +13,10 @@ export module Plot {
      *
      * @constructor
      * @param {IDataset} dataset The dataset to render.
-     * @param {Scale} xScale The x scale to use.
-     * @param {Scale} yScale The y scale to use.
+     * @param {QuantitativeScale} xScale The x scale to use.
+     * @param {QuantitativeScale} yScale The y scale to use.
      */
-    constructor(dataset: any, xScale: Abstract.Scale, yScale: Abstract.Scale) {
+    constructor(dataset: any, xScale: Abstract.QuantitativeScale<any>, yScale: Abstract.QuantitativeScale<any>) {
       super(dataset, xScale, yScale);
       this.classed("area-plot", true);
       this.project("y0", 0, yScale); // default
@@ -43,7 +43,7 @@ export module Plot {
 
     public _updateYDomainer() {
       super._updateYDomainer();
-      var scale = <Abstract.QuantitativeScale> this.yScale;
+      var scale = <Abstract.QuantitativeScale<any>> <any> this.yScale;
 
       var y0Projector = this._projectors["y0"];
       var y0Accessor = y0Projector != null ? y0Projector.accessor : null;
@@ -61,7 +61,7 @@ export module Plot {
       }
     }
 
-    public project(attrToSet: string, accessor: any, scale?: Abstract.Scale) {
+    public project(attrToSet: string, accessor: any, scale?: Abstract.Scale<any, any>) {
       super.project(attrToSet, accessor, scale);
       if (attrToSet === "y0") {
         this._updateYDomainer();

--- a/src/components/plots/clusteredBarPlot.ts
+++ b/src/components/plots/clusteredBarPlot.ts
@@ -7,7 +7,7 @@ export module Plot {
     public _isVertical = true;
     private innerScale: Scale.Ordinal;
 
-    constructor(xScale: Abstract.Scale, yScale: Abstract.QuantitativeScale) {
+    constructor(xScale: Abstract.Scale<any, number>, yScale: Abstract.QuantitativeScale<number>) {
       super(xScale, yScale);
       this.innerScale = new Scale.Ordinal();
     }

--- a/src/components/plots/gridPlot.ts
+++ b/src/components/plots/gridPlot.ts
@@ -3,7 +3,7 @@
 module Plottable {
 export module Plot {
   export class Grid extends Abstract.XYPlot {
-    public colorScale: Abstract.Scale;
+    public colorScale: Abstract.Scale<any, string>;
     public xScale: Scale.Ordinal;
     public yScale: Scale.Ordinal;
 
@@ -22,7 +22,7 @@ export module Plot {
      * @param {ColorScale|InterpolatedColorScale} colorScale The color scale to use for each grid
      *     cell.
      */
-    constructor(dataset: any, xScale: Scale.Ordinal, yScale: Scale.Ordinal, colorScale: Abstract.Scale) {
+    constructor(dataset: any, xScale: Scale.Ordinal, yScale: Scale.Ordinal, colorScale: Abstract.Scale<any, string>) {
       super(dataset, xScale, yScale);
       this.classed("grid-plot", true);
 
@@ -34,7 +34,7 @@ export module Plot {
       this.project("fill", "value", colorScale); // default
     }
 
-    public project(attrToSet: string, accessor: any, scale?: Abstract.Scale) {
+    public project(attrToSet: string, accessor: any, scale?: Abstract.Scale<any, any>) {
       super.project(attrToSet, accessor, scale);
       if (attrToSet === "fill") {
         this.colorScale = this._projectors["fill"].scale;

--- a/src/components/plots/horizontalBarPlot.ts
+++ b/src/components/plots/horizontalBarPlot.ts
@@ -23,7 +23,7 @@ export module Plot {
      * @param {QuantitativeScale} xScale The x scale to use.
      * @param {Scale} yScale The y scale to use.
      */
-    constructor(dataset: any, xScale: Abstract.QuantitativeScale, yScale: Abstract.Scale) {
+    constructor(dataset: any, xScale: Abstract.QuantitativeScale<number>, yScale: Abstract.Scale<any, number>) {
       super(dataset, xScale, yScale);
     }
 

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -17,10 +17,10 @@ export module Plot {
      *
      * @constructor
      * @param {IDataset} dataset The dataset to render.
-     * @param {Scale} xScale The x scale to use.
-     * @param {Scale} yScale The y scale to use.
+     * @param {QuantitativeScale} xScale The x scale to use.
+     * @param {QuantitativeScale} yScale The y scale to use.
      */
-    constructor(dataset: any, xScale: Abstract.Scale, yScale: Abstract.Scale) {
+    constructor(dataset: any, xScale: Abstract.QuantitativeScale<any>, yScale: Abstract.QuantitativeScale<any>) {
       super(dataset, xScale, yScale);
       this.classed("line-plot", true);
       this.project("stroke", () => Core.Colors.INDIGO); // default

--- a/src/components/plots/newStyleBarPlot.ts
+++ b/src/components/plots/newStyleBarPlot.ts
@@ -23,7 +23,7 @@ export module Abstract {
      * @param {Scale} xScale The x scale to use.
      * @param {Scale} yScale The y scale to use.
      */
-    constructor(xScale: Abstract.Scale, yScale: Abstract.Scale) {
+    constructor(xScale: Abstract.Scale<any, number>, yScale: Abstract.Scale<any, number>) {
       super(xScale, yScale);
       this.classed("bar-plot", true);
       this.project("fill", () => Core.Colors.INDIGO);
@@ -45,7 +45,7 @@ export module Abstract {
 
       var primaryScale = this._isVertical ? this.yScale : this.xScale;
       var scaledBaseline = primaryScale.scale(this._baselineValue);
-      var baselineAttr: IAttributeToProjector = {
+      var baselineAttr: any = {
         "x1": this._isVertical ? 0 : scaledBaseline,
         "y1": this._isVertical ? scaledBaseline : 0,
         "x2": this._isVertical ? this.availableWidth : scaledBaseline,
@@ -64,7 +64,7 @@ export module Abstract {
       return Abstract.BarPlot.prototype.baseline.apply(this, [value]);
     }
 
-    public _updateDomainer(scale: Scale) {
+    public _updateDomainer(scale: Scale<any, number>) {
       return Abstract.BarPlot.prototype._updateDomainer.apply(this, [scale]);
     }
 

--- a/src/components/plots/scatterPlot.ts
+++ b/src/components/plots/scatterPlot.ts
@@ -19,7 +19,7 @@ export module Plot {
      * @param {Scale} xScale The x scale to use.
      * @param {Scale} yScale The y scale to use.
      */
-    constructor(dataset: any, xScale: Abstract.Scale, yScale: Abstract.Scale) {
+    constructor(dataset: any, xScale: Abstract.Scale<any, number>, yScale: Abstract.Scale<any, number>) {
       super(dataset, xScale, yScale);
       this.classed("scatter-plot", true);
       this.project("r", 3); // default
@@ -27,7 +27,7 @@ export module Plot {
       this.project("fill", () => Core.Colors.INDIGO); // default
     }
 
-    public project(attrToSet: string, accessor: any, scale?: Abstract.Scale) {
+    public project(attrToSet: string, accessor: any, scale?: Abstract.Scale<any, any>) {
       attrToSet = attrToSet === "cx" ? "x" : attrToSet;
       attrToSet = attrToSet === "cy" ? "y" : attrToSet;
       super.project(attrToSet, accessor, scale);

--- a/src/components/plots/stackedBarPlot.ts
+++ b/src/components/plots/stackedBarPlot.ts
@@ -11,7 +11,7 @@ export module Plot {
     public _baseline: D3.Selection;
     private stackedExtent: number[] = [];
 
-    constructor(xScale?: Abstract.Scale, yScale?: Abstract.Scale) {
+    constructor(xScale?: Abstract.Scale<any, number>, yScale?: Abstract.QuantitativeScale<number>) {
       super(xScale, yScale);
     }
 

--- a/src/components/plots/verticalBarPlot.ts
+++ b/src/components/plots/verticalBarPlot.ts
@@ -23,7 +23,7 @@ export module Plot {
      * @param {Scale} xScale The x scale to use.
      * @param {QuantitativeScale} yScale The y scale to use.
      */
-    constructor(dataset: any, xScale: Abstract.Scale, yScale: Abstract.QuantitativeScale) {
+    constructor(dataset: any, xScale: Abstract.Scale<any, number>, yScale: Abstract.QuantitativeScale<number>) {
       super(dataset, xScale, yScale);
     }
 

--- a/src/components/plots/xyPlot.ts
+++ b/src/components/plots/xyPlot.ts
@@ -3,8 +3,9 @@
 module Plottable {
 export module Abstract {
   export class XYPlot extends Plot {
-    public xScale: Abstract.Scale;
-    public yScale: Abstract.Scale;
+    public xScale: Abstract.Scale<any, number>;
+    public yScale: Abstract.Scale<any, number>;
+    // TODO - replace any typing
     /**
      * Creates an XYPlot.
      *
@@ -13,7 +14,7 @@ export module Abstract {
      * @param {Scale} xScale The x scale to use.
      * @param {Scale} yScale The y scale to use.
      */
-    constructor(dataset: any, xScale: Abstract.Scale, yScale: Abstract.Scale) {
+    constructor(dataset: any, xScale: Abstract.Scale<any, number>, yScale: Abstract.Scale<any, number>) {
       super(dataset);
       if (xScale == null || yScale == null) {throw new Error("XYPlots require an xScale and yScale");}
       this.classed("xy-plot", true);
@@ -22,7 +23,7 @@ export module Abstract {
       this.project("y", "y", yScale); // default accessor
     }
 
-    public project(attrToSet: string, accessor: any, scale?: Abstract.Scale) {
+    public project(attrToSet: string, accessor: any, scale?: Abstract.Scale<any, any>) {
       // We only want padding and nice-ing on scales that will correspond to axes / pixel layout.
       // So when we get an "x" or "y" scale, enable autoNiceing and autoPadding.
       if (attrToSet === "x" && scale != null) {
@@ -48,7 +49,7 @@ export module Abstract {
 
     public _updateXDomainer() {
       if (this.xScale instanceof QuantitativeScale) {
-        var scale = <QuantitativeScale> this.xScale;
+        var scale = <QuantitativeScale<any>> this.xScale;
         if (!scale._userSetDomainer) {
           scale.domainer().pad().nice();
         }
@@ -57,7 +58,7 @@ export module Abstract {
 
     public _updateYDomainer() {
       if (this.yScale instanceof QuantitativeScale) {
-        var scale = <QuantitativeScale> this.yScale;
+        var scale = <QuantitativeScale<any>> this.yScale;
         if (!scale._userSetDomainer) {
           scale.domainer().pad().nice();
         }

--- a/src/core/domainer.ts
+++ b/src/core/domainer.ts
@@ -39,7 +39,7 @@ module Plottable {
      * @return {any[]} The domain, as a merging of all exents, as a [min, max]
      *                 pair.
      */
-    public computeDomain(extents: any[][], scale: Abstract.QuantitativeScale): any[] {
+    public computeDomain(extents: any[][], scale: Abstract.QuantitativeScale<any>): any[] {
       var domain: any[];
       if (this.combineExtents != null) {
         domain = this.combineExtents(extents);
@@ -170,7 +170,7 @@ module Plottable {
       }
     }
 
-    private padDomain(scale: Abstract.QuantitativeScale, domain: any[]): any[] {
+    private padDomain(scale: Abstract.QuantitativeScale<any>, domain: any[]): any[] {
       var min = domain[0];
       var max = domain[1];
       if (min === max && this.padProportion > 0.0) {
@@ -204,7 +204,7 @@ module Plottable {
       return [newMin, newMax];
     }
 
-    private niceDomain(scale: Abstract.QuantitativeScale, domain: any[]): any[] {
+    private niceDomain(scale: Abstract.QuantitativeScale<any>, domain: any[]): any[] {
       if (this.doNice) {
         return scale._niceDomain(domain, this.niceCount);
       } else {

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -19,7 +19,7 @@ module Plottable {
 
   export interface _IProjector {
     accessor: IAccessor;
-    scale?: Abstract.Scale;
+    scale?: Abstract.Scale<any, any>;
     attribute: string;
   }
 

--- a/src/core/newStylePlot.ts
+++ b/src/core/newStylePlot.ts
@@ -20,7 +20,7 @@ export module Abstract {
      * @param [Scale] xScale The x scale to use
      * @param [Scale] yScale The y scale to use
      */
-    constructor(xScale?: Abstract.Scale, yScale?: Abstract.Scale) {
+    constructor(xScale?: Abstract.Scale<any, number>, yScale?: Abstract.Scale<any, number>) {
       // make a dummy dataSource to satisfy the base Plot (HACKHACK)
       this._key2DatasetDrawerKey = d3.map();
       this._datasetKeysInOrder = [];

--- a/src/core/plot.ts
+++ b/src/core/plot.ts
@@ -95,7 +95,7 @@ export module Abstract {
       this._render();
     }
 
-    public project(attrToSet: string, accessor: any, scale?: Abstract.Scale) {
+    public project(attrToSet: string, accessor: any, scale?: Abstract.Scale<any, any>) {
       attrToSet = attrToSet.toLowerCase();
       var currentProjection = this._projectors[attrToSet];
       var existingScale = (currentProjection != null) ? currentProjection.scale : null;

--- a/src/core/scale.ts
+++ b/src/core/scale.ts
@@ -2,11 +2,11 @@
 
 module Plottable {
 export module Abstract {
-  export class Scale extends PlottableObject implements Core.IListenable {
+  export class Scale<D,R> extends PlottableObject implements Core.IListenable {
     public _d3Scale: D3.Scale.Scale;
-    private autoDomainAutomatically = true;
+    public _autoDomainAutomatically = true;
     public broadcaster = new Plottable.Core.Broadcaster(this);
-    public _rendererAttrID2Extent: {[rendererAttrID: string]: any[]} = {};
+    public _rendererAttrID2Extent: {[rendererAttrID: string]: D[]} = {};
     /**
      * Creates a new Scale.
      *
@@ -18,11 +18,11 @@ export module Abstract {
       this._d3Scale = scale;
     }
 
-    public _getAllExtents(): any[][] {
+    public _getAllExtents(): D[][] {
       return d3.values(this._rendererAttrID2Extent);
     }
 
-    public _getExtent(): any[] {
+    public _getExtent(): D[] {
       return []; // this should be overwritten
     }
 
@@ -34,13 +34,13 @@ export module Abstract {
      * represents a view in to the data.
      */
     public autoDomain() {
-      this.autoDomainAutomatically = true;
+      this._autoDomainAutomatically = true;
       this._setDomain(this._getExtent());
       return this;
     }
 
     public _autoDomainIfAutomaticMode() {
-      if (this.autoDomainAutomatically) {
+      if (this._autoDomainAutomatically) {
         this.autoDomain();
       }
     }
@@ -48,34 +48,34 @@ export module Abstract {
     /**
      * Returns the range value corresponding to a given domain value.
      *
-     * @param value {any} A domain value to be scaled.
-     * @returns {any} The range value corresponding to the supplied domain value.
+     * @param value {D} A domain value to be scaled.
+     * @returns {D} The range value corresponding to the supplied domain value.
      */
-    public scale(value: any) {
+    public scale(value: D): R {
       return this._d3Scale(value);
     }
 
     /**
      * Gets the domain.
      *
-     * @returns {any[]} The current domain.
+     * @returns {D[]} The current domain.
      */
-    public domain(): any[];
+    public domain(): D[];
     /**
      * Sets the Scale's domain to the specified values.
      *
-     * @param {any[]} values The new value for the domain. This array may
+     * @param {D[]} values The new value for the domain. This array may
      *     contain more than 2 values if the scale type allows it (e.g.
      *     ordinal scales). Other scales such as quantitative scales accept
      *     only a 2-value extent array.
      * @returns {Scale} The calling Scale.
      */
-    public domain(values: any[]): Scale;
-    public domain(values?: any[]): any {
+    public domain(values: D[]): Scale<D,R>;
+    public domain(values?: D[]): any {
       if (values == null) {
         return this._getDomain();
       } else {
-        this.autoDomainAutomatically = false;
+        this._autoDomainAutomatically = false;
         this._setDomain(values);
         return this;
       }
@@ -85,7 +85,7 @@ export module Abstract {
       return this._d3Scale.domain();
     }
 
-    public _setDomain(values: any[]) {
+    public _setDomain(values: D[]) {
       this._d3Scale.domain(values);
       this.broadcaster.broadcast();
     }
@@ -93,17 +93,17 @@ export module Abstract {
     /**
      * Gets the range.
      *
-     * @returns {any[]} The current range.
+     * @returns {R[]} The current range.
      */
-    public range(): any[];
+    public range(): R[];
     /**
      * Sets the Scale's range to the specified values.
      *
-     * @param {any[]} values The new values for the range.
+     * @param {R[]} values The new values for the range.
      * @returns {Scale} The calling Scale.
      */
-    public range(values: any[]): Scale;
-    public range(values?: any[]): any {
+    public range(values: R[]): Scale<D,R>;
+    public range(values?: R[]): any {
       if (values == null) {
         return this._d3Scale.range();
       } else {
@@ -117,8 +117,8 @@ export module Abstract {
      *
      * @returns {Scale} A copy of the calling Scale.
      */
-    public copy(): Scale {
-      return new Scale(this._d3Scale.copy());
+    public copy(): Scale<D,R> {
+      return new Scale<D,R>(this._d3Scale.copy());
     }
 
     /**
@@ -129,9 +129,9 @@ export module Abstract {
      * @param {number} rendererID A unique indentifier of the renderer sending
      *                 the new extent.
      * @param {string} attr The attribute being projected, e.g. "x", "y0", "r"
-     * @param {any[]} extent The new extent to be included in the scale.
+     * @param {D[]} extent The new extent to be included in the scale.
      */
-    public updateExtent(plotProvidedKey: string, attr: string, extent: any[]) {
+    public updateExtent(plotProvidedKey: string, attr: string, extent: D[]) {
       this._rendererAttrID2Extent[plotProvidedKey + attr] = extent;
       this._autoDomainIfAutomaticMode();
       return this;

--- a/src/interactions/drag/dragInteraction.ts
+++ b/src/interactions/drag/dragInteraction.ts
@@ -148,7 +148,7 @@ export module Interaction {
       return this;
     }
 
-    public setupZoomCallback(xScale?: Abstract.QuantitativeScale, yScale?: Abstract.QuantitativeScale) {
+    public setupZoomCallback(xScale?: Abstract.QuantitativeScale<any>, yScale?: Abstract.QuantitativeScale<any>) {
       var xDomainOriginal = xScale != null ? xScale.domain() : null;
       var yDomainOriginal = yScale != null ? yScale.domain() : null;
       var resetOnNextClick = false;

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -4,8 +4,8 @@ module Plottable {
 export module Interaction {
   export class PanZoom extends Abstract.Interaction {
     private zoom: D3.Behavior.Zoom;
-    public xScale: Abstract.QuantitativeScale;
-    public yScale: Abstract.QuantitativeScale;
+    public xScale: Abstract.QuantitativeScale<any>;
+    public yScale: Abstract.QuantitativeScale<any>;
 
     /**
      * Creates a PanZoomInteraction.
@@ -15,7 +15,8 @@ export module Interaction {
      * @param {QuantitativeScale} [xScale] The X scale to update on panning/zooming.
      * @param {QuantitativeScale} [yScale] The Y scale to update on panning/zooming.
      */
-    constructor(componentToListenTo: Abstract.Component, xScale?: Abstract.QuantitativeScale, yScale?: Abstract.QuantitativeScale) {
+    constructor(componentToListenTo: Abstract.Component,
+                xScale?: Abstract.QuantitativeScale<any>, yScale?: Abstract.QuantitativeScale<any>) {
       super(componentToListenTo);
       if (xScale == null) {
         xScale = new Plottable.Scale.Linear();

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -2,7 +2,7 @@
 
 module Plottable {
 export module Scale {
-  export class Color extends Abstract.Scale {
+  export class Color extends Abstract.Scale<string, string> {
     /**
      * Creates a ColorScale.
      *
@@ -45,7 +45,7 @@ export module Scale {
     }
 
     // Duplicated from OrdinalScale._getExtent - should be removed in #388
-    public _getExtent(): any[] {
+    public _getExtent(): string[] {
       var extents = this._getAllExtents();
       var concatenatedExtents: string[] = [];
       extents.forEach((e) => {

--- a/src/scales/interpolatedColorScale.ts
+++ b/src/scales/interpolatedColorScale.ts
@@ -13,7 +13,7 @@ export module Scale {
    *
    * By default it generates a linear scale internally.
    */
-  export class InterpolatedColor extends Abstract.QuantitativeScale {
+  export class InterpolatedColor extends Abstract.Scale<number, string> {
     private static COLOR_SCALES: ColorGroups = {
       reds : [
         "#FFFFFF", // white

--- a/src/scales/linearScale.ts
+++ b/src/scales/linearScale.ts
@@ -2,7 +2,7 @@
 
 module Plottable {
 export module Scale {
-  export class Linear extends Abstract.QuantitativeScale {
+  export class Linear extends Abstract.QuantitativeScale<number> {
 
     /**
      * Creates a new LinearScale.

--- a/src/scales/logScale.ts
+++ b/src/scales/logScale.ts
@@ -2,7 +2,7 @@
 
 module Plottable {
 export module Scale {
-  export class Log extends Abstract.QuantitativeScale {
+  export class Log extends Abstract.QuantitativeScale<number> {
 
     private static warned = false;
 

--- a/src/scales/modifiedLogScale.ts
+++ b/src/scales/modifiedLogScale.ts
@@ -2,7 +2,7 @@
 
 module Plottable {
 export module Scale {
-  export class ModifiedLog extends Abstract.QuantitativeScale {
+  export class ModifiedLog extends Abstract.QuantitativeScale<number> {
     private base: number;
     private pivot: number;
     private untransformedDomain: number[];

--- a/src/scales/ordinalScale.ts
+++ b/src/scales/ordinalScale.ts
@@ -2,7 +2,7 @@
 
 module Plottable {
 export module Scale {
-  export class Ordinal extends Abstract.Scale {
+  export class Ordinal extends Abstract.Scale<string, number> {
     public _d3Scale: D3.Scale.OrdinalScale;
     private _range = [0, 1];
     private _rangeType: string = "bands";

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -2,12 +2,12 @@
 
 module Plottable {
 export module Abstract {
-  export class QuantitativeScale extends Scale {
+  export class QuantitativeScale<D> extends Scale<D, number> {
     public _d3Scale: D3.Scale.QuantitativeScale;
     public _lastRequestedTickCount = 10;
     public _PADDING_FOR_IDENTICAL_DOMAIN = 1;
     public _userSetDomainer: boolean = false;
-    private _domainer: Domainer = new Domainer();
+    public _domainer: Domainer = new Domainer();
 
     /**
      * Creates a new QuantitativeScale.
@@ -19,7 +19,7 @@ export module Abstract {
       super(scale);
     }
 
-    public _getExtent(): any[] {
+    public _getExtent(): D[] {
       return this._domainer.computeDomain(this._getAllExtents(), this);
     }
 
@@ -27,10 +27,10 @@ export module Abstract {
      * Retrieves the domain value corresponding to a supplied range value.
      *
      * @param {number} value: A value from the Scale's range.
-     * @returns {number} The domain value corresponding to the supplied range value.
+     * @returns {D} The domain value corresponding to the supplied range value.
      */
-    public invert(value: number) {
-      return this._d3Scale.invert(value);
+    public invert(value: number): D {
+      return <any> this._d3Scale.invert(value);
     }
 
     /**
@@ -38,17 +38,17 @@ export module Abstract {
      *
      * @returns {QuantitativeScale} A copy of the calling QuantitativeScale.
      */
-    public copy(): QuantitativeScale {
-      return new QuantitativeScale(this._d3Scale.copy());
+    public copy(): QuantitativeScale<D> {
+      return new QuantitativeScale<D>(this._d3Scale.copy());
     }
 
-    public domain(): any[];
-    public domain(values: any[]): QuantitativeScale;
-    public domain(values?: any[]): any {
+    public domain(): D[];
+    public domain(values: D[]): QuantitativeScale<D>;
+    public domain(values?: D[]): any {
       return super.domain(values); // need to override type sig to enable method chaining :/
     }
 
-    public _setDomain(values: any[]) {
+    public _setDomain(values: D[]) {
         var isNaNOrInfinity = (x: any) => x !== x || x === Infinity || x === -Infinity;
         if (isNaNOrInfinity(values[0]) || isNaNOrInfinity(values[1])) {
             Util.Methods.warn("Warning: QuantitativeScales cannot take NaN or Infinity as a domain value. Ignoring.");
@@ -64,7 +64,7 @@ export module Abstract {
      * @returns {D3.Transition.Interpolate|QuantitativeScale} The current output interpolator, or the calling QuantitativeScale.
      */
     public interpolate(): D3.Transition.Interpolate;
-    public interpolate(factory: D3.Transition.Interpolate): QuantitativeScale;
+    public interpolate(factory: D3.Transition.Interpolate): QuantitativeScale<D>;
     public interpolate(factory?: D3.Transition.Interpolate): any {
       if (factory == null) {
         return this._d3Scale.interpolate();
@@ -95,7 +95,7 @@ export module Abstract {
      * @param {boolean} clamp Whether or not to clamp the QuantitativeScale.
      * @returns {QuantitativeScale} The calling QuantitativeScale.
      */
-    public clamp(clamp: boolean): QuantitativeScale;
+    public clamp(clamp: boolean): QuantitativeScale<D>;
     public clamp(clamp?: boolean): any {
       if (clamp == null) {
         return this._d3Scale.clamp();
@@ -154,7 +154,7 @@ export module Abstract {
      * @param {Domainer} domainer The domainer to be set.
      * @return {QuantitativeScale} The calling scale.
      */
-    public domainer(domainer: Domainer): QuantitativeScale;
+    public domainer(domainer: Domainer): QuantitativeScale<D>;
     public domainer(domainer?: Domainer): any {
       if (domainer == null) {
         return this._domainer;

--- a/src/scales/scaleDomainCoordinator.ts
+++ b/src/scales/scaleDomainCoordinator.ts
@@ -2,13 +2,13 @@
 
 module Plottable {
 export module Util {
-  export class ScaleDomainCoordinator {
+  export class ScaleDomainCoordinator<D,R> {
     /* This class is responsible for maintaining coordination between linked scales.
     It registers event listeners for when one of its scales changes its domain. When the scale
     does change its domain, it re-propogates the change to every linked scale.
     */
     private rescaleInProgress = false;
-    private scales: Abstract.Scale[];
+    private scales: Abstract.Scale<D,R>[];
 
     /**
      * Creates a ScaleDomainCoordinator.
@@ -16,13 +16,13 @@ export module Util {
      * @constructor
      * @param {Scale[]} scales A list of scales whose domains should be linked.
      */
-    constructor(scales: Abstract.Scale[]) {
+    constructor(scales: Abstract.Scale<D,R>[]) {
       if (scales == null) {throw new Error("ScaleDomainCoordinator requires scales to coordinate");}
       this.scales = scales;
-      this.scales.forEach((s) => s.broadcaster.registerListener(this, (sx: Abstract.Scale) => this.rescale(sx)));
+      this.scales.forEach((s) => s.broadcaster.registerListener(this, (sx: Abstract.Scale<D,R>) => this.rescale(sx)));
     }
 
-    public rescale(scale: Abstract.Scale) {
+    public rescale(scale: Abstract.Scale<D,R>) {
       if (this.rescaleInProgress) {
         return;
       }

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -2,7 +2,7 @@
 
 module Plottable {
 export module Scale {
-  export class Time extends Abstract.QuantitativeScale {
+  export class Time extends Abstract.QuantitativeScale<any> {
     /**
      * Creates a new Time Scale.
      *

--- a/test/interactions/interactionTests.ts
+++ b/test/interactions/interactionTests.ts
@@ -83,8 +83,8 @@ describe("Interactions", () => {
     var svgHeight = 400;
     var svg: D3.Selection;
     var dataset: Plottable.DataSource;
-    var xScale: Plottable.Abstract.QuantitativeScale;
-    var yScale: Plottable.Abstract.QuantitativeScale;
+    var xScale: Plottable.Abstract.QuantitativeScale<number>;
+    var yScale: Plottable.Abstract.QuantitativeScale<number>;
     var renderer: Plottable.Abstract.XYPlot;
     var interaction: Plottable.Interaction.XYDragBox;
 
@@ -164,8 +164,8 @@ describe("Interactions", () => {
     var svgHeight = 400;
     var svg: D3.Selection;
     var dataset: Plottable.DataSource;
-    var xScale: Plottable.Abstract.QuantitativeScale;
-    var yScale: Plottable.Abstract.QuantitativeScale;
+    var xScale: Plottable.Abstract.QuantitativeScale<number>;
+    var yScale: Plottable.Abstract.QuantitativeScale<number>;
     var renderer: Plottable.Abstract.XYPlot;
     var interaction: Plottable.Interaction.XYDragBox;
 

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -27,7 +27,7 @@ describe("Scales", () => {
     scale.domain([0, 10]);
     assert.isTrue(callbackWasCalled, "The registered callback was called");
 
-    (<any> scale).autoDomainAutomatically = true;
+    (<any> scale)._autoDomainAutomatically = true;
     scale.updateExtent("1", "x", [0.08, 9.92]);
     callbackWasCalled = false;
     scale.domainer(new Plottable.Domainer().nice());
@@ -51,10 +51,10 @@ describe("Scales", () => {
     it("scale autoDomain flag is not overwritten without explicitly setting the domain", () => {
       scale.updateExtent("1", "x", d3.extent(data, (e) => e.foo));
       scale.domainer(new Plottable.Domainer().pad().nice());
-      assert.isTrue((<any> scale).autoDomainAutomatically,
+      assert.isTrue((<any> scale)._autoDomainAutomatically,
                           "the autoDomain flag is still set after autoranginging and padding and nice-ing");
       scale.domain([0, 5]);
-      assert.isFalse((<any> scale).autoDomainAutomatically, "the autoDomain flag is false after domain explicitly set");
+      assert.isFalse((<any> scale)._autoDomainAutomatically, "the autoDomain flag is false after domain explicitly set");
     });
 
     it("scale autorange works as expected with single dataSource", () => {
@@ -94,17 +94,17 @@ describe("Scales", () => {
     });
 
     it("scale perspectives can be removed appropriately", () => {
-      assert.isTrue((<any> scale).autoDomainAutomatically, "autoDomain enabled1");
+      assert.isTrue((<any> scale)._autoDomainAutomatically, "autoDomain enabled1");
       scale.updateExtent("1", "x", d3.extent(data, (e) => e.foo));
       scale.updateExtent("2", "x", d3.extent(data, (e) => e.bar));
-      assert.isTrue((<any> scale).autoDomainAutomatically, "autoDomain enabled2");
+      assert.isTrue((<any> scale)._autoDomainAutomatically, "autoDomain enabled2");
       assert.deepEqual(scale.domain(), [-20, 5], "scale domain includes both perspectives");
-      assert.isTrue((<any> scale).autoDomainAutomatically, "autoDomain enabled3");
+      assert.isTrue((<any> scale)._autoDomainAutomatically, "autoDomain enabled3");
       scale.removeExtent("1", "x");
-      assert.isTrue((<any> scale).autoDomainAutomatically, "autoDomain enabled4");
+      assert.isTrue((<any> scale)._autoDomainAutomatically, "autoDomain enabled4");
       assert.deepEqual(scale.domain(), [-20, 1], "only the bar accessor is active");
       scale.updateExtent("2", "x", d3.extent(data, (e) => e.foo));
-      assert.isTrue((<any> scale).autoDomainAutomatically, "autoDomain enabled5");
+      assert.isTrue((<any> scale)._autoDomainAutomatically, "autoDomain enabled5");
       assert.deepEqual(scale.domain(), [0, 5], "the bar accessor was overwritten");
     });
 
@@ -298,14 +298,6 @@ describe("Scales", () => {
       assert.equal("#000000", scale.scale(0));
       assert.equal("#ffffff", scale.scale(16));
       assert.equal("#e3e3e3", scale.scale(8));
-    });
-
-    it("doesn't use a domainer", () => {
-      var scale = new Plottable.Scale.InterpolatedColor(["black", "white"]);
-      var startDomain = scale.domain();
-      scale.domainer().pad(1.0);
-      scale.autoDomain();
-      assert.equal(scale.domain(), startDomain);
     });
   });
   describe("Modified Log Scale", () => {

--- a/test/tests.js
+++ b/test/tests.js
@@ -3488,7 +3488,7 @@ describe("Scales", function () {
         scale.broadcaster.registerListener(null, testCallback);
         scale.domain([0, 10]);
         assert.isTrue(callbackWasCalled, "The registered callback was called");
-        scale.autoDomainAutomatically = true;
+        scale._autoDomainAutomatically = true;
         scale.updateExtent("1", "x", [0.08, 9.92]);
         callbackWasCalled = false;
         scale.domainer(new Plottable.Domainer().nice());
@@ -3509,9 +3509,9 @@ describe("Scales", function () {
         it("scale autoDomain flag is not overwritten without explicitly setting the domain", function () {
             scale.updateExtent("1", "x", d3.extent(data, function (e) { return e.foo; }));
             scale.domainer(new Plottable.Domainer().pad().nice());
-            assert.isTrue(scale.autoDomainAutomatically, "the autoDomain flag is still set after autoranginging and padding and nice-ing");
+            assert.isTrue(scale._autoDomainAutomatically, "the autoDomain flag is still set after autoranginging and padding and nice-ing");
             scale.domain([0, 5]);
-            assert.isFalse(scale.autoDomainAutomatically, "the autoDomain flag is false after domain explicitly set");
+            assert.isFalse(scale._autoDomainAutomatically, "the autoDomain flag is false after domain explicitly set");
         });
         it("scale autorange works as expected with single dataSource", function () {
             var svg = generateSVG(100, 100);
@@ -3540,17 +3540,17 @@ describe("Scales", function () {
             svg2.remove();
         });
         it("scale perspectives can be removed appropriately", function () {
-            assert.isTrue(scale.autoDomainAutomatically, "autoDomain enabled1");
+            assert.isTrue(scale._autoDomainAutomatically, "autoDomain enabled1");
             scale.updateExtent("1", "x", d3.extent(data, function (e) { return e.foo; }));
             scale.updateExtent("2", "x", d3.extent(data, function (e) { return e.bar; }));
-            assert.isTrue(scale.autoDomainAutomatically, "autoDomain enabled2");
+            assert.isTrue(scale._autoDomainAutomatically, "autoDomain enabled2");
             assert.deepEqual(scale.domain(), [-20, 5], "scale domain includes both perspectives");
-            assert.isTrue(scale.autoDomainAutomatically, "autoDomain enabled3");
+            assert.isTrue(scale._autoDomainAutomatically, "autoDomain enabled3");
             scale.removeExtent("1", "x");
-            assert.isTrue(scale.autoDomainAutomatically, "autoDomain enabled4");
+            assert.isTrue(scale._autoDomainAutomatically, "autoDomain enabled4");
             assert.deepEqual(scale.domain(), [-20, 1], "only the bar accessor is active");
             scale.updateExtent("2", "x", d3.extent(data, function (e) { return e.foo; }));
-            assert.isTrue(scale.autoDomainAutomatically, "autoDomain enabled5");
+            assert.isTrue(scale._autoDomainAutomatically, "autoDomain enabled5");
             assert.deepEqual(scale.domain(), [0, 5], "the bar accessor was overwritten");
         });
         it("should resize when a plot is removed", function () {
@@ -3723,13 +3723,6 @@ describe("Scales", function () {
             assert.equal("#000000", scale.scale(0));
             assert.equal("#ffffff", scale.scale(16));
             assert.equal("#e3e3e3", scale.scale(8));
-        });
-        it("doesn't use a domainer", function () {
-            var scale = new Plottable.Scale.InterpolatedColor(["black", "white"]);
-            var startDomain = scale.domain();
-            scale.domainer().pad(1.0);
-            scale.autoDomain();
-            assert.equal(scale.domain(), startDomain);
         });
     });
     describe("Modified Log Scale", function () {


### PR DESCRIPTION
```
Abstract.Scale -> Abstract.Scale<D,R>
QuantitativeScale<D> extends Scale<D, number>
OrdinalScale extends Scale<string, number>
ColorScale extends Scale<string, string>
InterpolatedColorScale extends Scale<number, string>
```

Changes: `InterpolatedColorScale` no longer inherits `QuantitiveScale`
Some vars on scales made public to fix mysterious ts issues
`<any>`s added into Plots so as to reduce the size of this PR.

QE: Recommend checking `InterpolatedColorScales` in particular
