### PR TITLE
[Drawer] - removing instance methods from constructor

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -3086,7 +3086,7 @@ var Plottable;
             function Rect(key, isVertical) {
                 _super.call(this, key);
                 this._labelsTooWide = false;
-                this.svgElement("rect");
+                this._svgElement = "rect";
                 this._isVertical = isVertical;
             }
             Rect.prototype.setup = function (area) {

--- a/src/drawers/rectDrawer.ts
+++ b/src/drawers/rectDrawer.ts
@@ -13,7 +13,7 @@ export module _Drawer {
 
     constructor(key: string, isVertical: boolean) {
       super(key);
-      this.svgElement("rect");
+      this._svgElement = "rect";
       this._isVertical = isVertical;
     }
 


### PR DESCRIPTION
Changing the instance function call to the simpler setter