### PR TITLE
Add Plot.project("color") as an alias for "fill" or "stroke"

### DIFF
--- a/plottable-dev.d.ts
+++ b/plottable-dev.d.ts
@@ -864,13 +864,13 @@ declare module Plottable {
 declare module Plottable {
     module Abstract {
         class Plot extends Component {
+            static _colorVar: string;
             _dataset: Dataset;
             _dataChanged: boolean;
             _renderArea: D3.Selection;
             _animate: boolean;
             _animators: Plottable.Animator.IPlotAnimatorMap;
             _ANIMATION_DURATION: number;
-            _colorVar: string;
             _projectors: {
                 [x: string]: _IProjector;
             };
@@ -1029,8 +1029,8 @@ declare module Plottable {
 declare module Plottable {
     module Plot {
         class Line<X> extends Plottable.Abstract.XYPlot<X, number> {
+            static _colorVar: string;
             _animators: Plottable.Animator.IPlotAnimatorMap;
-            _colorVar: string;
             _yScale: Plottable.Abstract.QuantitativeScale<number>;
             constructor(dataset: any, xScale: Plottable.Abstract.QuantitativeScale<X>, yScale: Plottable.Abstract.QuantitativeScale<number>);
             _setup(): void;

--- a/plottable.js
+++ b/plottable.js
@@ -4349,7 +4349,6 @@ var Plottable;
                 this._animate = false;
                 this._animators = {};
                 this._ANIMATION_DURATION = 250;
-                this._colorVar = "fill";
                 this._projectors = {};
                 this.animateOnNextRender = true;
                 this.clipPathEnabled = true;
@@ -4409,7 +4408,7 @@ var Plottable;
                 var _this = this;
                 attrToSet = attrToSet.toLowerCase();
                 if (attrToSet === "color") {
-                    attrToSet = this._colorVar;
+                    attrToSet = this.constructor._colorVar;
                 }
                 var currentProjection = this._projectors[attrToSet];
                 var existingScale = (currentProjection != null) ? currentProjection.scale : null;
@@ -4493,6 +4492,7 @@ var Plottable;
                     return this;
                 }
             };
+            Plot._colorVar = "fill";
             return Plot;
         })(Abstract.Component);
         Abstract.Plot = Plot;
@@ -5061,7 +5061,6 @@ var Plottable;
                     "line-reset": new Plottable.Animator.Null(),
                     "line": new Plottable.Animator.Base().duration(600).easing("exp-in-out")
                 };
-                this._colorVar = "stroke";
                 this.classed("line-plot", true);
                 this.project("stroke", function () { return Plottable.Core.Colors.INDIGO; });
                 this.project("stroke-width", function () { return "2px"; });
@@ -5125,6 +5124,7 @@ var Plottable;
             Line.prototype._wholeDatumAttributes = function () {
                 return ["x", "y"];
             };
+            Line._colorVar = "stroke";
             return Line;
         })(Plottable.Abstract.XYPlot);
         Plot.Line = Line;

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -3,7 +3,7 @@
 module Plottable {
 export module Plot {
   export class Line<X> extends Abstract.XYPlot<X,number> {
-    private linePath: D3.Selection;
+    public static _colorVar = "stroke";
 
     public _animators: Animator.IPlotAnimatorMap = {
       "line-reset" : new Animator.Null(),
@@ -11,8 +11,9 @@ export module Plot {
         .duration(600)
         .easing("exp-in-out")
     };
-    public _colorVar = "stroke";
     public _yScale: Abstract.QuantitativeScale<number>;
+
+    private linePath: D3.Selection;
 
     /**
      * Constructs a LinePlot.

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -3,15 +3,16 @@
 module Plottable {
 export module Abstract {
   export class Plot extends Component {
+    public static _colorVar = "fill";
+
     public _dataset: Dataset;
     public _dataChanged = false;
-
     public _renderArea: D3.Selection;
     public _animate: boolean = false;
     public _animators: Animator.IPlotAnimatorMap = {};
     public _ANIMATION_DURATION = 250; // milliseconds
-    public _colorVar = "fill";
     public _projectors: { [attrToSet: string]: _IProjector; } = {};
+
     private animateOnNextRender = true;
 
     /**
@@ -125,7 +126,7 @@ export module Abstract {
     public project(attrToSet: string, accessor: any, scale?: Abstract.Scale<any, any>) {
       attrToSet = attrToSet.toLowerCase();
       if (attrToSet === "color") {
-        attrToSet = this._colorVar;
+        attrToSet = (<any> this.constructor)._colorVar;
       }
       var currentProjection = this._projectors[attrToSet];
       var existingScale = (currentProjection != null) ? currentProjection.scale : null;

--- a/test/components/plots/linePlotTests.ts
+++ b/test/components/plots/linePlotTests.ts
@@ -75,6 +75,15 @@ describe("Plots", () => {
       verifier.end();
     });
 
+    it("color projector maps onto stroke", () => {
+      var lp = new Plottable.Plot.Line([], xScale, yScale);
+      lp.project("color", () => "testColor");
+      var a2p = lp._generateAttrToProjector();
+      assert.isNotNull(a2p["stroke"], "stroke inserted in a2p");
+      assert.equal(a2p["stroke"]([1,2,3], 0), "testColor", "color projector assigned to stroke");
+      verifier.end();
+    });
+
     after(() => {
       if (verifier.passed) {svg.remove();};
     });

--- a/test/components/plots/plotTests.ts
+++ b/test/components/plots/plotTests.ts
@@ -20,6 +20,10 @@ describe("Plots", () => {
     it("Plots default correctly", () => {
       var r = new Plottable.Abstract.Plot();
       assert.isTrue(r.clipPathEnabled, "clipPathEnabled defaults to true");
+      r.project("color", () => "testColor");
+      var a2p = r._generateAttrToProjector();
+      assert.isNotNull(a2p["fill"], "fill inserted in a2p");
+      assert.equal(a2p["fill"](null, 0), "testColor", "color projector assigned to fill");
     });
 
     it("Base Plot functionality works", () => {

--- a/test/tests.js
+++ b/test/tests.js
@@ -1371,6 +1371,10 @@ describe("Plots", function () {
         it("Plots default correctly", function () {
             var r = new Plottable.Abstract.Plot();
             assert.isTrue(r.clipPathEnabled, "clipPathEnabled defaults to true");
+            r.project("color", function () { return "testColor"; });
+            var a2p = r._generateAttrToProjector();
+            assert.isNotNull(a2p["fill"], "fill inserted in a2p");
+            assert.equal(a2p["fill"](null, 0), "testColor", "color projector assigned to fill");
         });
         it("Base Plot functionality works", function () {
             var svg = generateSVG(400, 300);
@@ -1619,6 +1623,14 @@ describe("Plots", function () {
             data[0].stroke = "green";
             simpleDataset.data(data);
             assert.equal(areaPath.attr("stroke"), "green", "stroke set to first datum stroke color");
+            verifier.end();
+        });
+        it("color projector maps onto stroke", function () {
+            var lp = new Plottable.Plot.Line([], xScale, yScale);
+            lp.project("color", function () { return "testColor"; });
+            var a2p = lp._generateAttrToProjector();
+            assert.isNotNull(a2p["stroke"], "stroke inserted in a2p");
+            assert.equal(a2p["stroke"]([1, 2, 3], 0), "testColor", "color projector assigned to stroke");
             verifier.end();
         });
         after(function () {


### PR DESCRIPTION
(it chooses intelligently).

This abstracts away the messy particulars of SVG, but is a little magical.

I'm not in a huge rush to get this one in.
