### PR TITLE
[AbstractComponent] - Adding getters for foreground/background/hitBox

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1936,7 +1936,7 @@ declare module Plottable {
              *
              * @return {D3.Selection} foreground selection for the component
              */
-            getForeground(): D3.Selection;
+            foreground(): D3.Selection;
             /**
              * Returns the background selection for the component
              * (A selection appearing behind of the component)
@@ -1945,7 +1945,7 @@ declare module Plottable {
              *
              * @return {D3.Selection} background selection for the component
              */
-            getBackground(): D3.Selection;
+            background(): D3.Selection;
             /**
              * Returns the hitbox selection for the component
              * (A selection in front of the foreground used mainly for interactions)
@@ -1954,7 +1954,7 @@ declare module Plottable {
              *
              * @return {D3.Selection} hitbox selection for the component
              */
-            getHitBox(): D3.Selection;
+            hitBox(): D3.Selection;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -4216,7 +4216,7 @@ var Plottable;
              *
              * @return {D3.Selection} foreground selection for the component
              */
-            AbstractComponent.prototype.getForeground = function () {
+            AbstractComponent.prototype.foreground = function () {
                 return this._foregroundContainer;
             };
             /**
@@ -4227,7 +4227,7 @@ var Plottable;
              *
              * @return {D3.Selection} background selection for the component
              */
-            AbstractComponent.prototype.getBackground = function () {
+            AbstractComponent.prototype.background = function () {
                 return this._backgroundContainer;
             };
             /**
@@ -4238,7 +4238,7 @@ var Plottable;
              *
              * @return {D3.Selection} hitbox selection for the component
              */
-            AbstractComponent.prototype.getHitBox = function () {
+            AbstractComponent.prototype.hitBox = function () {
                 return this._hitBox;
             };
             AbstractComponent.AUTORESIZE_BY_DEFAULT = true;

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -519,7 +519,7 @@ export module Component {
      *
      * @return {D3.Selection} foreground selection for the component
      */
-    public getForeground(): D3.Selection {
+    public foreground(): D3.Selection {
       return this._foregroundContainer;
     }
 
@@ -531,7 +531,7 @@ export module Component {
      *
      * @return {D3.Selection} background selection for the component
      */
-    public getBackground(): D3.Selection {
+    public background(): D3.Selection {
       return this._backgroundContainer;
     }
 
@@ -543,7 +543,7 @@ export module Component {
      *
      * @return {D3.Selection} hitbox selection for the component
      */
-    public getHitBox(): D3.Selection {
+    public hitBox(): D3.Selection {
       return this._hitBox;
     }
   }


### PR DESCRIPTION
Having these variables exposed can make for easier time building interactions.
