### PR TITLE
Time Formatter Quicktest Fix

### DIFF
--- a/quicktests/js/categoryAxis_timeAxis.js
+++ b/quicktests/js/categoryAxis_timeAxis.js
@@ -20,7 +20,7 @@ function run(div, data, Plottable) {
     .addDataset(data)
     .attr("x", function (d) { return d3.time.format("%x").parse(d.x); }, xScale);
 
-  var xAxis = new Plottable.Axis.Time(xScale, "bottom", Plottable.Formatters.time());
+  var xAxis = new Plottable.Axis.Time(xScale, "bottom", Plottable.Formatters.multiTime());
   var yAxis = new Plottable.Axis.Category(yScale, "left");
 
   var gridlines = new Plottable.Component.Gridlines(xScale, null);


### PR DESCRIPTION
Renaming Formatters.time() -> Formatters.multiTime()
