### PR TITLE
IAppliedAccessor interface optional function args

### DIFF
--- a/plottable-dev.d.ts
+++ b/plottable-dev.d.ts
@@ -798,7 +798,7 @@ declare module Plottable {
      * Index, if used, will be the index of the datum in the array.
      */
     interface IAppliedAccessor {
-        (datum: any, index?: number): any;
+        (datum?: any, index?: number): any;
     }
     interface _IProjector {
         accessor: _IAccessor;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -791,7 +791,7 @@ declare module Plottable {
      * Index, if used, will be the index of the datum in the array.
      */
     interface IAppliedAccessor {
-        (datum: any, index?: number): any;
+        (datum?: any, index?: number): any;
     }
     interface _IProjector {
         accessor: _IAccessor;

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -25,7 +25,7 @@ module Plottable {
    * Index, if used, will be the index of the datum in the array.
    */
   export interface IAppliedAccessor {
-    (datum: any, index?: number) : any;
+    (datum?: any, index?: number) : any;
   }
 
   export interface _IProjector {


### PR DESCRIPTION
This argument is not necessary in some accessors, so we shouldn't enforce that all of them should use this index.
