### PR TITLE
Fix extending domainer and update tests.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3336,6 +3336,10 @@ declare module Plottable {
             _keyAccessor(): _Accessor;
             _valueAccessor(): _Accessor;
             _getPlotMetadataForDataset(key: string): StackedPlotMetadata;
+            _normalizeDatasets<A, B>(fromX: boolean): {
+                a: A;
+                b: B;
+            }[];
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -7419,7 +7419,7 @@ var Plottable;
                         else {
                             qscale.domainer().removePaddingException("BAR_PLOT+" + this._plottableID).removeIncludedValue("BAR_PLOT+" + this._plottableID);
                         }
-                        qscale.domainer().pad();
+                        qscale.domainer().pad().nice();
                     }
                     // prepending "BAR_PLOT" is unnecessary but reduces likely of user accidentally creating collisions
                     qscale._autoDomainIfAutomaticMode();
@@ -8332,7 +8332,7 @@ var Plottable;
                 _super.prototype._updateYDomainer.call(this);
                 var scale = this._yScale;
                 if (!scale._userSetDomainer) {
-                    scale.domainer().addPaddingException(0, "STACKED_AREA_PLOT+" + this._plottableID);
+                    scale.domainer().addPaddingException(0, "STACKED_AREA_PLOT+" + this._plottableID).addIncludedValue(0, "STACKED_AREA_PLOT+" + this._plottableID);
                     // prepending "AREA_PLOT" is unnecessary but reduces likely of user accidentally creating collisions
                     scale._autoDomainIfAutomaticMode();
                 }
@@ -8406,6 +8406,9 @@ var Plottable;
             };
             StackedArea.prototype._getPlotMetadataForDataset = function (key) {
                 return Plot.AbstractStacked.prototype._getPlotMetadataForDataset.call(this, key);
+            };
+            StackedArea.prototype._normalizeDatasets = function (fromX) {
+                return Plot.AbstractStacked.prototype._normalizeDatasets.call(this, fromX);
             };
             return StackedArea;
         })(Plot.Area);

--- a/src/components/plots/abstractBarPlot.ts
+++ b/src/components/plots/abstractBarPlot.ts
@@ -218,7 +218,7 @@ export module Plot {
               .removePaddingException("BAR_PLOT+" + this._plottableID)
               .removeIncludedValue("BAR_PLOT+" + this._plottableID);
           }
-          qscale.domainer().pad();
+          qscale.domainer().pad().nice();
         }
             // prepending "BAR_PLOT" is unnecessary but reduces likely of user accidentally creating collisions
         qscale._autoDomainIfAutomaticMode();

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -50,7 +50,8 @@ export module Plot {
       super._updateYDomainer();
       var scale = <Scale.AbstractQuantitative<any>> this._yScale;
       if (!scale._userSetDomainer) {
-        scale.domainer().addPaddingException(0, "STACKED_AREA_PLOT+" + this._plottableID);
+        scale.domainer().addPaddingException(0, "STACKED_AREA_PLOT+" + this._plottableID)
+                        .addIncludedValue(0, "STACKED_AREA_PLOT+" + this._plottableID);
         // prepending "AREA_PLOT" is unnecessary but reduces likely of user accidentally creating collisions
         scale._autoDomainIfAutomaticMode();
       }
@@ -140,6 +141,10 @@ export module Plot {
 
     public _getPlotMetadataForDataset(key: string): StackedPlotMetadata {
       return AbstractStacked.prototype._getPlotMetadataForDataset.call(this, key);
+    }
+
+    public _normalizeDatasets<A,B>(fromX: boolean): {a: A; b: B;}[] {
+      return AbstractStacked.prototype._normalizeDatasets.call(this, fromX);
     }
     //===== /Stack logic =====
   }

--- a/test/components/plots/stackedPlotTests.ts
+++ b/test/components/plots/stackedPlotTests.ts
@@ -180,37 +180,37 @@ describe("Plots", () => {
       data1 = [
         {x: 1, y: 1},
         {x: 2, y: 2},
-        {x: 3, y: 1}
+        {x: 3, y: 8}
       ];
 
       data2 = [
         {x: 1, y: 2},
-        {x: 2, y: 3},
+        {x: 2, y: 2},
         {x: 3, y: 3}
       ];
     });
 
     it("auto scales correctly on stacked area", () => {
       var plot = new Plottable.Plot.StackedArea(xScale, yScale)
-                               .automaticallyAdjustYScaleOverVisiblePoints(true)
                                .addDataset(data1)
                                .addDataset(data2)
                                .project("x", "x", xScale)
                                .project("y", "y", yScale);
+      (<any>plot).automaticallyAdjustYScaleOverVisiblePoints(true);
       plot.renderTo(svg);
-      assert.deepEqual(yScale.domain(), [0, 5.5], "auto scales takes stacking into account");
+      assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
       svg.remove();
     });
 
     it("auto scales correctly on stacked bar", () => {
-      var plot = new Plottable.Plot.StackedBar(yScale, xScale, false)
-                               .automaticallyAdjustXScaleOverVisiblePoints(true)
+      var plot = new Plottable.Plot.StackedBar(xScale, yScale)
                                .addDataset(data1)
                                .addDataset(data2)
-                               .project("x", "y", yScale)
-                               .project("y", "x", xScale);
+                               .project("x", "x", xScale)
+                               .project("y", "y", yScale);
+      (<any>plot).automaticallyAdjustYScaleOverVisiblePoints(true);
       plot.renderTo(svg);
-      assert.deepEqual(yScale.domain(), [0, 5.125], "auto scales takes stacking into account");
+      assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
       svg.remove();
     });
   });

--- a/test/tests.js
+++ b/test/tests.js
@@ -3315,24 +3315,26 @@ describe("Plots", function () {
             data1 = [
                 { x: 1, y: 1 },
                 { x: 2, y: 2 },
-                { x: 3, y: 1 }
+                { x: 3, y: 8 }
             ];
             data2 = [
                 { x: 1, y: 2 },
-                { x: 2, y: 3 },
+                { x: 2, y: 2 },
                 { x: 3, y: 3 }
             ];
         });
         it("auto scales correctly on stacked area", function () {
-            var plot = new Plottable.Plot.StackedArea(xScale, yScale).automaticallyAdjustYScaleOverVisiblePoints(true).addDataset(data1).addDataset(data2).project("x", "x", xScale).project("y", "y", yScale);
+            var plot = new Plottable.Plot.StackedArea(xScale, yScale).addDataset(data1).addDataset(data2).project("x", "x", xScale).project("y", "y", yScale);
+            plot.automaticallyAdjustYScaleOverVisiblePoints(true);
             plot.renderTo(svg);
-            assert.deepEqual(yScale.domain(), [0, 5.5], "auto scales takes stacking into account");
+            assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
             svg.remove();
         });
         it("auto scales correctly on stacked bar", function () {
-            var plot = new Plottable.Plot.StackedBar(yScale, xScale, false).automaticallyAdjustXScaleOverVisiblePoints(true).addDataset(data1).addDataset(data2).project("x", "y", yScale).project("y", "x", xScale);
+            var plot = new Plottable.Plot.StackedBar(xScale, yScale).addDataset(data1).addDataset(data2).project("x", "x", xScale).project("y", "y", yScale);
+            plot.automaticallyAdjustYScaleOverVisiblePoints(true);
             plot.renderTo(svg);
-            assert.deepEqual(yScale.domain(), [0, 5.125], "auto scales takes stacking into account");
+            assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
             svg.remove();
         });
     });


### PR DESCRIPTION
`Plot.StackedArea`:
- `automaticallyAdjustYScaleOverVisiblePoints` was broken because after switch parent class to `Plot.Area` it used wrong `_normalizeDatasets` and didn't take stacking into account.
- in `_updateYDomainer` baseline has not been added to `domainer`
  `Plot.StackedBar`:
- to make consistent with `Plot.StackedArea` it calling `nice()` on `domainer`

Close #1424.
