### PR TITLE
[Pie] - Projectors are retargeted so they target the datum

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -4545,7 +4545,7 @@ var Plottable;
             };
             Pie.prototype._generateAttrToProjector = function () {
                 var _this = this;
-                var attrToProjector = _super.prototype._generateAttrToProjector.call(this);
+                var attrToProjector = this.retargetProjectors(_super.prototype._generateAttrToProjector.call(this));
                 var innerRadiusF = attrToProjector["innerradius"] || d3.functor(0);
                 var outerRadiusF = attrToProjector["outerradius"] || d3.functor(Math.min(this.width(), this.height()) / 2);
                 attrToProjector["d"] = d3.svg.arc().innerRadius(innerRadiusF).outerRadius(outerRadiusF);
@@ -4557,6 +4557,13 @@ var Plottable;
                 attrToProjector["transform"] = function () { return "translate(" + _this.width() / 2 + "," + _this.height() / 2 + ")"; };
                 delete attrToProjector["value"];
                 return attrToProjector;
+            };
+            Pie.prototype.retargetProjectors = function (attrToProjector) {
+                var retargetedAttrToProjector = {};
+                d3.entries(attrToProjector).forEach(function (entry) {
+                    retargetedAttrToProjector[entry.key] = function (d, i) { return entry.value(d.data, i); };
+                });
+                return retargetedAttrToProjector;
             };
             Pie.prototype._getAnimator = function (drawer, index) {
                 return Plottable.Abstract.NewStylePlot.prototype._getAnimator.call(this, drawer, index);

--- a/src/components/plots/piePlot.ts
+++ b/src/components/plots/piePlot.ts
@@ -71,7 +71,7 @@ export module Plot {
     }
 
     public _generateAttrToProjector(): IAttributeToProjector {
-      var attrToProjector = super._generateAttrToProjector();
+      var attrToProjector = this.retargetProjectors(super._generateAttrToProjector());
       var innerRadiusF = attrToProjector["innerradius"] || d3.functor(0);
       var outerRadiusF = attrToProjector["outerradius"] || d3.functor(Math.min(this.width(), this.height()) / 2);
       attrToProjector["d"] = d3.svg.arc()
@@ -87,6 +87,14 @@ export module Plot {
       attrToProjector["transform"] = () => "translate(" + this.width() / 2 + "," + this.height() / 2 + ")";
       delete attrToProjector["value"];
       return attrToProjector;
+    }
+
+    private retargetProjectors(attrToProjector: IAttributeToProjector): IAttributeToProjector {
+      var retargetedAttrToProjector: IAttributeToProjector = {};
+      d3.entries(attrToProjector).forEach((entry) => {
+        retargetedAttrToProjector[entry.key] = (d: any, i: number) => entry.value(d.data, i);
+      });
+      return retargetedAttrToProjector;
     }
 
     public _getAnimator(drawer: Abstract._Drawer, index: number): Animator.IPlotAnimator {

--- a/test/components/plots/piePlotTests.ts
+++ b/test/components/plots/piePlotTests.ts
@@ -15,7 +15,7 @@ describe("Plots", () => {
     before(() => {
       svg = generateSVG(500, 500);
       verifier = new MultiTestVerifier();
-      simpleDataset = new Plottable.Dataset([{value: 5, value2: 10}, {value: 15, value2: 10}]);
+      simpleDataset = new Plottable.Dataset([{value: 5, value2: 10, type: "A"}, {value: 15, value2: 10, type: "B"}]);
       piePlot = new Plottable.Plot.Pie();
       piePlot.addDataset(simpleDataset);
       piePlot.renderTo(svg);
@@ -157,6 +157,16 @@ describe("Plots", () => {
 
         var arcPath1 = d3.select(arcPaths[0][1]);
         assert.strictEqual(arcPath1.attr("fill"), "#ff7f0e", "second sector filled appropriately");
+
+        piePlot.project("fill", "type", new Plottable.Scale.Color("20"));
+
+        arcPaths = renderArea.selectAll(".arc");
+
+        arcPath0 = d3.select(arcPaths[0][0]);
+        assert.strictEqual(arcPath0.attr("fill"), "#1f77b4", "first sector filled appropriately");
+
+        arcPath1 = d3.select(arcPaths[0][1]);
+        assert.strictEqual(arcPath1.attr("fill"), "#aec7e8", "second sector filled appropriately");
         verifier.end();
       });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1497,7 +1497,7 @@ describe("Plots", function () {
         before(function () {
             svg = generateSVG(500, 500);
             verifier = new MultiTestVerifier();
-            simpleDataset = new Plottable.Dataset([{ value: 5, value2: 10 }, { value: 15, value2: 10 }]);
+            simpleDataset = new Plottable.Dataset([{ value: 5, value2: 10, type: "A" }, { value: 15, value2: 10, type: "B" }]);
             piePlot = new Plottable.Plot.Pie();
             piePlot.addDataset(simpleDataset);
             piePlot.renderTo(svg);
@@ -1604,6 +1604,12 @@ describe("Plots", function () {
                 assert.strictEqual(arcPath0.attr("fill"), "#1f77b4", "first sector filled appropriately");
                 var arcPath1 = d3.select(arcPaths[0][1]);
                 assert.strictEqual(arcPath1.attr("fill"), "#ff7f0e", "second sector filled appropriately");
+                piePlot.project("fill", "type", new Plottable.Scale.Color("20"));
+                arcPaths = renderArea.selectAll(".arc");
+                arcPath0 = d3.select(arcPaths[0][0]);
+                assert.strictEqual(arcPath0.attr("fill"), "#1f77b4", "first sector filled appropriately");
+                arcPath1 = d3.select(arcPaths[0][1]);
+                assert.strictEqual(arcPath1.attr("fill"), "#aec7e8", "second sector filled appropriately");
                 verifier.end();
             });
         });


### PR DESCRIPTION
Before the data is binded, it goes through a pie layout transformation, meaning that projectors that want to point to a datum now point to an arc container for the datum.  retargetProjectors now have them target the datum as an argument
