### PR TITLE
Removing deselectAll from codebase

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3024,11 +3024,6 @@ declare module Plottable {
             getBars(xValOrExtent: number, yValOrExtent: Extent): D3.Selection;
             getBars(xValOrExtent: Extent, yValOrExtent: number): D3.Selection;
             getBars(xValOrExtent: number, yValOrExtent: number): D3.Selection;
-            /**
-             * Deselects all bars.
-             * @returns {AbstractBarPlot} The calling AbstractBarPlot.
-             */
-            deselectAll(): AbstractBarPlot<X, Y>;
             _updateDomainer(scale: Scale.AbstractScale<any, number>): void;
             _updateYDomainer(): void;
             _updateXDomainer(): void;

--- a/plottable.js
+++ b/plottable.js
@@ -7228,16 +7228,6 @@ var Plottable;
                 });
                 return d3.selectAll(bars);
             };
-            /**
-             * Deselects all bars.
-             * @returns {AbstractBarPlot} The calling AbstractBarPlot.
-             */
-            AbstractBarPlot.prototype.deselectAll = function () {
-                if (this._isSetup) {
-                    this._getDrawersInOrder().forEach(function (d) { return d._renderArea.selectAll("rect").classed("selected", false); });
-                }
-                return this;
-            };
             AbstractBarPlot.prototype._updateDomainer = function (scale) {
                 if (scale instanceof Plottable.Scale.AbstractQuantitative) {
                     var qscale = scale;

--- a/src/components/plots/abstractBarPlot.ts
+++ b/src/components/plots/abstractBarPlot.ts
@@ -199,17 +199,6 @@ export module Plot {
       return d3.selectAll(bars);
     }
 
-    /**
-     * Deselects all bars.
-     * @returns {AbstractBarPlot} The calling AbstractBarPlot.
-     */
-    public deselectAll() {
-      if (this._isSetup) {
-        this._getDrawersInOrder().forEach((d) => d._renderArea.selectAll("rect").classed("selected", false));
-      }
-      return this;
-    }
-
     public _updateDomainer(scale: Scale.AbstractScale<any, number>) {
       if (scale instanceof Scale.AbstractQuantitative) {
         var qscale = <Scale.AbstractQuantitative<any>> scale;

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -134,21 +134,6 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("shouldn't blow up if members called before the first render", () => {
-        var brandNew = new Plottable.Plot.VerticalBar(xScale, yScale);
-        brandNew.addDataset(dataset);
-
-        assert.isNotNull(brandNew.deselectAll(), "deselects return self");
-        assert.isTrue(brandNew.getBars(0, 0).empty(), "getBars returns empty selection");
-
-        brandNew._anchor(d3.select(document.createElement("svg"))); // calls `_setup()`
-
-        assert.isNotNull(brandNew.deselectAll(), "deselects return self after setup");
-        assert.isTrue(brandNew.getBars(0, 0).empty(), "getBars returns empty selection after setup");
-
-        svg.remove();
-      });
-
       it("don't show points from outside of domain", () => {
         xScale.domain(["C"]);
         var bars =  barPlot._renderArea.selectAll("rect");

--- a/test/tests.js
+++ b/test/tests.js
@@ -2529,16 +2529,6 @@ describe("Plots", function () {
                 assert.equal(bar.data()[2], dataset.data()[2], "the data in bar 2 matches the datasource");
                 svg.remove();
             });
-            it("shouldn't blow up if members called before the first render", function () {
-                var brandNew = new Plottable.Plot.VerticalBar(xScale, yScale);
-                brandNew.addDataset(dataset);
-                assert.isNotNull(brandNew.deselectAll(), "deselects return self");
-                assert.isTrue(brandNew.getBars(0, 0).empty(), "getBars returns empty selection");
-                brandNew._anchor(d3.select(document.createElement("svg"))); // calls `_setup()`
-                assert.isNotNull(brandNew.deselectAll(), "deselects return self after setup");
-                assert.isTrue(brandNew.getBars(0, 0).empty(), "getBars returns empty selection after setup");
-                svg.remove();
-            });
             it("don't show points from outside of domain", function () {
                 xScale.domain(["C"]);
                 var bars = barPlot._renderArea.selectAll("rect");


### PR DESCRIPTION
Due to the earlier removal of selectBar, deselectAll in accordance should be removed as the behavior is better described through getAllBars
