### PR TITLE
[Plot] - getAllSelections() with dataset key params

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2736,7 +2736,14 @@ declare module Plottable {
              * @param {string} key The key of new dataset
              */
             protected _getPlotMetadataForDataset(key: string): PlotMetadata;
-            getAllSelections(): D3.Selection;
+            /**
+             * Retrieves all of the selections of this plot for the specified dataset(s)
+             *
+             * @param {string | string[]} datasetKeys The datasets to retrieve the selections from.
+             * If not provided, all selections will be retrieved.
+             * @returns {D3.Selection} The retrieved selections.
+             */
+            getAllSelections(datasetKeys?: string | string[]): D3.Selection;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2739,7 +2739,7 @@ declare module Plottable {
             /**
              * Retrieves all of the selections of this plot for the specified dataset(s)
              *
-             * @param {string | string[]} datasetKeys The datasets to retrieve the selections from.
+             * @param {string | string[]} datasetKeys The dataset(s) to retrieve the selections from.
              * If not provided, all selections will be retrieved.
              * @returns {D3.Selection} The retrieved selections.
              */

--- a/plottable.js
+++ b/plottable.js
@@ -6528,19 +6528,18 @@ var Plottable;
                 else {
                     datasetKeyArray = datasetKeys;
                 }
-                var allSelections = d3.select();
-                allSelections[0] = [];
+                var allSelections = [];
                 datasetKeyArray.forEach(function (datasetKey) {
                     var plotDatasetKey = _this._key2PlotDatasetKey.get(datasetKey);
                     if (plotDatasetKey == null) {
                         return;
                     }
                     var drawer = plotDatasetKey.drawer;
-                    drawer._getRenderArea().selectAll(drawer._getSelector())[0].forEach(function (selection) {
-                        allSelections[0].push(selection);
+                    drawer._getRenderArea().selectAll(drawer._getSelector()).each(function () {
+                        allSelections.push(this);
                     });
                 });
-                return allSelections;
+                return d3.selectAll(allSelections);
             };
             return AbstractPlot;
         })(Plottable.Component.AbstractComponent);

--- a/plottable.js
+++ b/plottable.js
@@ -6509,7 +6509,14 @@ var Plottable;
                 var maxTime = Plottable._Util.Methods.max(times, 0);
                 this._additionalPaint(maxTime);
             };
-            AbstractPlot.prototype.getAllSelections = function () {
+            /**
+             * Retrieves all of the selections of this plot for the specified dataset(s)
+             *
+             * @param {string | string[]} datasetKeys The datasets to retrieve the selections from.
+             * If not provided, all selections will be retrieved.
+             * @returns {D3.Selection} The retrieved selections.
+             */
+            AbstractPlot.prototype.getAllSelections = function (datasetKeys) {
                 var allSelections = d3.select();
                 allSelections[0] = [];
                 this._getDrawersInOrder().forEach(function (drawer) {

--- a/plottable.js
+++ b/plottable.js
@@ -6532,6 +6532,9 @@ var Plottable;
                 allSelections[0] = [];
                 datasetKeyArray.forEach(function (datasetKey) {
                     var plotDatasetKey = _this._key2PlotDatasetKey.get(datasetKey);
+                    if (plotDatasetKey == null) {
+                        return;
+                    }
                     var drawer = plotDatasetKey.drawer;
                     drawer._getRenderArea().selectAll(drawer._getSelector())[0].forEach(function (selection) {
                         allSelections[0].push(selection);

--- a/plottable.js
+++ b/plottable.js
@@ -6512,14 +6512,27 @@ var Plottable;
             /**
              * Retrieves all of the selections of this plot for the specified dataset(s)
              *
-             * @param {string | string[]} datasetKeys The datasets to retrieve the selections from.
+             * @param {string | string[]} datasetKeys The dataset(s) to retrieve the selections from.
              * If not provided, all selections will be retrieved.
              * @returns {D3.Selection} The retrieved selections.
              */
             AbstractPlot.prototype.getAllSelections = function (datasetKeys) {
+                var _this = this;
+                var datasetKeyArray = [];
+                if (datasetKeys == null) {
+                    datasetKeyArray = this._datasetKeysInOrder;
+                }
+                else if (typeof (datasetKeys) === "string") {
+                    datasetKeyArray = [datasetKeys];
+                }
+                else {
+                    datasetKeyArray = datasetKeys;
+                }
                 var allSelections = d3.select();
                 allSelections[0] = [];
-                this._getDrawersInOrder().forEach(function (drawer) {
+                datasetKeyArray.forEach(function (datasetKey) {
+                    var plotDatasetKey = _this._key2PlotDatasetKey.get(datasetKey);
+                    var drawer = plotDatasetKey.drawer;
                     drawer._getRenderArea().selectAll(drawer._getSelector())[0].forEach(function (selection) {
                         allSelections[0].push(selection);
                     });

--- a/src/components/plots/abstractPlot.ts
+++ b/src/components/plots/abstractPlot.ts
@@ -420,7 +420,14 @@ export module Plot {
       this._additionalPaint(maxTime);
     }
 
-    public getAllSelections(): D3.Selection {
+    /**
+     * Retrieves all of the selections of this plot for the specified dataset(s)
+     *
+     * @param {string | string[]} datasetKeys The datasets to retrieve the selections from.
+     * If not provided, all selections will be retrieved.
+     * @returns {D3.Selection} The retrieved selections.
+     */
+    public getAllSelections(datasetKeys?: string | string[]): D3.Selection {
       var allSelections = d3.select();
       allSelections[0] = [];
       this._getDrawersInOrder().forEach((drawer) => {

--- a/src/components/plots/abstractPlot.ts
+++ b/src/components/plots/abstractPlot.ts
@@ -442,6 +442,7 @@ export module Plot {
 
       datasetKeyArray.forEach((datasetKey) => {
         var plotDatasetKey = this._key2PlotDatasetKey.get(datasetKey);
+        if (plotDatasetKey == null) { return; }
         var drawer = plotDatasetKey.drawer;
         drawer._getRenderArea().selectAll(drawer._getSelector())[0].forEach((selection: EventTarget) => {
           allSelections[0].push(selection);

--- a/src/components/plots/abstractPlot.ts
+++ b/src/components/plots/abstractPlot.ts
@@ -437,19 +437,18 @@ export module Plot {
         datasetKeyArray = <string[]> datasetKeys;
       }
 
-      var allSelections = d3.select();
-      allSelections[0] = [];
+      var allSelections: EventTarget[] = [];
 
       datasetKeyArray.forEach((datasetKey) => {
         var plotDatasetKey = this._key2PlotDatasetKey.get(datasetKey);
         if (plotDatasetKey == null) { return; }
         var drawer = plotDatasetKey.drawer;
-        drawer._getRenderArea().selectAll(drawer._getSelector())[0].forEach((selection: EventTarget) => {
-          allSelections[0].push(selection);
+        drawer._getRenderArea().selectAll(drawer._getSelector()).each(function () {
+          allSelections.push(this);
         });
       });
 
-      return allSelections;
+      return d3.selectAll(allSelections);
     }
   }
 }

--- a/src/components/plots/abstractPlot.ts
+++ b/src/components/plots/abstractPlot.ts
@@ -423,14 +423,26 @@ export module Plot {
     /**
      * Retrieves all of the selections of this plot for the specified dataset(s)
      *
-     * @param {string | string[]} datasetKeys The datasets to retrieve the selections from.
+     * @param {string | string[]} datasetKeys The dataset(s) to retrieve the selections from.
      * If not provided, all selections will be retrieved.
      * @returns {D3.Selection} The retrieved selections.
      */
     public getAllSelections(datasetKeys?: string | string[]): D3.Selection {
+      var datasetKeyArray: string[] = [];
+      if (datasetKeys == null) {
+        datasetKeyArray = this._datasetKeysInOrder;
+      } else if (typeof(datasetKeys) === "string") {
+        datasetKeyArray = [<string> datasetKeys];
+      } else {
+        datasetKeyArray = <string[]> datasetKeys;
+      }
+
       var allSelections = d3.select();
       allSelections[0] = [];
-      this._getDrawersInOrder().forEach((drawer) => {
+
+      datasetKeyArray.forEach((datasetKey) => {
+        var plotDatasetKey = this._key2PlotDatasetKey.get(datasetKey);
+        var drawer = plotDatasetKey.drawer;
         drawer._getRenderArea().selectAll(drawer._getSelector())[0].forEach((selection: EventTarget) => {
           allSelections[0].push(selection);
         });

--- a/test/components/plots/areaPlotTests.ts
+++ b/test/components/plots/areaPlotTests.ts
@@ -31,7 +31,7 @@ describe("Plots", () => {
       svg = generateSVG(500, 500);
       simpleDataset = new Plottable.Dataset(twoPointData);
       areaPlot = new Plottable.Plot.Area(xScale, yScale);
-      areaPlot.addDataset(simpleDataset)
+      areaPlot.addDataset("sd", simpleDataset)
               .project("x", xAccessor, xScale)
               .project("y", yAccessor, yScale)
               .project("y0", y0Accessor, yScale)
@@ -113,17 +113,54 @@ describe("Plots", () => {
       svg.remove();
     });
 
-    it("getAllSelections retrieves correct selections", () => {
-      var newTwoPointData = [{foo: 2, bar: 1}, {foo: 3, bar: 2}];
-      var newDataset = new Plottable.Dataset(twoPointData);
-      areaPlot.addDataset(new Plottable.Dataset(newTwoPointData));
-      var allAreas = areaPlot.getAllSelections();
-      assert.strictEqual(allAreas.size(), 2, "all areas retrieved");
-      var selectionData = allAreas.data();
-      assert.include(selectionData, twoPointData, "first dataset data in selection data");
-      assert.include(selectionData, newTwoPointData, "new dataset data in selection data");
+    describe("getAllSelections()", () => {
 
-      svg.remove();
+      it("retrieves all selections with no args", () => {
+        var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
+        var newDataset = new Plottable.Dataset(twoPointData);
+        areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
+        var allAreas = areaPlot.getAllSelections();
+        var allAreas2 = areaPlot.getAllSelections((<any> areaPlot)._datasetKeysInOrder);
+        assert.deepEqual(allAreas, allAreas2, "all areas retrieved");
+
+        svg.remove();
+      });
+
+      it("retrieves correct selections (string arg)", () => {
+        var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
+        var newDataset = new Plottable.Dataset(twoPointData);
+        areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
+        var allAreas = areaPlot.getAllSelections("newTwo");
+        assert.strictEqual(allAreas.size(), 1, "all areas retrieved");
+        var selectionData = allAreas.data();
+        assert.include(selectionData, newTwoPointData, "new dataset data in selection data");
+
+        svg.remove();
+      });
+
+      it("retrieves correct selections (string arg)", () => {
+        var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
+        var newDataset = new Plottable.Dataset(twoPointData);
+        areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
+        var allAreas = areaPlot.getAllSelections(["newTwo"]);
+        assert.strictEqual(allAreas.size(), 1, "all areas retrieved");
+        var selectionData = allAreas.data();
+        assert.include(selectionData, newTwoPointData, "new dataset data in selection data");
+
+        svg.remove();
+      });
+
+      it("skips invalid keys", () => {
+        var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
+        var newDataset = new Plottable.Dataset(twoPointData);
+        areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
+        var allAreas = areaPlot.getAllSelections(["newTwo", "test"]);
+        assert.strictEqual(allAreas.size(), 1, "all areas retrieved");
+        var selectionData = allAreas.data();
+        assert.include(selectionData, newTwoPointData, "new dataset data in selection data");
+
+        svg.remove();
+      });
     });
 
     it("retains original classes when class is projected", () => {

--- a/test/components/plots/areaPlotTests.ts
+++ b/test/components/plots/areaPlotTests.ts
@@ -117,7 +117,6 @@ describe("Plots", () => {
 
       it("retrieves all selections with no args", () => {
         var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
-        var newDataset = new Plottable.Dataset(twoPointData);
         areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
         var allAreas = areaPlot.getAllSelections();
         var allAreas2 = areaPlot.getAllSelections((<any> areaPlot)._datasetKeysInOrder);
@@ -128,7 +127,6 @@ describe("Plots", () => {
 
       it("retrieves correct selections (string arg)", () => {
         var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
-        var newDataset = new Plottable.Dataset(twoPointData);
         areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
         var allAreas = areaPlot.getAllSelections("newTwo");
         assert.strictEqual(allAreas.size(), 1, "all areas retrieved");
@@ -140,7 +138,6 @@ describe("Plots", () => {
 
       it("retrieves correct selections (array arg)", () => {
         var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
-        var newDataset = new Plottable.Dataset(twoPointData);
         areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
         var allAreas = areaPlot.getAllSelections(["newTwo"]);
         assert.strictEqual(allAreas.size(), 1, "all areas retrieved");
@@ -152,7 +149,6 @@ describe("Plots", () => {
 
       it("skips invalid keys", () => {
         var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
-        var newDataset = new Plottable.Dataset(twoPointData);
         areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
         var allAreas = areaPlot.getAllSelections(["newTwo", "test"]);
         assert.strictEqual(allAreas.size(), 1, "all areas retrieved");

--- a/test/components/plots/areaPlotTests.ts
+++ b/test/components/plots/areaPlotTests.ts
@@ -138,7 +138,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("retrieves correct selections (string arg)", () => {
+      it("retrieves correct selections (array arg)", () => {
         var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
         var newDataset = new Plottable.Dataset(twoPointData);
         areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -467,7 +467,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("retrieves correct selections (dataset string arg)", () => {
+      it("retrieves correct selections (string arg)", () => {
         var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
         var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
         verticalBarPlot.addDataset("a", barData);
@@ -482,7 +482,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("retrieves correct selections (dataset array arg)", () => {
+      it("retrieves correct selections (array arg)", () => {
         var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
         var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
         verticalBarPlot.addDataset("a", barData);

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -453,14 +453,43 @@ describe("Plots", () => {
         verticalBarPlot.project("y", "y", yScale);
       });
 
-      it("getAllSelections retrieves correct selections",() => {
+      it("getAllSelections retrieves all dataset selections with no args",() => {
         var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
         var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
-        verticalBarPlot.addDataset(barData);
-        verticalBarPlot.addDataset(barData2);
+        verticalBarPlot.addDataset("a", barData);
+        verticalBarPlot.addDataset("b", barData2);
         verticalBarPlot.renderTo(svg);
 
         var allBars = verticalBarPlot.getAllSelections();
+        var allBars2 = verticalBarPlot.getAllSelections(["a", "b"]);
+        assert.deepEqual(allBars, allBars2, "both ways of getting all selections work");
+
+        svg.remove();
+      });
+
+      it("getAllSelections retrieves correct selections (dataset string arg)",() => {
+        var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
+        var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
+        verticalBarPlot.addDataset("a", barData);
+        verticalBarPlot.addDataset(barData2);
+        verticalBarPlot.renderTo(svg);
+
+        var allBars = verticalBarPlot.getAllSelections("a");
+        assert.strictEqual(allBars.size(), 3, "all bars retrieved");
+        var selectionData = allBars.data();
+        assert.includeMembers(selectionData, barData, "first dataset data in selection data");
+
+        svg.remove();
+      });
+
+      it("getAllSelections retrieves correct selections (dataset array arg)",() => {
+        var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
+        var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
+        verticalBarPlot.addDataset("a", barData);
+        verticalBarPlot.addDataset("b", barData2);
+        verticalBarPlot.renderTo(svg);
+
+        var allBars = verticalBarPlot.getAllSelections(["a", "b"]);
         assert.strictEqual(allBars.size(), 6, "all bars retrieved");
         var selectionData = allBars.data();
         assert.includeMembers(selectionData, barData, "first dataset data in selection data");

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -498,6 +498,21 @@ describe("Plots", () => {
         svg.remove();
       });
 
+      it("getAllSelections skips invalid keys",() => {
+        var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
+        var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
+        verticalBarPlot.addDataset("a", barData);
+        verticalBarPlot.addDataset("b", barData2);
+        verticalBarPlot.renderTo(svg);
+
+        var allBars = verticalBarPlot.getAllSelections(["a", "c"]);
+        assert.strictEqual(allBars.size(), 3, "all bars retrieved");
+        var selectionData = allBars.data();
+        assert.includeMembers(selectionData, barData, "first dataset data in selection data");
+
+        svg.remove();
+      });
+
     });
 
     it("plot auto domain scale to visible points on ordinal scale", () => {

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -453,7 +453,7 @@ describe("Plots", () => {
         verticalBarPlot.project("y", "y", yScale);
       });
 
-      it("getAllSelections retrieves all dataset selections with no args",() => {
+      it("retrieves all dataset selections with no args", () => {
         var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
         var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
         verticalBarPlot.addDataset("a", barData);
@@ -461,13 +461,13 @@ describe("Plots", () => {
         verticalBarPlot.renderTo(svg);
 
         var allBars = verticalBarPlot.getAllSelections();
-        var allBars2 = verticalBarPlot.getAllSelections(["a", "b"]);
+        var allBars2 = verticalBarPlot.getAllSelections((<any> verticalBarPlot)._datasetKeysInOrder);
         assert.deepEqual(allBars, allBars2, "both ways of getting all selections work");
 
         svg.remove();
       });
 
-      it("getAllSelections retrieves correct selections (dataset string arg)",() => {
+      it("retrieves correct selections (dataset string arg)", () => {
         var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
         var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
         verticalBarPlot.addDataset("a", barData);
@@ -482,7 +482,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("getAllSelections retrieves correct selections (dataset array arg)",() => {
+      it("retrieves correct selections (dataset array arg)", () => {
         var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
         var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
         verticalBarPlot.addDataset("a", barData);
@@ -498,7 +498,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("getAllSelections skips invalid keys",() => {
+      it("skips invalid keys", () => {
         var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
         var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
         verticalBarPlot.addDataset("a", barData);

--- a/test/components/plots/gridPlotTests.ts
+++ b/test/components/plots/gridPlotTests.ts
@@ -119,24 +119,88 @@ describe("Plots", () => {
       svg.remove();
     });
 
-    it("getAllSelections retrieves correct selections",() => {
-      var xScale: Plottable.Scale.Ordinal = new Plottable.Scale.Ordinal();
-      var yScale: Plottable.Scale.Ordinal = new Plottable.Scale.Ordinal();
-      var colorScale: Plottable.Scale.InterpolatedColor = new Plottable.Scale.InterpolatedColor(["black", "white"]);
-      var svg: D3.Selection = generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      var gridPlot: Plottable.Plot.Grid = new Plottable.Plot.Grid(xScale, yScale, colorScale);
-      gridPlot.addDataset(DATA)
-        .project("fill", "magnitude", colorScale)
-        .project("x", "x", xScale)
-        .project("y", "y", yScale);
-      gridPlot.renderTo(svg);
+    describe("getAllSelections()", () => {
 
-      var allCells = gridPlot.getAllSelections();
-      assert.strictEqual(allCells.size(), 4, "all cells retrieved");
-      var selectionData = allCells.data();
-      assert.includeMembers(selectionData, DATA, "data in selection data");
+      it("retrieves all selections with no args", () => {
+        var xScale: Plottable.Scale.Ordinal = new Plottable.Scale.Ordinal();
+        var yScale: Plottable.Scale.Ordinal = new Plottable.Scale.Ordinal();
+        var colorScale: Plottable.Scale.InterpolatedColor = new Plottable.Scale.InterpolatedColor(["black", "white"]);
+        var svg: D3.Selection = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        var gridPlot: Plottable.Plot.Grid = new Plottable.Plot.Grid(xScale, yScale, colorScale);
+        gridPlot.addDataset("a", DATA)
+                .project("fill", "magnitude", colorScale)
+                .project("x", "x", xScale)
+                .project("y", "y", yScale);
+        gridPlot.renderTo(svg);
 
-      svg.remove();
+        var allCells = gridPlot.getAllSelections();
+        var allCells2 = gridPlot.getAllSelections((<any> gridPlot)._datasetKeysInOrder);
+        assert.deepEqual(allCells, allCells2, "all cells retrieved");
+
+        svg.remove();
+      });
+
+      it("retrieves correct selections (string arg)", () => {
+        var xScale: Plottable.Scale.Ordinal = new Plottable.Scale.Ordinal();
+        var yScale: Plottable.Scale.Ordinal = new Plottable.Scale.Ordinal();
+        var colorScale: Plottable.Scale.InterpolatedColor = new Plottable.Scale.InterpolatedColor(["black", "white"]);
+        var svg: D3.Selection = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        var gridPlot: Plottable.Plot.Grid = new Plottable.Plot.Grid(xScale, yScale, colorScale);
+        gridPlot.addDataset("a", DATA)
+                .project("fill", "magnitude", colorScale)
+                .project("x", "x", xScale)
+                .project("y", "y", yScale);
+        gridPlot.renderTo(svg);
+
+        var allCells = gridPlot.getAllSelections("a");
+        assert.strictEqual(allCells.size(), 4, "all cells retrieved");
+        var selectionData = allCells.data();
+        assert.includeMembers(selectionData, DATA, "data in selection data");
+
+        svg.remove();
+      });
+
+      it("retrieves correct selections (array arg)", () => {
+        var xScale: Plottable.Scale.Ordinal = new Plottable.Scale.Ordinal();
+        var yScale: Plottable.Scale.Ordinal = new Plottable.Scale.Ordinal();
+        var colorScale: Plottable.Scale.InterpolatedColor = new Plottable.Scale.InterpolatedColor(["black", "white"]);
+        var svg: D3.Selection = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        var gridPlot: Plottable.Plot.Grid = new Plottable.Plot.Grid(xScale, yScale, colorScale);
+        gridPlot.addDataset("a", DATA)
+          .project("fill", "magnitude", colorScale)
+          .project("x", "x", xScale)
+          .project("y", "y", yScale);
+        gridPlot.renderTo(svg);
+
+        var allCells = gridPlot.getAllSelections(["a"]);
+        assert.strictEqual(allCells.size(), 4, "all cells retrieved");
+        var selectionData = allCells.data();
+        assert.includeMembers(selectionData, DATA, "data in selection data");
+
+        svg.remove();
+      });
+
+      it("skips invalid keys", () => {
+        var xScale: Plottable.Scale.Ordinal = new Plottable.Scale.Ordinal();
+        var yScale: Plottable.Scale.Ordinal = new Plottable.Scale.Ordinal();
+        var colorScale: Plottable.Scale.InterpolatedColor = new Plottable.Scale.InterpolatedColor(["black", "white"]);
+        var svg: D3.Selection = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        var gridPlot: Plottable.Plot.Grid = new Plottable.Plot.Grid(xScale, yScale, colorScale);
+        gridPlot.addDataset("a", DATA)
+          .project("fill", "magnitude", colorScale)
+          .project("x", "x", xScale)
+          .project("y", "y", yScale);
+        gridPlot.renderTo(svg);
+
+        var allCells = gridPlot.getAllSelections(["a", "b"]);
+        assert.strictEqual(allCells.size(), 4, "all cells retrieved");
+        var selectionData = allCells.data();
+        assert.includeMembers(selectionData, DATA, "data in selection data");
+
+        svg.remove();
+      });
+
     });
+
   });
 });

--- a/test/components/plots/linePlotTests.ts
+++ b/test/components/plots/linePlotTests.ts
@@ -165,7 +165,7 @@ describe("Plots", () => {
 
     describe("getAllSelections()",() => {
 
-      it("getAllSelections retrieves all dataset selections with no args", () => {
+      it("retrieves all dataset selections with no args", () => {
         var dataset3 = [
           { foo: 0, bar: 1 },
           { foo: 1, bar: 0.95 }
@@ -173,13 +173,13 @@ describe("Plots", () => {
         linePlot.addDataset("d3", dataset3);
 
         var allLines = linePlot.getAllSelections();
-        var allLines2 = linePlot.getAllSelections(["s1", "s2", "d3"]);
+        var allLines2 = linePlot.getAllSelections((<any> linePlot)._datasetKeysInOrder);
         assert.deepEqual(allLines, allLines2, "all lines retrieved");
 
         svg.remove();
       });
 
-      it("getAllSelections retrieves correct selections (dataset array arg)", () => {
+      it("retrieves correct selections (string arg)", () => {
         var dataset3 = [
           { foo: 0, bar: 1 },
           { foo: 1, bar: 0.95 }
@@ -194,7 +194,22 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("getAllSelections ignores invalid selections",() => {
+      it("retrieves correct selections (dataset array arg)", () => {
+        var dataset3 = [
+          { foo: 0, bar: 1 },
+          { foo: 1, bar: 0.95 }
+        ];
+        linePlot.addDataset("d3", dataset3);
+
+        var allLines = linePlot.getAllSelections(["d3"]);
+        assert.strictEqual(allLines.size(), 1, "all lines retrieved");
+        var selectionData = allLines.data();
+        assert.include(selectionData, dataset3, "third dataset data in selection data");
+
+        svg.remove();
+      });
+
+      it("skips invalid keys",() => {
         var dataset3 = [
           { foo: 0, bar: 1 },
           { foo: 1, bar: 0.95 }

--- a/test/components/plots/linePlotTests.ts
+++ b/test/components/plots/linePlotTests.ts
@@ -27,11 +27,11 @@ describe("Plots", () => {
       svg = generateSVG(500, 500);
       simpleDataset = new Plottable.Dataset(twoPointData);
       linePlot = new Plottable.Plot.Line(xScale, yScale);
-      linePlot.addDataset(simpleDataset)
+      linePlot.addDataset("s1", simpleDataset)
               .project("x", xAccessor, xScale)
               .project("y", yAccessor, yScale)
               .project("stroke", colorAccessor)
-              .addDataset(simpleDataset)
+              .addDataset("s2", simpleDataset)
               .renderTo(svg);
       renderArea = (<any> linePlot)._renderArea;
     });
@@ -163,20 +163,52 @@ describe("Plots", () => {
       svg.remove();
     });
 
-    it("getAllSelections retrieves correct selections",() => {
-      var dataset3 = [
-        { foo: 0, bar: 1 },
-        { foo: 1, bar: 0.95 }
-      ];
-      linePlot.addDataset(dataset3);
+    describe("getAllSelections()",() => {
 
-      var allLines = linePlot.getAllSelections();
-      assert.strictEqual(allLines.size(), 3, "all lines retrieved");
-      var selectionData = allLines.data();
-      assert.include(selectionData, twoPointData, "first dataset data in selection data");
-      assert.include(selectionData, dataset3, "third dataset data in selection data");
+      it("getAllSelections retrieves all dataset selections with no args", () => {
+        var dataset3 = [
+          { foo: 0, bar: 1 },
+          { foo: 1, bar: 0.95 }
+        ];
+        linePlot.addDataset("d3", dataset3);
 
-      svg.remove();
+        var allLines = linePlot.getAllSelections();
+        var allLines2 = linePlot.getAllSelections(["s1", "s2", "d3"]);
+        assert.deepEqual(allLines, allLines2, "all lines retrieved");
+
+        svg.remove();
+      });
+
+      it("getAllSelections retrieves correct selections (dataset array arg)", () => {
+        var dataset3 = [
+          { foo: 0, bar: 1 },
+          { foo: 1, bar: 0.95 }
+        ];
+        linePlot.addDataset("d3", dataset3);
+
+        var allLines = linePlot.getAllSelections("d3");
+        assert.strictEqual(allLines.size(), 1, "all lines retrieved");
+        var selectionData = allLines.data();
+        assert.include(selectionData, dataset3, "third dataset data in selection data");
+
+        svg.remove();
+      });
+
+      it("getAllSelections ignores invalid selections",() => {
+        var dataset3 = [
+          { foo: 0, bar: 1 },
+          { foo: 1, bar: 0.95 }
+        ];
+        linePlot.addDataset("d3", dataset3);
+
+        var allLines = linePlot.getAllSelections(["d3", "test"]);
+        assert.strictEqual(allLines.size(), 1, "all lines retrieved");
+        var selectionData = allLines.data();
+        assert.include(selectionData, dataset3, "third dataset data in selection data");
+
+        svg.remove();
+      });
+
     });
 
     it("retains original classes when class is projected", () => {

--- a/test/components/plots/linePlotTests.ts
+++ b/test/components/plots/linePlotTests.ts
@@ -194,7 +194,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("retrieves correct selections (dataset array arg)", () => {
+      it("retrieves correct selections (array arg)", () => {
         var dataset3 = [
           { foo: 0, bar: 1 },
           { foo: 1, bar: 0.95 }

--- a/test/components/plots/piePlotTests.ts
+++ b/test/components/plots/piePlotTests.ts
@@ -129,13 +129,32 @@ describe("Plots", () => {
       svg.remove();
     });
 
-    it("getAllSelections retrieves correct selections",() => {
-      var allSectors = piePlot.getAllSelections();
-      assert.strictEqual(allSectors.size(), 2, "all sectors retrieved");
-      var selectionData = allSectors.data();
-      assert.includeMembers(selectionData.map((datum) => datum.data), simpleData, "dataset data in selection data");
+    describe("getAllSelections", () => {
 
-      svg.remove();
+      it("getAllSelections retrieves all dataset selections with no args",() => {
+        var allSectors = piePlot.getAllSelections();
+        var allSectors2 = piePlot.getAllSelections(["simpleDataset"]);
+        assert.deepEqual(allSectors, allSectors2, "all sectors retrieved");
+
+        svg.remove();
+      });
+
+      it("getAllSelections retrieves correct selections (dataset array arg)",() => {
+        var allSectors = piePlot.getAllSelections(["simpleDataset"]);
+        assert.strictEqual(allSectors.size(), 2, "all sectors retrieved");
+        var selectionData = allSectors.data();
+        assert.includeMembers(selectionData.map((datum) => datum.data), simpleData, "dataset data in selection data");
+
+        svg.remove();
+      });
+
+      it("getAllSelections ignores invalid selections",() => {
+        var allSectors = piePlot.getAllSelections(["whoo"]);
+        assert.strictEqual(allSectors.size(), 0, "all sectors retrieved");
+
+        svg.remove();
+      });
+
     });
 
     describe("Fill", () => {

--- a/test/components/plots/piePlotTests.ts
+++ b/test/components/plots/piePlotTests.ts
@@ -139,7 +139,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("retrieves correct selections (dataset array arg)",() => {
+      it("retrieves correct selections (array arg)",() => {
         var allSectors = piePlot.getAllSelections(["simpleDataset"]);
         assert.strictEqual(allSectors.size(), 2, "all sectors retrieved");
         var selectionData = allSectors.data();

--- a/test/components/plots/piePlotTests.ts
+++ b/test/components/plots/piePlotTests.ts
@@ -131,15 +131,15 @@ describe("Plots", () => {
 
     describe("getAllSelections", () => {
 
-      it("getAllSelections retrieves all dataset selections with no args",() => {
+      it("retrieves all dataset selections with no args",() => {
         var allSectors = piePlot.getAllSelections();
-        var allSectors2 = piePlot.getAllSelections(["simpleDataset"]);
+        var allSectors2 = piePlot.getAllSelections((<any> piePlot)._datasetKeysInOrder);
         assert.deepEqual(allSectors, allSectors2, "all sectors retrieved");
 
         svg.remove();
       });
 
-      it("getAllSelections retrieves correct selections (dataset array arg)",() => {
+      it("retrieves correct selections (dataset array arg)",() => {
         var allSectors = piePlot.getAllSelections(["simpleDataset"]);
         assert.strictEqual(allSectors.size(), 2, "all sectors retrieved");
         var selectionData = allSectors.data();
@@ -148,7 +148,16 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("getAllSelections ignores invalid selections",() => {
+      it("retrieves correct selections (string arg)",() => {
+        var allSectors = piePlot.getAllSelections("simpleDataset");
+        assert.strictEqual(allSectors.size(), 2, "all sectors retrieved");
+        var selectionData = allSectors.data();
+        assert.includeMembers(selectionData.map((datum) => datum.data), simpleData, "dataset data in selection data");
+
+        svg.remove();
+      });
+
+      it("skips invalid keys",() => {
         var allSectors = piePlot.getAllSelections(["whoo"]);
         assert.strictEqual(allSectors.size(), 0, "all sectors retrieved");
 

--- a/test/components/plots/plotTests.ts
+++ b/test/components/plots/plotTests.ts
@@ -139,6 +139,49 @@ describe("Plots", () => {
       svg2.remove();
     });
 
+    it("getAllSelections() with dataset retrieval", () => {
+      var svg = generateSVG(400, 400);
+      var plot = new Plottable.Plot.AbstractPlot();
+
+      // Create mock drawers with already drawn items
+      var mockDrawer1 = new Plottable._Drawer.AbstractDrawer("ds1");
+      var renderArea1 = svg.append("g");
+      renderArea1.append("circle").attr("cx", 100).attr("cy", 100).attr("r", 10);
+      (<any> mockDrawer1).setup = () => (<any> mockDrawer1)._renderArea = renderArea1;
+      (<any> mockDrawer1)._getSelector = () => "circle";
+
+      var renderArea2 = svg.append("g");
+      renderArea2.append("circle").attr("cx", 10).attr("cy", 10).attr("r", 10);
+      var mockDrawer2 = new Plottable._Drawer.AbstractDrawer("ds2");
+      (<any> mockDrawer2).setup = () => (<any> mockDrawer2)._renderArea = renderArea2;
+      (<any> mockDrawer2)._getSelector = () => "circle";
+
+      // Mock _getDrawer to return the mock drawers
+      (<any> plot)._getDrawer = (key: string) => {
+        if (key === "ds1") {
+          return mockDrawer1;
+        } else {
+          return mockDrawer2;
+        }
+      };
+
+      plot.addDataset("ds1", [{value: 0}, {value: 1}, {value: 2}]);
+      plot.addDataset("ds2", [{value: 1}, {value: 2}, {value: 3}]);
+      plot.renderTo(svg);
+
+      var selections = plot.getAllSelections();
+      assert.strictEqual(selections.size(), 2, "all circle selections gotten");
+
+      var oneSelection = plot.getAllSelections("ds1");
+      assert.strictEqual(oneSelection.size(), 1);
+      assert.strictEqual(numAttr(oneSelection, "cx"), 100, "retrieved selection in renderArea1");
+
+      var oneElementSelection = plot.getAllSelections(["ds2"]);
+      assert.strictEqual(oneElementSelection.size(), 1);
+      assert.strictEqual(numAttr(oneElementSelection, "cy"), 10, "retreieved selection in renderArea2");
+      svg.remove();
+    });
+
     describe("Dataset removal", () => {
       var plot: Plottable.Plot.AbstractPlot;
       var d1: Plottable.Dataset;

--- a/test/tests.js
+++ b/test/tests.js
@@ -2460,7 +2460,6 @@ describe("Plots", function () {
         describe("getAllSelections()", function () {
             it("retrieves all selections with no args", function () {
                 var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
-                var newDataset = new Plottable.Dataset(twoPointData);
                 areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
                 var allAreas = areaPlot.getAllSelections();
                 var allAreas2 = areaPlot.getAllSelections(areaPlot._datasetKeysInOrder);
@@ -2469,7 +2468,6 @@ describe("Plots", function () {
             });
             it("retrieves correct selections (string arg)", function () {
                 var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
-                var newDataset = new Plottable.Dataset(twoPointData);
                 areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
                 var allAreas = areaPlot.getAllSelections("newTwo");
                 assert.strictEqual(allAreas.size(), 1, "all areas retrieved");
@@ -2479,7 +2477,6 @@ describe("Plots", function () {
             });
             it("retrieves correct selections (array arg)", function () {
                 var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
-                var newDataset = new Plottable.Dataset(twoPointData);
                 areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
                 var allAreas = areaPlot.getAllSelections(["newTwo"]);
                 assert.strictEqual(allAreas.size(), 1, "all areas retrieved");
@@ -2489,7 +2486,6 @@ describe("Plots", function () {
             });
             it("skips invalid keys", function () {
                 var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
-                var newDataset = new Plottable.Dataset(twoPointData);
                 areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
                 var allAreas = areaPlot.getAllSelections(["newTwo", "test"]);
                 assert.strictEqual(allAreas.size(), 1, "all areas retrieved");

--- a/test/tests.js
+++ b/test/tests.js
@@ -1709,6 +1709,42 @@ describe("Plots", function () {
             svg1.remove();
             svg2.remove();
         });
+        it("getAllSelections() with dataset retrieval", function () {
+            var svg = generateSVG(400, 400);
+            var plot = new Plottable.Plot.AbstractPlot();
+            // Create mock drawers with already drawn items
+            var mockDrawer1 = new Plottable._Drawer.AbstractDrawer("ds1");
+            var renderArea1 = svg.append("g");
+            renderArea1.append("circle").attr("cx", 100).attr("cy", 100).attr("r", 10);
+            mockDrawer1.setup = function () { return mockDrawer1._renderArea = renderArea1; };
+            mockDrawer1._getSelector = function () { return "circle"; };
+            var renderArea2 = svg.append("g");
+            renderArea2.append("circle").attr("cx", 10).attr("cy", 10).attr("r", 10);
+            var mockDrawer2 = new Plottable._Drawer.AbstractDrawer("ds2");
+            mockDrawer2.setup = function () { return mockDrawer2._renderArea = renderArea2; };
+            mockDrawer2._getSelector = function () { return "circle"; };
+            // Mock _getDrawer to return the mock drawers
+            plot._getDrawer = function (key) {
+                if (key === "ds1") {
+                    return mockDrawer1;
+                }
+                else {
+                    return mockDrawer2;
+                }
+            };
+            plot.addDataset("ds1", [{ value: 0 }, { value: 1 }, { value: 2 }]);
+            plot.addDataset("ds2", [{ value: 1 }, { value: 2 }, { value: 3 }]);
+            plot.renderTo(svg);
+            var selections = plot.getAllSelections();
+            assert.strictEqual(selections.size(), 2, "all circle selections gotten");
+            var oneSelection = plot.getAllSelections("ds1");
+            assert.strictEqual(oneSelection.size(), 1);
+            assert.strictEqual(numAttr(oneSelection, "cx"), 100, "retrieved selection in renderArea1");
+            var oneElementSelection = plot.getAllSelections(["ds2"]);
+            assert.strictEqual(oneElementSelection.size(), 1);
+            assert.strictEqual(numAttr(oneElementSelection, "cy"), 10, "retreieved selection in renderArea2");
+            svg.remove();
+        });
         describe("Dataset removal", function () {
             var plot;
             var d1;

--- a/test/tests.js
+++ b/test/tests.js
@@ -2816,13 +2816,36 @@ describe("Plots", function () {
                 verticalBarPlot.project("x", "x", xScale);
                 verticalBarPlot.project("y", "y", yScale);
             });
-            it("getAllSelections retrieves correct selections", function () {
+            it("getAllSelections retrieves all dataset selections with no args", function () {
                 var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
                 var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
-                verticalBarPlot.addDataset(barData);
-                verticalBarPlot.addDataset(barData2);
+                verticalBarPlot.addDataset("a", barData);
+                verticalBarPlot.addDataset("b", barData2);
                 verticalBarPlot.renderTo(svg);
                 var allBars = verticalBarPlot.getAllSelections();
+                var allBars2 = verticalBarPlot.getAllSelections(["a", "b"]);
+                assert.deepEqual(allBars, allBars2, "both ways of getting all selections work");
+                svg.remove();
+            });
+            it("getAllSelections retrieves correct selections (dataset string arg)", function () {
+                var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
+                var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
+                verticalBarPlot.addDataset("a", barData);
+                verticalBarPlot.addDataset(barData2);
+                verticalBarPlot.renderTo(svg);
+                var allBars = verticalBarPlot.getAllSelections("a");
+                assert.strictEqual(allBars.size(), 3, "all bars retrieved");
+                var selectionData = allBars.data();
+                assert.includeMembers(selectionData, barData, "first dataset data in selection data");
+                svg.remove();
+            });
+            it("getAllSelections retrieves correct selections (dataset array arg)", function () {
+                var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
+                var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
+                verticalBarPlot.addDataset("a", barData);
+                verticalBarPlot.addDataset("b", barData2);
+                verticalBarPlot.renderTo(svg);
+                var allBars = verticalBarPlot.getAllSelections(["a", "b"]);
                 assert.strictEqual(allBars.size(), 6, "all bars retrieved");
                 var selectionData = allBars.data();
                 assert.includeMembers(selectionData, barData, "first dataset data in selection data");

--- a/test/tests.js
+++ b/test/tests.js
@@ -2038,7 +2038,7 @@ describe("Plots", function () {
                 assert.deepEqual(allSectors, allSectors2, "all sectors retrieved");
                 svg.remove();
             });
-            it("retrieves correct selections (dataset array arg)", function () {
+            it("retrieves correct selections (array arg)", function () {
                 var allSectors = piePlot.getAllSelections(["simpleDataset"]);
                 assert.strictEqual(allSectors.size(), 2, "all sectors retrieved");
                 var selectionData = allSectors.data();
@@ -2330,7 +2330,7 @@ describe("Plots", function () {
                 assert.include(selectionData, dataset3, "third dataset data in selection data");
                 svg.remove();
             });
-            it("retrieves correct selections (dataset array arg)", function () {
+            it("retrieves correct selections (array arg)", function () {
                 var dataset3 = [
                     { foo: 0, bar: 1 },
                     { foo: 1, bar: 0.95 }
@@ -2477,7 +2477,7 @@ describe("Plots", function () {
                 assert.include(selectionData, newTwoPointData, "new dataset data in selection data");
                 svg.remove();
             });
-            it("retrieves correct selections (string arg)", function () {
+            it("retrieves correct selections (array arg)", function () {
                 var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
                 var newDataset = new Plottable.Dataset(twoPointData);
                 areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
@@ -2913,7 +2913,7 @@ describe("Plots", function () {
                 assert.deepEqual(allBars, allBars2, "both ways of getting all selections work");
                 svg.remove();
             });
-            it("retrieves correct selections (dataset string arg)", function () {
+            it("retrieves correct selections (string arg)", function () {
                 var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
                 var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
                 verticalBarPlot.addDataset("a", barData);
@@ -2925,7 +2925,7 @@ describe("Plots", function () {
                 assert.includeMembers(selectionData, barData, "first dataset data in selection data");
                 svg.remove();
             });
-            it("retrieves correct selections (dataset array arg)", function () {
+            it("retrieves correct selections (array arg)", function () {
                 var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
                 var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
                 verticalBarPlot.addDataset("a", barData);
@@ -3060,19 +3060,62 @@ describe("Plots", function () {
             cellAV.attr("y", "100");
             svg.remove();
         });
-        it("getAllSelections retrieves correct selections", function () {
-            var xScale = new Plottable.Scale.Ordinal();
-            var yScale = new Plottable.Scale.Ordinal();
-            var colorScale = new Plottable.Scale.InterpolatedColor(["black", "white"]);
-            var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
-            var gridPlot = new Plottable.Plot.Grid(xScale, yScale, colorScale);
-            gridPlot.addDataset(DATA).project("fill", "magnitude", colorScale).project("x", "x", xScale).project("y", "y", yScale);
-            gridPlot.renderTo(svg);
-            var allCells = gridPlot.getAllSelections();
-            assert.strictEqual(allCells.size(), 4, "all cells retrieved");
-            var selectionData = allCells.data();
-            assert.includeMembers(selectionData, DATA, "data in selection data");
-            svg.remove();
+        describe("getAllSelections()", function () {
+            it("retrieves all selections with no args", function () {
+                var xScale = new Plottable.Scale.Ordinal();
+                var yScale = new Plottable.Scale.Ordinal();
+                var colorScale = new Plottable.Scale.InterpolatedColor(["black", "white"]);
+                var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+                var gridPlot = new Plottable.Plot.Grid(xScale, yScale, colorScale);
+                gridPlot.addDataset("a", DATA).project("fill", "magnitude", colorScale).project("x", "x", xScale).project("y", "y", yScale);
+                gridPlot.renderTo(svg);
+                var allCells = gridPlot.getAllSelections();
+                var allCells2 = gridPlot.getAllSelections(gridPlot._datasetKeysInOrder);
+                assert.deepEqual(allCells, allCells2, "all cells retrieved");
+                svg.remove();
+            });
+            it("retrieves correct selections (string arg)", function () {
+                var xScale = new Plottable.Scale.Ordinal();
+                var yScale = new Plottable.Scale.Ordinal();
+                var colorScale = new Plottable.Scale.InterpolatedColor(["black", "white"]);
+                var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+                var gridPlot = new Plottable.Plot.Grid(xScale, yScale, colorScale);
+                gridPlot.addDataset("a", DATA).project("fill", "magnitude", colorScale).project("x", "x", xScale).project("y", "y", yScale);
+                gridPlot.renderTo(svg);
+                var allCells = gridPlot.getAllSelections("a");
+                assert.strictEqual(allCells.size(), 4, "all cells retrieved");
+                var selectionData = allCells.data();
+                assert.includeMembers(selectionData, DATA, "data in selection data");
+                svg.remove();
+            });
+            it("retrieves correct selections (array arg)", function () {
+                var xScale = new Plottable.Scale.Ordinal();
+                var yScale = new Plottable.Scale.Ordinal();
+                var colorScale = new Plottable.Scale.InterpolatedColor(["black", "white"]);
+                var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+                var gridPlot = new Plottable.Plot.Grid(xScale, yScale, colorScale);
+                gridPlot.addDataset("a", DATA).project("fill", "magnitude", colorScale).project("x", "x", xScale).project("y", "y", yScale);
+                gridPlot.renderTo(svg);
+                var allCells = gridPlot.getAllSelections(["a"]);
+                assert.strictEqual(allCells.size(), 4, "all cells retrieved");
+                var selectionData = allCells.data();
+                assert.includeMembers(selectionData, DATA, "data in selection data");
+                svg.remove();
+            });
+            it("skips invalid keys", function () {
+                var xScale = new Plottable.Scale.Ordinal();
+                var yScale = new Plottable.Scale.Ordinal();
+                var colorScale = new Plottable.Scale.InterpolatedColor(["black", "white"]);
+                var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+                var gridPlot = new Plottable.Plot.Grid(xScale, yScale, colorScale);
+                gridPlot.addDataset("a", DATA).project("fill", "magnitude", colorScale).project("x", "x", xScale).project("y", "y", yScale);
+                gridPlot.renderTo(svg);
+                var allCells = gridPlot.getAllSelections(["a", "b"]);
+                assert.strictEqual(allCells.size(), 4, "all cells retrieved");
+                var selectionData = allCells.data();
+                assert.includeMembers(selectionData, DATA, "data in selection data");
+                svg.remove();
+            });
         });
     });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -2852,6 +2852,18 @@ describe("Plots", function () {
                 assert.includeMembers(selectionData, barData2, "second dataset data in selection data");
                 svg.remove();
             });
+            it("getAllSelections skips invalid keys", function () {
+                var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
+                var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
+                verticalBarPlot.addDataset("a", barData);
+                verticalBarPlot.addDataset("b", barData2);
+                verticalBarPlot.renderTo(svg);
+                var allBars = verticalBarPlot.getAllSelections(["a", "c"]);
+                assert.strictEqual(allBars.size(), 3, "all bars retrieved");
+                var selectionData = allBars.data();
+                assert.includeMembers(selectionData, barData, "first dataset data in selection data");
+                svg.remove();
+            });
         });
         it("plot auto domain scale to visible points on ordinal scale", function () {
             var svg = generateSVG(500, 500);

--- a/test/tests.js
+++ b/test/tests.js
@@ -2031,12 +2031,25 @@ describe("Plots", function () {
             piePlot.project("outer-radius", function () { return 250; });
             svg.remove();
         });
-        it("getAllSelections retrieves correct selections", function () {
-            var allSectors = piePlot.getAllSelections();
-            assert.strictEqual(allSectors.size(), 2, "all sectors retrieved");
-            var selectionData = allSectors.data();
-            assert.includeMembers(selectionData.map(function (datum) { return datum.data; }), simpleData, "dataset data in selection data");
-            svg.remove();
+        describe("getAllSelections", function () {
+            it("getAllSelections retrieves all dataset selections with no args", function () {
+                var allSectors = piePlot.getAllSelections();
+                var allSectors2 = piePlot.getAllSelections(["simpleDataset"]);
+                assert.deepEqual(allSectors, allSectors2, "all sectors retrieved");
+                svg.remove();
+            });
+            it("getAllSelections retrieves correct selections (dataset array arg)", function () {
+                var allSectors = piePlot.getAllSelections(["simpleDataset"]);
+                assert.strictEqual(allSectors.size(), 2, "all sectors retrieved");
+                var selectionData = allSectors.data();
+                assert.includeMembers(selectionData.map(function (datum) { return datum.data; }), simpleData, "dataset data in selection data");
+                svg.remove();
+            });
+            it("getAllSelections ignores invalid selections", function () {
+                var allSectors = piePlot.getAllSelections(["whoo"]);
+                assert.strictEqual(allSectors.size(), 0, "all sectors retrieved");
+                svg.remove();
+            });
         });
         describe("Fill", function () {
             it("sectors are filled in according to defaults", function () {
@@ -2175,7 +2188,7 @@ describe("Plots", function () {
             svg = generateSVG(500, 500);
             simpleDataset = new Plottable.Dataset(twoPointData);
             linePlot = new Plottable.Plot.Line(xScale, yScale);
-            linePlot.addDataset(simpleDataset).project("x", xAccessor, xScale).project("y", yAccessor, yScale).project("stroke", colorAccessor).addDataset(simpleDataset).renderTo(svg);
+            linePlot.addDataset("s1", simpleDataset).project("x", xAccessor, xScale).project("y", yAccessor, yScale).project("stroke", colorAccessor).addDataset("s2", simpleDataset).renderTo(svg);
             renderArea = linePlot._renderArea;
         });
         it("draws a line correctly", function () {
@@ -2286,18 +2299,42 @@ describe("Plots", function () {
             assert.strictEqual(parseFloat(hoverTarget.attr("cy")), yScale.scale(expectedDatum.bar), "hover target was positioned correctly (y)");
             svg.remove();
         });
-        it("getAllSelections retrieves correct selections", function () {
-            var dataset3 = [
-                { foo: 0, bar: 1 },
-                { foo: 1, bar: 0.95 }
-            ];
-            linePlot.addDataset(dataset3);
-            var allLines = linePlot.getAllSelections();
-            assert.strictEqual(allLines.size(), 3, "all lines retrieved");
-            var selectionData = allLines.data();
-            assert.include(selectionData, twoPointData, "first dataset data in selection data");
-            assert.include(selectionData, dataset3, "third dataset data in selection data");
-            svg.remove();
+        describe("getAllSelections()", function () {
+            it("getAllSelections retrieves all dataset selections with no args", function () {
+                var dataset3 = [
+                    { foo: 0, bar: 1 },
+                    { foo: 1, bar: 0.95 }
+                ];
+                linePlot.addDataset("d3", dataset3);
+                var allLines = linePlot.getAllSelections();
+                var allLines2 = linePlot.getAllSelections(["s1", "s2", "d3"]);
+                assert.deepEqual(allLines, allLines2, "all lines retrieved");
+                svg.remove();
+            });
+            it("getAllSelections retrieves correct selections (dataset array arg)", function () {
+                var dataset3 = [
+                    { foo: 0, bar: 1 },
+                    { foo: 1, bar: 0.95 }
+                ];
+                linePlot.addDataset("d3", dataset3);
+                var allLines = linePlot.getAllSelections("d3");
+                assert.strictEqual(allLines.size(), 1, "all lines retrieved");
+                var selectionData = allLines.data();
+                assert.include(selectionData, dataset3, "third dataset data in selection data");
+                svg.remove();
+            });
+            it("getAllSelections ignores invalid selections", function () {
+                var dataset3 = [
+                    { foo: 0, bar: 1 },
+                    { foo: 1, bar: 0.95 }
+                ];
+                linePlot.addDataset("d3", dataset3);
+                var allLines = linePlot.getAllSelections(["d3", "test"]);
+                assert.strictEqual(allLines.size(), 1, "all lines retrieved");
+                var selectionData = allLines.data();
+                assert.include(selectionData, dataset3, "third dataset data in selection data");
+                svg.remove();
+            });
         });
         it("retains original classes when class is projected", function () {
             var newClassProjector = function () { return "pink"; };

--- a/test/tests.js
+++ b/test/tests.js
@@ -2032,20 +2032,27 @@ describe("Plots", function () {
             svg.remove();
         });
         describe("getAllSelections", function () {
-            it("getAllSelections retrieves all dataset selections with no args", function () {
+            it("retrieves all dataset selections with no args", function () {
                 var allSectors = piePlot.getAllSelections();
-                var allSectors2 = piePlot.getAllSelections(["simpleDataset"]);
+                var allSectors2 = piePlot.getAllSelections(piePlot._datasetKeysInOrder);
                 assert.deepEqual(allSectors, allSectors2, "all sectors retrieved");
                 svg.remove();
             });
-            it("getAllSelections retrieves correct selections (dataset array arg)", function () {
+            it("retrieves correct selections (dataset array arg)", function () {
                 var allSectors = piePlot.getAllSelections(["simpleDataset"]);
                 assert.strictEqual(allSectors.size(), 2, "all sectors retrieved");
                 var selectionData = allSectors.data();
                 assert.includeMembers(selectionData.map(function (datum) { return datum.data; }), simpleData, "dataset data in selection data");
                 svg.remove();
             });
-            it("getAllSelections ignores invalid selections", function () {
+            it("retrieves correct selections (string arg)", function () {
+                var allSectors = piePlot.getAllSelections("simpleDataset");
+                assert.strictEqual(allSectors.size(), 2, "all sectors retrieved");
+                var selectionData = allSectors.data();
+                assert.includeMembers(selectionData.map(function (datum) { return datum.data; }), simpleData, "dataset data in selection data");
+                svg.remove();
+            });
+            it("skips invalid keys", function () {
                 var allSectors = piePlot.getAllSelections(["whoo"]);
                 assert.strictEqual(allSectors.size(), 0, "all sectors retrieved");
                 svg.remove();
@@ -2300,18 +2307,18 @@ describe("Plots", function () {
             svg.remove();
         });
         describe("getAllSelections()", function () {
-            it("getAllSelections retrieves all dataset selections with no args", function () {
+            it("retrieves all dataset selections with no args", function () {
                 var dataset3 = [
                     { foo: 0, bar: 1 },
                     { foo: 1, bar: 0.95 }
                 ];
                 linePlot.addDataset("d3", dataset3);
                 var allLines = linePlot.getAllSelections();
-                var allLines2 = linePlot.getAllSelections(["s1", "s2", "d3"]);
+                var allLines2 = linePlot.getAllSelections(linePlot._datasetKeysInOrder);
                 assert.deepEqual(allLines, allLines2, "all lines retrieved");
                 svg.remove();
             });
-            it("getAllSelections retrieves correct selections (dataset array arg)", function () {
+            it("retrieves correct selections (string arg)", function () {
                 var dataset3 = [
                     { foo: 0, bar: 1 },
                     { foo: 1, bar: 0.95 }
@@ -2323,7 +2330,19 @@ describe("Plots", function () {
                 assert.include(selectionData, dataset3, "third dataset data in selection data");
                 svg.remove();
             });
-            it("getAllSelections ignores invalid selections", function () {
+            it("retrieves correct selections (dataset array arg)", function () {
+                var dataset3 = [
+                    { foo: 0, bar: 1 },
+                    { foo: 1, bar: 0.95 }
+                ];
+                linePlot.addDataset("d3", dataset3);
+                var allLines = linePlot.getAllSelections(["d3"]);
+                assert.strictEqual(allLines.size(), 1, "all lines retrieved");
+                var selectionData = allLines.data();
+                assert.include(selectionData, dataset3, "third dataset data in selection data");
+                svg.remove();
+            });
+            it("skips invalid keys", function () {
                 var dataset3 = [
                     { foo: 0, bar: 1 },
                     { foo: 1, bar: 0.95 }
@@ -2377,7 +2396,7 @@ describe("Plots", function () {
             svg = generateSVG(500, 500);
             simpleDataset = new Plottable.Dataset(twoPointData);
             areaPlot = new Plottable.Plot.Area(xScale, yScale);
-            areaPlot.addDataset(simpleDataset).project("x", xAccessor, xScale).project("y", yAccessor, yScale).project("y0", y0Accessor, yScale).project("fill", fillAccessor).project("stroke", colorAccessor).renderTo(svg);
+            areaPlot.addDataset("sd", simpleDataset).project("x", xAccessor, xScale).project("y", yAccessor, yScale).project("y0", y0Accessor, yScale).project("fill", fillAccessor).project("stroke", colorAccessor).renderTo(svg);
             renderArea = areaPlot._renderArea;
         });
         it("draws area and line correctly", function () {
@@ -2438,16 +2457,46 @@ describe("Plots", function () {
             assertAreaPathCloseTo(areaPathString, expectedPath, 0.1, "area d was set correctly (x=undefined case)");
             svg.remove();
         });
-        it("getAllSelections retrieves correct selections", function () {
-            var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
-            var newDataset = new Plottable.Dataset(twoPointData);
-            areaPlot.addDataset(new Plottable.Dataset(newTwoPointData));
-            var allAreas = areaPlot.getAllSelections();
-            assert.strictEqual(allAreas.size(), 2, "all areas retrieved");
-            var selectionData = allAreas.data();
-            assert.include(selectionData, twoPointData, "first dataset data in selection data");
-            assert.include(selectionData, newTwoPointData, "new dataset data in selection data");
-            svg.remove();
+        describe("getAllSelections()", function () {
+            it("retrieves all selections with no args", function () {
+                var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
+                var newDataset = new Plottable.Dataset(twoPointData);
+                areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
+                var allAreas = areaPlot.getAllSelections();
+                var allAreas2 = areaPlot.getAllSelections(areaPlot._datasetKeysInOrder);
+                assert.deepEqual(allAreas, allAreas2, "all areas retrieved");
+                svg.remove();
+            });
+            it("retrieves correct selections (string arg)", function () {
+                var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
+                var newDataset = new Plottable.Dataset(twoPointData);
+                areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
+                var allAreas = areaPlot.getAllSelections("newTwo");
+                assert.strictEqual(allAreas.size(), 1, "all areas retrieved");
+                var selectionData = allAreas.data();
+                assert.include(selectionData, newTwoPointData, "new dataset data in selection data");
+                svg.remove();
+            });
+            it("retrieves correct selections (string arg)", function () {
+                var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
+                var newDataset = new Plottable.Dataset(twoPointData);
+                areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
+                var allAreas = areaPlot.getAllSelections(["newTwo"]);
+                assert.strictEqual(allAreas.size(), 1, "all areas retrieved");
+                var selectionData = allAreas.data();
+                assert.include(selectionData, newTwoPointData, "new dataset data in selection data");
+                svg.remove();
+            });
+            it("skips invalid keys", function () {
+                var newTwoPointData = [{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }];
+                var newDataset = new Plottable.Dataset(twoPointData);
+                areaPlot.addDataset("newTwo", new Plottable.Dataset(newTwoPointData));
+                var allAreas = areaPlot.getAllSelections(["newTwo", "test"]);
+                assert.strictEqual(allAreas.size(), 1, "all areas retrieved");
+                var selectionData = allAreas.data();
+                assert.include(selectionData, newTwoPointData, "new dataset data in selection data");
+                svg.remove();
+            });
         });
         it("retains original classes when class is projected", function () {
             var newClassProjector = function () { return "pink"; };
@@ -2853,18 +2902,18 @@ describe("Plots", function () {
                 verticalBarPlot.project("x", "x", xScale);
                 verticalBarPlot.project("y", "y", yScale);
             });
-            it("getAllSelections retrieves all dataset selections with no args", function () {
+            it("retrieves all dataset selections with no args", function () {
                 var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
                 var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
                 verticalBarPlot.addDataset("a", barData);
                 verticalBarPlot.addDataset("b", barData2);
                 verticalBarPlot.renderTo(svg);
                 var allBars = verticalBarPlot.getAllSelections();
-                var allBars2 = verticalBarPlot.getAllSelections(["a", "b"]);
+                var allBars2 = verticalBarPlot.getAllSelections(verticalBarPlot._datasetKeysInOrder);
                 assert.deepEqual(allBars, allBars2, "both ways of getting all selections work");
                 svg.remove();
             });
-            it("getAllSelections retrieves correct selections (dataset string arg)", function () {
+            it("retrieves correct selections (dataset string arg)", function () {
                 var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
                 var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
                 verticalBarPlot.addDataset("a", barData);
@@ -2876,7 +2925,7 @@ describe("Plots", function () {
                 assert.includeMembers(selectionData, barData, "first dataset data in selection data");
                 svg.remove();
             });
-            it("getAllSelections retrieves correct selections (dataset array arg)", function () {
+            it("retrieves correct selections (dataset array arg)", function () {
                 var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
                 var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
                 verticalBarPlot.addDataset("a", barData);
@@ -2889,7 +2938,7 @@ describe("Plots", function () {
                 assert.includeMembers(selectionData, barData2, "second dataset data in selection data");
                 svg.remove();
             });
-            it("getAllSelections skips invalid keys", function () {
+            it("skips invalid keys", function () {
                 var barData = [{ x: "foo", y: 5 }, { x: "bar", y: 640 }, { x: "zoo", y: 12345 }];
                 var barData2 = [{ x: "one", y: 5 }, { x: "two", y: 640 }, { x: "three", y: 12345 }];
                 verticalBarPlot.addDataset("a", barData);


### PR DESCRIPTION
Adding optional parameters to the API point getAllSelections to look like
`getAllSelections(datasetKeys?: string | string[])`

The above API endpoint will allow users to retrieve all of the selections for the specified dataset(s).

NOTE: One possible API would be to change getAllSelections to
`getAllSelections(...datasetKeys?: string[] | string[][])`

This would allow input like
`getAllSelections("a", "b", "c")` instead of forcing to use an array.  I still would want the array API endpoint but this is optional.

NOTE: I'm currently in consideration of a second optional boolean argument `exclude` which will return the selections of all datasets excluding the ones specified by the first datasetKeys argument