### PR TITLE
Check if _className is defined before applying in Drawer.Element

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -3301,7 +3301,9 @@ var Plottable;
                 _super.prototype._enterData.call(this, data);
                 var dataElements = this._getDrawSelection().data(data);
                 dataElements.enter().append(this._svgElement);
-                dataElements.classed(this._className, true);
+                if (this._className != null) {
+                    dataElements.classed(this._className, true);
+                }
                 dataElements.exit().remove();
             };
             return Element;

--- a/src/drawers/elementDrawer.ts
+++ b/src/drawers/elementDrawer.ts
@@ -32,7 +32,9 @@ export module _Drawer {
       super._enterData(data);
       var dataElements = this._getDrawSelection().data(data);
       dataElements.enter().append(this._svgElement);
-      dataElements.classed(this._className, true);
+      if (this._className != null) {
+        dataElements.classed(this._className, true);
+      }
       dataElements.exit().remove();
     }
   }


### PR DESCRIPTION
Previously, we blindly attached the class, which would attach the
CSS class "undefined" to elements.
