### PR TITLE
[PlottableObject] - Enabling getID() getter

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -601,7 +601,7 @@ declare module Plottable {
          * unique ID.
          */
         class PlottableObject {
-            _plottableID: number;
+            getID(): number;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -1579,6 +1579,9 @@ var Plottable;
             function PlottableObject() {
                 this._plottableID = PlottableObject._nextID++;
             }
+            PlottableObject.prototype.getID = function () {
+                return this._plottableID;
+            };
             PlottableObject._nextID = 0;
             return PlottableObject;
         })();
@@ -1870,7 +1873,7 @@ var Plottable;
                 if (_isCurrentlyFlushing) {
                     Plottable._Util.Methods.warn("Registered to render while other components are flushing: request may be ignored");
                 }
-                _componentsNeedingRender[c._plottableID] = c;
+                _componentsNeedingRender[c.getID()] = c;
                 requestRender();
             }
             RenderController.registerToRender = registerToRender;
@@ -1881,8 +1884,8 @@ var Plottable;
              * @param {AbstractComponent} component Any Plottable component.
              */
             function registerToComputeLayout(c) {
-                _componentsNeedingComputeLayout[c._plottableID] = c;
-                _componentsNeedingRender[c._plottableID] = c;
+                _componentsNeedingComputeLayout[c.getID()] = c;
+                _componentsNeedingRender[c.getID()] = c;
                 requestRender();
             }
             RenderController.registerToComputeLayout = registerToComputeLayout;
@@ -1999,7 +2002,7 @@ var Plottable;
              */
             function register(c) {
                 _lazyInitialize();
-                broadcaster.registerListener(c._plottableID, function () { return c._invalidateLayout(); });
+                broadcaster.registerListener(c.getID(), function () { return c._invalidateLayout(); });
             }
             ResizeBroadcaster.register = register;
             /**
@@ -2011,7 +2014,7 @@ var Plottable;
              */
             function deregister(c) {
                 if (broadcaster) {
-                    broadcaster.deregisterListener(c._plottableID);
+                    broadcaster.deregisterListener(c.getID());
                 }
             }
             ResizeBroadcaster.deregister = deregister;
@@ -4061,8 +4064,8 @@ var Plottable;
                 // They don't need the current URL in the clip path reference.
                 var prefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
                 prefix = prefix.split("#")[0]; // To fix cases where an anchor tag was used
-                this._element.attr("clip-path", "url(\"" + prefix + "#clipPath" + this._plottableID + "\")");
-                var clipPathParent = this._boxContainer.append("clipPath").attr("id", "clipPath" + this._plottableID);
+                this._element.attr("clip-path", "url(\"" + prefix + "#clipPath" + this.getID() + "\")");
+                var clipPathParent = this._boxContainer.append("clipPath").attr("id", "clipPath" + this.getID());
                 this._addBox("clip-rect", clipPathParent);
             };
             /**
@@ -6460,7 +6463,7 @@ var Plottable;
                 var existingScale = currentProjection && currentProjection.scale;
                 if (existingScale) {
                     this._datasetKeysInOrder.forEach(function (key) {
-                        existingScale._removeExtent(_this._plottableID.toString() + "_" + key, attrToSet);
+                        existingScale._removeExtent(_this.getID().toString() + "_" + key, attrToSet);
                         existingScale.broadcaster.deregisterListener(_this);
                     });
                 }
@@ -6524,7 +6527,7 @@ var Plottable;
                         var dataset = plotDatasetKey.dataset;
                         var plotMetadata = plotDatasetKey.plotMetadata;
                         var extent = dataset._getExtent(projector.accessor, projector.scale._typeCoercer, plotMetadata);
-                        var scaleKey = _this._plottableID.toString() + "_" + key;
+                        var scaleKey = _this.getID().toString() + "_" + key;
                         if (extent.length === 0 || !_this._isAnchored) {
                             projector.scale._removeExtent(scaleKey, attr);
                         }
@@ -6580,7 +6583,7 @@ var Plottable;
                     var pdk = this._key2PlotDatasetKey.get(key);
                     pdk.drawer.remove();
                     var projectors = d3.values(this._projections);
-                    var scaleKey = this._plottableID.toString() + "_" + key;
+                    var scaleKey = this.getID().toString() + "_" + key;
                     projectors.forEach(function (p) {
                         if (p.scale != null) {
                             p.scale._removeExtent(scaleKey, p.attribute);
@@ -6740,9 +6743,9 @@ var Plottable;
                 this._xScale = xScale;
                 this._yScale = yScale;
                 this._updateXDomainer();
-                xScale.broadcaster.registerListener("yDomainAdjustment" + this._plottableID, function () { return _this._adjustYDomainOnChangeFromX(); });
+                xScale.broadcaster.registerListener("yDomainAdjustment" + this.getID(), function () { return _this._adjustYDomainOnChangeFromX(); });
                 this._updateYDomainer();
-                yScale.broadcaster.registerListener("xDomainAdjustment" + this._plottableID, function () { return _this._adjustXDomainOnChangeFromY(); });
+                yScale.broadcaster.registerListener("xDomainAdjustment" + this.getID(), function () { return _this._adjustXDomainOnChangeFromY(); });
             }
             /**
              * @param {string} attrToSet One of ["x", "y"] which determines the point's
@@ -6754,19 +6757,19 @@ var Plottable;
                 // So when we get an "x" or "y" scale, enable autoNiceing and autoPadding.
                 if (attrToSet === "x" && scale) {
                     if (this._xScale) {
-                        this._xScale.broadcaster.deregisterListener("yDomainAdjustment" + this._plottableID);
+                        this._xScale.broadcaster.deregisterListener("yDomainAdjustment" + this.getID());
                     }
                     this._xScale = scale;
                     this._updateXDomainer();
-                    scale.broadcaster.registerListener("yDomainAdjustment" + this._plottableID, function () { return _this._adjustYDomainOnChangeFromX(); });
+                    scale.broadcaster.registerListener("yDomainAdjustment" + this.getID(), function () { return _this._adjustYDomainOnChangeFromX(); });
                 }
                 if (attrToSet === "y" && scale) {
                     if (this._yScale) {
-                        this._yScale.broadcaster.deregisterListener("xDomainAdjustment" + this._plottableID);
+                        this._yScale.broadcaster.deregisterListener("xDomainAdjustment" + this.getID());
                     }
                     this._yScale = scale;
                     this._updateYDomainer();
-                    scale.broadcaster.registerListener("xDomainAdjustment" + this._plottableID, function () { return _this._adjustXDomainOnChangeFromY(); });
+                    scale.broadcaster.registerListener("xDomainAdjustment" + this.getID(), function () { return _this._adjustXDomainOnChangeFromY(); });
                 }
                 _super.prototype.project.call(this, attrToSet, accessor, scale);
                 return this;
@@ -6774,10 +6777,10 @@ var Plottable;
             AbstractXYPlot.prototype.remove = function () {
                 _super.prototype.remove.call(this);
                 if (this._xScale) {
-                    this._xScale.broadcaster.deregisterListener("yDomainAdjustment" + this._plottableID);
+                    this._xScale.broadcaster.deregisterListener("yDomainAdjustment" + this.getID());
                 }
                 if (this._yScale) {
-                    this._yScale.broadcaster.deregisterListener("xDomainAdjustment" + this._plottableID);
+                    this._yScale.broadcaster.deregisterListener("xDomainAdjustment" + this.getID());
                 }
                 return this;
             };
@@ -7265,10 +7268,10 @@ var Plottable;
                     var qscale = scale;
                     if (!qscale._userSetDomainer) {
                         if (this._baselineValue != null) {
-                            qscale.domainer().addPaddingException(this._baselineValue, "BAR_PLOT+" + this._plottableID).addIncludedValue(this._baselineValue, "BAR_PLOT+" + this._plottableID);
+                            qscale.domainer().addPaddingException(this._baselineValue, "BAR_PLOT+" + this.getID()).addIncludedValue(this._baselineValue, "BAR_PLOT+" + this.getID());
                         }
                         else {
-                            qscale.domainer().removePaddingException("BAR_PLOT+" + this._plottableID).removeIncludedValue("BAR_PLOT+" + this._plottableID);
+                            qscale.domainer().removePaddingException("BAR_PLOT+" + this.getID()).removeIncludedValue("BAR_PLOT+" + this.getID());
                         }
                         qscale.domainer().pad().nice();
                     }
@@ -7816,10 +7819,10 @@ var Plottable;
                 }
                 if (!this._yScale._userSetDomainer) {
                     if (constantBaseline != null) {
-                        this._yScale.domainer().addPaddingException(constantBaseline, "AREA_PLOT+" + this._plottableID);
+                        this._yScale.domainer().addPaddingException(constantBaseline, "AREA_PLOT+" + this.getID());
                     }
                     else {
-                        this._yScale.domainer().removePaddingException("AREA_PLOT+" + this._plottableID);
+                        this._yScale.domainer().removePaddingException("AREA_PLOT+" + this.getID());
                     }
                     // prepending "AREA_PLOT" is unnecessary but reduces likely of user accidentally creating collisions
                     this._yScale._autoDomainIfAutomaticMode();
@@ -8098,10 +8101,10 @@ var Plottable;
                     return;
                 }
                 if (this._isAnchored && this._stackedExtent.length > 0) {
-                    primaryScale._updateExtent(this._plottableID.toString(), "_PLOTTABLE_PROTECTED_FIELD_STACK_EXTENT", this._stackedExtent);
+                    primaryScale._updateExtent(this.getID().toString(), "_PLOTTABLE_PROTECTED_FIELD_STACK_EXTENT", this._stackedExtent);
                 }
                 else {
-                    primaryScale._removeExtent(this._plottableID.toString(), "_PLOTTABLE_PROTECTED_FIELD_STACK_EXTENT");
+                    primaryScale._removeExtent(this.getID().toString(), "_PLOTTABLE_PROTECTED_FIELD_STACK_EXTENT");
                 }
             };
             AbstractStacked.prototype._normalizeDatasets = function (fromX) {
@@ -8183,7 +8186,7 @@ var Plottable;
                 _super.prototype._updateYDomainer.call(this);
                 var scale = this._yScale;
                 if (!scale._userSetDomainer) {
-                    scale.domainer().addPaddingException(0, "STACKED_AREA_PLOT+" + this._plottableID).addIncludedValue(0, "STACKED_AREA_PLOT+" + this._plottableID);
+                    scale.domainer().addPaddingException(0, "STACKED_AREA_PLOT+" + this.getID()).addIncludedValue(0, "STACKED_AREA_PLOT+" + this.getID());
                     // prepending "AREA_PLOT" is unnecessary but reduces likely of user accidentally creating collisions
                     scale._autoDomainIfAutomaticMode();
                 }
@@ -8652,7 +8655,7 @@ var Plottable;
              * Gets a namespaced version of the event name.
              */
             AbstractDispatcher.prototype._getEventString = function (eventName) {
-                return eventName + ".dispatcher" + this._plottableID;
+                return eventName + ".dispatcher" + this.getID();
             };
             /**
              * Attaches the Dispatcher's listeners to the Dispatcher's target element.

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -350,9 +350,9 @@ export module Component {
       // They don't need the current URL in the clip path reference.
       var prefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
       prefix = prefix.split("#")[0]; // To fix cases where an anchor tag was used
-      this._element.attr("clip-path", "url(\"" + prefix + "#clipPath" + this._plottableID + "\")");
+      this._element.attr("clip-path", "url(\"" + prefix + "#clipPath" + this.getID() + "\")");
       var clipPathParent = this._boxContainer.append("clipPath")
-                                      .attr("id", "clipPath" + this._plottableID);
+                                      .attr("id", "clipPath" + this.getID());
       this._addBox("clip-rect", clipPathParent);
     }
 

--- a/src/components/plots/abstractBarPlot.ts
+++ b/src/components/plots/abstractBarPlot.ts
@@ -211,12 +211,12 @@ export module Plot {
         if (!qscale._userSetDomainer) {
           if (this._baselineValue != null) {
             qscale.domainer()
-              .addPaddingException(this._baselineValue, "BAR_PLOT+" + this._plottableID)
-              .addIncludedValue(this._baselineValue, "BAR_PLOT+" + this._plottableID);
+              .addPaddingException(this._baselineValue, "BAR_PLOT+" + this.getID())
+              .addIncludedValue(this._baselineValue, "BAR_PLOT+" + this.getID());
           } else {
             qscale.domainer()
-              .removePaddingException("BAR_PLOT+" + this._plottableID)
-              .removeIncludedValue("BAR_PLOT+" + this._plottableID);
+              .removePaddingException("BAR_PLOT+" + this.getID())
+              .removeIncludedValue("BAR_PLOT+" + this.getID());
           }
           qscale.domainer().pad().nice();
         }

--- a/src/components/plots/abstractPlot.ts
+++ b/src/components/plots/abstractPlot.ts
@@ -177,7 +177,7 @@ export module Plot {
 
       if (existingScale) {
         this._datasetKeysInOrder.forEach((key) => {
-          existingScale._removeExtent(this._plottableID.toString() + "_" + key, attrToSet);
+          existingScale._removeExtent(this.getID().toString() + "_" + key, attrToSet);
           existingScale.broadcaster.deregisterListener(this);
         });
       }
@@ -245,7 +245,7 @@ export module Plot {
           var dataset = plotDatasetKey.dataset;
           var plotMetadata = plotDatasetKey.plotMetadata;
           var extent = dataset._getExtent(projector.accessor, projector.scale._typeCoercer, plotMetadata);
-          var scaleKey = this._plottableID.toString() + "_" + key;
+          var scaleKey = this.getID().toString() + "_" + key;
           if (extent.length === 0 || !this._isAnchored) {
             projector.scale._removeExtent(scaleKey, attr);
           } else {
@@ -353,7 +353,7 @@ export module Plot {
         pdk.drawer.remove();
 
         var projectors = d3.values(this._projections);
-        var scaleKey = this._plottableID.toString() + "_" + key;
+        var scaleKey = this.getID().toString() + "_" + key;
         projectors.forEach((p) => {
           if (p.scale != null) {
             p.scale._removeExtent(scaleKey, p.attribute);

--- a/src/components/plots/abstractStackedPlot.ts
+++ b/src/components/plots/abstractStackedPlot.ts
@@ -179,9 +179,9 @@ export module Plot {
         return;
       }
       if (this._isAnchored && this._stackedExtent.length > 0) {
-        primaryScale._updateExtent(this._plottableID.toString(), "_PLOTTABLE_PROTECTED_FIELD_STACK_EXTENT", this._stackedExtent);
+        primaryScale._updateExtent(this.getID().toString(), "_PLOTTABLE_PROTECTED_FIELD_STACK_EXTENT", this._stackedExtent);
       } else {
-        primaryScale._removeExtent(this._plottableID.toString(), "_PLOTTABLE_PROTECTED_FIELD_STACK_EXTENT");
+        primaryScale._removeExtent(this.getID().toString(), "_PLOTTABLE_PROTECTED_FIELD_STACK_EXTENT");
       }
     }
 

--- a/src/components/plots/abstractXYPlot.ts
+++ b/src/components/plots/abstractXYPlot.ts
@@ -29,9 +29,9 @@ export module Plot {
       this._xScale = xScale;
       this._yScale = yScale;
       this._updateXDomainer();
-      xScale.broadcaster.registerListener("yDomainAdjustment" + this._plottableID, () => this._adjustYDomainOnChangeFromX());
+      xScale.broadcaster.registerListener("yDomainAdjustment" + this.getID(), () => this._adjustYDomainOnChangeFromX());
       this._updateYDomainer();
-      yScale.broadcaster.registerListener("xDomainAdjustment" + this._plottableID, () => this._adjustXDomainOnChangeFromY());
+      yScale.broadcaster.registerListener("xDomainAdjustment" + this.getID(), () => this._adjustXDomainOnChangeFromY());
     }
 
     /**
@@ -43,20 +43,20 @@ export module Plot {
       // So when we get an "x" or "y" scale, enable autoNiceing and autoPadding.
       if (attrToSet === "x" && scale) {
         if (this._xScale) {
-          this._xScale.broadcaster.deregisterListener("yDomainAdjustment" + this._plottableID);
+          this._xScale.broadcaster.deregisterListener("yDomainAdjustment" + this.getID());
         }
         this._xScale = scale;
         this._updateXDomainer();
-        scale.broadcaster.registerListener("yDomainAdjustment" + this._plottableID, () => this._adjustYDomainOnChangeFromX());
+        scale.broadcaster.registerListener("yDomainAdjustment" + this.getID(), () => this._adjustYDomainOnChangeFromX());
       }
 
       if (attrToSet === "y" && scale) {
         if (this._yScale) {
-          this._yScale.broadcaster.deregisterListener("xDomainAdjustment" + this._plottableID);
+          this._yScale.broadcaster.deregisterListener("xDomainAdjustment" + this.getID());
         }
         this._yScale = scale;
         this._updateYDomainer();
-        scale.broadcaster.registerListener("xDomainAdjustment" + this._plottableID, () => this._adjustXDomainOnChangeFromY());
+        scale.broadcaster.registerListener("xDomainAdjustment" + this.getID(), () => this._adjustXDomainOnChangeFromY());
       }
 
       super.project(attrToSet, accessor, scale);
@@ -67,10 +67,10 @@ export module Plot {
     public remove() {
       super.remove();
       if (this._xScale) {
-        this._xScale.broadcaster.deregisterListener("yDomainAdjustment" + this._plottableID);
+        this._xScale.broadcaster.deregisterListener("yDomainAdjustment" + this.getID());
       }
       if (this._yScale) {
-        this._yScale.broadcaster.deregisterListener("xDomainAdjustment" + this._plottableID);
+        this._yScale.broadcaster.deregisterListener("xDomainAdjustment" + this.getID());
       }
       return this;
     }

--- a/src/components/plots/areaPlot.ts
+++ b/src/components/plots/areaPlot.ts
@@ -56,9 +56,9 @@ export module Plot {
 
       if (!this._yScale._userSetDomainer) {
         if (constantBaseline != null) {
-          this._yScale.domainer().addPaddingException(constantBaseline, "AREA_PLOT+" + this._plottableID);
+          this._yScale.domainer().addPaddingException(constantBaseline, "AREA_PLOT+" + this.getID());
         } else {
-          this._yScale.domainer().removePaddingException("AREA_PLOT+" + this._plottableID);
+          this._yScale.domainer().removePaddingException("AREA_PLOT+" + this.getID());
         }
         // prepending "AREA_PLOT" is unnecessary but reduces likely of user accidentally creating collisions
         this._yScale._autoDomainIfAutomaticMode();

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -50,8 +50,8 @@ export module Plot {
       super._updateYDomainer();
       var scale = <Scale.AbstractQuantitative<any>> this._yScale;
       if (!scale._userSetDomainer) {
-        scale.domainer().addPaddingException(0, "STACKED_AREA_PLOT+" + this._plottableID)
-                        .addIncludedValue(0, "STACKED_AREA_PLOT+" + this._plottableID);
+        scale.domainer().addPaddingException(0, "STACKED_AREA_PLOT+" + this.getID())
+                        .addIncludedValue(0, "STACKED_AREA_PLOT+" + this.getID());
         // prepending "AREA_PLOT" is unnecessary but reduces likely of user accidentally creating collisions
         scale._autoDomainIfAutomaticMode();
       }

--- a/src/core/plottableObject.ts
+++ b/src/core/plottableObject.ts
@@ -8,7 +8,11 @@ export module Core {
    */
   export class PlottableObject {
     private static _nextID = 0;
-    public _plottableID = PlottableObject._nextID++;
+    private _plottableID = PlottableObject._nextID++;
+
+    public getID() {
+      return this._plottableID;
+    }
   }
 }
 }

--- a/src/core/renderController.ts
+++ b/src/core/renderController.ts
@@ -60,7 +60,7 @@ export module Core {
       if (_isCurrentlyFlushing) {
         _Util.Methods.warn("Registered to render while other components are flushing: request may be ignored");
       }
-      _componentsNeedingRender[c._plottableID] = c;
+      _componentsNeedingRender[c.getID()] = c;
       requestRender();
     }
 
@@ -71,8 +71,8 @@ export module Core {
      * @param {AbstractComponent} component Any Plottable component.
      */
     export function registerToComputeLayout(c: Component.AbstractComponent) {
-      _componentsNeedingComputeLayout[c._plottableID] = c;
-      _componentsNeedingRender[c._plottableID] = c;
+      _componentsNeedingComputeLayout[c.getID()] = c;
+      _componentsNeedingRender[c.getID()] = c;
       requestRender();
     }
 

--- a/src/core/resizeBroadcaster.ts
+++ b/src/core/resizeBroadcaster.ts
@@ -60,7 +60,7 @@ export module Core {
      */
     export function register(c: Component.AbstractComponent) {
       _lazyInitialize();
-      broadcaster.registerListener(c._plottableID, () => c._invalidateLayout());
+      broadcaster.registerListener(c.getID(), () => c._invalidateLayout());
     }
 
     /**
@@ -72,7 +72,7 @@ export module Core {
      */
     export function deregister(c: Component.AbstractComponent) {
       if (broadcaster) {
-        broadcaster.deregisterListener(c._plottableID);
+        broadcaster.deregisterListener(c.getID());
       }
     }
   }

--- a/src/dispatchers/abstractDispatcher.ts
+++ b/src/dispatchers/abstractDispatcher.ts
@@ -49,7 +49,7 @@ export module Dispatcher {
      * Gets a namespaced version of the event name.
      */
     public _getEventString(eventName: string) {
-      return eventName + ".dispatcher" + this._plottableID;
+      return eventName + ".dispatcher" + this.getID();
     }
 
     /**

--- a/test/components/plots/plotTests.ts
+++ b/test/components/plots/plotTests.ts
@@ -391,9 +391,9 @@ describe("Plots", () => {
       plot.automaticallyAdjustYScaleOverVisiblePoints(true);
       plot.remove();
       var key2callback = (<any> xScale).broadcaster._key2callback;
-      assert.isUndefined(key2callback.get("yDomainAdjustment" + plot._plottableID), "the plot is no longer attached to the xScale");
+      assert.isUndefined(key2callback.get("yDomainAdjustment" + plot.getID()), "the plot is no longer attached to the xScale");
       key2callback = (<any> yScale).broadcaster._key2callback;
-      assert.isUndefined(key2callback.get("xDomainAdjustment" + plot._plottableID), "the plot is no longer attached to the yScale");
+      assert.isUndefined(key2callback.get("xDomainAdjustment" + plot.getID()), "the plot is no longer attached to the yScale");
       svg.remove();
     });
 

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -201,7 +201,7 @@ it("components can be offset relative to their alignment, and throw errors if th
   it("clipPath works as expected", () => {
     assert.isFalse(c.clipPathEnabled, "clipPathEnabled defaults to false");
     c.clipPathEnabled = true;
-    var expectedClipPathID = c._plottableID;
+    var expectedClipPathID = c.getID();
     c._anchor(svg);
     c._computeLayout(0, 0, 100, 100);
     c._render();
@@ -220,9 +220,9 @@ it("components can be offset relative to their alignment, and throw errors if th
   it("componentID works as expected", () => {
     var expectedID = (<any> Plottable.Core.PlottableObject)._nextID;
     var c1 = new Plottable.Component.AbstractComponent();
-    assert.equal(c1._plottableID, expectedID, "component id on next component was as expected");
+    assert.equal(c1.getID(), expectedID, "component id on next component was as expected");
     var c2 = new Plottable.Component.AbstractComponent();
-    assert.equal(c2._plottableID, expectedID+1, "future components increment appropriately");
+    assert.equal(c2.getID(), expectedID+1, "future components increment appropriately");
     svg.remove();
   });
 
@@ -409,11 +409,11 @@ it("components can be offset relative to their alignment, and throw errors if th
       oldRegister = Plottable.Core.ResizeBroadcaster.register;
       oldDeregister = Plottable.Core.ResizeBroadcaster.deregister;
       var mockRegister = (c: Plottable.Component.AbstractComponent) => {
-        registeredComponents.add(c._plottableID);
+        registeredComponents.add(c.getID());
       };
 
       var mockDeregister = (c: Plottable.Component.AbstractComponent) => {
-        registeredComponents.remove(c._plottableID);
+        registeredComponents.remove(c.getID());
       };
       Plottable.Core.ResizeBroadcaster.register = mockRegister;
       Plottable.Core.ResizeBroadcaster.deregister = mockDeregister;
@@ -426,7 +426,7 @@ it("components can be offset relative to their alignment, and throw errors if th
 
     beforeEach(() => {
       registeredComponents = d3.set();
-      id = c._plottableID;
+      id = c.getID();
     });
 
     afterEach(() => {

--- a/test/tests.js
+++ b/test/tests.js
@@ -1762,9 +1762,9 @@ describe("Plots", function () {
             plot.automaticallyAdjustYScaleOverVisiblePoints(true);
             plot.remove();
             var key2callback = xScale.broadcaster._key2callback;
-            assert.isUndefined(key2callback.get("yDomainAdjustment" + plot._plottableID), "the plot is no longer attached to the xScale");
+            assert.isUndefined(key2callback.get("yDomainAdjustment" + plot.getID()), "the plot is no longer attached to the xScale");
             key2callback = yScale.broadcaster._key2callback;
-            assert.isUndefined(key2callback.get("xDomainAdjustment" + plot._plottableID), "the plot is no longer attached to the yScale");
+            assert.isUndefined(key2callback.get("xDomainAdjustment" + plot.getID()), "the plot is no longer attached to the yScale");
             svg.remove();
         });
         it("listeners are deregistered for changed scale", function () {
@@ -4578,7 +4578,7 @@ describe("Component behavior", function () {
     it("clipPath works as expected", function () {
         assert.isFalse(c.clipPathEnabled, "clipPathEnabled defaults to false");
         c.clipPathEnabled = true;
-        var expectedClipPathID = c._plottableID;
+        var expectedClipPathID = c.getID();
         c._anchor(svg);
         c._computeLayout(0, 0, 100, 100);
         c._render();
@@ -4595,9 +4595,9 @@ describe("Component behavior", function () {
     it("componentID works as expected", function () {
         var expectedID = Plottable.Core.PlottableObject._nextID;
         var c1 = new Plottable.Component.AbstractComponent();
-        assert.equal(c1._plottableID, expectedID, "component id on next component was as expected");
+        assert.equal(c1.getID(), expectedID, "component id on next component was as expected");
         var c2 = new Plottable.Component.AbstractComponent();
-        assert.equal(c2._plottableID, expectedID + 1, "future components increment appropriately");
+        assert.equal(c2.getID(), expectedID + 1, "future components increment appropriately");
         svg.remove();
     });
     it("boxes work as expected", function () {
@@ -4758,10 +4758,10 @@ describe("Component behavior", function () {
             oldRegister = Plottable.Core.ResizeBroadcaster.register;
             oldDeregister = Plottable.Core.ResizeBroadcaster.deregister;
             var mockRegister = function (c) {
-                registeredComponents.add(c._plottableID);
+                registeredComponents.add(c.getID());
             };
             var mockDeregister = function (c) {
-                registeredComponents.remove(c._plottableID);
+                registeredComponents.remove(c.getID());
             };
             Plottable.Core.ResizeBroadcaster.register = mockRegister;
             Plottable.Core.ResizeBroadcaster.deregister = mockDeregister;
@@ -4772,7 +4772,7 @@ describe("Component behavior", function () {
         });
         beforeEach(function () {
             registeredComponents = d3.set();
-            id = c._plottableID;
+            id = c.getID();
         });
         afterEach(function () {
             svg.remove(); // svg contains no useful info


### PR DESCRIPTION
PlottableObjects have always held an internal ID that is used to help differentiate between objects.

The ID starts off at 0 for the first object and then increases across all PlottableObjects as they are instantiated.

This is mainly exposing that ID through a getter to privitize the associated instance variable.
