### PR TITLE
Clear error messages for renderTo

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -2351,12 +2351,8 @@ var Plottable;
                     else {
                         selection = d3.select(element);
                     }
-                    if (!element.node()) {
-                        throw new Error("Plottable requires a valid selection to renderTo");
-                    }
-                    if (element.node().nodeName !== "svg") {
-                        Plottable._Util.Methods.warn("Plottable expects to be placed in a SVG. Auto-generating one for you...");
-                        selection = selection.append("svg");
+                    if (!element.node() || element.node().nodeName !== "svg") {
+                        throw new Error("Plottable requires a valid SVG to renderTo");
                     }
                     this._anchor(selection);
                 }

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -208,12 +208,8 @@ export module Abstract {
         } else {
           selection = d3.select(element);
         }
-        if (!element.node()) {
-          throw new Error("Plottable requires a valid selection to renderTo");
-        }
-        if (element.node().nodeName !== "svg") {
-          _Util.Methods.warn("Plottable expects to be placed in a SVG. Auto-generating one for you...");
-          selection = selection.append("svg");
+        if (!element.node() || element.node().nodeName !== "svg") {
+          throw new Error("Plottable requires a valid SVG to renderTo");
         }
         this._anchor(selection);
       }


### PR DESCRIPTION
Make Plottable easier to use by giving clear errors when the `renderTo` contract is not satisfied.

Right now if you `renderTo("invalid_selector_lol")` it gives an obscure error message, and if you accidentally put in a div or something it will similarly blow up. Now it checks the arguments and gives clear feedback on what went wrong.
Based on discussion with @themadcreator 
