### PR TITLE
[TS1.4] - Utilizing the 'type' feature in Typescript

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2477,14 +2477,14 @@ declare module Plottable {
 
 declare module Plottable {
     module Component {
-        interface _IterateLayoutResult {
+        type _IterateLayoutResult = {
             colProportionalSpace: number[];
             rowProportionalSpace: number[];
             guaranteedWidths: number[];
             guaranteedHeights: number[];
             wantsWidth: boolean;
             wantsHeight: boolean;
-        }
+        };
         class Table extends AbstractComponentContainer {
             /**
              * Constructs a Table.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -749,9 +749,9 @@ declare module Plottable {
      * with both `foo` and `bar`, an entry in this type might be `{"r":
      * function(d) { return foo + bar; }`.
      */
-    interface AttributeToProjector {
+    type AttributeToProjector = {
         [attrToSet: string]: _Projector;
-    }
+    };
     interface _AttributeToAppliedProjector {
         [attrToSet: string]: _AppliedProjector;
     }
@@ -2841,7 +2841,9 @@ declare module Plottable {
              */
             project(attrToSet: string, accessor: any, scale?: Scale.AbstractScale<any, any>): Scatter<X, Y>;
             protected _getDrawer(key: string): _Drawer.Element;
-            protected _generateAttrToProjector(): AttributeToProjector;
+            protected _generateAttrToProjector(): {
+                [attrToSet: string]: (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+            };
             protected _generateDrawSteps(): _Drawer.DrawStep[];
             protected _getClosestStruckPoint(p: Point, range: number): Interaction.HoverData;
             _hoverOverComponent(p: Point): void;
@@ -2875,7 +2877,9 @@ declare module Plottable {
              * the data should return a valid CSS color.
              */
             project(attrToSet: string, accessor: any, scale?: Scale.AbstractScale<any, any>): Grid;
-            protected _generateAttrToProjector(): AttributeToProjector;
+            protected _generateAttrToProjector(): {
+                [attrToSet: string]: (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+            };
             protected _generateDrawSteps(): _Drawer.DrawStep[];
         }
     }
@@ -2973,7 +2977,9 @@ declare module Plottable {
             protected _additionalPaint(time: number): void;
             protected _drawLabels(): void;
             protected _generateDrawSteps(): _Drawer.DrawStep[];
-            protected _generateAttrToProjector(): AttributeToProjector;
+            protected _generateAttrToProjector(): {
+                [attrToSet: string]: (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+            };
             /**
              * Computes the barPixelWidth of all the bars in the plot.
              *
@@ -3020,7 +3026,9 @@ declare module Plottable {
             protected _getDrawer(key: string): _Drawer.Line;
             protected _getResetYFunction(): (d: any, i: number, u: any, m: PlotMetadata) => number;
             protected _generateDrawSteps(): _Drawer.DrawStep[];
-            protected _generateAttrToProjector(): AttributeToProjector;
+            protected _generateAttrToProjector(): {
+                [attrToSet: string]: (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+            };
             protected _wholeDatumAttributes(): string[];
             protected _getClosestWithinRange(p: Point, range: number): {
                 closestValue: any;
@@ -3054,7 +3062,9 @@ declare module Plottable {
             project(attrToSet: string, accessor: any, scale?: Scale.AbstractScale<any, any>): Area<X>;
             protected _getResetYFunction(): (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
             protected _wholeDatumAttributes(): string[];
-            protected _generateAttrToProjector(): AttributeToProjector;
+            protected _generateAttrToProjector(): {
+                [attrToSet: string]: (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+            };
         }
     }
 }
@@ -3079,7 +3089,9 @@ declare module Plottable {
              * @param {boolean} isVertical if the plot if vertical.
              */
             constructor(xScale: Scale.AbstractScale<X, number>, yScale: Scale.AbstractScale<Y, number>, isVertical?: boolean);
-            protected _generateAttrToProjector(): AttributeToProjector;
+            protected _generateAttrToProjector(): {
+                [attrToSet: string]: (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+            };
             protected _getDataToDraw(): D3.Map<any[]>;
             protected _getPlotMetadataForDataset(key: string): ClusteredPlotMetadata;
         }
@@ -3146,7 +3158,9 @@ declare module Plottable {
             protected _updateYDomainer(): void;
             project(attrToSet: string, accessor: any, scale?: Scale.AbstractScale<any, any>): StackedArea<X>;
             protected _onDatasetUpdate(): StackedArea<X>;
-            protected _generateAttrToProjector(): AttributeToProjector;
+            protected _generateAttrToProjector(): {
+                [attrToSet: string]: (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+            };
             protected _wholeDatumAttributes(): string[];
             _updateStackOffsets(): void;
             _updateStackExtents(): void;
@@ -3181,7 +3195,9 @@ declare module Plottable {
              */
             constructor(xScale?: Scale.AbstractScale<X, number>, yScale?: Scale.AbstractScale<Y, number>, isVertical?: boolean);
             protected _getAnimator(key: string): Animator.PlotAnimator;
-            protected _generateAttrToProjector(): AttributeToProjector;
+            protected _generateAttrToProjector(): {
+                [attrToSet: string]: (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+            };
             protected _generateDrawSteps(): _Drawer.DrawStep[];
             project(attrToSet: string, accessor: any, scale?: Scale.AbstractScale<any, any>): StackedBar<X, Y>;
             protected _onDatasetUpdate(): StackedBar<X, Y>;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3824,11 +3824,11 @@ declare module Plottable {
 
 declare module Plottable {
     module Interaction {
-        interface HoverData {
+        type HoverData = {
             data: any[];
             pixelPositions: Point[];
             selection: D3.Selection;
-        }
+        };
         interface Hoverable extends Component.AbstractComponent {
             /**
              * Called when the user first mouses over the Component.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1470,14 +1470,14 @@ declare module Plottable {
          *
          * Specifies how AttributeToProjector needs to be animated.
          */
-        interface DrawStep {
+        type DrawStep = {
             attrToProjector: AttributeToProjector;
             animator: Animator.PlotAnimator;
-        }
-        interface AppliedDrawStep {
+        };
+        type AppliedDrawStep = {
             attrToProjector: _AttributeToAppliedProjector;
             animator: Animator.PlotAnimator;
-        }
+        };
         class AbstractDrawer {
             protected _className: string;
             key: string;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -752,9 +752,9 @@ declare module Plottable {
     type AttributeToProjector = {
         [attrToSet: string]: _Projector;
     };
-    interface _AttributeToAppliedProjector {
+    type _AttributeToAppliedProjector = {
         [attrToSet: string]: _AppliedProjector;
-    }
+    };
     /**
      * A simple bounding box.
      */

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3233,9 +3233,9 @@ declare module Plottable {
              */
             getTiming(numberOfIterations: number): number;
         }
-        interface PlotAnimatorMap {
+        type PlotAnimatorMap = {
             [animatorKey: string]: PlotAnimator;
-        }
+        };
     }
 }
 

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -483,9 +483,7 @@ declare module Plottable {
          * The Listenable is passed as the first argument so that it is easy for the callback to reference the
          * current state of the Listenable in the resolution logic.
          */
-        interface BroadcasterCallback {
-            (listenable: Listenable, ...args: any[]): any;
-        }
+        type BroadcasterCallback = (listenable: Listenable, ...args: any[]) => any;
         /**
          * The Broadcaster class is owned by an Listenable. Third parties can register and deregister listeners
          * from the broadcaster. When the broadcaster.broadcast method is activated, all registered callbacks are

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -724,9 +724,7 @@ declare module Plottable {
     /**
      * Access specific datum property.
      */
-    interface _Accessor {
-        (datum: any, index?: number, userMetadata?: any, plotMetadata?: Plot.PlotMetadata): any;
-    }
+    type _Accessor = (datum: any, index?: number, userMetadata?: any, plotMetadata?: Plot.PlotMetadata) => any;
     /**
      * Retrieves scaled datum property.
      */

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2579,12 +2579,12 @@ declare module Plottable {
         /**
          * A key that is also coupled with a dataset, a drawer and a metadata in Plot.
          */
-        interface PlotDatasetKey {
+        type PlotDatasetKey = {
             dataset: Dataset;
             drawer: _Drawer.AbstractDrawer;
             plotMetadata: PlotMetadata;
             key: string;
-        }
+        };
         interface PlotMetadata {
             datasetKey: string;
         }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -734,11 +734,11 @@ declare module Plottable {
     /**
      * Defines a way how specific attribute needs be retrieved before rendering.
      */
-    interface _Projection {
+    type _Projection = {
         accessor: _Accessor;
         scale?: Scale.AbstractScale<any, any>;
         attribute: string;
-    }
+    };
     /**
      * A mapping from attributes ("x", "fill", etc.) to the functions that get
      * that information out of the data.
@@ -756,24 +756,24 @@ declare module Plottable {
     /**
      * A simple bounding box.
      */
-    interface SelectionArea {
+    type SelectionArea = {
         xMin: number;
         xMax: number;
         yMin: number;
         yMax: number;
-    }
-    interface _SpaceRequest {
+    };
+    type _SpaceRequest = {
         width: number;
         height: number;
         wantsWidth: boolean;
         wantsHeight: boolean;
-    }
-    interface _PixelArea {
+    };
+    type _PixelArea = {
         xMin: number;
         xMax: number;
         yMin: number;
         yMax: number;
-    }
+    };
     /**
      * The range of your current data. For example, [1, 2, 6, -5] has the Extent
      * `{min: -5, max: 6}`.
@@ -781,17 +781,17 @@ declare module Plottable {
      * The point of this type is to hopefully replace the less-elegant `[min,
      * max]` extents produced by d3.
      */
-    interface Extent {
+    type Extent = {
         min: number;
         max: number;
-    }
+    };
     /**
      * A simple location on the screen.
      */
-    interface Point {
+    type Point = {
         x: number;
         y: number;
-    }
+    };
 }
 
 
@@ -2813,7 +2813,11 @@ declare module Plottable {
                 a: A;
                 b: B;
             }[];
-            protected _projectorsReady(): _Projection;
+            protected _projectorsReady(): {
+                accessor: (datum: any, index?: number, userMetadata?: any, plotMetadata?: PlotMetadata) => any;
+                scale?: Scale.AbstractScale<any, any>;
+                attribute: string;
+            };
         }
     }
 }
@@ -3028,7 +3032,10 @@ declare module Plottable {
             protected _wholeDatumAttributes(): string[];
             protected _getClosestWithinRange(p: Point, range: number): {
                 closestValue: any;
-                closestPoint: Point;
+                closestPoint: {
+                    x: number;
+                    y: number;
+                };
             };
             _hoverOverComponent(p: Point): void;
             _hoverOutComponent(p: Point): void;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -728,9 +728,7 @@ declare module Plottable {
     /**
      * Retrieves scaled datum property.
      */
-    interface _Projector {
-        (datum: any, index: number, userMetadata: any, plotMetadata: Plot.PlotMetadata): any;
-    }
+    type _Projector = (datum: any, index: number, userMetadata: any, plotMetadata: Plot.PlotMetadata) => any;
     /**
      * Projector with applied user and plot metadata
      */
@@ -3056,7 +3054,7 @@ declare module Plottable {
             protected _getDrawer(key: string): _Drawer.Area;
             protected _updateYDomainer(): void;
             project(attrToSet: string, accessor: any, scale?: Scale.AbstractScale<any, any>): Area<X>;
-            protected _getResetYFunction(): _Projector;
+            protected _getResetYFunction(): (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
             protected _wholeDatumAttributes(): string[];
             protected _generateAttrToProjector(): AttributeToProjector;
         }
@@ -3374,7 +3372,7 @@ declare module Plottable {
             isReverse: boolean;
             constructor(isVertical?: boolean, isReverse?: boolean);
             animate(selection: any, attrToProjector: AttributeToProjector): any;
-            protected _startMovingProjector(attrToProjector: AttributeToProjector): _Projector;
+            protected _startMovingProjector(attrToProjector: AttributeToProjector): (datum: any, index: number, userMetadata: any, plotMetadata: Plot.PlotMetadata) => any;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2076,19 +2076,17 @@ declare module Plottable {
          * step - number of intervals between each tick.
          * formatter - formatter used to format tick labels.
          */
-        interface TimeAxisTierConfiguration {
+        type TimeAxisTierConfiguration = {
             interval: D3.Time.Interval;
             step: number;
             formatter: Formatter;
-        }
+        };
         /**
          * An array of linked TimeAxisTierConfigurations.
          * Each configuration will be shown on a different tier.
          * Currently, up to two tiers are supported.
          */
-        interface TimeAxisConfiguration {
-            tierConfigurations: TimeAxisTierConfiguration[];
-        }
+        type TimeAxisConfiguration = TimeAxisTierConfiguration[];
         class Time extends AbstractAxis {
             /**
              * Constructs a TimeAxis.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -320,9 +320,7 @@ declare module Plottable {
 
 
 declare module Plottable {
-    interface Formatter {
-        (d: any): string;
-    }
+    type Formatter = (d: any) => string;
     var MILLISECONDS_IN_ONE_DAY: number;
     module Formatters {
         /**

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -732,9 +732,7 @@ declare module Plottable {
     /**
      * Projector with applied user and plot metadata
      */
-    interface _AppliedProjector {
-        (datum: any, index: number): any;
-    }
+    type _AppliedProjector = (datum: any, index: number) => any;
     /**
      * Defines a way how specific attribute needs be retrieved before rendering.
      */

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3100,11 +3100,11 @@ declare module Plottable {
         interface StackedPlotMetadata extends PlotMetadata {
             offsets: D3.Map<number>;
         }
-        interface StackedDatum {
+        type StackedDatum = {
             key: any;
             value: number;
             offset?: number;
-        }
+        };
         class AbstractStacked<X, Y> extends AbstractXYPlot<X, Y> {
             protected _isVertical: boolean;
             _getPlotMetadataForDataset(key: string): StackedPlotMetadata;

--- a/plottable.js
+++ b/plottable.js
@@ -1479,7 +1479,6 @@ var Plottable;
 
 var Plottable;
 (function (Plottable) {
-    ;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />

--- a/plottable.js
+++ b/plottable.js
@@ -2476,7 +2476,6 @@ var Plottable;
 (function (Plottable) {
     var Scale;
     (function (Scale) {
-        ;
         /**
          * This class implements a color scale that takes quantitive input and
          * interpolates between a list of color values. It returns a hex string

--- a/plottable.js
+++ b/plottable.js
@@ -8169,6 +8169,12 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+var Plottable;
+(function (Plottable) {
+    var Animator;
+    (function (Animator) {
+    })(Animator = Plottable.Animator || (Plottable.Animator = {}));
+})(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
 var Plottable;

--- a/plottable.js
+++ b/plottable.js
@@ -4322,7 +4322,6 @@ var Plottable;
 (function (Plottable) {
     var Axis;
     (function (Axis) {
-        ;
         var Time = (function (_super) {
             __extends(Time, _super);
             /**
@@ -4340,113 +4339,113 @@ var Plottable;
                  * Default possible axis configurations.
                  */
                 this._possibleTimeAxisConfigurations = [
-                    { tierConfigurations: [
+                    [
                         { interval: d3.time.second, step: 1, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.second, step: 5, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.second, step: 10, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.second, step: 15, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.second, step: 30, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.minute, step: 1, formatter: Plottable.Formatters.time("%I:%M %p") },
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.minute, step: 5, formatter: Plottable.Formatters.time("%I:%M %p") },
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.minute, step: 10, formatter: Plottable.Formatters.time("%I:%M %p") },
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.minute, step: 15, formatter: Plottable.Formatters.time("%I:%M %p") },
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.minute, step: 30, formatter: Plottable.Formatters.time("%I:%M %p") },
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.hour, step: 1, formatter: Plottable.Formatters.time("%I %p") },
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.hour, step: 3, formatter: Plottable.Formatters.time("%I %p") },
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.hour, step: 6, formatter: Plottable.Formatters.time("%I %p") },
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.hour, step: 12, formatter: Plottable.Formatters.time("%I %p") },
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%a %e") },
                         { interval: d3.time.month, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%e") },
                         { interval: d3.time.month, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.month, step: 1, formatter: Plottable.Formatters.time("%B") },
                         { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.month, step: 1, formatter: Plottable.Formatters.time("%b") },
                         { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.month, step: 3, formatter: Plottable.Formatters.time("%b") },
                         { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.month, step: 6, formatter: Plottable.Formatters.time("%b") },
                         { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.year, step: 5, formatter: Plottable.Formatters.time("%Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.year, step: 25, formatter: Plottable.Formatters.time("%Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.year, step: 50, formatter: Plottable.Formatters.time("%Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.year, step: 100, formatter: Plottable.Formatters.time("%Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.year, step: 200, formatter: Plottable.Formatters.time("%Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.year, step: 500, formatter: Plottable.Formatters.time("%Y") }
-                    ] },
-                    { tierConfigurations: [
+                    ],
+                    [
                         { interval: d3.time.year, step: 1000, formatter: Plottable.Formatters.time("%Y") }
-                    ] }
+                    ]
                 ];
                 this.classed("time-axis", true);
                 this.tickLabelPadding(5);
@@ -4480,7 +4479,7 @@ var Plottable;
                 var _this = this;
                 var mostPreciseIndex = this._possibleTimeAxisConfigurations.length;
                 this._possibleTimeAxisConfigurations.forEach(function (interval, index) {
-                    if (index < mostPreciseIndex && interval.tierConfigurations.every(function (tier) { return _this._checkTimeAxisTierConfigurationWidth(tier); })) {
+                    if (index < mostPreciseIndex && interval.every(function (tier) { return _this._checkTimeAxisTierConfigurationWidth(tier); })) {
                         mostPreciseIndex = index;
                     }
                 });
@@ -4544,7 +4543,7 @@ var Plottable;
             };
             Time.prototype._getTickValues = function () {
                 var _this = this;
-                return this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex].tierConfigurations.reduce(function (ticks, config) { return ticks.concat(_this._getTickIntervalValues(config)); }, []);
+                return this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex].reduce(function (ticks, config) { return ticks.concat(_this._getTickIntervalValues(config)); }, []);
             };
             Time.prototype._cleanTier = function (index) {
                 this._tierLabelContainers[index].selectAll("." + Axis.AbstractAxis.TICK_LABEL_CLASS).remove();
@@ -4654,12 +4653,12 @@ var Plottable;
                 if (this._mostPreciseConfigIndex < 1) {
                     return [];
                 }
-                return this._getTickIntervalValues(this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex - 1].tierConfigurations[0]);
+                return this._getTickIntervalValues(this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex - 1][0]);
             };
             Time.prototype._doRender = function () {
                 var _this = this;
                 this._mostPreciseConfigIndex = this._getMostPreciseConfigurationIndex();
-                var tierConfigs = this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex].tierConfigurations;
+                var tierConfigs = this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex];
                 for (var i = 0; i < Time._NUM_TIERS; ++i) {
                     this._cleanTier(i);
                 }

--- a/plottable.js
+++ b/plottable.js
@@ -5846,7 +5846,6 @@ var Plottable;
 (function (Plottable) {
     var Component;
     (function (Component) {
-        ;
         var Table = (function (_super) {
             __extends(Table, _super);
             /**

--- a/plottable.js
+++ b/plottable.js
@@ -795,9 +795,7 @@ var Plottable;
         function fixed(precision) {
             if (precision === void 0) { precision = 3; }
             verifyPrecision(precision);
-            return function (d) {
-                return d.toFixed(precision);
-            };
+            return function (d) { return d.toFixed(precision); };
         }
         Formatters.fixed = fixed;
         /**
@@ -829,9 +827,7 @@ var Plottable;
          * @returns {Formatter} A formatter that stringifies its input.
          */
         function identity() {
-            return function (d) {
-                return String(d);
-            };
+            return function (d) { return String(d); };
         }
         Formatters.identity = identity;
         /**
@@ -867,9 +863,7 @@ var Plottable;
         function siSuffix(precision) {
             if (precision === void 0) { precision = 3; }
             verifyPrecision(precision);
-            return function (d) {
-                return d3.format("." + precision + "s")(d);
-            };
+            return function (d) { return d3.format("." + precision + "s")(d); };
         }
         Formatters.siSuffix = siSuffix;
         /**

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -9,7 +9,7 @@ export module Axis {
    * step - number of intervals between each tick.
    * formatter - formatter used to format tick labels.
    */
-  export interface TimeAxisTierConfiguration {
+  export type TimeAxisTierConfiguration = {
     interval: D3.Time.Interval;
     step: number;
     formatter: Formatter;
@@ -20,9 +20,7 @@ export module Axis {
    * Each configuration will be shown on a different tier.
    * Currently, up to two tiers are supported.
    */
-  export interface TimeAxisConfiguration {
-    tierConfigurations: TimeAxisTierConfiguration[];
-  }
+  export type TimeAxisConfiguration = TimeAxisTierConfiguration[];
 
   export class Time extends AbstractAxis {
 
@@ -30,113 +28,113 @@ export module Axis {
      * Default possible axis configurations.
      */
     private _possibleTimeAxisConfigurations: TimeAxisConfiguration[] = [
-      {tierConfigurations: [
+      [
         {interval: d3.time.second, step: 1, formatter: Formatters.time("%I:%M:%S %p")},
         {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.second, step: 5, formatter: Formatters.time("%I:%M:%S %p")},
         {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.second, step: 10, formatter: Formatters.time("%I:%M:%S %p")},
         {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
-      ]},
-        {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.second, step: 15, formatter: Formatters.time("%I:%M:%S %p")},
         {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.second, step: 30, formatter: Formatters.time("%I:%M:%S %p")},
         {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.minute, step: 1, formatter: Formatters.time("%I:%M %p")},
         {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.minute, step: 5, formatter: Formatters.time("%I:%M %p")},
         {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.minute, step: 10, formatter: Formatters.time("%I:%M %p")},
         {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.minute, step: 15, formatter: Formatters.time("%I:%M %p")},
         {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.minute, step: 30, formatter: Formatters.time("%I:%M %p")},
         {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.hour, step: 1, formatter: Formatters.time("%I %p")},
         {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.hour, step: 3, formatter: Formatters.time("%I %p")},
         {interval: d3.time.day, step: 1,formatter: Formatters.time("%B %e, %Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.hour, step: 6, formatter: Formatters.time("%I %p")},
         {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.hour, step: 12, formatter: Formatters.time("%I %p")},
         {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.day, step: 1, formatter: Formatters.time("%a %e")},
         {interval: d3.time.month, step: 1, formatter: Formatters.time("%B %Y")}
-        ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.day, step: 1, formatter: Formatters.time("%e")},
         {interval: d3.time.month, step: 1, formatter: Formatters.time("%B %Y")}
-        ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.month, step: 1, formatter: Formatters.time("%B")},
         {interval: d3.time.year, step: 1, formatter: Formatters.time("%Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.month, step: 1, formatter: Formatters.time("%b")},
         {interval: d3.time.year, step: 1, formatter: Formatters.time("%Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.month, step: 3, formatter: Formatters.time("%b")},
         {interval: d3.time.year, step: 1, formatter: Formatters.time("%Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.month, step: 6, formatter: Formatters.time("%b")},
         {interval: d3.time.year, step: 1, formatter: Formatters.time("%Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.year, step: 1, formatter: Formatters.time("%Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.year, step: 1, formatter: Formatters.time("%y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.year, step: 5, formatter: Formatters.time("%Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.year, step: 25, formatter: Formatters.time("%Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.year, step: 50, formatter: Formatters.time("%Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.year, step: 100, formatter: Formatters.time("%Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.year, step: 200, formatter: Formatters.time("%Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.year, step: 500, formatter: Formatters.time("%Y")}
-      ]},
-      {tierConfigurations: [
+      ],
+      [
         {interval: d3.time.year, step: 1000, formatter: Formatters.time("%Y")}
-      ]}
+      ]
     ];
 
     private _tierLabelContainers: D3.Selection[];
@@ -217,7 +215,7 @@ export module Axis {
     private _getMostPreciseConfigurationIndex(): number {
       var mostPreciseIndex = this._possibleTimeAxisConfigurations.length;
       this._possibleTimeAxisConfigurations.forEach((interval: TimeAxisConfiguration, index: number) => {
-        if (index < mostPreciseIndex && interval.tierConfigurations.every((tier: TimeAxisTierConfiguration) =>
+        if (index < mostPreciseIndex && interval.every((tier: TimeAxisTierConfiguration) =>
           this._checkTimeAxisTierConfigurationWidth(tier))) {
           mostPreciseIndex = index;
         }
@@ -294,7 +292,7 @@ export module Axis {
     }
 
     protected _getTickValues(): any[] {
-      return this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex].tierConfigurations.reduce(
+      return this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex].reduce(
           (ticks: any[], config: TimeAxisTierConfiguration) => ticks.concat(this._getTickIntervalValues(config)),
           []
         );
@@ -416,13 +414,12 @@ export module Axis {
         return [];
       }
 
-      return this._getTickIntervalValues(this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex - 1].
-                                            tierConfigurations[0]);
+      return this._getTickIntervalValues(this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex - 1][0]);
     }
 
     public _doRender() {
       this._mostPreciseConfigIndex = this._getMostPreciseConfigurationIndex();
-      var tierConfigs = this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex].tierConfigurations;
+      var tierConfigs = this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex];
       for (var i = 0; i < Time._NUM_TIERS; ++i) {
         this._cleanTier(i);
       }

--- a/src/components/plots/abstractPlot.ts
+++ b/src/components/plots/abstractPlot.ts
@@ -5,7 +5,7 @@ export module Plot {
   /**
    * A key that is also coupled with a dataset, a drawer and a metadata in Plot.
    */
-  export interface PlotDatasetKey {
+  export type PlotDatasetKey = {
     dataset: Dataset;
     drawer: _Drawer.AbstractDrawer;
     plotMetadata: PlotMetadata;

--- a/src/components/plots/abstractStackedPlot.ts
+++ b/src/components/plots/abstractStackedPlot.ts
@@ -6,7 +6,7 @@ export module Plot {
     offsets: D3.Map<number>;
   }
 
-  export interface StackedDatum {
+  export type StackedDatum = {
     key: any;
     value: number;
     offset?: number;

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -2,14 +2,14 @@
 
 module Plottable {
 export module Component {
-  interface _LayoutAllocation {
+  type _LayoutAllocation = {
     guaranteedWidths : number[];
     guaranteedHeights: number[];
     wantsWidthArr : boolean[];
     wantsHeightArr: boolean[];
   }
 
-  export interface _IterateLayoutResult {
+  export type _IterateLayoutResult = {
     colProportionalSpace: number[];
     rowProportionalSpace: number[];
     guaranteedWidths    : number[];

--- a/src/core/animator.ts
+++ b/src/core/animator.ts
@@ -24,9 +24,7 @@ export module Animator {
     getTiming(numberOfIterations: number): number;
   }
 
-  export interface PlotAnimatorMap {
-    [animatorKey: string] : PlotAnimator;
-  }
+  export type PlotAnimatorMap = { [animatorKey: string] : PlotAnimator; };
 
 }
 }

--- a/src/core/broadcaster.ts
+++ b/src/core/broadcaster.ts
@@ -24,9 +24,7 @@ export module Core {
    * The Listenable is passed as the first argument so that it is easy for the callback to reference the
    * current state of the Listenable in the resolution logic.
    */
-  export interface BroadcasterCallback {
-    (listenable: Listenable, ...args: any[]): any;
-  }
+  export type BroadcasterCallback = (listenable: Listenable, ...args: any[]) => any;
 
 
   /**

--- a/src/core/broadcaster.ts
+++ b/src/core/broadcaster.ts
@@ -26,7 +26,6 @@ export module Core {
    */
   export type BroadcasterCallback = (listenable: Listenable, ...args: any[]) => any;
 
-
   /**
    * The Broadcaster class is owned by an Listenable. Third parties can register and deregister listeners
    * from the broadcaster. When the broadcaster.broadcast method is activated, all registered callbacks are

--- a/src/core/dataset.ts
+++ b/src/core/dataset.ts
@@ -1,7 +1,7 @@
 ///<reference path="../reference.ts" />
 
 module Plottable {
-  interface CachedExtent {
+  type CachedExtent = {
     accessor: _Accessor;
     extent: any[];
   }

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -12,9 +12,7 @@ module Plottable {
   /**
    * Projector with applied user and plot metadata
    */
-  export interface _AppliedProjector {
-    (datum: any, index: number) : any;
-  }
+  export type _AppliedProjector = (datum: any, index: number) => any;
 
   /**
    * Defines a way how specific attribute needs be retrieved before rendering.

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -2,9 +2,7 @@ module Plottable {
   /**
    * Access specific datum property.
    */
-  export interface _Accessor {
-    (datum: any, index?: number, userMetadata?: any, plotMetadata?: Plot.PlotMetadata): any;
-  };
+  export type _Accessor = (datum: any, index?: number, userMetadata?: any, plotMetadata?: Plot.PlotMetadata) => any;
 
   /**
    * Retrieves scaled datum property.

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -31,9 +31,7 @@ module Plottable {
    * with both `foo` and `bar`, an entry in this type might be `{"r":
    * function(d) { return foo + bar; }`.
    */
-  export interface AttributeToProjector {
-    [attrToSet: string]: _Projector;
-  }
+  export type AttributeToProjector = { [attrToSet: string]: _Projector; };
 
   export interface _AttributeToAppliedProjector {
     [attrToSet: string]: _AppliedProjector;

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -7,9 +7,7 @@ module Plottable {
   /**
    * Retrieves scaled datum property.
    */
-  export interface _Projector {
-    (datum: any, index: number, userMetadata: any, plotMetadata: Plot.PlotMetadata) : any;
-  }
+  export type _Projector = (datum: any, index: number, userMetadata: any, plotMetadata: Plot.PlotMetadata) => any;
 
   /**
    * Projector with applied user and plot metadata

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -33,9 +33,7 @@ module Plottable {
    */
   export type AttributeToProjector = { [attrToSet: string]: _Projector; };
 
-  export interface _AttributeToAppliedProjector {
-    [attrToSet: string]: _AppliedProjector;
-  }
+  export type _AttributeToAppliedProjector = { [attrToSet: string]: _AppliedProjector; };
 
   /**
    * A simple bounding box.

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -17,7 +17,7 @@ module Plottable {
   /**
    * Defines a way how specific attribute needs be retrieved before rendering.
    */
-  export interface _Projection {
+  export type _Projection = {
     accessor: _Accessor;
     scale?: Scale.AbstractScale<any, any>;
     attribute: string;
@@ -38,21 +38,21 @@ module Plottable {
   /**
    * A simple bounding box.
    */
-  export interface SelectionArea {
+  export type SelectionArea = {
     xMin: number;
     xMax: number;
     yMin: number;
     yMax: number;
   }
 
-  export interface _SpaceRequest {
+  export type _SpaceRequest = {
     width: number;
     height: number;
     wantsWidth: boolean;
     wantsHeight: boolean;
   }
 
-  export interface _PixelArea {
+  export type _PixelArea = {
     xMin: number;
     xMax: number;
     yMin: number;
@@ -66,7 +66,7 @@ module Plottable {
    * The point of this type is to hopefully replace the less-elegant `[min,
    * max]` extents produced by d3.
    */
-  export interface Extent {
+  export type Extent = {
     min: number;
     max: number;
   }
@@ -74,7 +74,7 @@ module Plottable {
   /**
    * A simple location on the screen.
    */
-  export interface Point {
+  export type Point = {
     x: number;
     y: number;
   }

--- a/src/drawers/abstractDrawer.ts
+++ b/src/drawers/abstractDrawer.ts
@@ -7,12 +7,12 @@ export module _Drawer {
    *
    * Specifies how AttributeToProjector needs to be animated.
    */
-  export interface DrawStep {
+  export type DrawStep = {
     attrToProjector: AttributeToProjector;
     animator: Animator.PlotAnimator;
   }
 
-  export interface AppliedDrawStep {
+  export type AppliedDrawStep = {
     attrToProjector: _AttributeToAppliedProjector;
     animator: Animator.PlotAnimator;
   }

--- a/src/interactions/drag/dragBoxInteraction.ts
+++ b/src/interactions/drag/dragBoxInteraction.ts
@@ -6,7 +6,7 @@ export module Interaction {
    * A DragBox is an interaction that automatically draws a box across the
    * element you attach it to when you drag.
    */
-  interface ResizeDimension {
+  type ResizeDimension = {
     offset: number; // px offset between where the resize drag started and the edge of the box (<= RESIZE_PADDING)
     origin: boolean; // whether we are resizing the origin coordinate or the location coordinate
     positive: boolean; // whether the resize is on the positive edge or the negative edge of the dragbox

--- a/src/interactions/hoverInteraction.ts
+++ b/src/interactions/hoverInteraction.ts
@@ -2,7 +2,7 @@
 
 module Plottable {
 export module Interaction {
-  export interface HoverData {
+  export type HoverData = {
     data: any[];
     pixelPositions: Point[];
     selection: D3.Selection;

--- a/src/scales/interpolatedColorScale.ts
+++ b/src/scales/interpolatedColorScale.ts
@@ -2,9 +2,7 @@
 
 module Plottable {
 export module Scale {
-  interface ColorGroups {
-    [key: string]: string[];
-  };
+  type ColorGroups = { [key: string]: string[]; };
 
   /**
    * This class implements a color scale that takes quantitive input and

--- a/src/scales/tickGenerators.ts
+++ b/src/scales/tickGenerators.ts
@@ -3,6 +3,8 @@
 module Plottable {
   export module Scale {
     export module TickGenerators {
+      // HACKHACK: Generic types in type definition fails compilation
+      // https://github.com/Microsoft/TypeScript/issues/1616
       export interface TickGenerator<D> {
         (scale: Plottable.Scale.AbstractQuantitative<D>): D[]
       }

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -2,9 +2,7 @@
 
 module Plottable {
 
-  export interface Formatter {
-    (d: any): string;
-  }
+  export type Formatter = (d: any) => string;
 
   export var MILLISECONDS_IN_ONE_DAY = 24 * 60 * 60 * 1000;
 
@@ -27,7 +25,7 @@ module Plottable {
      */
     export function currency(precision = 2, symbol = "$", prefix = true) {
       var fixedFormatter = Formatters.fixed(precision);
-      return function(d: any) {
+      return (d: any) => {
         var formattedValue = fixedFormatter(Math.abs(d));
         if (formattedValue !== "") {
           if (prefix) {
@@ -54,9 +52,7 @@ module Plottable {
      */
     export function fixed(precision = 3) {
       verifyPrecision(precision);
-      return function(d: any) {
-        return (<number> d).toFixed(precision);
-      };
+      return (d: any) => (<number> d).toFixed(precision);
     }
 
     /**
@@ -70,7 +66,7 @@ module Plottable {
      */
     export function general(precision = 3) {
       verifyPrecision(precision);
-      return function(d: any) {
+      return (d: any) => {
         if (typeof d === "number") {
           var multiplier = Math.pow(10, precision);
           return String(Math.round(d * multiplier) / multiplier);
@@ -86,9 +82,7 @@ module Plottable {
      * @returns {Formatter} A formatter that stringifies its input.
      */
     export function identity() {
-      return function(d: any) {
-        return String(d);
-      };
+      return (d: any) => String(d);
     }
 
     /**
@@ -102,7 +96,7 @@ module Plottable {
      */
     export function percentage(precision = 0) {
       var fixedFormatter = Formatters.fixed(precision);
-      return function(d: any) {
+      return (d: any) => {
         var valToFormat = d * 100;
 
         // Account for float imprecision
@@ -124,9 +118,7 @@ module Plottable {
      */
     export function siSuffix(precision = 3) {
       verifyPrecision(precision);
-      return function(d: any) {
-        return d3.format("." + precision + "s")(d);
-      };
+      return (d: any) => d3.format("." + precision + "s")(d);
     }
 
     /**
@@ -175,7 +167,7 @@ module Plottable {
         filter: () => true
       };
 
-      return function(d: any) {
+      return (d: any) => {
         for (var i = 0; i < numFormats; i++) {
           if (timeFormat[i].filter(d)) {
             return d3.time.format(timeFormat[i].format)(d);
@@ -207,7 +199,7 @@ module Plottable {
      * @returns {Formatter} A formatter for time/date values.
      */
     export function relativeDate(baseValue: number = 0, increment: number = MILLISECONDS_IN_ONE_DAY, label: string = "") {
-      return function (d: any) {
+      return (d: any) => {
         var relativeDate = Math.round((d.valueOf() - baseValue) / increment);
         return relativeDate.toString() + label;
       };

--- a/test/components/timeAxisTests.ts
+++ b/test/components/timeAxisTests.ts
@@ -89,7 +89,7 @@ describe("TimeAxis", () => {
     var axis = new Plottable.Axis.Time(scale, "bottom");
     var configurations = axis.axisConfigurations();
     var newPossibleConfigurations = configurations.slice(0, 3);
-    newPossibleConfigurations.forEach(axisConfig => axisConfig.tierConfigurations.forEach(tierConfig => {
+    newPossibleConfigurations.forEach(axisConfig => axisConfig.forEach(tierConfig => {
       tierConfig.interval = d3.time.minute;
       tierConfig.step += 3;
     }));
@@ -100,7 +100,7 @@ describe("TimeAxis", () => {
     scale.domain([twoMinutesBefore, now]);
     scale.range([0, 800]);
     axis.renderTo(svg);
-    var configs = newPossibleConfigurations[(<any> axis)._mostPreciseConfigIndex].tierConfigurations;
+    var configs = newPossibleConfigurations[(<any> axis)._mostPreciseConfigIndex];
     assert.deepEqual(configs[0].interval, d3.time.minute, "axis used new time unit");
     assert.deepEqual(configs[0].step, 4, "axis used new step");
     svg.remove();

--- a/test/tests.js
+++ b/test/tests.js
@@ -546,7 +546,7 @@ describe("TimeAxis", function () {
         var axis = new Plottable.Axis.Time(scale, "bottom");
         var configurations = axis.axisConfigurations();
         var newPossibleConfigurations = configurations.slice(0, 3);
-        newPossibleConfigurations.forEach(function (axisConfig) { return axisConfig.tierConfigurations.forEach(function (tierConfig) {
+        newPossibleConfigurations.forEach(function (axisConfig) { return axisConfig.forEach(function (tierConfig) {
             tierConfig.interval = d3.time.minute;
             tierConfig.step += 3;
         }); });
@@ -557,7 +557,7 @@ describe("TimeAxis", function () {
         scale.domain([twoMinutesBefore, now]);
         scale.range([0, 800]);
         axis.renderTo(svg);
-        var configs = newPossibleConfigurations[axis._mostPreciseConfigIndex].tierConfigurations;
+        var configs = newPossibleConfigurations[axis._mostPreciseConfigIndex];
         assert.deepEqual(configs[0].interval, d3.time.minute, "axis used new time unit");
         assert.deepEqual(configs[0].step, 4, "axis used new step");
         svg.remove();


### PR DESCRIPTION
Now that Typescript has added the type feature in Typescript 1.4, we can make use of it: http://blogs.msdn.com/b/typescript/archive/2015/01/16/announcing-typescript-1-4.aspx

The type feature allows for Type aliasing which means that you can alias a type into a different name.

One simple example can be to alias
`type Phrase = string;`
so that you can use the term `phrase` as a replacement for the term `string` throughout the codebase, which is very nice for semantical reasoning.

A more useful example can be to alias
`type InteractionCallback = (data: any) => any;`
so that we can now alias callbacks with hard-to-reason-about signatures to a concise, short term

A more interesting example can be to alias
`type Person = {
  firstName: string;
  lastName: string;
}`
so that we can now encapsulate complex ideas even further.