### PR TITLE
Setting default width/height of component to 0

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -2234,6 +2234,8 @@ var Plottable;
                 this.interactionsToRegister = [];
                 this.boxes = [];
                 this.isTopLevelComponent = false;
+                this._width = 0;
+                this._height = 0;
                 this._xOffset = 0;
                 this._yOffset = 0;
                 this.cssClasses = ["component"];

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -27,8 +27,8 @@ export module Abstract {
     private boxContainer: D3.Selection;
     private rootSVG: D3.Selection;
     private isTopLevelComponent = false;
-    private _width : number; // Width and height of the component. Used to size the hitbox, bounding box, etc
-    private _height: number;
+    private _width = 0; // Width and height of the component. Used to size the hitbox, bounding box, etc
+    private _height = 0;
     private _xOffset = 0; // Offset from Origin, used for alignment and floating positioning
     private _yOffset = 0;
     private cssClasses: string[] = ["component"];


### PR DESCRIPTION
If components render before computeLayout is called and if they depend on the width / height of the component, they will be receiving undefined for those values.
