### PR TITLE
[BarPlot] - Remove checking if data is invalid for barPixelWidth

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -7010,14 +7010,6 @@ var Plottable;
                 }
                 else {
                     var barAccessor = this._isVertical ? this._projections["x"].accessor : this._projections["y"].accessor;
-                    var barAccessorData = d3.set(Plottable._Util.Methods.flatten(this._datasetKeysInOrder.map(function (k) {
-                        var dataset = _this._key2PlotDatasetKey.get(k).dataset;
-                        var plotMetadata = _this._key2PlotDatasetKey.get(k).plotMetadata;
-                        return dataset.data().map(function (d, i) { return barAccessor(d, i, dataset.metadata(), plotMetadata); });
-                    }))).values();
-                    if (barAccessorData.some(function (datum) { return datum === "undefined"; })) {
-                        return -1;
-                    }
                     var numberBarAccessorData = d3.set(Plottable._Util.Methods.flatten(this._datasetKeysInOrder.map(function (k) {
                         var dataset = _this._key2PlotDatasetKey.get(k).dataset;
                         var plotMetadata = _this._key2PlotDatasetKey.get(k).plotMetadata;

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -375,14 +375,6 @@ export module Plot {
       } else {
         var barAccessor = this._isVertical ? this._projections["x"].accessor : this._projections["y"].accessor;
 
-        var barAccessorData = d3.set(_Util.Methods.flatten(this._datasetKeysInOrder.map((k) => {
-          var dataset = this._key2PlotDatasetKey.get(k).dataset;
-          var plotMetadata = this._key2PlotDatasetKey.get(k).plotMetadata;
-          return dataset.data().map((d, i) => barAccessor(d, i, dataset.metadata(), plotMetadata));
-        }))).values();
-
-        if (barAccessorData.some((datum) => datum === "undefined")) { return -1; }
-
         var numberBarAccessorData = d3.set(_Util.Methods.flatten(this._datasetKeysInOrder.map((k) => {
           var dataset = this._key2PlotDatasetKey.get(k).dataset;
           var plotMetadata = this._key2PlotDatasetKey.get(k).plotMetadata;


### PR DESCRIPTION
This needed to exist before since we needed to guard for default accessors being invalid.  This is no longer the case, so this somewhat hefty computation can be removed.

QE: We probably want to regression pass over this for specifically bar charts.