### PR TITLE
Module definition for node.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,6 +10,7 @@ module.exports = function(grunt) {
       outDir: "build/src/",
       options: {
         target: 'es5',
+        module: 'commonjs',
         noImplicitAny: true,
         sourceMap: false,
         declaration: true,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/palantir/plottable.git"
   },
   "author": "Palantir Technologies",
+  "main": "plottable.js",
   "scripts": {
     "test": "grunt test-travis"
   },

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -423,6 +423,7 @@ declare module Plottable {
             function getSVGPixelWidth(svg: D3.Selection): number;
             function translate(s: D3.Selection, x?: number, y?: number): any;
             function boxesOverlap(boxA: ClientRect, boxB: ClientRect): boolean;
+            function isSvg(selection: D3.Selection): boolean;
         }
     }
 }
@@ -3866,3 +3867,11 @@ declare module Plottable {
         }
     }
 }
+
+
+
+declare var module: any;
+declare var define: any;
+declare var window: Window;
+declare var document: Document;
+declare var navigator: Navigator;

--- a/plottable.js
+++ b/plottable.js
@@ -290,7 +290,7 @@ var Plottable;
                 colorTester.classed(className, true);
                 // Use regex to get the text inside the rgb parentheses
                 var colorStyle = colorTester.style("background-color");
-                if (colorStyle === "transparent") {
+                if (colorStyle === "transparent" || colorStyle === "") {
                     return null;
                 }
                 var rgb = /\((.+)\)/.exec(colorStyle)[1].split(",").map(function (colorValue) {
@@ -1072,7 +1072,7 @@ var Plottable;
             }
             function isSelectionRemovedFromSVG(selection) {
                 var n = selection.node();
-                while (n !== null && n.nodeName !== "svg") {
+                while (n !== null && !isSvg(selection)) {
                     n = n.parentNode;
                 }
                 return (n == null);
@@ -1139,6 +1139,10 @@ var Plottable;
                 return true;
             }
             DOM.boxesOverlap = boxesOverlap;
+            function isSvg(selection) {
+                return selection.node().nodeName.toLowerCase() === "svg";
+            }
+            DOM.isSvg = isSvg;
         })(_Util.DOM || (_Util.DOM = {}));
         var DOM = _Util.DOM;
     })(Plottable._Util || (Plottable._Util = {}));
@@ -3615,7 +3619,7 @@ var Plottable;
                 if (this.removed) {
                     throw new Error("Can't reuse remove()-ed components!");
                 }
-                if (element.node().nodeName === "svg") {
+                if (Plottable._Util.DOM.isSvg(element)) {
                     // svg node gets the "plottable" CSS class
                     this.rootSVG = element;
                     this.rootSVG.classed("plottable", true);
@@ -3746,7 +3750,7 @@ var Plottable;
                     else {
                         selection = d3.select(element);
                     }
-                    if (!selection.node() || selection.node().nodeName !== "svg") {
+                    if (!selection.node() || !Plottable._Util.DOM.isSvg(selection)) {
                         throw new Error("Plottable requires a valid SVG to renderTo");
                     }
                     this._anchor(selection);
@@ -9216,3 +9220,23 @@ var Plottable;
     })(Plottable.Interaction || (Plottable.Interaction = {}));
     var Interaction = Plottable.Interaction;
 })(Plottable || (Plottable = {}));
+
+///<reference path="../typings/d3/d3.d.ts" />
+///<reference path="./reference.ts" />
+//declarations required to use Plottable in Node
+var window;
+var document;
+var navigator;
+if (typeof module === 'object' && module.exports) {
+    module.exports = function (windowObj, documentObj, navigatorObj) {
+        window = windowObj;
+        document = documentObj;
+        navigator = navigatorObj;
+        return Plottable;
+    };
+}
+else if (typeof define === 'function' && define.amd) {
+    define(function () {
+        return Plottable;
+    });
+}

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -45,7 +45,7 @@ export module Component {
         throw new Error("Can't reuse remove()-ed components!");
       }
 
-      if (element.node().nodeName === "svg") {
+      if (_Util.DOM.isSvg(element)) {
         // svg node gets the "plottable" CSS class
         this.rootSVG = element;
         this.rootSVG.classed("plottable", true);
@@ -192,7 +192,7 @@ export module Component {
         } else {
           selection = d3.select(element);
         }
-        if (!selection.node() || selection.node().nodeName !== "svg") {
+        if (!selection.node() || !_Util.DOM.isSvg(selection)) {
           throw new Error("Plottable requires a valid SVG to renderTo");
         }
         this._anchor(selection);

--- a/src/module_def.ts
+++ b/src/module_def.ts
@@ -1,0 +1,22 @@
+///<reference path="../typings/d3/d3.d.ts" />
+///<reference path="./reference.ts" />
+
+//Ambient declarations for 'module' and 'define' required by node
+declare var module: any;
+declare var define: any;
+
+//declarations required to use Plottable in Node
+var window: Window;
+var document: Document;
+var navigator: Navigator;
+
+if (typeof module === 'object' && module.exports) {
+    module.exports = function(windowObj:any, documentObj:any, navigatorObj:any): any {
+        window = windowObj;
+        document = documentObj;
+        navigator = navigatorObj;
+        return Plottable;
+    };
+} else if (typeof define === 'function' && define.amd) {
+    define(function () { return Plottable; });
+}

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -92,3 +92,5 @@
 /// <reference path="interactions/drag/xyDragBoxInteraction.ts" />
 /// <reference path="interactions/drag/yDragBoxInteraction.ts" />
 /// <reference path="interactions/hoverInteraction.ts" />
+
+/// <reference path="module_def.ts" />

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -40,7 +40,7 @@ export module _Util {
 
     export function isSelectionRemovedFromSVG(selection: D3.Selection) {
       var n = (<Node> selection.node());
-      while (n !== null && n.nodeName !== "svg") {
+      while (n !== null && !isSvg(selection)) {
         n = n.parentNode;
       }
       return (n == null);
@@ -106,6 +106,10 @@ export module _Util {
       if (boxA.bottom < boxB.top) { return false; }
       if (boxA.top > boxB.bottom) { return false; }
       return true;
+    }
+
+    export function isSvg(selection: D3.Selection) {
+        return (<Node> selection.node()).nodeName.toLowerCase() === "svg"
     }
   }
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -298,7 +298,7 @@ export module _Util {
       colorTester.classed(className, true);
       // Use regex to get the text inside the rgb parentheses
       var colorStyle = colorTester.style("background-color");
-      if (colorStyle === "transparent") {
+      if (colorStyle === "transparent" || colorStyle === "") {
         return null;
       }
       var rgb = /\((.+)\)/.exec(colorStyle)[1]


### PR DESCRIPTION
Hi,
We are trying to use plottable to generate charts in Node.js, to be able to import Plottable we had to change several things:
- add module definition 
- shadow window, document and navigator objects
- add isSvg function (jsdom return  "SVG" as a nodName, so we had to check "svg" and "SVG" strings)

These changes allowed us to require Plottable but still we had to patch several functions to get a html string with valid svg chart. Here https://github.com/BrandwatchLtd/node-plottable you can find a node module that is using Plottable (it's an alpha version with patches).

The biggest issues that we have are related to calculation of the elements size (getBoundingClientRect in jsdom returns 0 values, we created a very simple function to hide overlapping labels and legends are not working because of calculation of the text dimensions), we found some memory leaks related to event listeners (they are patched as well).

 Could you let us know what do you think about this and if there is a plan to make plottable as a node package?