### PR TITLE
Clearer tick generation on Axis.Time

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -4557,11 +4557,16 @@ var Plottable;
                 this._tierMarkContainers[index].selectAll("." + Axis.AbstractAxis.TICK_MARK_CLASS).remove();
                 this._tierBaselines[index].style("visibility", "hidden");
             };
+            Time.prototype._getTickValuesForConfiguration = function (config) {
+                var tickPos = this._scale.tickInterval(config.interval, config.step);
+                var domain = this._scale.domain();
+                tickPos.unshift(domain[0]);
+                tickPos.push(domain[1]);
+                return tickPos;
+            };
             Time.prototype._renderTierLabels = function (container, config, index) {
                 var _this = this;
-                var tickPos = this._scale.tickInterval(config.interval, config.step);
-                tickPos.splice(0, 0, this._scale.domain()[0]);
-                tickPos.push(this._scale.domain()[1]);
+                var tickPos = this._getTickValuesForConfiguration(config);
                 var labelPos = [];
                 if (this._tierLabelPositions[index] === "between" && config.step === 1) {
                     tickPos.map(function (datum, index) {
@@ -4596,13 +4601,6 @@ var Plottable;
                 tickLabels.attr("transform", function (d) { return "translate(" + _this._scale.scale(d) + ",0)"; });
                 var anchor = (this._tierLabelPositions[index] === "center" || config.step === 1) ? "middle" : "start";
                 tickLabels.selectAll("text").text(config.formatter).style("text-anchor", anchor);
-                if (filteredTicks.indexOf(this._scale.domain()[0]) === -1) {
-                    filteredTicks.splice(0, 1, this._scale.domain()[0]);
-                }
-                if (filteredTicks.indexOf(this._scale.domain()[1]) === -1) {
-                    filteredTicks.push(this._scale.domain()[1]);
-                }
-                return filteredTicks;
             };
             Time.prototype._canFitLabelFilter = function (position, bounds, config, labelPosition) {
                 if (labelPosition === "center") {
@@ -4672,7 +4670,10 @@ var Plottable;
                 for (var i = 0; i < Time._NUM_TIERS; ++i) {
                     this._cleanTier(i);
                 }
-                var tierTicks = tierConfigs.map(function (config, i) { return _this._renderTierLabels(_this._tierLabelContainers[i], config, i); });
+                var tierTicks = tierConfigs.map(function (config, i) {
+                    _this._renderTierLabels(_this._tierLabelContainers[i], config, i);
+                    return _this._getTickValuesForConfiguration(config);
+                });
                 var baselineOffset = 0;
                 for (i = 0; i < Math.max(tierConfigs.length, 1); ++i) {
                     var attr = this._generateBaselineAttrHash();

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -304,10 +304,16 @@ export module Axis {
       this._tierBaselines[index].style("visibility", "hidden");
     }
 
-    private _renderTierLabels(container: D3.Selection, config: TimeAxisTierConfiguration, index: number) {
+    private _getTickValuesForConfiguration(config: TimeAxisTierConfiguration) {
       var tickPos = (<Scale.Time> this._scale).tickInterval(config.interval, config.step);
-      tickPos.splice(0, 0, this._scale.domain()[0]);
-      tickPos.push(this._scale.domain()[1]);
+      var domain = this._scale.domain();
+      tickPos.unshift(domain[0]);
+      tickPos.push(domain[1]);
+      return tickPos;
+    }
+
+    private _renderTierLabels(container: D3.Selection, config: TimeAxisTierConfiguration, index: number) {
+      var tickPos = this._getTickValuesForConfiguration(config);
       var labelPos: Date[] = [];
       if (this._tierLabelPositions[index] === "between" && config.step === 1) {
         tickPos.map((datum: any, index: any) => {
@@ -345,14 +351,6 @@ export module Axis {
       tickLabels.attr("transform", (d: any) => "translate(" + this._scale.scale(d) + ",0)");
       var anchor = (this._tierLabelPositions[index] === "center" || config.step === 1) ? "middle" : "start";
       tickLabels.selectAll("text").text(config.formatter).style("text-anchor", anchor);
-      if (filteredTicks.indexOf(this._scale.domain()[0]) === -1) {
-        filteredTicks.splice(0, 1, this._scale.domain()[0]);
-      }
-      if (filteredTicks.indexOf(this._scale.domain()[1]) === -1) {
-        filteredTicks.push(this._scale.domain()[1]);
-      }
-
-      return filteredTicks;
     }
 
     private _canFitLabelFilter(position: Date, bounds: Date[], config: TimeAxisTierConfiguration, labelPosition: string): boolean {
@@ -429,9 +427,10 @@ export module Axis {
         this._cleanTier(i);
       }
 
-      var tierTicks = tierConfigs.map((config: TimeAxisTierConfiguration, i: number) =>
-        this._renderTierLabels(this._tierLabelContainers[i], config, i)
-      );
+      var tierTicks = tierConfigs.map((config: TimeAxisTierConfiguration, i: number) => {
+        this._renderTierLabels(this._tierLabelContainers[i], config, i);
+        return this._getTickValuesForConfiguration(config);
+      });
 
       var baselineOffset = 0;
       for (i = 0; i < Math.max(tierConfigs.length, 1); ++i) {


### PR DESCRIPTION
We were splicing/etc, when the correct tick marks were already generated.

Close #1606.