### PR TITLE
Fix Axis.Category position bug caused by mistake in table layout

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -3254,22 +3254,13 @@ var Plottable;
                 }
                 this.xOrigin = xOrigin;
                 this.yOrigin = yOrigin;
-                var xPosition = this.xOrigin;
-                var yPosition = this.yOrigin;
                 var requestedSpace = this._requestedSpace(availableWidth, availableHeight);
-                xPosition += this._xOffset;
-                if (this._isFixedWidth()) {
-                    xPosition += (availableWidth - requestedSpace.width) * this._xAlignProportion;
-                    // Decrease size so hitbox / bounding box and children are sized correctly
-                    availableWidth = Math.min(availableWidth, requestedSpace.width);
-                }
-                yPosition += this._yOffset;
-                if (this._isFixedHeight()) {
-                    yPosition += (availableHeight - requestedSpace.height) * this._yAlignProportion;
-                    availableHeight = Math.min(availableHeight, requestedSpace.height);
-                }
-                this._width = availableWidth;
-                this._height = availableHeight;
+                this._width = this._isFixedWidth() ? Math.min(availableWidth, requestedSpace.width) : availableWidth;
+                this._height = this._isFixedHeight() ? Math.min(availableHeight, requestedSpace.height) : availableHeight;
+                var xPosition = this.xOrigin + this._xOffset;
+                var yPosition = this.yOrigin + this._yOffset;
+                xPosition += (availableWidth - this.width()) * this._xAlignProportion;
+                yPosition += (availableHeight - requestedSpace.height) * this._yAlignProportion;
                 this._element.attr("transform", "translate(" + xPosition + "," + yPosition + ")");
                 this.boxes.forEach(function (b) { return b.attr("width", _this.width()).attr("height", _this.height()); });
             };

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -138,27 +138,15 @@ export module Component {
       }
       this.xOrigin = xOrigin;
       this.yOrigin = yOrigin;
-      var xPosition = this.xOrigin;
-      var yPosition = this.yOrigin;
+      var requestedSpace = this._requestedSpace(availableWidth, availableHeight);
+      this._width  = this._isFixedWidth()  ? Math.min(availableWidth , requestedSpace.width)  : availableWidth ;
+      this._height = this._isFixedHeight() ? Math.min(availableHeight, requestedSpace.height) : availableHeight;
 
-      var requestedSpace = this._requestedSpace(availableWidth , availableHeight);
+      var xPosition = this.xOrigin + this._xOffset;
+      var yPosition = this.yOrigin + this._yOffset;
+      xPosition += (availableWidth - this.width()) * this._xAlignProportion;
+      yPosition += (availableHeight - requestedSpace.height) * this._yAlignProportion;
 
-      xPosition += this._xOffset;
-      if (this._isFixedWidth()) {
-        xPosition += (availableWidth - requestedSpace.width) * this._xAlignProportion;
-
-        // Decrease size so hitbox / bounding box and children are sized correctly
-        availableWidth  = Math.min(availableWidth, requestedSpace.width);
-      }
-
-      yPosition += this._yOffset;
-      if (this._isFixedHeight()) {
-        yPosition += (availableHeight - requestedSpace.height) * this._yAlignProportion;
-        availableHeight = Math.min(availableHeight, requestedSpace.height);
-      }
-
-      this._width  = availableWidth;
-      this._height = availableHeight;
       this._element.attr("transform", "translate(" + xPosition + "," + yPosition + ")");
       this.boxes.forEach((b: D3.Selection) => b.attr("width", this.width()).attr("height", this.height()));
     }

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -385,4 +385,19 @@ it("components can be offset relative to their alignment, and throw errors if th
 
     svg.remove();
   });
+
+  it("Components will not translate if they are fixed width/height and request more space than offered", () => {
+    // catches #1188
+    var c: any = new Plottable.Component.AbstractComponent();
+    c._requestedSpace = () => {return {width: 500, height: 500, wantsWidth: true, wantsHeight: true};};
+    c._fixedWidthFlag = true;
+    c._fixedHeightFlag = true;
+    c.xAlign("left");
+    var t = new Plottable.Component.Table([[c]]);
+    t.renderTo(svg);
+
+    var transform = d3.transform(c._element.attr("transform"));
+    assert.deepEqual(transform.translate, [0, 0], "the element was not translated");
+    svg.remove();
+  });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -3929,6 +3929,21 @@ describe("Component behavior", function () {
         assertBBoxInclusion(t.boxContainer.select(".bounding-box"), horizontalComponent._element.select(".bounding-box"));
         svg.remove();
     });
+    it("Components will not translate if they are fixed width/height and request more space than offered", function () {
+        // catches #1188
+        var c = new Plottable.Component.AbstractComponent();
+        c._requestedSpace = function () {
+            return { width: 500, height: 500, wantsWidth: true, wantsHeight: true };
+        };
+        c._fixedWidthFlag = true;
+        c._fixedHeightFlag = true;
+        c.xAlign("left");
+        var t = new Plottable.Component.Table([[c]]);
+        t.renderTo(svg);
+        var transform = d3.transform(c._element.attr("transform"));
+        assert.deepEqual(transform.translate, [0, 0], "the element was not translated");
+        svg.remove();
+    });
 });
 
 ///<reference path="../testReference.ts" />


### PR DESCRIPTION
Fix works by setting the width and height of component sooner, and
ensuring that it is never greater than offered width.

Code is also cleaner.
Add a unit test.
Close #1188.
