### PR TITLE
802 - Horizontal mode on stackedBarPlots

### DIFF
--- a/plottable-dev.d.ts
+++ b/plottable-dev.d.ts
@@ -1136,9 +1136,9 @@ declare module Plottable {
         class StackedBar extends Plottable.Abstract.NewStyleBarPlot {
             stackedData: any[][];
             _yAccessor: IAccessor;
-            _isVertical: boolean;
             _baselineValue: number;
             _baseline: D3.Selection;
+            constructor(xScale?: Plottable.Abstract.Scale, yScale?: Plottable.Abstract.Scale, isVertical?: boolean);
             _addDataset(key: string, dataset: any): void;
             _updateAllProjectors(): void;
             _generateAttrToProjector(): IAttributeToProjector;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -902,10 +902,7 @@ declare module Plottable {
     module Plot {
         class StackedBar extends Plottable.Abstract.NewStyleBarPlot {
             stackedData: any[][];
-<<<<<<< HEAD
             constructor(xScale?: Plottable.Abstract.Scale, yScale?: Plottable.Abstract.Scale, isVertical?: boolean);
-=======
->>>>>>> develop
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -5446,14 +5446,9 @@ var Plottable;
     (function (Plot) {
         var StackedBar = (function (_super) {
             __extends(StackedBar, _super);
-<<<<<<< HEAD
             function StackedBar(xScale, yScale, isVertical) {
                 if (isVertical === void 0) { isVertical = true; }
                 _super.call(this, xScale, yScale);
-=======
-            function StackedBar() {
-                _super.apply(this, arguments);
->>>>>>> develop
                 this.stackedData = [];
                 this._baselineValue = 0;
                 this.stackedExtent = [];

--- a/src/components/plots/stackedBarPlot.ts
+++ b/src/components/plots/stackedBarPlot.ts
@@ -10,14 +10,19 @@ export module Plot {
     public _baseline: D3.Selection;
     private stackedExtent: number[] = [];
 
-<<<<<<< HEAD
+    /**
+     * Constructs a StackedBar plot.
+     *
+     * @constructor
+     * @param {Scale} xScale the x scale of the plot
+     * @param {Scale} yScale the y scale of the plot
+     * @param {boolean} isVertical if the plot if vertical
+     */
     constructor(xScale?: Abstract.Scale, yScale?: Abstract.Scale, isVertical = true) {
       super(xScale, yScale);
       this._isVertical = isVertical;
     }
 
-=======
->>>>>>> develop
     public _addDataset(key: string, dataset: any) {
       super._addDataset(key, dataset);
       var accessor = this._isVertical ? this._projectors["y"].accessor : this._projectors["x"].accessor;

--- a/test/components/plots/stackedBarPlotTests.ts
+++ b/test/components/plots/stackedBarPlotTests.ts
@@ -126,7 +126,7 @@ describe("Plots", () => {
       renderer.baseline(0);
       var yAxis = new Plottable.Axis.Category(yScale, "left");
       var table = new Plottable.Component.Table([[yAxis, renderer]]).renderTo(svg);
-      rendererWidth = renderer.availableWidth;
+      rendererWidth = renderer.width();
       bandWidth = yScale.rangeBand();
     });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -2546,7 +2546,7 @@ describe("Plots", function () {
             renderer.baseline(0);
             var yAxis = new Plottable.Axis.Category(yScale, "left");
             var table = new Plottable.Component.Table([[yAxis, renderer]]).renderTo(svg);
-            rendererWidth = renderer.availableWidth;
+            rendererWidth = renderer.width();
             bandWidth = yScale.rangeBand();
         });
         beforeEach(function () {


### PR DESCRIPTION
Horizontal mode enabled on a stackedBarPlot by adding a false argument to the constructor call, stating that the stackedBarPlot is not vertical.

Changed all 'y' references to instead be 'primary' references where the 'primary' attribute is determined if the plot is vertical or not.

Incremental pr for #802
