### PR TITLE
Set default radius for hover target.

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -7759,7 +7759,7 @@ var Plottable;
             }
             Line.prototype._setup = function () {
                 _super.prototype._setup.call(this);
-                this._hoverTarget = this._foregroundContainer.append("circle").classed("hover-target", true).attr("radius", this._hoverDetectionRadius).style("visibility", "hidden");
+                this._hoverTarget = this._foregroundContainer.append("circle").classed("hover-target", true).attr("r", this._hoverDetectionRadius).style("visibility", "hidden");
             };
             Line.prototype._rejectNullsAndNaNs = function (d, i, userMetdata, plotMetadata, accessor) {
                 var value = accessor(d, i, userMetdata, plotMetadata);

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -31,7 +31,7 @@ export module Plot {
       super._setup();
       this._hoverTarget = this._foregroundContainer.append("circle")
                                                    .classed("hover-target", true)
-                                                   .attr("radius", this._hoverDetectionRadius)
+                                                   .attr("r", this._hoverDetectionRadius)
                                                    .style("visibility", "hidden");
     }
 


### PR DESCRIPTION
Close #1375.
Previous #1390, used `radius` attribute, which is not recognized.
