### PR TITLE
add_time quicktest now shows up on both sides

### DIFF
--- a/quicktests/js/add_time.js
+++ b/quicktests/js/add_time.js
@@ -24,7 +24,7 @@ function run(div, data, Plottable) {
 
   var gridlines = new Plottable.Component.Gridlines(xScale, yScale);
   var renderGroup = plot.merge(gridlines);
-  new Plottable.Template.StandardChart().center(renderGroup).xAxis(xAxis).yAxis(yAxis).titleLabel(title).renderTo("svg");
+  new Plottable.Template.StandardChart().center(renderGroup).xAxis(xAxis).yAxis(yAxis).titleLabel(title).renderTo(svg);
 
 
   function addData(){


### PR DESCRIPTION
Old quicktest was referencing an "svg" element, which means that it could just select the first svg it sees and writes it there.  The change should specify the correct svg element to draw in.
