### PR TITLE
Have `Scale.Ordinal` provide a type coercer too. 

### DIFF
--- a/plottable-dev.d.ts
+++ b/plottable-dev.d.ts
@@ -455,6 +455,7 @@ declare module Plottable {
     module Scale {
         class Ordinal extends Plottable.Abstract.Scale<string, number> {
             _d3Scale: D3.Scale.OrdinalScale;
+            _typeCoercer: (d: any) => any;
             constructor(scale?: D3.Scale.OrdinalScale);
             _getExtent(): string[];
             domain(): string[];

--- a/plottable.js
+++ b/plottable.js
@@ -1086,10 +1086,7 @@ var Plottable;
             return cachedExtent;
         };
         Dataset.prototype.computeExtent = function (accessor, typeCoercer) {
-            var mappedData = this._data.map(accessor);
-            if (typeCoercer) {
-                mappedData = mappedData.map(typeCoercer);
-            }
+            var mappedData = this._data.map(accessor).map(typeCoercer);
             if (mappedData.length === 0) {
                 return [];
             }
@@ -1420,6 +1417,7 @@ var Plottable;
                 this._autoDomainAutomatically = true;
                 this.broadcaster = new Plottable.Core.Broadcaster(this);
                 this._rendererAttrID2Extent = {};
+                this._typeCoercer = function (d) { return d; };
                 this._d3Scale = scale;
             }
             Scale.prototype._getAllExtents = function () {
@@ -1773,6 +1771,7 @@ var Plottable;
                 this._rangeType = "bands";
                 this._innerPadding = 0.3;
                 this._outerPadding = 0.5;
+                this._typeCoercer = function (d) { return d != null && d.toString ? d.toString() : d; };
                 if (this._innerPadding > this._outerPadding) {
                     throw new Error("outerPadding must be >= innerPadding so cat axis bands work out reasonably");
                 }

--- a/src/core/dataset.ts
+++ b/src/core/dataset.ts
@@ -87,10 +87,7 @@ module Plottable {
     }
 
     private computeExtent(accessor: _IAccessor, typeCoercer: (d: any) => any): any[] {
-      var mappedData = this._data.map(accessor);
-      if (typeCoercer) {
-        mappedData = mappedData.map(typeCoercer);
-      }
+      var mappedData = this._data.map(accessor).map(typeCoercer);
       if (mappedData.length === 0){
         return [];
       } else if (typeof(mappedData[0]) === "string") {

--- a/src/scales/ordinalScale.ts
+++ b/src/scales/ordinalScale.ts
@@ -10,6 +10,7 @@ export module Scale {
     // Padding as a proportion of the spacing between domain values
     private _innerPadding: number = 0.3;
     private _outerPadding: number = 0.5;
+    public _typeCoercer: (d: any) => any = (d: any) => d != null && d.toString ? d.toString() : d;
 
     /**
      * Creates an OrdinalScale.

--- a/src/scales/scale.ts
+++ b/src/scales/scale.ts
@@ -7,7 +7,7 @@ export module Abstract {
     public _autoDomainAutomatically = true;
     public broadcaster = new Plottable.Core.Broadcaster(this);
     public _rendererAttrID2Extent: {[rendererAttrID: string]: D[]} = {};
-    public _typeCoercer: (d: any) => any;
+    public _typeCoercer: (d: any) => any = (d: any) => d;
     /**
      * Constructs a new Scale.
      *

--- a/test/core/datasetTests.ts
+++ b/test/core/datasetTests.ts
@@ -40,17 +40,18 @@ describe("Dataset", () => {
   it("_getExtent works as expected", () => {
     var data = [1,2,3,4,1];
     var metadata = {foo: 11};
+    var id = (d: any) => d;
     var dataset = new Plottable.Dataset(data, metadata);
     var plot = new Plottable.Abstract.Plot(dataset);
     var apply = (a: any) => Plottable._Util.Methods._applyAccessor(a, plot);
     var a1 = (d: number, i: number, m: any) => d + i - 2;
-    assert.deepEqual(dataset._getExtent(apply(a1), null), [-1, 5], "extent for numerical data works properly");
+    assert.deepEqual(dataset._getExtent(apply(a1), id), [-1, 5], "extent for numerical data works properly");
     var a2 = (d: number, i: number, m: any) => d + m.foo;
-    assert.deepEqual(dataset._getExtent(apply(a2), null), [12, 15], "extent uses metadata appropriately");
+    assert.deepEqual(dataset._getExtent(apply(a2), id), [12, 15], "extent uses metadata appropriately");
     dataset.metadata({foo: -1});
-    assert.deepEqual(dataset._getExtent(apply(a2), null), [0, 3], "metadata change is reflected in extent results");
+    assert.deepEqual(dataset._getExtent(apply(a2), id), [0, 3], "metadata change is reflected in extent results");
     var a3 = (d: number, i: number, m: any) => "_" + d;
-    assert.deepEqual(dataset._getExtent(apply(a3), null), ["_1", "_2", "_3", "_4"], "extent works properly on string domains (no repeats)");
+    assert.deepEqual(dataset._getExtent(apply(a3), id), ["_1", "_2", "_3", "_4"], "extent works properly on string domains (no repeats)");
     var a_toString = (d: any) => (d + 2).toString();
     var coerce = (d: any) => +d;
     assert.deepEqual(dataset._getExtent(apply(a_toString), coerce), [3, 6], "type coercion works as expected");

--- a/test/tests.js
+++ b/test/tests.js
@@ -3406,17 +3406,18 @@ describe("Dataset", function () {
     it("_getExtent works as expected", function () {
         var data = [1, 2, 3, 4, 1];
         var metadata = { foo: 11 };
+        var id = function (d) { return d; };
         var dataset = new Plottable.Dataset(data, metadata);
         var plot = new Plottable.Abstract.Plot(dataset);
         var apply = function (a) { return Plottable._Util.Methods._applyAccessor(a, plot); };
         var a1 = function (d, i, m) { return d + i - 2; };
-        assert.deepEqual(dataset._getExtent(apply(a1), null), [-1, 5], "extent for numerical data works properly");
+        assert.deepEqual(dataset._getExtent(apply(a1), id), [-1, 5], "extent for numerical data works properly");
         var a2 = function (d, i, m) { return d + m.foo; };
-        assert.deepEqual(dataset._getExtent(apply(a2), null), [12, 15], "extent uses metadata appropriately");
+        assert.deepEqual(dataset._getExtent(apply(a2), id), [12, 15], "extent uses metadata appropriately");
         dataset.metadata({ foo: -1 });
-        assert.deepEqual(dataset._getExtent(apply(a2), null), [0, 3], "metadata change is reflected in extent results");
+        assert.deepEqual(dataset._getExtent(apply(a2), id), [0, 3], "metadata change is reflected in extent results");
         var a3 = function (d, i, m) { return "_" + d; };
-        assert.deepEqual(dataset._getExtent(apply(a3), null), ["_1", "_2", "_3", "_4"], "extent works properly on string domains (no repeats)");
+        assert.deepEqual(dataset._getExtent(apply(a3), id), ["_1", "_2", "_3", "_4"], "extent works properly on string domains (no repeats)");
         var a_toString = function (d) { return (d + 2).toString(); };
         var coerce = function (d) { return +d; };
         assert.deepEqual(dataset._getExtent(apply(a_toString), coerce), [3, 6], "type coercion works as expected");


### PR DESCRIPTION
It will coerce things to strings if possible. Based on offline discussion with Justin.
Related to #1018, 1019.
