### PR TITLE
Ordinal scale bands revamp

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1295,6 +1295,7 @@ declare module Plottable {
              */
             rangeType(rangeType: string, outerPadding?: number, innerPadding?: number): Ordinal;
             copy(): Ordinal;
+            scale(value: string): number;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -2333,6 +2333,13 @@ var Plottable;
             Ordinal.prototype.copy = function () {
                 return new Ordinal(this._d3Scale.copy());
             };
+            Ordinal.prototype.scale = function (value) {
+                var scaledValue = _super.prototype.scale.call(this, value);
+                if (this.rangeType() === "bands") {
+                    //scale it to the middle
+                    return scaledValue + this.rangeBand() / 2;
+                }
+            };
             return Ordinal;
         })(Scale.AbstractScale);
         Scale.Ordinal = Ordinal;
@@ -4991,7 +4998,7 @@ var Plottable;
                         break;
                 }
                 ticks.each(function (d) {
-                    var bandWidth = scale.fullBandStartAndWidth(d)[1];
+                    var bandWidth = scale.rangeBand();
                     var width = self._isHorizontal() ? bandWidth : axisWidth - self._maxLabelTickLength() - self.tickLabelPadding();
                     var height = self._isHorizontal() ? axisHeight - self._maxLabelTickLength() - self.tickLabelPadding() : bandWidth;
                     var writeOptions = {
@@ -5033,7 +5040,7 @@ var Plottable;
                 var getTickLabelTransform = function (d, i) {
                     var startAndWidth = ordScale.fullBandStartAndWidth(d);
                     var bandStartPosition = startAndWidth[0];
-                    var x = _this._isHorizontal() ? bandStartPosition : 0;
+                    var x = ordScale.scale(d) - ordScale.rangeBand() / 2;
                     var y = _this._isHorizontal() ? 0 : bandStartPosition;
                     return "translate(" + x + "," + y + ")";
                 };
@@ -5044,10 +5051,8 @@ var Plottable;
                 tickLabels.text("");
                 this._drawTicks(this.width(), this.height(), ordScale, tickLabels);
                 var translate = this._isHorizontal() ? [ordScale.rangeBand() / 2, 0] : [0, ordScale.rangeBand() / 2];
-                var xTranslate = this.orient() === "right" ? this._maxLabelTickLength() + this.tickLabelPadding() : 0;
                 var yTranslate = this.orient() === "bottom" ? this._maxLabelTickLength() + this.tickLabelPadding() : 0;
-                Plottable._Util.DOM.translate(this._tickLabelContainer, xTranslate, yTranslate);
-                Plottable._Util.DOM.translate(this._tickMarkContainer, translate[0], translate[1]);
+                Plottable._Util.DOM.translate(this._tickLabelContainer, 0, yTranslate);
                 return this;
             };
             Category.prototype._computeLayout = function (xOrigin, yOrigin, availableWidth, availableHeight) {
@@ -6961,8 +6966,7 @@ var Plottable;
                     attrToProjector[secondaryAttr] = function (d, i, u, m) { return positionF(d, i, u, m) - widthF(d, i, u, m) * _this._barAlignmentFactor; };
                 }
                 else {
-                    var bandWidth = secondaryScale.rangeBand();
-                    attrToProjector[secondaryAttr] = function (d, i, u, m) { return positionF(d, i, u, m) - widthF(d, i, u, m) / 2 + bandWidth / 2; };
+                    attrToProjector[secondaryAttr] = function (d, i, u, m) { return positionF(d, i, u, m) - widthF(d, i, u, m) / 2; };
                 }
                 attrToProjector[primaryAttr] = function (d, i, u, m) {
                     var originalPos = originalPositionFn(d, i, u, m);

--- a/plottable.js
+++ b/plottable.js
@@ -2339,6 +2339,9 @@ var Plottable;
                     //scale it to the middle
                     return scaledValue + this.rangeBand() / 2;
                 }
+                else {
+                    return scaledValue;
+                }
             };
             return Ordinal;
         })(Scale.AbstractScale);
@@ -5038,10 +5041,9 @@ var Plottable;
                 var ordScale = this._scale;
                 var tickLabels = this._tickLabelContainer.selectAll("." + Axis.AbstractAxis.TICK_LABEL_CLASS).data(this._scale.domain(), function (d) { return d; });
                 var getTickLabelTransform = function (d, i) {
-                    var startAndWidth = ordScale.fullBandStartAndWidth(d);
-                    var bandStartPosition = startAndWidth[0];
-                    var x = ordScale.scale(d) - ordScale.rangeBand() / 2;
-                    var y = _this._isHorizontal() ? 0 : bandStartPosition;
+                    var scaledValue = ordScale.scale(d) - ordScale.rangeBand() / 2;
+                    var x = _this._isHorizontal() ? scaledValue : 0;
+                    var y = _this._isHorizontal() ? 0 : scaledValue;
                     return "translate(" + x + "," + y + ")";
                 };
                 tickLabels.enter().append("g").classed(Axis.AbstractAxis.TICK_LABEL_CLASS, true);
@@ -5051,6 +5053,7 @@ var Plottable;
                 tickLabels.text("");
                 this._drawTicks(this.width(), this.height(), ordScale, tickLabels);
                 var translate = this._isHorizontal() ? [ordScale.rangeBand() / 2, 0] : [0, ordScale.rangeBand() / 2];
+                var xTranslate = this.orient() === "left" ? 0 : this._maxLabelTickLength() + this.tickLabelPadding();
                 var yTranslate = this.orient() === "bottom" ? this._maxLabelTickLength() + this.tickLabelPadding() : 0;
                 Plottable._Util.DOM.translate(this._tickLabelContainer, 0, yTranslate);
                 return this;
@@ -7509,7 +7512,7 @@ var Plottable;
                 var innerScale = this._makeInnerScale();
                 this._datasetKeysInOrder.forEach(function (key) {
                     var plotMetadata = _this._key2PlotDatasetKey.get(key).plotMetadata;
-                    plotMetadata.position = innerScale.scale(key);
+                    plotMetadata.position = innerScale.scale(key) - innerScale.rangeBand() / 2;
                 });
             };
             ClusteredBar.prototype._makeInnerScale = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -6720,6 +6720,10 @@ var Plottable;
                 var yStep = this._yScale.rangeBand();
                 attrToProjector["width"] = function () { return xStep; };
                 attrToProjector["height"] = function () { return yStep; };
+                var xAttr = attrToProjector["x"];
+                var yAttr = attrToProjector["y"];
+                attrToProjector["x"] = function (d, i, u, m) { return xAttr(d, i, u, m) - xStep / 2; };
+                attrToProjector["y"] = function (d, i, u, m) { return yAttr(d, i, u, m) - yStep / 2; };
                 return attrToProjector;
             };
             Grid.prototype._generateDrawSteps = function () {

--- a/src/components/axes/categoryAxis.ts
+++ b/src/components/axes/categoryAxis.ts
@@ -116,7 +116,7 @@ export module Axis {
           break;
       }
       ticks.each(function (d: string) {
-        var bandWidth = scale.fullBandStartAndWidth(d)[1];
+        var bandWidth = scale.rangeBand();
         var width  = self._isHorizontal() ? bandWidth  : axisWidth - self._maxLabelTickLength() - self.tickLabelPadding();
         var height = self._isHorizontal() ? axisHeight - self._maxLabelTickLength() - self.tickLabelPadding() : bandWidth;
         var writeOptions = {
@@ -164,7 +164,7 @@ export module Axis {
       var getTickLabelTransform = (d: string, i: number) => {
         var startAndWidth = ordScale.fullBandStartAndWidth(d);
         var bandStartPosition = startAndWidth[0];
-        var x = this._isHorizontal() ? bandStartPosition : 0;
+        var x = ordScale.scale(d) - ordScale.rangeBand() / 2;
         var y = this._isHorizontal() ? 0 : bandStartPosition;
         return "translate(" + x + "," + y + ")";
       };
@@ -176,10 +176,8 @@ export module Axis {
       this._drawTicks(this.width(), this.height(), ordScale, tickLabels);
       var translate = this._isHorizontal() ? [ordScale.rangeBand() / 2, 0] : [0, ordScale.rangeBand() / 2];
 
-      var xTranslate = this.orient() === "right" ? this._maxLabelTickLength() + this.tickLabelPadding() : 0;
       var yTranslate = this.orient() === "bottom" ? this._maxLabelTickLength() + this.tickLabelPadding() : 0;
-      _Util.DOM.translate(this._tickLabelContainer, xTranslate, yTranslate);
-      _Util.DOM.translate(this._tickMarkContainer, translate[0], translate[1]);
+      _Util.DOM.translate(this._tickLabelContainer, 0, yTranslate);
       return this;
     }
 

--- a/src/components/axes/categoryAxis.ts
+++ b/src/components/axes/categoryAxis.ts
@@ -162,10 +162,9 @@ export module Axis {
       var tickLabels = this._tickLabelContainer.selectAll("." + AbstractAxis.TICK_LABEL_CLASS).data(this._scale.domain(), (d) => d);
 
       var getTickLabelTransform = (d: string, i: number) => {
-        var startAndWidth = ordScale.fullBandStartAndWidth(d);
-        var bandStartPosition = startAndWidth[0];
-        var x = ordScale.scale(d) - ordScale.rangeBand() / 2;
-        var y = this._isHorizontal() ? 0 : bandStartPosition;
+        var scaledValue = ordScale.scale(d) - ordScale.rangeBand() / 2;
+        var x = this._isHorizontal() ? scaledValue : 0;
+        var y = this._isHorizontal() ? 0 : scaledValue;
         return "translate(" + x + "," + y + ")";
       };
       tickLabels.enter().append("g").classed(AbstractAxis.TICK_LABEL_CLASS, true);
@@ -176,6 +175,7 @@ export module Axis {
       this._drawTicks(this.width(), this.height(), ordScale, tickLabels);
       var translate = this._isHorizontal() ? [ordScale.rangeBand() / 2, 0] : [0, ordScale.rangeBand() / 2];
 
+      var xTranslate = this.orient() === "left" ? 0 : this._maxLabelTickLength() + this.tickLabelPadding();
       var yTranslate = this.orient() === "bottom" ? this._maxLabelTickLength() + this.tickLabelPadding() : 0;
       _Util.DOM.translate(this._tickLabelContainer, 0, yTranslate);
       return this;

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -319,9 +319,8 @@ export module Plot {
         attrToProjector[secondaryAttr] = (d: any, i: number, u: any, m: PlotMetadata) =>
           positionF(d, i, u, m) - widthF(d, i, u, m) * this._barAlignmentFactor;
       } else {
-        var bandWidth = (<Plottable.Scale.Ordinal> <any> secondaryScale).rangeBand();
         attrToProjector[secondaryAttr] = (d: any, i: number, u: any, m: PlotMetadata) =>
-          positionF(d, i, u, m) - widthF(d, i, u, m) / 2 + bandWidth / 2;
+          positionF(d, i, u, m) - widthF(d, i, u, m) / 2;
       }
 
       attrToProjector[primaryAttr] = (d: any, i: number, u: any, m: PlotMetadata) => {

--- a/src/components/plots/clusteredBarPlot.ts
+++ b/src/components/plots/clusteredBarPlot.ts
@@ -46,7 +46,7 @@ export module Plot {
       var innerScale = this._makeInnerScale();
       this._datasetKeysInOrder.forEach((key: string) => {
         var plotMetadata = <ClusteredPlotMetadata>this._key2PlotDatasetKey.get(key).plotMetadata;
-        plotMetadata.position = innerScale.scale(key);
+        plotMetadata.position = innerScale.scale(key) - innerScale.rangeBand() / 2;
       });
     }
 

--- a/src/components/plots/gridPlot.ts
+++ b/src/components/plots/gridPlot.ts
@@ -60,6 +60,10 @@ export module Plot {
       var yStep = (<Scale.Ordinal> this._yScale).rangeBand();
       attrToProjector["width"]  = () => xStep;
       attrToProjector["height"] = () => yStep;
+      var xAttr = attrToProjector["x"];
+      var yAttr = attrToProjector["y"];
+      attrToProjector["x"] = (d, i, u, m) => xAttr(d, i, u, m) - xStep / 2;
+      attrToProjector["y"] = (d, i, u, m) => yAttr(d, i, u, m) - yStep / 2;
       return attrToProjector;
     }
 

--- a/src/scales/ordinalScale.ts
+++ b/src/scales/ordinalScale.ts
@@ -131,6 +131,8 @@ export module Scale {
       if (this.rangeType() === "bands") {
         //scale it to the middle
         return scaledValue + this.rangeBand() / 2;
+      } else {
+        return scaledValue;
       }
     }
   }

--- a/src/scales/ordinalScale.ts
+++ b/src/scales/ordinalScale.ts
@@ -125,6 +125,14 @@ export module Scale {
     public copy(): Ordinal {
       return new Ordinal(this._d3Scale.copy());
     }
+
+    public scale(value: string): number {
+      var scaledValue = super.scale(value);
+      if (this.rangeType() === "bands") {
+        //scale it to the middle
+        return scaledValue + this.rangeBand() / 2;
+      }
+    }
   }
 }
 }

--- a/test/components/categoryAxisTests.ts
+++ b/test/components/categoryAxisTests.ts
@@ -90,12 +90,12 @@ describe("Category Axes", () => {
     var step = SVG_WIDTH / 5;
     var tickMarks = (<any> categoryAxis)._tickMarkContainer.selectAll(".tick-mark")[0];
     var ticksNormalizedPosition = tickMarks.map((s: any) => +d3.select(s).attr("x1") / step);
-    assert.deepEqual(ticksNormalizedPosition, [1, 2, 3]);
+    assert.deepEqual(ticksNormalizedPosition, [1.5, 2.5, 3.5], "bands");
 
     scale.rangeType("points", 1, 0);
     step = SVG_WIDTH / 4;
     ticksNormalizedPosition = tickMarks.map((s: any) => +d3.select(s).attr("x1") / step);
-    assert.deepEqual(ticksNormalizedPosition, [1, 2, 3]);
+    assert.deepEqual(ticksNormalizedPosition, [1, 2, 3], "points");
 
     svg.remove();
   });

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -439,9 +439,9 @@ describe("Plots", () => {
         assert.closeTo(numAttr(bar0, "width"), (600 - axisWidth) / 2, 0.01, "width is correct for bar0");
         assert.closeTo(numAttr(bar1, "width"), 600 - axisWidth, 0.01, "width is correct for bar1");
         // check that bar is aligned on the center of the scale
-        assert.closeTo(numAttr(bar0, "y") + numAttr(bar0, "height") / 2, yScale.scale(bar0y) + bandWidth / 2, 0.01
+        assert.closeTo(numAttr(bar0, "y"), yScale.scale(bar0y) - bandWidth / 2, 0.01
                     , "y pos correct for bar0");
-        assert.closeTo(numAttr(bar1, "y") + numAttr(bar1, "height") / 2, yScale.scale(bar1y) + bandWidth / 2, 0.01
+        assert.closeTo(numAttr(bar1, "y"), yScale.scale(bar1y) - bandWidth / 2, 0.01
                     , "y pos correct for bar1");
         svg.remove();
       });
@@ -457,8 +457,8 @@ describe("Plots", () => {
         assert.closeTo(numAttr(bar1, "height"), 10, 0.01, "bar1 height");
         assert.closeTo(numAttr(bar0, "width"), (600 - axisWidth) / 2, 0.01, "bar0 width");
         assert.closeTo(numAttr(bar1, "width"), 600 - axisWidth, 0.01, "bar1 width");
-        assert.closeTo(numAttr(bar0, "y") + numAttr(bar0, "height") / 2, yScale.scale(bar0y) + bandWidth / 2, 0.01, "bar0 ypos");
-        assert.closeTo(numAttr(bar1, "y") + numAttr(bar1, "height") / 2, yScale.scale(bar1y) + bandWidth / 2, 0.01, "bar1 ypos");
+        assert.closeTo(numAttr(bar0, "y"), yScale.scale(bar0y) - numAttr(bar0, "height") / 2, 0.01, "bar0 ypos");
+        assert.closeTo(numAttr(bar1, "y"), yScale.scale(bar1y) - numAttr(bar1, "height") / 2, 0.01, "bar1 ypos");
         svg.remove();
       });
     });

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -23,7 +23,7 @@ describe("Plots", () => {
           {x: "B", y: 1} // duplicate X-value
         ];
         dataset = new Plottable.Dataset(data);
-        barPlot = new Plottable.Plot.VerticalBar(xScale, yScale);
+        barPlot = new Plottable.Plot.Bar(xScale, yScale);
         barPlot.addDataset(dataset);
         barPlot.animate(false);
         barPlot.baseline(0);

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -23,7 +23,7 @@ describe("Plots", () => {
           {x: "B", y: 1} // duplicate X-value
         ];
         dataset = new Plottable.Dataset(data);
-        barPlot = new Plottable.Plot.Bar(xScale, yScale);
+        barPlot = new Plottable.Plot.VerticalBar(xScale, yScale);
         barPlot.addDataset(dataset);
         barPlot.animate(false);
         barPlot.baseline(0);

--- a/test/components/plots/clusteredBarPlotTests.ts
+++ b/test/components/plots/clusteredBarPlotTests.ts
@@ -80,14 +80,15 @@ describe("Plots", () => {
       assert.closeTo(numAttr(bar3, "height"), (400 - axisHeight) / 2, 0.01, "height is correct for bar3");
 
       // check that clustering is correct
-      var off = (<any>renderer)._makeInnerScale().scale("_0");
-      assert.closeTo(numAttr(bar0, "x") + numAttr(bar0, "width") / 2, xScale.scale(bar0X) + bandWidth / 2 - off, 0.01
+      var innerScale = (<any>renderer)._makeInnerScale();
+      var off = innerScale.scale("_0") - innerScale.rangeBand() / 2;
+      assert.closeTo(numAttr(bar0, "x") + numAttr(bar0, "width") / 2, xScale.scale(bar0X) - off, 0.01
           , "x pos correct for bar0");
-      assert.closeTo(numAttr(bar1, "x") + numAttr(bar1, "width") / 2, xScale.scale(bar1X) + bandWidth / 2 - off, 0.01
+      assert.closeTo(numAttr(bar1, "x") + numAttr(bar1, "width") / 2, xScale.scale(bar1X) - off, 0.01
           , "x pos correct for bar1");
-      assert.closeTo(numAttr(bar2, "x") + numAttr(bar2, "width") / 2, xScale.scale(bar2X) + bandWidth / 2 + off, 0.01
+      assert.closeTo(numAttr(bar2, "x") + numAttr(bar2, "width") / 2, xScale.scale(bar2X) + off, 0.01
           , "x pos correct for bar2");
-      assert.closeTo(numAttr(bar3, "x") + numAttr(bar3, "width") / 2, xScale.scale(bar3X) + bandWidth / 2 + off, 0.01
+      assert.closeTo(numAttr(bar3, "x") + numAttr(bar3, "width") / 2, xScale.scale(bar3X) + off, 0.01
           , "x pos correct for bar3");
 
       assert.deepEqual(dataset1.data(), originalData1, "underlying data is not modified");
@@ -121,7 +122,8 @@ describe("Plots", () => {
       assert.closeTo(numAttr(bar3, "height"), (400 - axisHeight) / 2, 0.01, "height is correct for bar3");
 
       // check that clustering is correct
-      var off = (<any>renderer)._makeInnerScale().scale("_0");
+      var innerScale = (<any>renderer)._makeInnerScale();
+      var off = innerScale.scale("_0") - innerScale.rangeBand() / 2;
       assert.closeTo(numAttr(bar0, "x"), xScale.scale(bar0X) - width / 2 - off, 0.1
           , "x pos correct for bar0");
       assert.closeTo(numAttr(bar1, "x"), xScale.scale(bar1X) - width / 2 - off, 0.1
@@ -203,14 +205,15 @@ describe("Plots", () => {
       var bar3Y = bar3.data()[0].y;
 
       // check that clustering is correct
-      var off = (<any>renderer)._makeInnerScale().scale("_0");
-      assert.closeTo(numAttr(bar0, "y") + numAttr(bar0, "height") / 2, yScale.scale(bar0Y) + bandWidth / 2 - off, 0.01
+      var innerScale = (<any>renderer)._makeInnerScale();
+      var off = innerScale.scale("_0") - innerScale.rangeBand() / 2;
+      assert.closeTo(numAttr(bar0, "y") + numAttr(bar0, "height") / 2, yScale.scale(bar0Y) - off, 0.01
             , "y pos correct for bar0");
-      assert.closeTo(numAttr(bar1, "y") + numAttr(bar1, "height") / 2, yScale.scale(bar1Y) + bandWidth / 2 - off, 0.01
+      assert.closeTo(numAttr(bar1, "y") + numAttr(bar1, "height") / 2, yScale.scale(bar1Y) - off, 0.01
             , "y pos correct for bar1");
-      assert.closeTo(numAttr(bar2, "y") + numAttr(bar2, "height") / 2, yScale.scale(bar2Y) + bandWidth / 2 + off, 0.01
+      assert.closeTo(numAttr(bar2, "y") + numAttr(bar2, "height") / 2, yScale.scale(bar2Y) + off, 0.01
             , "y pos correct for bar2");
-      assert.closeTo(numAttr(bar3, "y") + numAttr(bar3, "height") / 2, yScale.scale(bar3Y) + bandWidth / 2 + off, 0.01
+      assert.closeTo(numAttr(bar3, "y") + numAttr(bar3, "height") / 2, yScale.scale(bar3Y) + off, 0.01
             , "y pos correct for bar3");
       svg.remove();
     });

--- a/test/components/plots/stackedBarPlotTests.ts
+++ b/test/components/plots/stackedBarPlotTests.ts
@@ -75,10 +75,10 @@ describe("Plots", () => {
       assert.closeTo(numAttr(bar2, "height"), (400 - axisHeight) / 3 * 2, 0.01, "height is correct for bar2");
       assert.closeTo(numAttr(bar3, "height"), (400 - axisHeight) / 3, 0.01, "height is correct for bar3");
       // check that bar is aligned on the center of the scale
-      assert.closeTo(numAttr(bar0, "x") + numAttr(bar0, "width") / 2, xScale.scale(bar0X) + bandWidth / 2, 0.01, "x pos correct for bar0");
-      assert.closeTo(numAttr(bar1, "x") + numAttr(bar1, "width") / 2, xScale.scale(bar1X) + bandWidth / 2, 0.01, "x pos correct for bar1");
-      assert.closeTo(numAttr(bar2, "x") + numAttr(bar2, "width") / 2, xScale.scale(bar2X) + bandWidth / 2, 0.01, "x pos correct for bar2");
-      assert.closeTo(numAttr(bar3, "x") + numAttr(bar3, "width") / 2, xScale.scale(bar3X) + bandWidth / 2, 0.01, "x pos correct for bar3");
+      assert.closeTo(numAttr(bar0, "x") + numAttr(bar0, "width") / 2, xScale.scale(bar0X), 0.01, "x pos correct for bar0");
+      assert.closeTo(numAttr(bar1, "x") + numAttr(bar1, "width") / 2, xScale.scale(bar1X), 0.01, "x pos correct for bar1");
+      assert.closeTo(numAttr(bar2, "x") + numAttr(bar2, "width") / 2, xScale.scale(bar2X), 0.01, "x pos correct for bar2");
+      assert.closeTo(numAttr(bar3, "x") + numAttr(bar3, "width") / 2, xScale.scale(bar3X), 0.01, "x pos correct for bar3");
       // now check y values to ensure they do indeed stack
       assert.closeTo(numAttr(bar0, "y"), (400 - axisHeight) / 3 * 2, 0.01, "y is correct for bar0");
       assert.closeTo(numAttr(bar1, "y"), (400 - axisHeight) / 3, 0.01, "y is correct for bar1");
@@ -226,10 +226,10 @@ describe("Plots", () => {
       var bar3Y = bar3.data()[0].name;
 
       // check that bar is aligned on the center of the scale
-      assert.closeTo(numAttr(bar0, "y") + numAttr(bar0, "height") / 2, yScale.scale(bar0Y) + bandWidth / 2, 0.01, "y pos correct for bar0");
-      assert.closeTo(numAttr(bar1, "y") + numAttr(bar1, "height") / 2, yScale.scale(bar1Y) + bandWidth / 2, 0.01, "y pos correct for bar1");
-      assert.closeTo(numAttr(bar2, "y") + numAttr(bar2, "height") / 2, yScale.scale(bar2Y) + bandWidth / 2, 0.01, "y pos correct for bar2");
-      assert.closeTo(numAttr(bar3, "y") + numAttr(bar3, "height") / 2, yScale.scale(bar3Y) + bandWidth / 2, 0.01, "y pos correct for bar3");
+      assert.closeTo(numAttr(bar0, "y") + numAttr(bar0, "height") / 2, yScale.scale(bar0Y), 0.01, "y pos correct for bar0");
+      assert.closeTo(numAttr(bar1, "y") + numAttr(bar1, "height") / 2, yScale.scale(bar1Y), 0.01, "y pos correct for bar1");
+      assert.closeTo(numAttr(bar2, "y") + numAttr(bar2, "height") / 2, yScale.scale(bar2Y), 0.01, "y pos correct for bar2");
+      assert.closeTo(numAttr(bar3, "y") + numAttr(bar3, "height") / 2, yScale.scale(bar3Y), 0.01, "y pos correct for bar3");
       // now check x values to ensure they do indeed stack
       assert.closeTo(numAttr(bar0, "x"), 0, 0.01, "x is correct for bar0");
       assert.closeTo(numAttr(bar1, "x"), 0, 0.01, "x is correct for bar1");

--- a/test/tests.js
+++ b/test/tests.js
@@ -2250,7 +2250,7 @@ describe("Plots", function () {
                     { x: "B", y: 1 }
                 ];
                 dataset = new Plottable.Dataset(data);
-                barPlot = new Plottable.Plot.VerticalBar(xScale, yScale);
+                barPlot = new Plottable.Plot.Bar(xScale, yScale);
                 barPlot.addDataset(dataset);
                 barPlot.animate(false);
                 barPlot.baseline(0);

--- a/test/tests.js
+++ b/test/tests.js
@@ -2250,7 +2250,7 @@ describe("Plots", function () {
                     { x: "B", y: 1 }
                 ];
                 dataset = new Plottable.Dataset(data);
-                barPlot = new Plottable.Plot.Bar(xScale, yScale);
+                barPlot = new Plottable.Plot.VerticalBar(xScale, yScale);
                 barPlot.addDataset(dataset);
                 barPlot.animate(false);
                 barPlot.baseline(0);

--- a/test/tests.js
+++ b/test/tests.js
@@ -934,11 +934,11 @@ describe("Category Axes", function () {
         var step = SVG_WIDTH / 5;
         var tickMarks = categoryAxis._tickMarkContainer.selectAll(".tick-mark")[0];
         var ticksNormalizedPosition = tickMarks.map(function (s) { return +d3.select(s).attr("x1") / step; });
-        assert.deepEqual(ticksNormalizedPosition, [1, 2, 3]);
+        assert.deepEqual(ticksNormalizedPosition, [1.5, 2.5, 3.5], "bands");
         scale.rangeType("points", 1, 0);
         step = SVG_WIDTH / 4;
         ticksNormalizedPosition = tickMarks.map(function (s) { return +d3.select(s).attr("x1") / step; });
-        assert.deepEqual(ticksNormalizedPosition, [1, 2, 3]);
+        assert.deepEqual(ticksNormalizedPosition, [1, 2, 3], "points");
         svg.remove();
     });
     it("vertically aligns short words properly", function () {
@@ -2606,8 +2606,8 @@ describe("Plots", function () {
                 assert.closeTo(numAttr(bar0, "width"), (600 - axisWidth) / 2, 0.01, "width is correct for bar0");
                 assert.closeTo(numAttr(bar1, "width"), 600 - axisWidth, 0.01, "width is correct for bar1");
                 // check that bar is aligned on the center of the scale
-                assert.closeTo(numAttr(bar0, "y") + numAttr(bar0, "height") / 2, yScale.scale(bar0y) + bandWidth / 2, 0.01, "y pos correct for bar0");
-                assert.closeTo(numAttr(bar1, "y") + numAttr(bar1, "height") / 2, yScale.scale(bar1y) + bandWidth / 2, 0.01, "y pos correct for bar1");
+                assert.closeTo(numAttr(bar0, "y"), yScale.scale(bar0y) - bandWidth / 2, 0.01, "y pos correct for bar0");
+                assert.closeTo(numAttr(bar1, "y"), yScale.scale(bar1y) - bandWidth / 2, 0.01, "y pos correct for bar1");
                 svg.remove();
             });
             it("width projector may be overwritten, and calling project queues rerender", function () {
@@ -2621,8 +2621,8 @@ describe("Plots", function () {
                 assert.closeTo(numAttr(bar1, "height"), 10, 0.01, "bar1 height");
                 assert.closeTo(numAttr(bar0, "width"), (600 - axisWidth) / 2, 0.01, "bar0 width");
                 assert.closeTo(numAttr(bar1, "width"), 600 - axisWidth, 0.01, "bar1 width");
-                assert.closeTo(numAttr(bar0, "y") + numAttr(bar0, "height") / 2, yScale.scale(bar0y) + bandWidth / 2, 0.01, "bar0 ypos");
-                assert.closeTo(numAttr(bar1, "y") + numAttr(bar1, "height") / 2, yScale.scale(bar1y) + bandWidth / 2, 0.01, "bar1 ypos");
+                assert.closeTo(numAttr(bar0, "y"), yScale.scale(bar0y) - numAttr(bar0, "height") / 2, 0.01, "bar0 ypos");
+                assert.closeTo(numAttr(bar1, "y"), yScale.scale(bar1y) - numAttr(bar1, "height") / 2, 0.01, "bar1 ypos");
                 svg.remove();
             });
         });
@@ -3589,10 +3589,10 @@ describe("Plots", function () {
             assert.closeTo(numAttr(bar2, "height"), (400 - axisHeight) / 3 * 2, 0.01, "height is correct for bar2");
             assert.closeTo(numAttr(bar3, "height"), (400 - axisHeight) / 3, 0.01, "height is correct for bar3");
             // check that bar is aligned on the center of the scale
-            assert.closeTo(numAttr(bar0, "x") + numAttr(bar0, "width") / 2, xScale.scale(bar0X) + bandWidth / 2, 0.01, "x pos correct for bar0");
-            assert.closeTo(numAttr(bar1, "x") + numAttr(bar1, "width") / 2, xScale.scale(bar1X) + bandWidth / 2, 0.01, "x pos correct for bar1");
-            assert.closeTo(numAttr(bar2, "x") + numAttr(bar2, "width") / 2, xScale.scale(bar2X) + bandWidth / 2, 0.01, "x pos correct for bar2");
-            assert.closeTo(numAttr(bar3, "x") + numAttr(bar3, "width") / 2, xScale.scale(bar3X) + bandWidth / 2, 0.01, "x pos correct for bar3");
+            assert.closeTo(numAttr(bar0, "x") + numAttr(bar0, "width") / 2, xScale.scale(bar0X), 0.01, "x pos correct for bar0");
+            assert.closeTo(numAttr(bar1, "x") + numAttr(bar1, "width") / 2, xScale.scale(bar1X), 0.01, "x pos correct for bar1");
+            assert.closeTo(numAttr(bar2, "x") + numAttr(bar2, "width") / 2, xScale.scale(bar2X), 0.01, "x pos correct for bar2");
+            assert.closeTo(numAttr(bar3, "x") + numAttr(bar3, "width") / 2, xScale.scale(bar3X), 0.01, "x pos correct for bar3");
             // now check y values to ensure they do indeed stack
             assert.closeTo(numAttr(bar0, "y"), (400 - axisHeight) / 3 * 2, 0.01, "y is correct for bar0");
             assert.closeTo(numAttr(bar1, "y"), (400 - axisHeight) / 3, 0.01, "y is correct for bar1");
@@ -3724,10 +3724,10 @@ describe("Plots", function () {
             var bar2Y = bar2.data()[0].name;
             var bar3Y = bar3.data()[0].name;
             // check that bar is aligned on the center of the scale
-            assert.closeTo(numAttr(bar0, "y") + numAttr(bar0, "height") / 2, yScale.scale(bar0Y) + bandWidth / 2, 0.01, "y pos correct for bar0");
-            assert.closeTo(numAttr(bar1, "y") + numAttr(bar1, "height") / 2, yScale.scale(bar1Y) + bandWidth / 2, 0.01, "y pos correct for bar1");
-            assert.closeTo(numAttr(bar2, "y") + numAttr(bar2, "height") / 2, yScale.scale(bar2Y) + bandWidth / 2, 0.01, "y pos correct for bar2");
-            assert.closeTo(numAttr(bar3, "y") + numAttr(bar3, "height") / 2, yScale.scale(bar3Y) + bandWidth / 2, 0.01, "y pos correct for bar3");
+            assert.closeTo(numAttr(bar0, "y") + numAttr(bar0, "height") / 2, yScale.scale(bar0Y), 0.01, "y pos correct for bar0");
+            assert.closeTo(numAttr(bar1, "y") + numAttr(bar1, "height") / 2, yScale.scale(bar1Y), 0.01, "y pos correct for bar1");
+            assert.closeTo(numAttr(bar2, "y") + numAttr(bar2, "height") / 2, yScale.scale(bar2Y), 0.01, "y pos correct for bar2");
+            assert.closeTo(numAttr(bar3, "y") + numAttr(bar3, "height") / 2, yScale.scale(bar3Y), 0.01, "y pos correct for bar3");
             // now check x values to ensure they do indeed stack
             assert.closeTo(numAttr(bar0, "x"), 0, 0.01, "x is correct for bar0");
             assert.closeTo(numAttr(bar1, "x"), 0, 0.01, "x is correct for bar1");
@@ -3858,11 +3858,12 @@ describe("Plots", function () {
             assert.closeTo(numAttr(bar2, "height"), (400 - axisHeight), 0.01, "height is correct for bar2");
             assert.closeTo(numAttr(bar3, "height"), (400 - axisHeight) / 2, 0.01, "height is correct for bar3");
             // check that clustering is correct
-            var off = renderer._makeInnerScale().scale("_0");
-            assert.closeTo(numAttr(bar0, "x") + numAttr(bar0, "width") / 2, xScale.scale(bar0X) + bandWidth / 2 - off, 0.01, "x pos correct for bar0");
-            assert.closeTo(numAttr(bar1, "x") + numAttr(bar1, "width") / 2, xScale.scale(bar1X) + bandWidth / 2 - off, 0.01, "x pos correct for bar1");
-            assert.closeTo(numAttr(bar2, "x") + numAttr(bar2, "width") / 2, xScale.scale(bar2X) + bandWidth / 2 + off, 0.01, "x pos correct for bar2");
-            assert.closeTo(numAttr(bar3, "x") + numAttr(bar3, "width") / 2, xScale.scale(bar3X) + bandWidth / 2 + off, 0.01, "x pos correct for bar3");
+            var innerScale = renderer._makeInnerScale();
+            var off = innerScale.scale("_0") - innerScale.rangeBand() / 2;
+            assert.closeTo(numAttr(bar0, "x") + numAttr(bar0, "width") / 2, xScale.scale(bar0X) - off, 0.01, "x pos correct for bar0");
+            assert.closeTo(numAttr(bar1, "x") + numAttr(bar1, "width") / 2, xScale.scale(bar1X) - off, 0.01, "x pos correct for bar1");
+            assert.closeTo(numAttr(bar2, "x") + numAttr(bar2, "width") / 2, xScale.scale(bar2X) + off, 0.01, "x pos correct for bar2");
+            assert.closeTo(numAttr(bar3, "x") + numAttr(bar3, "width") / 2, xScale.scale(bar3X) + off, 0.01, "x pos correct for bar3");
             assert.deepEqual(dataset1.data(), originalData1, "underlying data is not modified");
             assert.deepEqual(dataset2.data(), originalData2, "underlying data is not modified");
             svg.remove();
@@ -3890,7 +3891,8 @@ describe("Plots", function () {
             assert.closeTo(numAttr(bar2, "height"), (400 - axisHeight), 0.01, "height is correct for bar2");
             assert.closeTo(numAttr(bar3, "height"), (400 - axisHeight) / 2, 0.01, "height is correct for bar3");
             // check that clustering is correct
-            var off = renderer._makeInnerScale().scale("_0");
+            var innerScale = renderer._makeInnerScale();
+            var off = innerScale.scale("_0") - innerScale.rangeBand() / 2;
             assert.closeTo(numAttr(bar0, "x"), xScale.scale(bar0X) - width / 2 - off, 0.1, "x pos correct for bar0");
             assert.closeTo(numAttr(bar1, "x"), xScale.scale(bar1X) - width / 2 - off, 0.1, "x pos correct for bar1");
             assert.closeTo(numAttr(bar2, "x"), xScale.scale(bar2X) - width / 2 + off, 0.1, "x pos correct for bar2");
@@ -3958,11 +3960,12 @@ describe("Plots", function () {
             var bar2Y = bar2.data()[0].y;
             var bar3Y = bar3.data()[0].y;
             // check that clustering is correct
-            var off = renderer._makeInnerScale().scale("_0");
-            assert.closeTo(numAttr(bar0, "y") + numAttr(bar0, "height") / 2, yScale.scale(bar0Y) + bandWidth / 2 - off, 0.01, "y pos correct for bar0");
-            assert.closeTo(numAttr(bar1, "y") + numAttr(bar1, "height") / 2, yScale.scale(bar1Y) + bandWidth / 2 - off, 0.01, "y pos correct for bar1");
-            assert.closeTo(numAttr(bar2, "y") + numAttr(bar2, "height") / 2, yScale.scale(bar2Y) + bandWidth / 2 + off, 0.01, "y pos correct for bar2");
-            assert.closeTo(numAttr(bar3, "y") + numAttr(bar3, "height") / 2, yScale.scale(bar3Y) + bandWidth / 2 + off, 0.01, "y pos correct for bar3");
+            var innerScale = renderer._makeInnerScale();
+            var off = innerScale.scale("_0") - innerScale.rangeBand() / 2;
+            assert.closeTo(numAttr(bar0, "y") + numAttr(bar0, "height") / 2, yScale.scale(bar0Y) - off, 0.01, "y pos correct for bar0");
+            assert.closeTo(numAttr(bar1, "y") + numAttr(bar1, "height") / 2, yScale.scale(bar1Y) - off, 0.01, "y pos correct for bar1");
+            assert.closeTo(numAttr(bar2, "y") + numAttr(bar2, "height") / 2, yScale.scale(bar2Y) + off, 0.01, "y pos correct for bar2");
+            assert.closeTo(numAttr(bar3, "y") + numAttr(bar3, "height") / 2, yScale.scale(bar3Y) + off, 0.01, "y pos correct for bar3");
             svg.remove();
         });
     });


### PR DESCRIPTION
After thinking about Ordinal Scales, it seems to be this:

Bands mode is useful for certain situations, and points mode is useful for certain situation.  However, bands mode scales the domain value to the start of the band, when interacting with the band usually makes more sense when the value is set to the center of the band.  Thus, we need to make a decision.  Does it make more sense for the default to scale to the center of the band (more work for placing the band) or does it make more sense to default to the start of the band (more work for interacting with the band).  Either way, another issue is that regardless of which we choose, we have to think about an easy way to do the other.

The next step of the revamp is likely to hide away setting the rangeType from the user.  We should either hide or show what happens to the scale and right now it seems that scales should be mostly hidden, only exposed to show connections between components.  In this case, we should have components that use an ordinal scale to explicitly set the rangeType as well as possibly the padding values on them explicity.  This is the next step.