### PR TITLE
[HOTFIX] Change Line and Area functional stylings to be applied in code.

### DIFF
--- a/plottable.css
+++ b/plottable.css
@@ -90,15 +90,6 @@ svg.plottable {
   line-height: normal;
 }
 
-.plottable .line-plot path.line {
-  fill: none;
-  vector-effect: non-scaling-stroke;
-}
-
-.plottable .area-plot path.area {
-  stroke: none;
-}
-
 .plottable .legend .toggled-off circle {
   fill: #d3d3d3;
 }

--- a/plottable.js
+++ b/plottable.js
@@ -3223,9 +3223,13 @@ var Plottable;
                 this.pathSelection.datum(data);
             };
             Line.prototype.setup = function (area) {
-                area.append("path").classed("line", true);
+                // area.append("path").classed("line", true);
+                this.pathSelection = area.append("path").classed("line", true).style({
+                    "fill": "none",
+                    "vector-effect": "non-scaling-stroke"
+                });
                 _super.prototype.setup.call(this, area);
-                this.pathSelection = this._renderArea.select(".line");
+                // this.pathSelection = this._renderArea.select(".line");
             };
             Line.prototype.createLine = function (xFunction, yFunction, definedFunction) {
                 if (!definedFunction) {
@@ -3295,14 +3299,15 @@ var Plottable;
                 return this;
             };
             Area.prototype.setup = function (area) {
-                area.append("path").classed("area", true);
+                // area.append("path").classed("area", true);
+                this.areaSelection = area.append("path").classed("area", true).style({ "stroke": "none" });
                 if (this._drawLine) {
                     _super.prototype.setup.call(this, area);
                 }
                 else {
                     _Drawer.AbstractDrawer.prototype.setup.call(this, area);
                 }
-                this.areaSelection = this._renderArea.select(".area");
+                // this.areaSelection = this._renderArea.select(".area");
             };
             Area.prototype.createArea = function (xFunction, y0Function, y1Function, definedFunction) {
                 if (!definedFunction) {

--- a/src/drawers/areaDrawer.ts
+++ b/src/drawers/areaDrawer.ts
@@ -26,13 +26,16 @@ export module _Drawer {
     }
 
     public setup(area: D3.Selection) {
-      area.append("path").classed("area", true);
+      // area.append("path").classed("area", true);
+      this.areaSelection = area.append("path")
+                               .classed("area", true)
+                               .style({ "stroke": "none" });
       if (this._drawLine) {
         super.setup(area);
       } else {
         AbstractDrawer.prototype.setup.call(this, area);
       }
-      this.areaSelection = this._renderArea.select(".area");
+      // this.areaSelection = this._renderArea.select(".area");
     }
 
     private createArea(xFunction: AppliedAccessor,

--- a/src/drawers/lineDrawer.ts
+++ b/src/drawers/lineDrawer.ts
@@ -11,9 +11,15 @@ export module _Drawer {
     }
 
     public setup(area: D3.Selection) {
-      area.append("path").classed("line", true);
+      // area.append("path").classed("line", true);
+      this.pathSelection = area.append("path")
+                               .classed("line", true)
+                               .style({
+                                 "fill": "none",
+                                 "vector-effect": "non-scaling-stroke"
+                               });
       super.setup(area);
-      this.pathSelection = this._renderArea.select(".line");
+      // this.pathSelection = this._renderArea.select(".line");
     }
 
     private createLine(xFunction: AppliedAccessor, yFunction: AppliedAccessor, definedFunction: (d: any, i: number) => boolean) {


### PR DESCRIPTION
line and area <path> elements had CSS classes applied that carried functional styling with them (no fill on lines, no stroke on area). It's more robust to apply these required stylings to the individual elements themselves, rather than as a class.
