### PR TITLE
Skipping flaky legend test

### DIFF
--- a/test/components/plots/plotTests.ts
+++ b/test/components/plots/plotTests.ts
@@ -304,7 +304,7 @@ describe("Plots", () => {
 
     it("plot auto domain scale to visible points", () => {
       xScale.domain([-3, 3]);
-      assert.deepEqual(yScale.domain(), [-7, 7], "domain has not been adjusted to viible points");
+      assert.deepEqual(yScale.domain(), [-7, 7], "domain has not been adjusted to visible points");
       plot.automaticallyAdjustYScaleOverVisiblePoints(true);
       assert.deepEqual(yScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points");
       plot.automaticallyAdjustYScaleOverVisiblePoints(false);

--- a/test/tests.js
+++ b/test/tests.js
@@ -1823,7 +1823,7 @@ describe("Plots", function () {
         });
         it("plot auto domain scale to visible points", function () {
             xScale.domain([-3, 3]);
-            assert.deepEqual(yScale.domain(), [-7, 7], "domain has not been adjusted to viible points");
+            assert.deepEqual(yScale.domain(), [-7, 7], "domain has not been adjusted to visible points");
             plot.automaticallyAdjustYScaleOverVisiblePoints(true);
             assert.deepEqual(yScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points");
             plot.automaticallyAdjustYScaleOverVisiblePoints(false);


### PR DESCRIPTION
Saucelabs is currently consistently failing on a legend test in Firefox version 30.  Skipping this test until it becomes less flaky.
