### PR TITLE
[HOTFIX] Add classes to legend rows/entries

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -5470,6 +5470,9 @@ var Plottable;
                 var r = textHeight * 0.3;
                 var legend = this._content.selectAll("." + Legend.SUBELEMENT_CLASS).data(domain, function (d) { return d; });
                 var legendEnter = legend.enter().append("g").classed(Legend.SUBELEMENT_CLASS, true);
+                legendEnter.each(function (d) {
+                    d3.select(this).classed(d.replace(" ", "-"), true);
+                });
                 legendEnter.append("circle");
                 legendEnter.append("g").classed("text-container", true);
                 legend.exit().remove();
@@ -5668,6 +5671,9 @@ var Plottable;
                 rows.attr("transform", function (d, i) { return "translate(0, " + (i * layout.textHeight + _this.padding) + ")"; });
                 var entries = rows.selectAll("g." + HorizontalLegend.LEGEND_ENTRY_CLASS).data(function (d) { return d; });
                 var entriesEnter = entries.enter().append("g").classed(HorizontalLegend.LEGEND_ENTRY_CLASS, true);
+                entries.each(function (d) {
+                    d3.select(this).classed(d.replace(" ", "-"), true);
+                });
                 entriesEnter.append("circle");
                 entriesEnter.append("g").classed("text-container", true);
                 entries.exit().remove();

--- a/src/components/horizontalLegend.ts
+++ b/src/components/horizontalLegend.ts
@@ -125,6 +125,9 @@ export module Component {
 
       var entries = rows.selectAll("g." + HorizontalLegend.LEGEND_ENTRY_CLASS).data((d) => d);
       var entriesEnter = entries.enter().append("g").classed(HorizontalLegend.LEGEND_ENTRY_CLASS, true);
+      entries.each(function(d: string) {
+        d3.select(this).classed(d.replace(" ", "-"), true);
+      });
       entriesEnter.append("circle");
       entriesEnter.append("g").classed("text-container", true);
       entries.exit().remove();

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -212,6 +212,10 @@ export module Component {
       var legendEnter = legend.enter()
           .append("g").classed(Legend.SUBELEMENT_CLASS, true);
 
+      legendEnter.each(function(d: String) {
+        d3.select(this).classed(d.replace(" ", "-"), true);
+      });
+
       legendEnter.append("circle");
       legendEnter.append("g").classed("text-container", true);
 


### PR DESCRIPTION
Rows on Legend now have the row text as a CSS class.
Entries on HorizontalLegend now have the entry text as a CSS class.

In both cases spaces in the text are replaced with dashes.
