### PR TITLE
[GridPlot] - Remove default value accessor

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -6932,7 +6932,6 @@ var Plottable;
                 this._xScale.rangeType("bands", 0, 0);
                 this._yScale.rangeType("bands", 0, 0);
                 this._colorScale = colorScale;
-                this.project("fill", "value", colorScale); // default
                 this._animators["cells"] = new Plottable.Animator.Null();
             }
             Grid.prototype._addDataset = function (key, dataset) {

--- a/src/components/plots/gridPlot.ts
+++ b/src/components/plots/gridPlot.ts
@@ -32,7 +32,6 @@ export module Plot {
       this._yScale.rangeType("bands", 0, 0);
 
       this._colorScale = colorScale;
-      this.project("fill", "value", colorScale); // default
       this._animators["cells"] = new Animator.Null();
     }
 


### PR DESCRIPTION
Going along with the idea that default accessors are bad because using them could lead to invalid results.
