### PR TITLE
Clip path fixes

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -3873,7 +3873,7 @@ var Plottable;
                 // They don't need the current URL in the clip path reference.
                 var prefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
                 prefix = prefix.split("#")[0]; // To fix cases where an anchor tag was used
-                this._element.attr("clip-path", "url(" + prefix + "#clipPath" + this._plottableID + ")");
+                this._element.attr("clip-path", "url(\"" + prefix + "#clipPath" + this._plottableID + "\")");
                 var clipPathParent = this.boxContainer.append("clipPath").attr("id", "clipPath" + this._plottableID);
                 this.addBox("clip-rect", clipPathParent);
             };

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -350,7 +350,7 @@ export module Component {
       // They don't need the current URL in the clip path reference.
       var prefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
       prefix = prefix.split("#")[0]; // To fix cases where an anchor tag was used
-      this._element.attr("clip-path", "url(" + prefix + "#clipPath" + this._plottableID + ")");
+      this._element.attr("clip-path", "url(\"" + prefix + "#clipPath" + this._plottableID + "\")");
       var clipPathParent = this.boxContainer.append("clipPath")
                                       .attr("id", "clipPath" + this._plottableID);
       this.addBox("clip-rect", clipPathParent);


### PR DESCRIPTION
- Fix bug where if there is any `#` symbol in the URL string, the clip paths break.
- Fix bug where if there are special characters (e.g. `(`, `)`) in the url string, the clip paths break. 
