### PR TITLE
Upgrade `grunt-ts` version to 1.12.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,16 +35,6 @@ module.exports = function(grunt) {
     }
   };
 
-  // poor man's deep copy
-  var deepCopy = function(x) {
-    return JSON.parse(JSON.stringify(x));
-  };
-
-  tsJSON.dev_release = deepCopy(tsJSON.dev);
-  delete tsJSON.dev_release.options.compiler;
-  tsJSON.test_release = deepCopy(tsJSON.test);
-  delete tsJSON.test_release.options.compiler;
-
   var bumpJSON = {
     options: {
       files: ['package.json', 'bower.json'],
@@ -58,7 +48,6 @@ module.exports = function(grunt) {
   var FILES_TO_COMMIT = ['plottable.js',
                          'plottable.min.js',
                          'plottable.d.ts',
-                         'examples/exampleUtil.js',
                          'test/tests.js',
                          "plottable.css",
                          "plottable.zip",
@@ -336,11 +325,10 @@ module.exports = function(grunt) {
                                   "concat:tests",
                                   ]);
   grunt.registerTask("default", "launch");
-  function makeDevCompile(release) {
-    return [
+  var compile_task = [
       "update_ts_files",
       "update_test_ts_files",
-      release ? "ts:dev_release" : "ts:dev",
+      "ts:dev",
       "concat:plottable",
       "concat:definitions",
       "sed:definitions",
@@ -355,18 +343,16 @@ module.exports = function(grunt) {
       "concat:plottable_multifile",
       "sed:plottable_multifile",
       "clean:tscommand"
-    ];
-  }
+  ];
 
-  grunt.registerTask("dev-compile", makeDevCompile(false));
-  grunt.registerTask("release-compile", makeDevCompile(true));
+  grunt.registerTask("dev-compile", compile_task);
 
   grunt.registerTask("release:patch", ["bump:patch", "dist-compile", "gitcommit:version"]);
   grunt.registerTask("release:minor", ["bump:minor", "dist-compile", "gitcommit:version"]);
   grunt.registerTask("release:major", ["bump:major", "dist-compile", "gitcommit:version"]);
 
   grunt.registerTask("dist-compile", [
-                                  "release-compile",
+                                  "dev-compile",
                                   "blanket_mocha",
                                   "tslint",
                                   "ts:verify_d_ts",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "grunt-cli": "0.1.6",
     "grunt-contrib-watch": "~0.5.3",
     "load-grunt-tasks": "~0.2.0",
-    "grunt-ts": "~1.11.6",
+    "grunt-ts": "~1.12.1",
     "grunt-tslint": "~0.4.0",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-mocha-phantomjs": "~0.4.0",


### PR DESCRIPTION
Stop using separate compilers for development and distribution.
Should speed up distribution compilation, and pull requests will no longer
randomly have tons of comments added or removed.
Close #1097.
