### PR TITLE
Fix projector on stacked area

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3208,6 +3208,7 @@ declare module Plottable {
             _updateYDomainer(): void;
             _onDatasetUpdate(): void;
             _generateAttrToProjector(): AttributeToProjector;
+            _wholeDatumAttributes(): string[];
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -7993,13 +7993,20 @@ var Plottable;
             StackedArea.prototype._generateAttrToProjector = function () {
                 var _this = this;
                 var attrToProjector = _super.prototype._generateAttrToProjector.call(this);
+                var wholeDatumAttributes = this._wholeDatumAttributes();
+                var isSingleDatumAttr = function (attr) { return wholeDatumAttributes.indexOf(attr) === -1; };
+                var singleDatumAttributes = d3.keys(attrToProjector).filter(isSingleDatumAttr);
+                singleDatumAttributes.forEach(function (attribute) {
+                    var projector = attrToProjector[attribute];
+                    attrToProjector[attribute] = function (data, i) { return data.length > 0 ? projector(data[0], i) : null; };
+                });
                 var yAccessor = this._projectors["y"].accessor;
                 attrToProjector["y"] = function (d) { return _this._yScale.scale(+yAccessor(d) + d["_PLOTTABLE_PROTECTED_FIELD_STACK_OFFSET"]); };
                 attrToProjector["y0"] = function (d) { return _this._yScale.scale(d["_PLOTTABLE_PROTECTED_FIELD_STACK_OFFSET"]); };
-                // Align fill with first index
-                var fillProjector = attrToProjector["fill"];
-                attrToProjector["fill"] = function (d, i) { return (d && d[0]) ? fillProjector(d[0], i) : null; };
                 return attrToProjector;
+            };
+            StackedArea.prototype._wholeDatumAttributes = function () {
+                return ["x", "y", "defined"];
             };
             return StackedArea;
         })(Plot.AbstractStacked);

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -73,15 +73,23 @@ export module Plot {
 
     public _generateAttrToProjector() {
       var attrToProjector = super._generateAttrToProjector();
+      var wholeDatumAttributes = this._wholeDatumAttributes();
+      var isSingleDatumAttr = (attr: string) => wholeDatumAttributes.indexOf(attr) === -1;
+      var singleDatumAttributes = d3.keys(attrToProjector).filter(isSingleDatumAttr);
+      singleDatumAttributes.forEach((attribute: string) => {
+        var projector = attrToProjector[attribute];
+        attrToProjector[attribute] = (data: any[], i: number) => data.length > 0 ? projector(data[0], i) : null;
+      });
+
       var yAccessor = this._projectors["y"].accessor;
       attrToProjector["y"] = (d: any) => this._yScale.scale(+yAccessor(d) + d["_PLOTTABLE_PROTECTED_FIELD_STACK_OFFSET"]);
       attrToProjector["y0"] = (d: any) => this._yScale.scale(d["_PLOTTABLE_PROTECTED_FIELD_STACK_OFFSET"]);
 
-      // Align fill with first index
-      var fillProjector = attrToProjector["fill"];
-      attrToProjector["fill"] = (d, i) => (d && d[0]) ? fillProjector(d[0], i) : null;
-
       return attrToProjector;
+    }
+
+    public _wholeDatumAttributes() {
+      return ["x", "y", "defined"];
     }
   }
 }

--- a/test/components/plots/stackedAreaPlotTests.ts
+++ b/test/components/plots/stackedAreaPlotTests.ts
@@ -348,5 +348,16 @@ describe("Plots", () => {
       svg.remove();
     });
 
+    it("project works correctly", () => {
+      renderer.project("check", "type");
+      var areas = renderer._renderArea.selectAll(".area");
+      var area0 = d3.select(areas[0][0]);
+      assert.strictEqual(area0.attr("check"), "a", "projector has been applied to first area");
+
+      var area1 = d3.select(areas[0][1]);
+      assert.strictEqual(area1.attr("check"), "b", "projector has been applied to second area");
+      svg.remove();
+    });
+
   });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -3506,6 +3506,15 @@ describe("Plots", function () {
             assert.strictEqual(4, domain[1], "highest area stacking is at upper limit of yScale domain");
             svg.remove();
         });
+        it("project works correctly", function () {
+            renderer.project("check", "type");
+            var areas = renderer._renderArea.selectAll(".area");
+            var area0 = d3.select(areas[0][0]);
+            assert.strictEqual(area0.attr("check"), "a", "projector has been applied to first area");
+            var area1 = d3.select(areas[0][1]);
+            assert.strictEqual(area1.attr("check"), "b", "projector has been applied to second area");
+            svg.remove();
+        });
     });
 });
 


### PR DESCRIPTION
`selection.data` return whole dataseries and it is passed to projector. 
This fix is a port from `Plot.Line`, which distinguished whole datum attributes and single datum one.
All attributes used to generate svg element should be whole datum attribute.

Close #1320.
