### PR TITLE
[Legend] Add prefix to legend entry class names

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2325,6 +2325,10 @@ declare module Plottable {
              */
             static LEGEND_ENTRY_CLASS: string;
             /**
+             * The css class that prepends every legend entry
+             */
+            static LEGEND_ENTRY_PREFIX: string;
+            /**
              * Creates a Legend.
              *
              * The legend consists of a series of legend entries, each with a color and label taken from the `colorScale`.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2325,10 +2325,6 @@ declare module Plottable {
              */
             static LEGEND_ENTRY_CLASS: string;
             /**
-             * The css class that prepends every legend entry
-             */
-            static LEGEND_ENTRY_PREFIX: string;
-            /**
              * Creates a Legend.
              *
              * The legend consists of a series of legend entries, each with a color and label taken from the `colorScale`.

--- a/plottable.js
+++ b/plottable.js
@@ -5485,7 +5485,7 @@ var Plottable;
                 var entries = rows.selectAll("g." + Legend.LEGEND_ENTRY_CLASS).data(function (d) { return d; });
                 var entriesEnter = entries.enter().append("g").classed(Legend.LEGEND_ENTRY_CLASS, true);
                 entries.each(function (d) {
-                    d3.select(this).classed(d.replace(" ", "-"), true);
+                    d3.select(this).classed(Legend.LEGEND_ENTRY_PREFIX + d.replace(" ", "-"), true);
                 });
                 entriesEnter.append("circle");
                 entriesEnter.append("g").classed("text-container", true);
@@ -5526,6 +5526,10 @@ var Plottable;
              * The css class applied to each legend entry
              */
             Legend.LEGEND_ENTRY_CLASS = "legend-entry";
+            /**
+             * The css class that prepends every legend entry
+             */
+            Legend.LEGEND_ENTRY_PREFIX = "legend-item-";
             return Legend;
         })(Component.AbstractComponent);
         Component.Legend = Legend;

--- a/plottable.js
+++ b/plottable.js
@@ -5485,7 +5485,8 @@ var Plottable;
                 var entries = rows.selectAll("g." + Legend.LEGEND_ENTRY_CLASS).data(function (d) { return d; });
                 var entriesEnter = entries.enter().append("g").classed(Legend.LEGEND_ENTRY_CLASS, true);
                 entries.each(function (d) {
-                    d3.select(this).classed(Legend.LEGEND_ENTRY_PREFIX + d.replace(" ", "-"), true);
+                    var entryClass = [Legend.LEGEND_ENTRY_CLASS, d.replace(" ", "-")].join("-");
+                    d3.select(this).classed(entryClass, true);
                 });
                 entriesEnter.append("circle");
                 entriesEnter.append("g").classed("text-container", true);
@@ -5526,10 +5527,6 @@ var Plottable;
              * The css class applied to each legend entry
              */
             Legend.LEGEND_ENTRY_CLASS = "legend-entry";
-            /**
-             * The css class that prepends every legend entry
-             */
-            Legend.LEGEND_ENTRY_PREFIX = "legend-item-";
             return Legend;
         })(Component.AbstractComponent);
         Component.Legend = Legend;

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -11,10 +11,6 @@ export module Component {
      * The css class applied to each legend entry
      */
     public static LEGEND_ENTRY_CLASS = "legend-entry";
-    /**
-     * The css class that prepends every legend entry
-     */
-    public static LEGEND_ENTRY_PREFIX = "legend-item-";
 
     private _padding = 5;
     private _scale: Scale.Color;
@@ -256,7 +252,8 @@ export module Component {
       var entries = rows.selectAll("g." + Legend.LEGEND_ENTRY_CLASS).data((d) => d);
       var entriesEnter = entries.enter().append("g").classed(Legend.LEGEND_ENTRY_CLASS, true);
       entries.each(function(d: string) {
-        d3.select(this).classed(Legend.LEGEND_ENTRY_PREFIX + d.replace(" ", "-"), true);
+        var entryClass = [Legend.LEGEND_ENTRY_CLASS, d.replace(" ", "-")].join("-");
+        d3.select(this).classed(entryClass, true);
       });
       entriesEnter.append("circle");
       entriesEnter.append("g").classed("text-container", true);

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -11,6 +11,10 @@ export module Component {
      * The css class applied to each legend entry
      */
     public static LEGEND_ENTRY_CLASS = "legend-entry";
+    /**
+     * The css class that prepends every legend entry
+     */
+    public static LEGEND_ENTRY_PREFIX = "legend-item-";
 
     private _padding = 5;
     private _scale: Scale.Color;
@@ -252,7 +256,7 @@ export module Component {
       var entries = rows.selectAll("g." + Legend.LEGEND_ENTRY_CLASS).data((d) => d);
       var entriesEnter = entries.enter().append("g").classed(Legend.LEGEND_ENTRY_CLASS, true);
       entries.each(function(d: string) {
-        d3.select(this).classed(d.replace(" ", "-"), true);
+        d3.select(this).classed(Legend.LEGEND_ENTRY_PREFIX + d.replace(" ", "-"), true);
       });
       entriesEnter.append("circle");
       entriesEnter.append("g").classed("text-container", true);


### PR DESCRIPTION
Fixes #1321. The approach used here is to prefix legend entry class names with the value of LEGEND_ENTRY, which should make all class names semantically correct according to http://stackoverflow.com/questions/448981/what-characters-are-valid-in-css-class-selectors