### PR TITLE
Clearer tick generation on Axis.Time

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -4559,11 +4559,16 @@ var Plottable;
                 this._tierMarkContainers[index].selectAll("." + Axis.AbstractAxis.TICK_MARK_CLASS).remove();
                 this._tierBaselines[index].style("visibility", "hidden");
             };
+            Time.prototype._getTickValuesForConfiguration = function (config) {
+                var tickPos = this._scale.tickInterval(config.interval, config.step);
+                var domain = this._scale.domain();
+                tickPos.unshift(domain[0]);
+                tickPos.push(domain[1]);
+                return tickPos;
+            };
             Time.prototype._renderTierLabels = function (container, config, index) {
                 var _this = this;
-                var tickPos = this._scale.tickInterval(config.interval, config.step);
-                tickPos.splice(0, 0, this._scale.domain()[0]);
-                tickPos.push(this._scale.domain()[1]);
+                var tickPos = this._getTickValuesForConfiguration(config);
                 var labelPos = [];
                 if (this._tierLabelPositions[index] === "between" && config.step === 1) {
                     tickPos.map(function (datum, index) {
@@ -4598,13 +4603,6 @@ var Plottable;
                 tickLabels.attr("transform", function (d) { return "translate(" + _this._scale.scale(d) + ",0)"; });
                 var anchor = (this._tierLabelPositions[index] === "center" || config.step === 1) ? "middle" : "start";
                 tickLabels.selectAll("text").text(config.formatter).style("text-anchor", anchor);
-                if (filteredTicks.indexOf(this._scale.domain()[0]) === -1) {
-                    filteredTicks.splice(0, 1, this._scale.domain()[0]);
-                }
-                if (filteredTicks.indexOf(this._scale.domain()[1]) === -1) {
-                    filteredTicks.push(this._scale.domain()[1]);
-                }
-                return filteredTicks;
             };
             Time.prototype._canFitLabelFilter = function (position, bounds, config, labelPosition) {
                 if (labelPosition === "center") {
@@ -4671,7 +4669,10 @@ var Plottable;
                 for (var i = 0; i < Time._NUM_TIERS; ++i) {
                     this._cleanTier(i);
                 }
-                var tierTicks = tierConfigs.map(function (config, i) { return _this._renderTierLabels(_this._tierLabelContainers[i], config, i); });
+                var tierTicks = tierConfigs.map(function (config, i) {
+                    _this._renderTierLabels(_this._tierLabelContainers[i], config, i);
+                    return _this._getTickValuesForConfiguration(config);
+                });
                 var baselineOffset = 0;
                 for (i = 0; i < Math.max(tierConfigs.length, 1); ++i) {
                     var attr = this._generateBaselineAttrHash();

--- a/plottable.js
+++ b/plottable.js
@@ -4581,14 +4581,6 @@ var Plottable;
                 else {
                     labelPos = tickPos;
                 }
-                var filteredTicks = [];
-                labelPos = labelPos.filter(function (d, i) {
-                    var fits = _this._canFitLabelFilter(d, tickPos.slice(i, i + 2), config, _this._tierLabelPositions[index]);
-                    if (fits) {
-                        filteredTicks.push(tickPos[i]);
-                    }
-                    return fits;
-                });
                 var tickLabels = container.selectAll("." + Axis.AbstractAxis.TICK_LABEL_CLASS).data(labelPos, function (d) { return d.valueOf(); });
                 var tickLabelsEnter = tickLabels.enter().append("g").classed(Axis.AbstractAxis.TICK_LABEL_CLASS, true);
                 tickLabelsEnter.append("text");
@@ -4603,25 +4595,6 @@ var Plottable;
                 tickLabels.attr("transform", function (d) { return "translate(" + _this._scale.scale(d) + ",0)"; });
                 var anchor = (this._tierLabelPositions[index] === "center" || config.step === 1) ? "middle" : "start";
                 tickLabels.selectAll("text").text(config.formatter).style("text-anchor", anchor);
-            };
-            Time.prototype._canFitLabelFilter = function (position, bounds, config, labelPosition) {
-                if (labelPosition === "center") {
-                    return true;
-                }
-                var endPosition;
-                var startPosition;
-                var width = this._measurer.measure(config.formatter(position)).width + ((config.step !== 1) ? this.tickLabelPadding() : 0);
-                var leftBound = this._scale.scale(bounds[0]);
-                var rightBound = this._scale.scale(bounds[1]);
-                if (labelPosition === "center" || config.step === 1) {
-                    endPosition = this._scale.scale(position) + width / 2;
-                    startPosition = this._scale.scale(position) - width / 2;
-                }
-                else {
-                    endPosition = this._scale.scale(position) + width;
-                    startPosition = this._scale.scale(position);
-                }
-                return endPosition <= rightBound && startPosition >= leftBound;
             };
             Time.prototype._renderTickMarks = function (tickValues, index) {
                 var tickMarks = this._tierMarkContainers[index].selectAll("." + Axis.AbstractAxis.TICK_MARK_CLASS).data(tickValues);

--- a/plottable.js
+++ b/plottable.js
@@ -4562,8 +4562,13 @@ var Plottable;
             Time.prototype._getTickValuesForConfiguration = function (config) {
                 var tickPos = this._scale.tickInterval(config.interval, config.step);
                 var domain = this._scale.domain();
-                tickPos.unshift(domain[0]);
-                tickPos.push(domain[1]);
+                var tickPosValues = tickPos.map(function (d) { return d.valueOf(); }); // can't indexOf with objects
+                if (tickPosValues.indexOf(domain[0].valueOf()) === -1) {
+                    tickPos.unshift(domain[0]);
+                }
+                if (tickPosValues.indexOf(domain[1].valueOf()) === -1) {
+                    tickPos.push(domain[1]);
+                }
                 return tickPos;
             };
             Time.prototype._renderTierLabels = function (container, config, index) {
@@ -4642,10 +4647,8 @@ var Plottable;
                 for (var i = 0; i < Time._NUM_TIERS; ++i) {
                     this._cleanTier(i);
                 }
-                var tierTicks = tierConfigs.map(function (config, i) {
-                    _this._renderTierLabels(_this._tierLabelContainers[i], config, i);
-                    return _this._getTickValuesForConfiguration(config);
-                });
+                tierConfigs.forEach(function (config, i) { return _this._renderTierLabels(_this._tierLabelContainers[i], config, i); });
+                var tierTicks = tierConfigs.map(function (config, i) { return _this._getTickValuesForConfiguration(config); });
                 var baselineOffset = 0;
                 for (i = 0; i < Math.max(tierConfigs.length, 1); ++i) {
                     var attr = this._generateBaselineAttrHash();

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -327,14 +327,6 @@ export module Axis {
       } else {
         labelPos = tickPos;
       }
-      var filteredTicks: Date[] = [];
-      labelPos = labelPos.filter((d: any, i: number) => {
-        var fits = this._canFitLabelFilter(d, tickPos.slice(i, i + 2), config, this._tierLabelPositions[index]);
-        if (fits) {
-          filteredTicks.push(tickPos[i]);
-        }
-        return fits;
-      });
 
       var tickLabels = container.selectAll("." + AbstractAxis.TICK_LABEL_CLASS).data(labelPos, (d) => d.valueOf());
       var tickLabelsEnter = tickLabels.enter().append("g").classed(AbstractAxis.TICK_LABEL_CLASS, true);
@@ -353,26 +345,6 @@ export module Axis {
       tickLabels.attr("transform", (d: any) => "translate(" + this._scale.scale(d) + ",0)");
       var anchor = (this._tierLabelPositions[index] === "center" || config.step === 1) ? "middle" : "start";
       tickLabels.selectAll("text").text(config.formatter).style("text-anchor", anchor);
-    }
-
-    private _canFitLabelFilter(position: Date, bounds: Date[], config: TimeAxisTierConfiguration, labelPosition: string): boolean {
-      if (labelPosition === "center") {
-        return true;
-      }
-      var endPosition: number;
-      var startPosition: number;
-      var width = this._measurer.measure(config.formatter(position)).width + ((config.step !== 1) ? this.tickLabelPadding() : 0);
-      var leftBound = this._scale.scale(bounds[0]);
-      var rightBound = this._scale.scale(bounds[1]);
-      if (labelPosition === "center" || config.step === 1) {
-          endPosition = this._scale.scale(position) + width / 2;
-          startPosition = this._scale.scale(position) - width / 2;
-      } else {
-          endPosition = this._scale.scale(position) + width;
-          startPosition = this._scale.scale(position);
-      }
-
-      return endPosition <= rightBound && startPosition >= leftBound;
     }
 
     private _renderTickMarks(tickValues: Date[], index: number) {

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -309,8 +309,13 @@ export module Axis {
     private _getTickValuesForConfiguration(config: TimeAxisTierConfiguration) {
       var tickPos = (<Scale.Time> this._scale).tickInterval(config.interval, config.step);
       var domain = this._scale.domain();
-      tickPos.unshift(domain[0]);
-      tickPos.push(domain[1]);
+      var tickPosValues = tickPos.map((d: Date) => d.valueOf()); // can't indexOf with objects
+      if (tickPosValues.indexOf(domain[0].valueOf()) === -1) {
+        tickPos.unshift(domain[0]);
+      }
+      if (tickPosValues.indexOf(domain[1].valueOf()) === -1) {
+        tickPos.push(domain[1]);
+      }
       return tickPos;
     }
 
@@ -397,10 +402,12 @@ export module Axis {
         this._cleanTier(i);
       }
 
-      var tierTicks = tierConfigs.map((config: TimeAxisTierConfiguration, i: number) => {
-        this._renderTierLabels(this._tierLabelContainers[i], config, i);
-        return this._getTickValuesForConfiguration(config);
-      });
+      tierConfigs.forEach((config: TimeAxisTierConfiguration, i: number) =>
+        this._renderTierLabels(this._tierLabelContainers[i], config, i)
+      );
+      var tierTicks = tierConfigs.map((config: TimeAxisTierConfiguration, i: number) =>
+        this._getTickValuesForConfiguration(config)
+      );
 
       var baselineOffset = 0;
       for (i = 0; i < Math.max(tierConfigs.length, 1); ++i) {


### PR DESCRIPTION
(from an earlier state of **develop**)

We were splicing/etc, when the correct tick marks were already generated.

Close #1606.