### PR TITLE
allow for specification of time axis as utc

### DIFF
--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -21,11 +21,7 @@ export module Scale {
     }
 
     public _tickInterval(interval: D3.Time.Interval, step?: number): any[] {
-      // temporarily creats a time scale from our linear scale into a time scale so we can get access to its api
-      var tempScale = d3.time.scale();
-      tempScale.domain(this.domain());
-      tempScale.range(this.range());
-      return tempScale.ticks(interval.range, step);
+      return this._d3Scale.ticks(interval.range, step);
     }
 
     public _setDomain(values: any[]) {


### PR DESCRIPTION
Submitting for comments. Likely a long way from being merged. 

I need the tick marks on a time axis to render in the UTC timezone. The current behavior renders labels and ticks on the time axis in the browser's timezone. d3 has good support for this, but it is not exposed in the Plottable API. This PR seeks to augment the Plottable API to allow specification of UTC for the time axis. 

This addresses #1218.
