### PR TITLE
[Pie] - _updateProjector taken from NewStylePlot

### DIFF
--- a/plottable-dev.d.ts
+++ b/plottable-dev.d.ts
@@ -927,6 +927,7 @@ declare module Plottable {
             _getDrawer(key: string): Plottable.Abstract._Drawer;
             _getDatasetsInOrder(): Dataset[];
             _getDrawersInOrder(): Plottable.Abstract._Drawer[];
+            _updateProjector(attr: string): void;
             _paint(): void;
         }
     }

--- a/plottable.js
+++ b/plottable.js
@@ -4617,6 +4617,9 @@ var Plottable;
             Pie.prototype._getDrawersInOrder = function () {
                 return Plottable.Abstract.NewStylePlot.prototype._getDrawersInOrder.call(this);
             };
+            Pie.prototype._updateProjector = function (attr) {
+                Plottable.Abstract.NewStylePlot.prototype._updateProjector.call(this, attr);
+            };
             Pie.prototype._paint = function () {
                 var _this = this;
                 var attrHash = this._generateAttrToProjector();

--- a/src/components/plots/piePlot.ts
+++ b/src/components/plots/piePlot.ts
@@ -116,6 +116,10 @@ export module Plot {
       return Abstract.NewStylePlot.prototype._getDrawersInOrder.call(this);
     }
 
+    public _updateProjector(attr: string) {
+      Abstract.NewStylePlot.prototype._updateProjector.call(this, attr);
+    }
+
     public _paint() {
       var attrHash = this._generateAttrToProjector();
       var datasets = this._getDatasetsInOrder();


### PR DESCRIPTION
As taken from #1010 

"Plot.Pie extends Plot, not NewStylePlot, but implements the addDataset() call. As a consequence, pie.dataset() always returns a dummy dataset with no data. When pie goes to compute extent, it tries to apply the accessor over the dummy dataset (as per the implementation of _updateProjector; see plot.ts line 208), and so of course gets nothing. Consequently, the domain for the Scale.Color is not updated properly and the Legend never draws." - @jtlan 

NewStylePlots handle this case so I'm just using their logic.  This is essentially a pain point from NewStylePlots not being the main class for plots.
