### PR TITLE
Removing unnecessary prototype calls

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3295,7 +3295,7 @@ declare module Plottable {
              */
             constructor(xScale?: Scale.AbstractScale<X, number>, yScale?: Scale.AbstractScale<Y, number>, isVertical?: boolean);
             _getAnimator(key: string): Animator.PlotAnimator;
-            _generateAttrToProjector(): any;
+            _generateAttrToProjector(): AttributeToProjector;
             _generateDrawSteps(): _Drawer.DrawStep[];
             project(attrToSet: string, accessor: any, scale?: Scale.AbstractScale<any, any>): StackedBar<X, Y>;
             _onDatasetUpdate(): StackedBar<X, Y>;
@@ -3308,7 +3308,6 @@ declare module Plottable {
             _updateScaleExtents(): void;
             _keyAccessor(): _Accessor;
             _valueAccessor(): _Accessor;
-            _getBarPixelWidth(): any;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -8204,7 +8204,7 @@ var Plottable;
             };
             StackedBar.prototype._generateAttrToProjector = function () {
                 var _this = this;
-                var attrToProjector = Plot.AbstractBarPlot.prototype._generateAttrToProjector.apply(this);
+                var attrToProjector = _super.prototype._generateAttrToProjector.call(this);
                 var primaryAttr = this._isVertical ? "y" : "x";
                 var primaryScale = this._isVertical ? this._yScale : this._xScale;
                 var primaryAccessor = this._projections[primaryAttr].accessor;
@@ -8258,10 +8258,6 @@ var Plottable;
             };
             StackedBar.prototype._valueAccessor = function () {
                 return Plot.AbstractStacked.prototype._valueAccessor.call(this);
-            };
-            //===== /Stack logic =====
-            StackedBar.prototype._getBarPixelWidth = function () {
-                return Plot.AbstractBarPlot.prototype._getBarPixelWidth.apply(this);
             };
             return StackedBar;
         })(Plot.AbstractBarPlot);

--- a/src/components/plots/stackedBarPlot.ts
+++ b/src/components/plots/stackedBarPlot.ts
@@ -44,7 +44,7 @@ export module Plot {
     }
 
     public _generateAttrToProjector() {
-      var attrToProjector = AbstractBarPlot.prototype._generateAttrToProjector.apply(this);
+      var attrToProjector = super._generateAttrToProjector();
 
       var primaryAttr = this._isVertical ? "y" : "x";
       var primaryScale: Scale.AbstractScale<any,number> = this._isVertical ? this._yScale : this._xScale;
@@ -119,10 +119,6 @@ export module Plot {
       return AbstractStacked.prototype._valueAccessor.call(this);
     }
     //===== /Stack logic =====
-
-    public _getBarPixelWidth() {
-      return AbstractBarPlot.prototype._getBarPixelWidth.apply(this);
-    }
   }
 }
 }


### PR DESCRIPTION
There were some prototype remnant calls from porting StackedBar to extend from AbstractBar.  This is just removing them.
