### PR TITLE
Making align member vars private

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1725,8 +1725,6 @@ declare module Plottable {
             _foregroundContainer: D3.Selection;
             clipPathEnabled: boolean;
             _parent: AbstractComponentContainer;
-            _xAlignProportion: number;
-            _yAlignProportion: number;
             _fixedHeightFlag: boolean;
             _fixedWidthFlag: boolean;
             _isSetup: boolean;

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -14,8 +14,8 @@ export module Component {
     private yOrigin: number;
 
     public _parent: AbstractComponentContainer;
-    public _xAlignProportion = 0; // What % along the free space do we want to position (0 = left, .5 = center, 1 = right)
-    public _yAlignProportion = 0;
+    private _xAlignProportion = 0; // What % along the free space do we want to position (0 = left, .5 = center, 1 = right)
+    private _yAlignProportion = 0;
     public _fixedHeightFlag = false;
     public _fixedWidthFlag = false;
     public _isSetup = false;


### PR DESCRIPTION
The variables can be gotten through the getter, meaning that the member variables shouldn't need to be exposed at all.
