### PR TITLE
Convert Dispatcher.Mouse to a <svg>-wide Dispatcher.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3435,8 +3435,15 @@ declare module Plottable {
 declare module Plottable {
     module Dispatcher {
         class Mouse {
-            static dispatcherKey: string;
             broadcaster: Core.Broadcaster;
+            /**
+             * Get a Dispatcher.Mouse for the <svg> containing elem. If one already exists
+             * on that <svg>, it will be returned; otherwise, a new one will be created.
+             *
+             * @param {SVGElement} elem A svg DOM element.
+             * @return {Dispatcher.Mouse} A Dispatcher.Mouse
+             */
+            static getDispatcher(elem: SVGElement): Dispatcher.Mouse;
             /**
              * Creates a Dispatcher.Mouse.
              * This constructor not be invoked directly under most circumstances.
@@ -3445,14 +3452,17 @@ declare module Plottable {
              */
             constructor(svg: SVGElement);
             /**
-             * Get a Dispatcher.Mouse for the <svg> containing elem. If one already exists
-             * on that <svg>, it will be returned; otherwise, a new one will be created.
+             * Registers a callback to be called whenever the mouse position changes,
+             * or removes the callback if `null` is passed as the callback.
              *
-             * @param {SVGElement} elem A svg DOM element.
-             *
-             * @return {Dispatcher.Mouse} A Dispatcher.Mouse
+             * @param {any} key The key associated with the callback.
+             *                  Key uniqueness is determined by deep equality.
+             * @param {(p: Point) => any} callback A callback that takes the pixel position
+             *                                     in svg-coordinate-space. Pass `null`
+             *                                     to remove a callback.
+             * @return {Dispatcher.Mouse} The calling Dispatcher.Mouse.
              */
-            static getDispatcher(elem: SVGElement): Dispatcher.Mouse;
+            onMouseMove(key: any, callback: (p: Point) => any): Mouse;
             /**
              * Returns the last computed mouse position.
              *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -272,6 +272,7 @@ declare module Plottable {
             function translate(s: D3.Selection, x?: number, y?: number): any;
             function boxesOverlap(boxA: ClientRect, boxB: ClientRect): boolean;
             function boxIsInside(inner: ClientRect, outer: ClientRect): boolean;
+            function getBoundingSVG(elem: SVGElement): SVGElement;
         }
     }
 }
@@ -3433,55 +3434,31 @@ declare module Plottable {
 
 declare module Plottable {
     module Dispatcher {
-        class Mouse extends Dispatcher.AbstractDispatcher {
+        class Mouse {
+            static dispatcherKey: string;
+            broadcaster: Core.Broadcaster;
             /**
-             * Constructs a Mouse Dispatcher with the specified target.
+             * Creates a Dispatcher.Mouse.
+             * This constructor not be invoked directly under most circumstances.
              *
-             * @param {D3.Selection} target The selection to listen for events on.
+             * @param {SVGElement} svg The root <svg> element to attach to.
              */
-            constructor(target: D3.Selection);
+            constructor(svg: SVGElement);
             /**
-             * Gets the current callback to be called on mouseover.
+             * Get a Dispatcher.Mouse for the <svg> containing elem. If one already exists
+             * on that <svg>, it will be returned; otherwise, a new one will be created.
              *
-             * @return {(location: Point) => any} The current mouseover callback.
+             * @param {SVGElement} elem A svg DOM element.
+             *
+             * @return {Dispatcher.Mouse} A Dispatcher.Mouse
              */
-            mouseover(): (location: Point) => any;
+            static getDispatcher(elem: SVGElement): Dispatcher.Mouse;
             /**
-             * Attaches a callback to be called on mouseover.
+             * Returns the last computed mouse position.
              *
-             * @param {(location: Point) => any} callback A function that takes the pixel position of the mouse event.
-             *                                            Pass in null to remove the callback.
-             * @return {Mouse} The calling Mouse Handler.
+             * @return {Point} The last known mouse position in <svg> coordinate space.
              */
-            mouseover(callback: (location: Point) => any): Mouse;
-            /**
-             * Gets the current callback to be called on mousemove.
-             *
-             * @return {(location: Point) => any} The current mousemove callback.
-             */
-            mousemove(): (location: Point) => any;
-            /**
-             * Attaches a callback to be called on mousemove.
-             *
-             * @param {(location: Point) => any} callback A function that takes the pixel position of the mouse event.
-             *                                            Pass in null to remove the callback.
-             * @return {Mouse} The calling Mouse Handler.
-             */
-            mousemove(callback: (location: Point) => any): Mouse;
-            /**
-             * Gets the current callback to be called on mouseout.
-             *
-             * @return {(location: Point) => any} The current mouseout callback.
-             */
-            mouseout(): (location: Point) => any;
-            /**
-             * Attaches a callback to be called on mouseout.
-             *
-             * @param {(location: Point) => any} callback A function that takes the pixel position of the mouse event.
-             *                                            Pass in null to remove the callback.
-             * @return {Mouse} The calling Mouse Handler.
-             */
-            mouseout(callback: (location: Point) => any): Mouse;
+            getLastMousePosition(): Point;
         }
     }
 }
@@ -3530,6 +3507,22 @@ declare module Plottable {
             protected _hitBox: D3.Selection;
             protected _componentToListenTo: Component.AbstractComponent;
             _anchor(component: Component.AbstractComponent, hitBox: D3.Selection): void;
+            /**
+             * Translates an <svg>-coordinate-space point to Component-space coordinates.
+             *
+             * @param {Point} p A Point in <svg>-space coordinates.
+             *
+             * @return {Point} The same location in Component-space coordinates.
+             */
+            protected _translateToComponentSpace(p: Point): Point;
+            /**
+             * Checks whether a Component-coordinate-space Point is inside the Component.
+             *
+             * @param {Point} p A Point in Coordinate-space coordinates.
+             *
+             * @return {boolean} Whether or not the point is inside the Component.
+             */
+            protected _isInsideComponent(p: Point): boolean;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -8526,10 +8526,10 @@ var Plottable;
              */
             Mouse.getDispatcher = function (elem) {
                 var svg = Plottable._Util.DOM.getBoundingSVG(elem);
-                var dispatcher = svg[Mouse.dispatcherKey];
+                var dispatcher = svg[Mouse._DISPATCHER_KEY];
                 if (dispatcher == null) {
                     dispatcher = new Mouse(svg);
-                    svg[Mouse.dispatcherKey] = dispatcher;
+                    svg[Mouse._DISPATCHER_KEY] = dispatcher;
                 }
                 return dispatcher;
             };
@@ -8557,7 +8557,7 @@ var Plottable;
                 return this;
             };
             Mouse.prototype._processMoveEvent = function (e) {
-                this._computeMousePosition(e.clientX, e.clientY);
+                this._lastMousePosition = this._computeMousePosition(e.clientX, e.clientY);
                 this.broadcaster.broadcast();
             };
             /**
@@ -8569,13 +8569,14 @@ var Plottable;
                 this._measureRect.setAttribute("y", "0");
                 var mrBCR = this._measureRect.getBoundingClientRect();
                 var origin = { x: mrBCR.left, y: mrBCR.top };
-                // caculate the scale
-                this._measureRect.setAttribute("x", "100");
-                this._measureRect.setAttribute("y", "100");
+                // calculate the scale
+                var sampleDistance = 100;
+                this._measureRect.setAttribute("x", String(sampleDistance));
+                this._measureRect.setAttribute("y", String(sampleDistance));
                 mrBCR = this._measureRect.getBoundingClientRect();
                 var testPoint = { x: mrBCR.left, y: mrBCR.top };
-                var scaleX = (testPoint.x - origin.x) / 100;
-                var scaleY = (testPoint.y - origin.y) / 100;
+                var scaleX = (testPoint.x - origin.x) / sampleDistance;
+                var scaleY = (testPoint.y - origin.y) / sampleDistance;
                 // get the true cursor position
                 this._measureRect.setAttribute("x", String((clientX - origin.x) / scaleX));
                 this._measureRect.setAttribute("y", String((clientY - origin.y) / scaleY));
@@ -8585,7 +8586,7 @@ var Plottable;
                     x: (trueCursorPosition.x - origin.x) / scaleX,
                     y: (trueCursorPosition.y - origin.y) / scaleY
                 };
-                this._lastMousePosition = scaledPosition;
+                return scaledPosition;
             };
             /**
              * Returns the last computed mouse position.
@@ -8595,7 +8596,7 @@ var Plottable;
             Mouse.prototype.getLastMousePosition = function () {
                 return this._lastMousePosition;
             };
-            Mouse.dispatcherKey = "__Plottable_Dispatcher_Mouse";
+            Mouse._DISPATCHER_KEY = "__Plottable_Dispatcher_Mouse";
             return Mouse;
         })();
         Dispatcher.Mouse = Mouse;

--- a/src/dispatchers/mouseDispatcher.ts
+++ b/src/dispatchers/mouseDispatcher.ts
@@ -3,7 +3,7 @@
 module Plottable {
 export module Dispatcher {
   export class Mouse {
-    private static dispatcherKey = "__Plottable_Dispatcher_Mouse";
+    private static _DISPATCHER_KEY = "__Plottable_Dispatcher_Mouse";
     private _svg: SVGElement;
     private _measureRect: SVGElement;
     private _lastMousePosition: Point;
@@ -19,10 +19,10 @@ export module Dispatcher {
     public static getDispatcher(elem: SVGElement): Dispatcher.Mouse {
       var svg = _Util.DOM.getBoundingSVG(elem);
 
-      var dispatcher: Mouse = (<any> svg)[Mouse.dispatcherKey];
+      var dispatcher: Mouse = (<any> svg)[Mouse._DISPATCHER_KEY];
       if (dispatcher == null) {
         dispatcher = new Mouse(svg);
-        (<any> svg)[Mouse.dispatcherKey] = dispatcher;
+        (<any> svg)[Mouse._DISPATCHER_KEY] = dispatcher;
       }
       return dispatcher;
     }
@@ -71,7 +71,7 @@ export module Dispatcher {
     }
 
     private _processMoveEvent(e: MouseEvent) {
-      this._computeMousePosition(e.clientX, e.clientY);
+      this._lastMousePosition = this._computeMousePosition(e.clientX, e.clientY);
       this.broadcaster.broadcast();
     }
 
@@ -85,14 +85,15 @@ export module Dispatcher {
       var mrBCR = this._measureRect.getBoundingClientRect();
       var origin = { x: mrBCR.left, y: mrBCR.top };
 
-      // caculate the scale
-      this._measureRect.setAttribute("x", "100");
-      this._measureRect.setAttribute("y", "100");
+      // calculate the scale
+      var sampleDistance = 100;
+      this._measureRect.setAttribute("x", String(sampleDistance));
+      this._measureRect.setAttribute("y", String(sampleDistance));
       mrBCR = this._measureRect.getBoundingClientRect();
       var testPoint = { x: mrBCR.left, y: mrBCR.top };
 
-      var scaleX = (testPoint.x - origin.x) / 100;
-      var scaleY = (testPoint.y - origin.y) / 100;
+      var scaleX = (testPoint.x - origin.x) / sampleDistance;
+      var scaleY = (testPoint.y - origin.y) / sampleDistance;
 
       // get the true cursor position
       this._measureRect.setAttribute("x", String((clientX - origin.x)/scaleX) );
@@ -105,7 +106,7 @@ export module Dispatcher {
         y: (trueCursorPosition.y - origin.y) / scaleY
       };
 
-      this._lastMousePosition = scaledPosition;
+      return scaledPosition;
     }
 
     /**

--- a/src/dispatchers/mouseDispatcher.ts
+++ b/src/dispatchers/mouseDispatcher.ts
@@ -2,110 +2,96 @@
 
 module Plottable {
 export module Dispatcher {
-  export class Mouse extends Dispatcher.AbstractDispatcher {
-    private _mouseover: (location: Point) => any;
-    private _mousemove: (location: Point) => any;
-    private _mouseout: (location: Point) => any;
+  export class Mouse {
+    static dispatcherKey = "__Plottable_Dispatcher_Mouse";
+    private _svg: SVGElement;
+    private _measureRect: SVGElement;
+    private _lastMousePosition: Point;
+    public broadcaster: Core.Broadcaster;
 
     /**
-     * Constructs a Mouse Dispatcher with the specified target.
+     * Creates a Dispatcher.Mouse.
+     * This constructor not be invoked directly under most circumstances.
      *
-     * @param {D3.Selection} target The selection to listen for events on.
+     * @param {SVGElement} svg The root <svg> element to attach to.
      */
-    constructor(target: D3.Selection) {
-      super(target);
+    constructor(svg: SVGElement) {
+      this._svg = svg;
+      this._measureRect = <SVGElement> <any>document.createElementNS(svg.namespaceURI, "rect");
+      this._measureRect.setAttribute("class", "measure-rect");
+      this._measureRect.setAttribute("style", "opacity: 0;");
+      this._measureRect.setAttribute("width", "1");
+      this._measureRect.setAttribute("height", "1");
+      this._svg.appendChild(this._measureRect);
 
-      this._event2Callback["mouseover"] = () => {
-        if (this._mouseover != null) {
-          this._mouseover(this._getMousePosition());
-        }
+      this._lastMousePosition = { x: -1, y: -1 };
+      this.broadcaster = new Core.Broadcaster(this);
+
+      svg.addEventListener("mouseover", (e) => this._computeMousePosition(e.clientX, e.clientY));
+      svg.addEventListener("mousemove", (e) => this._computeMousePosition(e.clientX, e.clientY));
+      svg.addEventListener("mouseout", (e) => this._computeMousePosition(e.clientX, e.clientY));
+    }
+
+    /**
+     * Computes the mouse position relative to the <svg> in svg-coordinate-space.
+     */
+    private _computeMousePosition(clientX: number, clientY: number) {
+      // get the origin
+      this._measureRect.setAttribute("x", "0");
+      this._measureRect.setAttribute("y", "0");
+      var mrBCR = this._measureRect.getBoundingClientRect();
+      var origin = { x: mrBCR.left, y: mrBCR.top };
+
+      // caculate the scale
+      this._measureRect.setAttribute("x", "100");
+      this._measureRect.setAttribute("y", "100");
+      mrBCR = this._measureRect.getBoundingClientRect();
+      var testPoint = { x: mrBCR.left, y: mrBCR.top };
+
+      var scaleX = (testPoint.x - origin.x) / 100;
+      var scaleY = (testPoint.y - origin.y) / 100;
+
+      // get the true cursor position
+      this._measureRect.setAttribute("x", String((clientX - origin.x)/scaleX) );
+      this._measureRect.setAttribute("y", String((clientY - origin.y)/scaleY) );
+      mrBCR = this._measureRect.getBoundingClientRect();
+      var trueCursorPosition = { x: mrBCR.left, y: mrBCR.top };
+
+      var scaledPosition = {
+        x: (trueCursorPosition.x - origin.x) / scaleX,
+        y: (trueCursorPosition.y - origin.y) / scaleY
       };
 
-      this._event2Callback["mousemove"] = () => {
-        if (this._mousemove != null) {
-          this._mousemove(this._getMousePosition());
-        }
-      };
-
-      this._event2Callback["mouseout"] = () => {
-        if (this._mouseout != null) {
-          this._mouseout(this._getMousePosition());
-        }
-      };
-    }
-
-    private _getMousePosition(): Point {
-      var xy = d3.mouse(this._target.node());
-      return {
-            x: xy[0],
-            y: xy[1]
-          };
+      this._lastMousePosition = scaledPosition;
+      this.broadcaster.broadcast();
     }
 
     /**
-     * Gets the current callback to be called on mouseover.
+     * Get a Dispatcher.Mouse for the <svg> containing elem. If one already exists
+     * on that <svg>, it will be returned; otherwise, a new one will be created.
      *
-     * @return {(location: Point) => any} The current mouseover callback.
-     */
-    public mouseover(): (location: Point) => any;
-    /**
-     * Attaches a callback to be called on mouseover.
+     * @param {SVGElement} elem A svg DOM element.
      *
-     * @param {(location: Point) => any} callback A function that takes the pixel position of the mouse event.
-     *                                            Pass in null to remove the callback.
-     * @return {Mouse} The calling Mouse Handler.
+     * @return {Dispatcher.Mouse} A Dispatcher.Mouse
      */
-    public mouseover(callback: (location: Point) => any): Mouse;
-    public mouseover(callback?: (location: Point) => any): any {
-      if (callback === undefined) {
-        return this._mouseover;
+    public static getDispatcher(elem: SVGElement): Dispatcher.Mouse {
+      var svg = _Util.DOM.getBoundingSVG(elem);
+
+      var dispatcher: Mouse = (<any> svg)[Mouse.dispatcherKey];
+      if (dispatcher == null) {
+        dispatcher = new Mouse(svg);
+        (<any> svg)[Mouse.dispatcherKey] = dispatcher;
       }
-      this._mouseover = callback;
-      return this;
+      return dispatcher;
     }
 
     /**
-     * Gets the current callback to be called on mousemove.
+     * Returns the last computed mouse position.
      *
-     * @return {(location: Point) => any} The current mousemove callback.
+     * @return {Point} The last known mouse position in <svg> coordinate space.
      */
-    public mousemove(): (location: Point) => any;
-    /**
-     * Attaches a callback to be called on mousemove.
-     *
-     * @param {(location: Point) => any} callback A function that takes the pixel position of the mouse event.
-     *                                            Pass in null to remove the callback.
-     * @return {Mouse} The calling Mouse Handler.
-     */
-    public mousemove(callback: (location: Point) => any): Mouse;
-    public mousemove(callback?: (location: Point) => any): any {
-      if (callback === undefined) {
-        return this._mousemove;
-      }
-      this._mousemove = callback;
-      return this;
-    }
-
-    /**
-     * Gets the current callback to be called on mouseout.
-     *
-     * @return {(location: Point) => any} The current mouseout callback.
-     */
-    public mouseout(): (location: Point) => any;
-    /**
-     * Attaches a callback to be called on mouseout.
-     *
-     * @param {(location: Point) => any} callback A function that takes the pixel position of the mouse event.
-     *                                            Pass in null to remove the callback.
-     * @return {Mouse} The calling Mouse Handler.
-     */
-    public mouseout(callback: (location: Point) => any): Mouse;
-    public mouseout(callback?: (location: Point) => any): any {
-      if (callback === undefined) {
-        return this._mouseout;
-      }
-      this._mouseout = callback;
-      return this;
+    public getLastMousePosition() {
+      return this._lastMousePosition;
     }
   }
 }

--- a/src/interactions/abstractInteraction.ts
+++ b/src/interactions/abstractInteraction.ts
@@ -17,6 +17,34 @@ export module Interaction {
       this._componentToListenTo = component;
       this._hitBox = hitBox;
     }
+
+    /**
+     * Translates an <svg>-coordinate-space point to Component-space coordinates.
+     *
+     * @param {Point} p A Point in <svg>-space coordinates.
+     *
+     * @return {Point} The same location in Component-space coordinates.
+     */
+    protected _translateToComponentSpace(p: Point): Point {
+      var origin = this._componentToListenTo.originToSVG();
+      return {
+        x: p.x - origin.x,
+        y: p.y - origin.y
+      };
+    }
+
+    /**
+     * Checks whether a Component-coordinate-space Point is inside the Component.
+     *
+     * @param {Point} p A Point in Coordinate-space coordinates.
+     *
+     * @return {boolean} Whether or not the point is inside the Component.
+     */
+    protected _isInsideComponent(p: Point) {
+      return 0 <= p.x && 0 <= p.y
+             && p.x <= this._componentToListenTo.width()
+             && p.y <= this._componentToListenTo.height();
+    }
   }
 }
 }

--- a/src/interactions/hoverInteraction.ts
+++ b/src/interactions/hoverInteraction.ts
@@ -48,7 +48,7 @@ export module Interaction {
       super._anchor(component, hitBox);
       this._dispatcher = Dispatcher.Mouse.getDispatcher(<SVGElement> (<any> this._componentToListenTo)._element.node());
 
-      this._dispatcher.onMouseMove("hover"+this.getID(), (p: Point) => this._handleMouseEvent(p));
+      this._dispatcher.onMouseMove("hover" + this.getID(), (p: Point) => this._handleMouseEvent(p));
     }
 
     private _handleMouseEvent(p: Point) {

--- a/src/interactions/hoverInteraction.ts
+++ b/src/interactions/hoverInteraction.ts
@@ -48,12 +48,11 @@ export module Interaction {
       super._anchor(component, hitBox);
       this._dispatcher = Dispatcher.Mouse.getDispatcher(<SVGElement> (<any> this._componentToListenTo)._element.node());
 
-      this._dispatcher.broadcaster.registerListener("hover"+this.getID(), () => this._handleMouseEvent());
+      this._dispatcher.onMouseMove("hover"+this.getID(), (p: Point) => this._handleMouseEvent(p));
     }
 
-    private _handleMouseEvent() {
-      var p = this._translateToComponentSpace(this._dispatcher.getLastMousePosition());
-
+    private _handleMouseEvent(p: Point) {
+      p = this._translateToComponentSpace(p);
       if (this._isInsideComponent(p)) {
         if (!this._overComponent) {
           this._componentToListenTo._hoverOverComponent(p);

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -116,6 +116,17 @@ export module _Util {
         Math.floor(inner.bottom) <= Math.ceil(outer.bottom)
       );
     }
+
+    export function getBoundingSVG(elem: SVGElement): SVGElement {
+      var ownerSVG = elem.ownerSVGElement;
+      if (ownerSVG != null) {
+        return ownerSVG;
+      }
+      if (elem.nodeName.toLowerCase() === "svg") { // elem itself is an SVG
+        return elem;
+      }
+      return null; // not in the DOM
+    }
   }
 }
 }

--- a/test/dispatchers/dispatcherTests.ts
+++ b/test/dispatchers/dispatcherTests.ts
@@ -80,8 +80,34 @@ describe("Dispatchers", () => {
   });
 
   describe("Mouse Dispatcher", () => {
-    it("passes event position to mouseover, mousemove, and mouseout callbacks", () => {
-      var target = generateSVG();
+    it("getDispatcher() creates only one Dispatcher.Mouse per <svg>", () => {
+      var svg = generateSVG();
+
+      var md1 = Plottable.Dispatcher.Mouse.getDispatcher(<SVGElement> svg.node());
+      assert.isNotNull(md1, "created a new Dispatcher on an SVG");
+      var md2 = Plottable.Dispatcher.Mouse.getDispatcher(<SVGElement> svg.node());
+      assert.strictEqual(md1, md2, "returned the existing Dispatcher if called again with same <svg>");
+
+      svg.remove();
+    });
+
+    it("getLastMousePosition() defaults to a safe value", () => {
+      var svg = generateSVG();
+
+      var md = Plottable.Dispatcher.Mouse.getDispatcher(<SVGElement> svg.node());
+      var p = md.getLastMousePosition();
+      assert.isNotNull(p, "returns a value after initialization");
+      assert.isNotNull(p.x, "x value is set");
+      assert.isNotNull(p.y, "y value is set");
+
+      svg.remove();
+    });
+
+    it("broadcasts on mouseover, mousemove, and mouseout", () => {
+      var targetWidth = 400, targetHeight = 400;
+      var target = generateSVG(targetWidth, targetHeight);
+      // HACKHACK: PhantomJS can't measure SVGs unless they have something in them occupying space
+      target.append("rect").attr("width", targetWidth).attr("height", targetHeight);
 
       var targetX = 17;
       var targetY = 76;
@@ -95,30 +121,24 @@ describe("Dispatchers", () => {
         assert.closeTo(actual.y, expected.y, epsilon, message + " (y)");
       };
 
-      var md = new Plottable.Dispatcher.Mouse(target);
-      var mouseoverCalled = false;
-      md.mouseover((p: Plottable.Point) => {
-        mouseoverCalled = true;
-        assertPointsClose(p, expectedPoint, 0.5, "the mouse position was passed to the callback");
-      });
-      var mousemoveCalled = false;
-      md.mousemove((p: Plottable.Point) => {
-        mousemoveCalled = true;
-        assertPointsClose(p, expectedPoint, 0.5, "the mouse position was passed to the callback");
-      });
-      var mouseoutCalled = false;
-      md.mouseout((p: Plottable.Point) => {
-        mouseoutCalled = true;
-        assertPointsClose(p, expectedPoint, 0.5, "the mouse position was passed to the callback");
-      });
+      var md = Plottable.Dispatcher.Mouse.getDispatcher(<SVGElement> target.node());
 
-      md.connect();
+      var callbackWasCalled = false;
+      var callback = function(mse: Plottable.Dispatcher.Mouse) {
+        callbackWasCalled = true;
+        assertPointsClose(mse.getLastMousePosition(), expectedPoint, 0.5, "mouse position is correct");
+      };
+
+      md.broadcaster.registerListener("unit test", callback);
+
       triggerFakeMouseEvent("mouseover", target, targetX, targetY);
-      assert.isTrue(mouseoverCalled, "mouseover callback was called");
+      assert.isTrue(callbackWasCalled, "callback was called on mouseover");
+      callbackWasCalled = false;
       triggerFakeMouseEvent("mousemove", target, targetX, targetY);
-      assert.isTrue(mousemoveCalled, "mousemove callback was called");
+      assert.isTrue(callbackWasCalled, "callback was called on mousemove");
+      callbackWasCalled = false;
       triggerFakeMouseEvent("mouseout", target, targetX, targetY);
-      assert.isTrue(mouseoutCalled, "mouseout callback was called");
+      assert.isTrue(callbackWasCalled, "callback was called on mouseout");
 
       target.remove();
     });

--- a/test/dispatchers/dispatcherTests.ts
+++ b/test/dispatchers/dispatcherTests.ts
@@ -91,7 +91,7 @@ describe("Dispatchers", () => {
       svg.remove();
     });
 
-    it("getLastMousePosition() defaults to a safe value", () => {
+    it("getLastMousePosition() defaults to a non-null value", () => {
       var svg = generateSVG();
 
       var md = Plottable.Dispatcher.Mouse.getDispatcher(<SVGElement> svg.node());

--- a/test/dispatchers/dispatcherTests.ts
+++ b/test/dispatchers/dispatcherTests.ts
@@ -103,7 +103,7 @@ describe("Dispatchers", () => {
       svg.remove();
     });
 
-    it("broadcasts on mouseover, mousemove, and mouseout", () => {
+    it("calls callbacks on mouseover, mousemove, and mouseout", () => {
       var targetWidth = 400, targetHeight = 400;
       var target = generateSVG(targetWidth, targetHeight);
       // HACKHACK: PhantomJS can't measure SVGs unless they have something in them occupying space
@@ -124,12 +124,12 @@ describe("Dispatchers", () => {
       var md = Plottable.Dispatcher.Mouse.getDispatcher(<SVGElement> target.node());
 
       var callbackWasCalled = false;
-      var callback = function(mse: Plottable.Dispatcher.Mouse) {
+      var callback = function(p: Plottable.Point) {
         callbackWasCalled = true;
-        assertPointsClose(mse.getLastMousePosition(), expectedPoint, 0.5, "mouse position is correct");
+        assertPointsClose(p, expectedPoint, 0.5, "mouse position is correct");
       };
 
-      md.broadcaster.registerListener("unit test", callback);
+      md.onMouseMove("unit test", callback);
 
       triggerFakeMouseEvent("mouseover", target, targetX, targetY);
       assert.isTrue(callbackWasCalled, "callback was called on mouseover");
@@ -139,6 +139,34 @@ describe("Dispatchers", () => {
       callbackWasCalled = false;
       triggerFakeMouseEvent("mouseout", target, targetX, targetY);
       assert.isTrue(callbackWasCalled, "callback was called on mouseout");
+
+      target.remove();
+    });
+
+    it("can remove callbacks by passing null", () => {
+      var targetWidth = 400, targetHeight = 400;
+      var target = generateSVG(targetWidth, targetHeight);
+      // HACKHACK: PhantomJS can't measure SVGs unless they have something in them occupying space
+      target.append("rect").attr("width", targetWidth).attr("height", targetHeight);
+
+      var targetX = 17;
+      var targetY = 76;
+
+      var md = Plottable.Dispatcher.Mouse.getDispatcher(<SVGElement> target.node());
+
+      var callbackWasCalled = false;
+      var callback = function(p: Plottable.Point) {
+        callbackWasCalled = true;
+      };
+
+      var keyString = "callbackTest";
+      md.onMouseMove(keyString, callback);
+      triggerFakeMouseEvent("mousemove", target, targetX, targetY);
+      assert.isTrue(callbackWasCalled, "callback was called on mousemove");
+      callbackWasCalled = false;
+      md.onMouseMove(keyString, null);
+      triggerFakeMouseEvent("mousemove", target, targetX, targetY);
+      assert.isFalse(callbackWasCalled, "callback was not called after blanking");
 
       target.remove();
     });

--- a/test/interactions/hoverInteractionTests.ts
+++ b/test/interactions/hoverInteractionTests.ts
@@ -90,7 +90,7 @@ describe("Interactions", () => {
       assert.deepEqual(overData.data, ["right"],
                         "onHoverOver was called with the new data only (left --> center)");
 
-      triggerFakeMouseEvent("mouseout", hitbox, 400, 200);
+      triggerFakeMouseEvent("mouseout", hitbox, 401, 200);
       overCallbackCalled = false;
       triggerFakeMouseEvent("mouseover", hitbox, 200, 200);
       assert.deepEqual(overData.pixelPositions, [testTarget.leftPoint, testTarget.rightPoint],
@@ -117,7 +117,7 @@ describe("Interactions", () => {
                         "onHoverOut was called with the correct data (center --> right)");
 
       outCallbackCalled = false;
-      triggerFakeMouseEvent("mouseout", hitbox, 400, 200);
+      triggerFakeMouseEvent("mouseout", hitbox, 401, 200);
       assert.isTrue(outCallbackCalled, "onHoverOut is called on mousing out of the Component");
       assert.deepEqual(outData.pixelPositions, [testTarget.rightPoint],
                         "onHoverOut was called with the correct pixel position");
@@ -125,7 +125,7 @@ describe("Interactions", () => {
 
       outCallbackCalled = false;
       triggerFakeMouseEvent("mouseover", hitbox, 200, 200);
-      triggerFakeMouseEvent("mouseout", hitbox, 200, 400);
+      triggerFakeMouseEvent("mouseout", hitbox, 200, 401);
       assert.deepEqual(outData.pixelPositions, [testTarget.leftPoint, testTarget.rightPoint],
                         "onHoverOut was called with the correct pixel positions");
       assert.deepEqual(outData.data, ["left", "right"], "onHoverOut is called with the correct data");
@@ -148,7 +148,7 @@ describe("Interactions", () => {
       assert.deepEqual(currentlyHovered.data, ["left", "right"],
                        "retrieves data corresponding to the current position");
 
-      triggerFakeMouseEvent("mouseout", hitbox, 400, 200);
+      triggerFakeMouseEvent("mouseout", hitbox, 401, 200);
       currentlyHovered = hoverInteraction.getCurrentHoverData();
       assert.isNull(currentlyHovered.data, "returns null if not currently hovering");
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -7277,7 +7277,7 @@ describe("Interactions", function () {
             assert.isTrue(overCallbackCalled, "onHoverOver was called when mousing into a new region");
             assert.deepEqual(overData.pixelPositions, [testTarget.rightPoint], "onHoverOver was called with the correct pixel position (left --> center)");
             assert.deepEqual(overData.data, ["right"], "onHoverOver was called with the new data only (left --> center)");
-            triggerFakeMouseEvent("mouseout", hitbox, 400, 200);
+            triggerFakeMouseEvent("mouseout", hitbox, 401, 200);
             overCallbackCalled = false;
             triggerFakeMouseEvent("mouseover", hitbox, 200, 200);
             assert.deepEqual(overData.pixelPositions, [testTarget.leftPoint, testTarget.rightPoint], "onHoverOver was called with the correct pixel positions");
@@ -7295,13 +7295,13 @@ describe("Interactions", function () {
             assert.deepEqual(outData.pixelPositions, [testTarget.leftPoint], "onHoverOut was called with the correct pixel position (center --> right)");
             assert.deepEqual(outData.data, ["left"], "onHoverOut was called with the correct data (center --> right)");
             outCallbackCalled = false;
-            triggerFakeMouseEvent("mouseout", hitbox, 400, 200);
+            triggerFakeMouseEvent("mouseout", hitbox, 401, 200);
             assert.isTrue(outCallbackCalled, "onHoverOut is called on mousing out of the Component");
             assert.deepEqual(outData.pixelPositions, [testTarget.rightPoint], "onHoverOut was called with the correct pixel position");
             assert.deepEqual(outData.data, ["right"], "onHoverOut was called with the correct data");
             outCallbackCalled = false;
             triggerFakeMouseEvent("mouseover", hitbox, 200, 200);
-            triggerFakeMouseEvent("mouseout", hitbox, 200, 400);
+            triggerFakeMouseEvent("mouseout", hitbox, 200, 401);
             assert.deepEqual(outData.pixelPositions, [testTarget.leftPoint, testTarget.rightPoint], "onHoverOut was called with the correct pixel positions");
             assert.deepEqual(outData.data, ["left", "right"], "onHoverOut is called with the correct data");
             svg.remove();
@@ -7315,7 +7315,7 @@ describe("Interactions", function () {
             currentlyHovered = hoverInteraction.getCurrentHoverData();
             assert.deepEqual(currentlyHovered.pixelPositions, [testTarget.leftPoint, testTarget.rightPoint], "retrieves pixel positions corresponding to the current position");
             assert.deepEqual(currentlyHovered.data, ["left", "right"], "retrieves data corresponding to the current position");
-            triggerFakeMouseEvent("mouseout", hitbox, 400, 200);
+            triggerFakeMouseEvent("mouseout", hitbox, 401, 200);
             currentlyHovered = hoverInteraction.getCurrentHoverData();
             assert.isNull(currentlyHovered.data, "returns null if not currently hovering");
             svg.remove();
@@ -7385,8 +7385,28 @@ describe("Dispatchers", function () {
         target.remove();
     });
     describe("Mouse Dispatcher", function () {
-        it("passes event position to mouseover, mousemove, and mouseout callbacks", function () {
-            var target = generateSVG();
+        it("getDispatcher() creates only one Dispatcher.Mouse per <svg>", function () {
+            var svg = generateSVG();
+            var md1 = Plottable.Dispatcher.Mouse.getDispatcher(svg.node());
+            assert.isNotNull(md1, "created a new Dispatcher on an SVG");
+            var md2 = Plottable.Dispatcher.Mouse.getDispatcher(svg.node());
+            assert.strictEqual(md1, md2, "returned the existing Dispatcher if called again with same <svg>");
+            svg.remove();
+        });
+        it("getLastMousePosition() defaults to a safe value", function () {
+            var svg = generateSVG();
+            var md = Plottable.Dispatcher.Mouse.getDispatcher(svg.node());
+            var p = md.getLastMousePosition();
+            assert.isNotNull(p, "returns a value after initialization");
+            assert.isNotNull(p.x, "x value is set");
+            assert.isNotNull(p.y, "y value is set");
+            svg.remove();
+        });
+        it("broadcasts on mouseover, mousemove, and mouseout", function () {
+            var targetWidth = 400, targetHeight = 400;
+            var target = generateSVG(targetWidth, targetHeight);
+            // HACKHACK: PhantomJS can't measure SVGs unless they have something in them occupying space
+            target.append("rect").attr("width", targetWidth).attr("height", targetHeight);
             var targetX = 17;
             var targetY = 76;
             var expectedPoint = {
@@ -7398,29 +7418,21 @@ describe("Dispatchers", function () {
                 assert.closeTo(actual.y, expected.y, epsilon, message + " (y)");
             }
             ;
-            var md = new Plottable.Dispatcher.Mouse(target);
-            var mouseoverCalled = false;
-            md.mouseover(function (p) {
-                mouseoverCalled = true;
-                assertPointsClose(p, expectedPoint, 0.5, "the mouse position was passed to the callback");
-            });
-            var mousemoveCalled = false;
-            md.mousemove(function (p) {
-                mousemoveCalled = true;
-                assertPointsClose(p, expectedPoint, 0.5, "the mouse position was passed to the callback");
-            });
-            var mouseoutCalled = false;
-            md.mouseout(function (p) {
-                mouseoutCalled = true;
-                assertPointsClose(p, expectedPoint, 0.5, "the mouse position was passed to the callback");
-            });
-            md.connect();
+            var md = Plottable.Dispatcher.Mouse.getDispatcher(target.node());
+            var callbackWasCalled = false;
+            var callback = function (mse) {
+                callbackWasCalled = true;
+                assertPointsClose(mse.getLastMousePosition(), expectedPoint, 0.5, "mouse position is correct");
+            };
+            md.broadcaster.registerListener("unit test", callback);
             triggerFakeMouseEvent("mouseover", target, targetX, targetY);
-            assert.isTrue(mouseoverCalled, "mouseover callback was called");
+            assert.isTrue(callbackWasCalled, "callback was called on mouseover");
+            callbackWasCalled = false;
             triggerFakeMouseEvent("mousemove", target, targetX, targetY);
-            assert.isTrue(mousemoveCalled, "mousemove callback was called");
+            assert.isTrue(callbackWasCalled, "callback was called on mousemove");
+            callbackWasCalled = false;
             triggerFakeMouseEvent("mouseout", target, targetX, targetY);
-            assert.isTrue(mouseoutCalled, "mouseout callback was called");
+            assert.isTrue(callbackWasCalled, "callback was called on mouseout");
             target.remove();
         });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -7393,7 +7393,7 @@ describe("Dispatchers", function () {
             assert.strictEqual(md1, md2, "returned the existing Dispatcher if called again with same <svg>");
             svg.remove();
         });
-        it("getLastMousePosition() defaults to a safe value", function () {
+        it("getLastMousePosition() defaults to a non-null value", function () {
             var svg = generateSVG();
             var md = Plottable.Dispatcher.Mouse.getDispatcher(svg.node());
             var p = md.getLastMousePosition();

--- a/test/tests.js
+++ b/test/tests.js
@@ -7402,7 +7402,7 @@ describe("Dispatchers", function () {
             assert.isNotNull(p.y, "y value is set");
             svg.remove();
         });
-        it("broadcasts on mouseover, mousemove, and mouseout", function () {
+        it("calls callbacks on mouseover, mousemove, and mouseout", function () {
             var targetWidth = 400, targetHeight = 400;
             var target = generateSVG(targetWidth, targetHeight);
             // HACKHACK: PhantomJS can't measure SVGs unless they have something in them occupying space
@@ -7420,11 +7420,11 @@ describe("Dispatchers", function () {
             ;
             var md = Plottable.Dispatcher.Mouse.getDispatcher(target.node());
             var callbackWasCalled = false;
-            var callback = function (mse) {
+            var callback = function (p) {
                 callbackWasCalled = true;
-                assertPointsClose(mse.getLastMousePosition(), expectedPoint, 0.5, "mouse position is correct");
+                assertPointsClose(p, expectedPoint, 0.5, "mouse position is correct");
             };
-            md.broadcaster.registerListener("unit test", callback);
+            md.onMouseMove("unit test", callback);
             triggerFakeMouseEvent("mouseover", target, targetX, targetY);
             assert.isTrue(callbackWasCalled, "callback was called on mouseover");
             callbackWasCalled = false;
@@ -7433,6 +7433,28 @@ describe("Dispatchers", function () {
             callbackWasCalled = false;
             triggerFakeMouseEvent("mouseout", target, targetX, targetY);
             assert.isTrue(callbackWasCalled, "callback was called on mouseout");
+            target.remove();
+        });
+        it("can remove callbacks by passing null", function () {
+            var targetWidth = 400, targetHeight = 400;
+            var target = generateSVG(targetWidth, targetHeight);
+            // HACKHACK: PhantomJS can't measure SVGs unless they have something in them occupying space
+            target.append("rect").attr("width", targetWidth).attr("height", targetHeight);
+            var targetX = 17;
+            var targetY = 76;
+            var md = Plottable.Dispatcher.Mouse.getDispatcher(target.node());
+            var callbackWasCalled = false;
+            var callback = function (p) {
+                callbackWasCalled = true;
+            };
+            var keyString = "callbackTest";
+            md.onMouseMove(keyString, callback);
+            triggerFakeMouseEvent("mousemove", target, targetX, targetY);
+            assert.isTrue(callbackWasCalled, "callback was called on mousemove");
+            callbackWasCalled = false;
+            md.onMouseMove(keyString, null);
+            triggerFakeMouseEvent("mousemove", target, targetX, targetY);
+            assert.isFalse(callbackWasCalled, "callback was not called after blanking");
             target.remove();
         });
     });


### PR DESCRIPTION
Only one is created per \<svg\>.
Now detects mouse position by drawing a test rectangle,
which allows it to account for CSS zoom and the IE9 zoom bug (#1490).

AbstractDispatcher to follow.