### PR TITLE
Fixed bug where checking node name is 'svg' is case sensitive (doesn't play nice with Backbone)

### DIFF
--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -45,7 +45,7 @@ export module Component {
         throw new Error("Can't reuse remove()-ed components!");
       }
 
-      if (element.node().nodeName === "svg") {
+      if (element.node().nodeName.toLowerCase() === "svg") {
         // svg node gets the "plottable" CSS class
         this.rootSVG = element;
         this.rootSVG.classed("plottable", true);
@@ -192,7 +192,7 @@ export module Component {
         } else {
           selection = d3.select(element);
         }
-        if (!selection.node() || selection.node().nodeName !== "svg") {
+        if (!selection.node() || selection.node().nodeName.toLowerCase() !== "svg") {
           throw new Error("Plottable requires a valid SVG to renderTo");
         }
         this._anchor(selection);

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -40,7 +40,7 @@ export module _Util {
 
     export function isSelectionRemovedFromSVG(selection: D3.Selection) {
       var n = (<Node> selection.node());
-      while (n !== null && n.nodeName !== "svg") {
+      while (n !== null && n.nodeName.toLowerCase() !== "svg") {
         n = n.parentNode;
       }
       return (n == null);


### PR DESCRIPTION
Fixed bug where checking node name is 'svg' is case sensitive (doesn't play nice with Backbone)
