### PR TITLE
[Component] - Still render on 0 width/height

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -3884,7 +3884,7 @@ var Plottable;
                 this._boxes.forEach(function (b) { return b.attr("width", _this.width()).attr("height", _this.height()); });
             };
             AbstractComponent.prototype._render = function () {
-                if (this._isAnchored && this._isSetup && this.width() > 0 && this.height() > 0) {
+                if (this._isAnchored && this._isSetup && this.width() >= 0 && this.height() >= 0) {
                     Plottable.Core.RenderController.registerToRender(this);
                 }
             };

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -153,7 +153,7 @@ export module Component {
     }
 
     public _render() {
-      if (this._isAnchored && this._isSetup && this.width() > 0 && this.height() > 0) {
+      if (this._isAnchored && this._isSetup && this.width() >= 0 && this.height() >= 0) {
         Core.RenderController.registerToRender(this);
       }
     }

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -414,7 +414,7 @@ describe("Component behavior", () => {
     c._width = 10;
     c._height = 0;
     c._render();
-    assert.isFalse(renderFlag, "render still doesn't occur if one of width/height is zero");
+    assert.isTrue(renderFlag, "render still occurs if one of width/height is zero");
 
     c._height = 10;
     c._render();

--- a/test/tests.js
+++ b/test/tests.js
@@ -4807,7 +4807,7 @@ describe("Component behavior", function () {
         c._width = 10;
         c._height = 0;
         c._render();
-        assert.isFalse(renderFlag, "render still doesn't occur if one of width/height is zero");
+        assert.isTrue(renderFlag, "render still occurs if one of width/height is zero");
         c._height = 10;
         c._render();
         assert.isTrue(renderFlag, "render occurs if width and height are positive");


### PR DESCRIPTION
Fixes a bug where if a component was previously rendered with a positive width/height and then given 0 width or 0 height, then the space calculation will be correct but the component will not rerender to blank itself from the DOM.
