### PR TITLE
[Hotfix] - default bar alignment factor

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -6754,7 +6754,7 @@ var Plottable;
             function AbstractBarPlot(xScale, yScale) {
                 _super.call(this, xScale, yScale);
                 this._baselineValue = 0;
-                this._barAlignmentFactor = 0;
+                this._barAlignmentFactor = 0.5;
                 this._barLabelFormatter = Plottable.Formatters.identity();
                 this._barLabelsEnabled = false;
                 this._hoverMode = "point";
@@ -7648,7 +7648,6 @@ var Plottable;
                 if (isVertical === void 0) { isVertical = true; }
                 this._isVertical = isVertical; // Has to be set before super()
                 this._baselineValue = 0;
-                this._barAlignmentFactor = 0.5;
                 _super.call(this, xScale, yScale);
                 this.classed("bar-plot", true);
                 this.project("fill", function () { return Plottable.Core.Colors.INDIGO; });

--- a/src/components/plots/abstractBarPlot.ts
+++ b/src/components/plots/abstractBarPlot.ts
@@ -7,7 +7,7 @@ export module Plot {
     private static DEFAULT_WIDTH = 10;
     public _baseline: D3.Selection;
     public _baselineValue = 0;
-    public _barAlignmentFactor = 0;
+    public _barAlignmentFactor = 0.5;
     public _isVertical: boolean;
     private _barLabelFormatter: Formatter = Formatters.identity();
     private _barLabelsEnabled = false;

--- a/src/components/plots/stackedBarPlot.ts
+++ b/src/components/plots/stackedBarPlot.ts
@@ -19,7 +19,6 @@ export module Plot {
     constructor(xScale?: Scale.AbstractScale<X,number>, yScale?: Scale.AbstractScale<Y,number>, isVertical = true) {
       this._isVertical = isVertical; // Has to be set before super()
       this._baselineValue = 0;
-      this._barAlignmentFactor = 0.5;
       super(xScale, yScale);
       this.classed("bar-plot", true);
       this.project("fill", () => Core.Colors.INDIGO);

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -41,8 +41,8 @@ describe("Plots", () => {
         assert.equal(bar1.attr("width"), "10", "bar1 width is correct");
         assert.equal(bar0.attr("height"), "100", "bar0 height is correct");
         assert.equal(bar1.attr("height"), "150", "bar1 height is correct");
-        assert.equal(bar0.attr("x"), "150", "bar0 x is correct");
-        assert.equal(bar1.attr("x"), "450", "bar1 x is correct");
+        assert.equal(bar0.attr("x"), "145", "bar0 x is correct");
+        assert.equal(bar1.attr("x"), "445", "bar1 x is correct");
         assert.equal(bar0.attr("y"), "100", "bar0 y is correct");
         assert.equal(bar1.attr("y"), "200", "bar1 y is correct");
 
@@ -199,8 +199,8 @@ describe("Plots", () => {
         assert.equal(bar1.attr("height"), "10", "bar1 height is correct");
         assert.equal(bar0.attr("width"), "100", "bar0 width is correct");
         assert.equal(bar1.attr("width"), "150", "bar1 width is correct");
-        assert.equal(bar0.attr("y"), "300", "bar0 y is correct");
-        assert.equal(bar1.attr("y"), "100", "bar1 y is correct");
+        assert.equal(bar0.attr("y"), "295", "bar0 y is correct");
+        assert.equal(bar1.attr("y"), "95", "bar1 y is correct");
         assert.equal(bar0.attr("x"), "300", "bar0 x is correct");
         assert.equal(bar1.attr("x"), "150", "bar1 x is correct");
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -2221,8 +2221,8 @@ describe("Plots", function () {
                 assert.equal(bar1.attr("width"), "10", "bar1 width is correct");
                 assert.equal(bar0.attr("height"), "100", "bar0 height is correct");
                 assert.equal(bar1.attr("height"), "150", "bar1 height is correct");
-                assert.equal(bar0.attr("x"), "150", "bar0 x is correct");
-                assert.equal(bar1.attr("x"), "450", "bar1 x is correct");
+                assert.equal(bar0.attr("x"), "145", "bar0 x is correct");
+                assert.equal(bar1.attr("x"), "445", "bar1 x is correct");
                 assert.equal(bar0.attr("y"), "100", "bar0 y is correct");
                 assert.equal(bar1.attr("y"), "200", "bar1 y is correct");
                 var baseline = renderArea.select(".baseline");
@@ -2352,8 +2352,8 @@ describe("Plots", function () {
                 assert.equal(bar1.attr("height"), "10", "bar1 height is correct");
                 assert.equal(bar0.attr("width"), "100", "bar0 width is correct");
                 assert.equal(bar1.attr("width"), "150", "bar1 width is correct");
-                assert.equal(bar0.attr("y"), "300", "bar0 y is correct");
-                assert.equal(bar1.attr("y"), "100", "bar1 y is correct");
+                assert.equal(bar0.attr("y"), "295", "bar0 y is correct");
+                assert.equal(bar1.attr("y"), "95", "bar1 y is correct");
                 assert.equal(bar0.attr("x"), "300", "bar0 x is correct");
                 assert.equal(bar1.attr("x"), "150", "bar1 x is correct");
                 var baseline = renderArea.select(".baseline");


### PR DESCRIPTION
Fixes regression where stacked bars are set to the right of the tick
