### PR TITLE
[OrdinalScale] - Cleaning up the constructor

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -2240,16 +2240,14 @@ var Plottable;
              * @constructor
              */
             function Ordinal(scale) {
-                _super.call(this, scale == null ? d3.scale.ordinal() : scale);
+                if (scale === void 0) { scale = d3.scale.ordinal(); }
+                _super.call(this, scale);
                 this._range = [0, 1];
                 this._rangeType = "bands";
                 // Padding as a proportion of the spacing between domain values
                 this._innerPadding = 0.3;
                 this._outerPadding = 0.5;
                 this._typeCoercer = function (d) { return d != null && d.toString ? d.toString() : d; };
-                if (this._innerPadding > this._outerPadding) {
-                    throw new Error("outerPadding must be >= innerPadding so cat axis bands work out reasonably");
-                }
             }
             Ordinal.prototype._getExtent = function () {
                 var extents = this._getAllExtents();

--- a/src/scales/ordinalScale.ts
+++ b/src/scales/ordinalScale.ts
@@ -20,11 +20,8 @@ export module Scale {
      *
      * @constructor
      */
-    constructor(scale?: D3.Scale.OrdinalScale) {
-      super(scale == null ? d3.scale.ordinal() : scale);
-      if (this._innerPadding > this._outerPadding) {
-        throw new Error("outerPadding must be >= innerPadding so cat axis bands work out reasonably");
-      }
+    constructor(scale: D3.Scale.OrdinalScale = d3.scale.ordinal()) {
+      super(scale);
     }
 
     protected _getExtent(): string[] {


### PR DESCRIPTION
The error doesn't make too much sense since we don't have a capability to set the innerPadding/outerPadding before this is called in the first place.  Also moving the scale validation to have a default paramter