### PR TITLE
Indentation enabled after tslint upgrade.  Removing rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -4,7 +4,6 @@
     "curly": true,
     "eofline": true,
     "forin": true,
-    "indent": [true, 2],
     "jsdoc-format": true,
     "label-position": true,
     "label-undefined": true,


### PR DESCRIPTION
Indentation is already not truly enforced.  After upgrading tslint, the indentation rule throws an error in a bunch of odd places.  Removing this rule.
