### PR TITLE
[Plot] - Switch order of addDataset parameters

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2617,12 +2617,11 @@ declare module Plottable {
              *
              * A key is automatically generated if not supplied.
              *
-             * @param {string} [key] The key of the dataset.
              * @param {Dataset | any[]} dataset dataset to add.
+             * @param {string} [key] The key of the dataset.
              * @returns {Plot} The calling Plot.
              */
-            addDataset(dataset: Dataset | any[]): AbstractPlot;
-            addDataset(key: string, dataset: Dataset | any[]): AbstractPlot;
+            addDataset(data: Dataset | any[], key?: string): AbstractPlot;
             protected _getDrawer(key: string): _Drawer.AbstractDrawer;
             protected _getAnimator(key: string): Animator.PlotAnimator;
             protected _onDatasetUpdate(): void;

--- a/plottable.js
+++ b/plottable.js
@@ -6241,20 +6241,25 @@ var Plottable;
                     }
                 });
             };
-            AbstractPlot.prototype.addDataset = function (keyOrDataset, dataset) {
-                if (typeof (keyOrDataset) !== "string" && dataset !== undefined) {
-                    throw new Error("invalid input to addDataset");
-                }
-                if (typeof (keyOrDataset) === "string" && keyOrDataset[0] === "_") {
+            /**
+             * Adds a dataset to this plot. Identify this dataset with a key.
+             *
+             * A key is automatically generated if not supplied.
+             *
+             * @param {Dataset | any[]} dataset dataset to add.
+             * @param {string} [key] The key of the dataset.
+             * @returns {Plot} The calling Plot.
+             */
+            AbstractPlot.prototype.addDataset = function (data, key) {
+                if (key === void 0) { key = "_" + this._nextSeriesIndex++; }
+                if (key[0] === "_") {
                     Plottable._Util.Methods.warn("Warning: Using _named series keys may produce collisions with unlabeled data sources");
                 }
-                var key = typeof (keyOrDataset) === "string" ? keyOrDataset : "_" + this._nextSeriesIndex++;
-                var data = typeof (keyOrDataset) !== "string" ? keyOrDataset : dataset;
-                dataset = (data instanceof Plottable.Dataset) ? data : new Plottable.Dataset(data);
-                this._addDataset(key, dataset);
+                var dataset = (data instanceof Plottable.Dataset) ? data : new Plottable.Dataset(data);
+                this._addDataset(dataset, key);
                 return this;
             };
-            AbstractPlot.prototype._addDataset = function (key, dataset) {
+            AbstractPlot.prototype._addDataset = function (dataset, key) {
                 var _this = this;
                 if (this._key2PlotDatasetKey.has(key)) {
                     this.removeDataset(key);

--- a/src/components/plots/abstractPlot.ts
+++ b/src/components/plots/abstractPlot.ts
@@ -81,28 +81,21 @@ export module Plot {
      *
      * A key is automatically generated if not supplied.
      *
-     * @param {string} [key] The key of the dataset.
      * @param {Dataset | any[]} dataset dataset to add.
+     * @param {string} [key] The key of the dataset.
      * @returns {Plot} The calling Plot.
      */
-    public addDataset(dataset: Dataset | any[]): AbstractPlot;
-    public addDataset(key: string, dataset: Dataset | any[]): AbstractPlot;
-    public addDataset(keyOrDataset: any, dataset?: any): AbstractPlot {
-      if (typeof(keyOrDataset) !== "string" && dataset !== undefined) {
-        throw new Error("invalid input to addDataset");
-      }
-      if (typeof(keyOrDataset) === "string" && keyOrDataset[0] === "_") {
+    public addDataset(data: Dataset | any[], key: string = "_" + this._nextSeriesIndex++): AbstractPlot {
+      if (key[0] === "_") {
         _Util.Methods.warn("Warning: Using _named series keys may produce collisions with unlabeled data sources");
       }
-      var key  = typeof(keyOrDataset) === "string" ? keyOrDataset : "_" + this._nextSeriesIndex++;
-      var data = typeof(keyOrDataset) !== "string" ? keyOrDataset : dataset;
-      dataset = (data instanceof Dataset) ? data : new Dataset(data);
+      var dataset = (data instanceof Dataset) ? <Dataset> data : new Dataset(<any[]> data);
 
-      this._addDataset(key, dataset);
+      this._addDataset(dataset, key);
       return this;
     }
 
-    private _addDataset(key: string, dataset: Dataset) {
+    private _addDataset(dataset: Dataset, key: string) {
       if (this._key2PlotDatasetKey.has(key)) {
         this.removeDataset(key);
       };

--- a/test/components/plots/newStylePlotTests.ts
+++ b/test/components/plots/newStylePlotTests.ts
@@ -16,9 +16,9 @@ describe("Plots", () => {
     });
 
     it("Datasets can be added and removed as expected", () => {
-      p.addDataset("foo", [1,2,3]);
+      p.addDataset([1,2,3], "foo");
       var d2 = new Plottable.Dataset([4,5,6]);
-      p.addDataset("bar", d2);
+      p.addDataset(d2, "bar");
       p.addDataset([7,8,9]);
       var d4 = new Plottable.Dataset([10,11,12]);
       p.addDataset(d4);
@@ -42,7 +42,7 @@ describe("Plots", () => {
       var callback = () => callbackCounter++;
       (<any> p)._onDatasetUpdate = callback;
       var d = new Plottable.Dataset([1,2,3]);
-      p.addDataset("foo", d);
+      p.addDataset(d, "foo");
       assert.equal(callbackCounter, 1, "adding dataset triggers listener");
       d.data([1,2,3,4]);
       assert.equal(callbackCounter, 2, "modifying data triggers listener");
@@ -51,9 +51,9 @@ describe("Plots", () => {
     });
 
     it("Datasets can be reordered", () => {
-      p.addDataset("foo", [1]);
-      p.addDataset("bar", [2]);
-      p.addDataset("baz", [3]);
+      p.addDataset([1], "foo");
+      p.addDataset([2], "bar");
+      p.addDataset([3], "baz");
       assert.deepEqual(p.datasetOrder(), ["foo", "bar", "baz"]);
       p.datasetOrder(["bar", "baz", "foo"]);
       assert.deepEqual(p.datasetOrder(), ["bar", "baz", "foo"]);
@@ -67,10 +67,10 @@ describe("Plots", () => {
     it("Has proper warnings", () => {
       var warned = 0;
       Plottable._Util.Methods.warn = () => warned++;
-      p.addDataset("_foo", []);
+      p.addDataset([], "_foo");
       assert.equal(warned, 1);
-      p.addDataset("2", []);
-      p.addDataset("4", []);
+      p.addDataset([], "2");
+      p.addDataset([], "4");
 
       // get warning for not a permutation
       p.datasetOrder(["_bar", "4", "2"]);

--- a/test/components/plots/piePlotTests.ts
+++ b/test/components/plots/piePlotTests.ts
@@ -15,7 +15,7 @@ describe("Plots", () => {
       simpleData = [{value: 5, value2: 10, type: "A"}, {value: 15, value2: 10, type: "B"}];
       simpleDataset = new Plottable.Dataset(simpleData);
       piePlot = new Plottable.Plot.Pie();
-      piePlot.addDataset("simpleDataset", simpleDataset);
+      piePlot.addDataset(simpleDataset, "simpleDataset");
       piePlot.project("value", "value");
       piePlot.renderTo(svg);
       renderArea = (<any> piePlot)._renderArea;
@@ -182,7 +182,7 @@ describe("Plots", () => {
       Plottable._Util.Methods.warn = (warn) => message = warn;
       piePlot.removeDataset("simpleDataset");
       var negativeDataset = new Plottable.Dataset([{value: -5}, {value: 15}]);
-      piePlot.addDataset("negativeDataset", negativeDataset);
+      piePlot.addDataset(negativeDataset, "negativeDataset");
       assert.equal(message, "Negative values will not render correctly in a pie chart.");
       Plottable._Util.Methods.warn = oldWarn;
       svg.remove();

--- a/test/components/plots/plotTests.ts
+++ b/test/components/plots/plotTests.ts
@@ -32,7 +32,7 @@ describe("Plots", () => {
       var dFoo = new Plottable.Dataset(["foo"], {cssClass: "bar"});
       var dBar = new Plottable.Dataset(["bar"], {cssClass: "boo"});
       var r = new CountingPlot();
-      r.addDataset("foo", dFoo);
+      r.addDataset(dFoo, "foo");
 
       assert.equal(1, r.renders, "initial render due to addDataset");
 
@@ -40,7 +40,7 @@ describe("Plots", () => {
       assert.equal(2, r.renders, "we re-render when our dataset changes");
 
 
-      r.addDataset("bar", dBar);
+      r.addDataset(dBar, "bar");
       assert.equal(3, r.renders, "we should redraw when we add a dataset");
 
       dFoo.broadcaster.broadcast();
@@ -59,7 +59,7 @@ describe("Plots", () => {
     it("Updates its projectors when the Dataset is changed", () => {
       var d1 = new Plottable.Dataset([{x: 5, y: 6}], {cssClass: "bar"});
       var r = new Plottable.Plot.AbstractPlot();
-      r.addDataset("d1", d1);
+      r.addDataset(d1, "d1");
 
       var xScaleCalls: number = 0;
       var yScaleCalls: number = 0;
@@ -103,7 +103,7 @@ describe("Plots", () => {
 
     it("Plot automatically generates a Dataset if only data is provided", () => {
       var data = ["foo", "bar"];
-      var r = new Plottable.Plot.AbstractPlot().addDataset("foo", data);
+      var r = new Plottable.Plot.AbstractPlot().addDataset(data, "foo");
       var dataset = r.datasets()[0];
       assert.isNotNull(dataset, "A Dataset was automatically generated");
       assert.deepEqual(dataset.data(), data, "The generated Dataset has the correct data");
@@ -148,8 +148,8 @@ describe("Plots", () => {
         plot = new Plottable.Plot.AbstractPlot();
         d1 = new Plottable.Dataset();
         d2 = new Plottable.Dataset();
-        plot.addDataset("foo", d1);
-        plot.addDataset("bar", d2);
+        plot.addDataset(d1, "foo");
+        plot.addDataset(d2, "bar");
         assert.deepEqual(plot.datasets(), [d1, d2], "datasets as expected");
       });
 
@@ -189,7 +189,7 @@ describe("Plots", () => {
 
       it("removeDataset behaves appropriately when the key 'undefined' is used", () => {
         var a = [1,2,3];
-        plot.addDataset("undefined", a);
+        plot.addDataset(a, "undefined");
         assert.lengthOf(plot.datasets(), 3, "there are three datasets initially");
         plot.removeDataset("foofoofoofoofoofoofoofoo");
         assert.lengthOf(plot.datasets(), 3, "there are three datasets after bad key removal");
@@ -277,8 +277,8 @@ describe("Plots", () => {
       var dataset1 = [{key: "A"}];
       var dataset2 = [{key: "B"}];
       var plot = new Plottable.Plot.AbstractPlot()
-                                   .addDataset("b", dataset2)
-                                   .addDataset("a", dataset1);
+                                   .addDataset(dataset2, "b")
+                                   .addDataset(dataset1, "a");
       plot.project("key", "key", ordinalScale);
 
       plot.datasetOrder(["a", "b"]);

--- a/test/components/plots/stackedAreaPlotTests.ts
+++ b/test/components/plots/stackedAreaPlotTests.ts
@@ -146,7 +146,7 @@ describe("Plots", () => {
         {x: 1, y: 0, type: "c"},
         {x: 3, y: 0, type: "c"}
       ];
-      renderer.addDataset("a", new Plottable.Dataset(data));
+      renderer.addDataset(new Plottable.Dataset(data), "a");
       renderer.renderTo(svg);
 
       assert.strictEqual(oldLowerBound, yScale.domain()[0], "lower bound doesn't change with 0 added");
@@ -159,7 +159,7 @@ describe("Plots", () => {
         {x: 1, y: 10, type: "d"},
         {x: 3, y: 3, type: "d"}
       ];
-      renderer.addDataset("b", new Plottable.Dataset(data));
+      renderer.addDataset(new Plottable.Dataset(data), "b");
       renderer.renderTo(svg);
 
       assert.closeTo(oldLowerBound, yScale.domain()[0], 2, "lower bound doesn't change on positive addition");
@@ -171,7 +171,7 @@ describe("Plots", () => {
         {x: 1, y: 0, type: "e"},
         {x: 3, y: 1, type: "e"}
       ];
-      renderer.addDataset("c", new Plottable.Dataset(data));
+      renderer.addDataset(new Plottable.Dataset(data), "c");
       renderer.renderTo(svg);
 
       assert.strictEqual(oldUpperBound, yScale.domain()[1], "upper bound doesn't increase since maximum doesn't increase");
@@ -189,19 +189,19 @@ describe("Plots", () => {
         {x: 1, y: 0, type: "c"},
         {x: 3, y: 0, type: "c"}
       ];
-      renderer.addDataset("a", new Plottable.Dataset(data));
+      renderer.addDataset(new Plottable.Dataset(data), "a");
 
       data = [
         {x: 1, y: 10, type: "d"},
         {x: 3, y: 3, type: "d"}
       ];
-      renderer.addDataset("b", new Plottable.Dataset(data));
+      renderer.addDataset(new Plottable.Dataset(data), "b");
 
       data = [
         {x: 1, y: 0, type: "e"},
         {x: 3, y: 1, type: "e"}
       ];
-      renderer.addDataset("c", new Plottable.Dataset(data));
+      renderer.addDataset(new Plottable.Dataset(data), "c");
       renderer.project("x", "x", xScale);
       renderer.project("y", "y", yScale);
 

--- a/test/components/plots/stackedPlotTests.ts
+++ b/test/components/plots/stackedPlotTests.ts
@@ -42,11 +42,11 @@ describe("Plots", () => {
         {x: 3, y: 1}
       ];
 
-      stackedPlot.addDataset("d1", data1);
-      stackedPlot.addDataset("d2", data2);
-      stackedPlot.addDataset("d3", data3);
-      stackedPlot.addDataset("d4", data4);
-      stackedPlot.addDataset("d5", data5);
+      stackedPlot.addDataset(data1, "d1");
+      stackedPlot.addDataset(data2, "d2");
+      stackedPlot.addDataset(data3, "d3");
+      stackedPlot.addDataset(data4, "d4");
+      stackedPlot.addDataset(data5, "d5");
 
       var ds2PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> stackedPlot)._key2PlotDatasetKey.get("d2").plotMetadata;
       var ds5PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> stackedPlot)._key2PlotDatasetKey.get("d5").plotMetadata;
@@ -68,10 +68,10 @@ describe("Plots", () => {
         {x: 1, y: 0}
       ];
 
-      stackedPlot.addDataset("d1", data1);
-      stackedPlot.addDataset("d2", data2);
-      stackedPlot.addDataset("d3", data3);
-      stackedPlot.addDataset("d4", data4);
+      stackedPlot.addDataset(data1, "d1");
+      stackedPlot.addDataset(data2, "d2");
+      stackedPlot.addDataset(data3, "d3");
+      stackedPlot.addDataset(data4, "d4");
 
       var ds2PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> stackedPlot)._key2PlotDatasetKey.get("d2").plotMetadata;
       var ds4PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> stackedPlot)._key2PlotDatasetKey.get("d4").plotMetadata;
@@ -87,8 +87,8 @@ describe("Plots", () => {
         { a: 1, b: 4 }
       ];
 
-      stackedPlot.addDataset("d1", data1);
-      stackedPlot.addDataset("d2", data2);
+      stackedPlot.addDataset(data1, "d1");
+      stackedPlot.addDataset(data2, "d2");
       var ds1PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> stackedPlot)._key2PlotDatasetKey.get("d1").plotMetadata;
       var ds2PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> stackedPlot)._key2PlotDatasetKey.get("d2").plotMetadata;
 
@@ -120,12 +120,12 @@ describe("Plots", () => {
         { x: 1, y: "-1" }
       ];
 
-      stackedPlot.addDataset("d1", data1);
-      stackedPlot.addDataset("d2", data2);
-      stackedPlot.addDataset("d3", data3);
-      stackedPlot.addDataset("d4", data4);
-      stackedPlot.addDataset("d5", data5);
-      stackedPlot.addDataset("d6", data6);
+      stackedPlot.addDataset(data1, "d1");
+      stackedPlot.addDataset(data2, "d2");
+      stackedPlot.addDataset(data3, "d3");
+      stackedPlot.addDataset(data4, "d4");
+      stackedPlot.addDataset(data5, "d5");
+      stackedPlot.addDataset(data6, "d6");
 
       var ds3PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> stackedPlot)._key2PlotDatasetKey.get("d3").plotMetadata;
       var ds4PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> stackedPlot)._key2PlotDatasetKey.get("d4").plotMetadata;
@@ -158,7 +158,7 @@ describe("Plots", () => {
         {x: 1, y: -2}
       ];
 
-      stackedPlot.addDataset("a", data1);
+      stackedPlot.addDataset(data1, "a");
       assert.doesNotThrow(() => stackedPlot.removeDataset("a"), Error);
     });
   });
@@ -305,8 +305,8 @@ describe("Plots", () => {
       ];
 
       var dataset2 = new Plottable.Dataset(data2);
-      stackedBarPlot.addDataset("d1", data1);
-      stackedBarPlot.addDataset("d2", dataset2);
+      stackedBarPlot.addDataset(data1);
+      stackedBarPlot.addDataset(dataset2);
 
       assert.closeTo(yScale.domain()[0], -6, 1, "min stacked extent is as normal");
       assert.closeTo(yScale.domain()[1], 4, 1, "max stacked extent is as normal");

--- a/test/core/metadataTests.ts
+++ b/test/core/metadataTests.ts
@@ -17,9 +17,9 @@ describe("Metadata", () => {
   it("plot metadata is set properly", () => {
     var d1 = new Plottable.Dataset();
     var r = new Plottable.Plot.AbstractPlot()
-                              .addDataset("d1", d1)
-                              .addDataset( d1)
-                              .addDataset("d2", [])
+                              .addDataset(d1, "d1")
+                              .addDataset(d1)
+                              .addDataset([], "d2")
                               .addDataset([]);
     (<any> r)._datasetKeysInOrder.forEach((key: string) => {
       var plotMetadata = (<any> r)._key2PlotDatasetKey.get(key).plotMetadata;
@@ -191,8 +191,8 @@ describe("Metadata", () => {
     var dataset2 = new Plottable.Dataset(data2, metadata);
 
     var checkPlot = (plot: Plottable.Plot.AbstractPlot) => {
-      plot.addDataset("ds1", dataset1)
-          .addDataset("ds2", dataset2)
+      plot.addDataset(dataset1, "ds1")
+          .addDataset(dataset2, "ds2")
           .project("x", (d: any, i: number, u: any, m: Plottable.Plot.PlotMetadata) => d.x + u.foo + m.datasetKey.length)
           .project("y", (d: any, i: number, u: any, m: Plottable.Plot.PlotMetadata) => d.y + u.foo - m.datasetKey.length);
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1628,11 +1628,11 @@ describe("Plots", function () {
             var dFoo = new Plottable.Dataset(["foo"], { cssClass: "bar" });
             var dBar = new Plottable.Dataset(["bar"], { cssClass: "boo" });
             var r = new CountingPlot();
-            r.addDataset("foo", dFoo);
+            r.addDataset(dFoo, "foo");
             assert.equal(1, r.renders, "initial render due to addDataset");
             dFoo.broadcaster.broadcast();
             assert.equal(2, r.renders, "we re-render when our dataset changes");
-            r.addDataset("bar", dBar);
+            r.addDataset(dBar, "bar");
             assert.equal(3, r.renders, "we should redraw when we add a dataset");
             dFoo.broadcaster.broadcast();
             assert.equal(4, r.renders, "we should still listen to the first dataset");
@@ -1646,7 +1646,7 @@ describe("Plots", function () {
         it("Updates its projectors when the Dataset is changed", function () {
             var d1 = new Plottable.Dataset([{ x: 5, y: 6 }], { cssClass: "bar" });
             var r = new Plottable.Plot.AbstractPlot();
-            r.addDataset("d1", d1);
+            r.addDataset(d1, "d1");
             var xScaleCalls = 0;
             var yScaleCalls = 0;
             var xScale = new Plottable.Scale.Linear();
@@ -1682,7 +1682,7 @@ describe("Plots", function () {
         });
         it("Plot automatically generates a Dataset if only data is provided", function () {
             var data = ["foo", "bar"];
-            var r = new Plottable.Plot.AbstractPlot().addDataset("foo", data);
+            var r = new Plottable.Plot.AbstractPlot().addDataset(data, "foo");
             var dataset = r.datasets()[0];
             assert.isNotNull(dataset, "A Dataset was automatically generated");
             assert.deepEqual(dataset.data(), data, "The generated Dataset has the correct data");
@@ -1717,8 +1717,8 @@ describe("Plots", function () {
                 plot = new Plottable.Plot.AbstractPlot();
                 d1 = new Plottable.Dataset();
                 d2 = new Plottable.Dataset();
-                plot.addDataset("foo", d1);
-                plot.addDataset("bar", d2);
+                plot.addDataset(d1, "foo");
+                plot.addDataset(d2, "bar");
                 assert.deepEqual(plot.datasets(), [d1, d2], "datasets as expected");
             });
             it("removeDataset can work on keys", function () {
@@ -1753,7 +1753,7 @@ describe("Plots", function () {
             });
             it("removeDataset behaves appropriately when the key 'undefined' is used", function () {
                 var a = [1, 2, 3];
-                plot.addDataset("undefined", a);
+                plot.addDataset(a, "undefined");
                 assert.lengthOf(plot.datasets(), 3, "there are three datasets initially");
                 plot.removeDataset("foofoofoofoofoofoofoofoo");
                 assert.lengthOf(plot.datasets(), 3, "there are three datasets after bad key removal");
@@ -1827,7 +1827,7 @@ describe("Plots", function () {
             var ordinalScale = new Plottable.Scale.Ordinal();
             var dataset1 = [{ key: "A" }];
             var dataset2 = [{ key: "B" }];
-            var plot = new Plottable.Plot.AbstractPlot().addDataset("b", dataset2).addDataset("a", dataset1);
+            var plot = new Plottable.Plot.AbstractPlot().addDataset(dataset2, "b").addDataset(dataset1, "a");
             plot.project("key", "key", ordinalScale);
             plot.datasetOrder(["a", "b"]);
             var svg = generateSVG();
@@ -1944,7 +1944,7 @@ describe("Plots", function () {
             simpleData = [{ value: 5, value2: 10, type: "A" }, { value: 15, value2: 10, type: "B" }];
             simpleDataset = new Plottable.Dataset(simpleData);
             piePlot = new Plottable.Plot.Pie();
-            piePlot.addDataset("simpleDataset", simpleDataset);
+            piePlot.addDataset(simpleDataset, "simpleDataset");
             piePlot.project("value", "value");
             piePlot.renderTo(svg);
             renderArea = piePlot._renderArea;
@@ -2069,7 +2069,7 @@ describe("Plots", function () {
             Plottable._Util.Methods.warn = function (warn) { return message = warn; };
             piePlot.removeDataset("simpleDataset");
             var negativeDataset = new Plottable.Dataset([{ value: -5 }, { value: 15 }]);
-            piePlot.addDataset("negativeDataset", negativeDataset);
+            piePlot.addDataset(negativeDataset, "negativeDataset");
             assert.equal(message, "Negative values will not render correctly in a pie chart.");
             Plottable._Util.Methods.warn = oldWarn;
             svg.remove();
@@ -2091,9 +2091,9 @@ describe("Plots", function () {
             Plottable._Util.Methods.warn = oldWarn;
         });
         it("Datasets can be added and removed as expected", function () {
-            p.addDataset("foo", [1, 2, 3]);
+            p.addDataset([1, 2, 3], "foo");
             var d2 = new Plottable.Dataset([4, 5, 6]);
-            p.addDataset("bar", d2);
+            p.addDataset(d2, "bar");
             p.addDataset([7, 8, 9]);
             var d4 = new Plottable.Dataset([10, 11, 12]);
             p.addDataset(d4);
@@ -2113,7 +2113,7 @@ describe("Plots", function () {
             var callback = function () { return callbackCounter++; };
             p._onDatasetUpdate = callback;
             var d = new Plottable.Dataset([1, 2, 3]);
-            p.addDataset("foo", d);
+            p.addDataset(d, "foo");
             assert.equal(callbackCounter, 1, "adding dataset triggers listener");
             d.data([1, 2, 3, 4]);
             assert.equal(callbackCounter, 2, "modifying data triggers listener");
@@ -2121,9 +2121,9 @@ describe("Plots", function () {
             assert.equal(callbackCounter, 3, "removing dataset triggers listener");
         });
         it("Datasets can be reordered", function () {
-            p.addDataset("foo", [1]);
-            p.addDataset("bar", [2]);
-            p.addDataset("baz", [3]);
+            p.addDataset([1], "foo");
+            p.addDataset([2], "bar");
+            p.addDataset([3], "baz");
             assert.deepEqual(p.datasetOrder(), ["foo", "bar", "baz"]);
             p.datasetOrder(["bar", "baz", "foo"]);
             assert.deepEqual(p.datasetOrder(), ["bar", "baz", "foo"]);
@@ -2136,10 +2136,10 @@ describe("Plots", function () {
         it("Has proper warnings", function () {
             var warned = 0;
             Plottable._Util.Methods.warn = function () { return warned++; };
-            p.addDataset("_foo", []);
+            p.addDataset([], "_foo");
             assert.equal(warned, 1);
-            p.addDataset("2", []);
-            p.addDataset("4", []);
+            p.addDataset([], "2");
+            p.addDataset([], "4");
             // get warning for not a permutation
             p.datasetOrder(["_bar", "4", "2"]);
             assert.equal(warned, 2);
@@ -3157,11 +3157,11 @@ describe("Plots", function () {
                 { x: 1, y: 0 },
                 { x: 3, y: 1 }
             ];
-            stackedPlot.addDataset("d1", data1);
-            stackedPlot.addDataset("d2", data2);
-            stackedPlot.addDataset("d3", data3);
-            stackedPlot.addDataset("d4", data4);
-            stackedPlot.addDataset("d5", data5);
+            stackedPlot.addDataset(data1, "d1");
+            stackedPlot.addDataset(data2, "d2");
+            stackedPlot.addDataset(data3, "d3");
+            stackedPlot.addDataset(data4, "d4");
+            stackedPlot.addDataset(data5, "d5");
             var ds2PlotMetadata = stackedPlot._key2PlotDatasetKey.get("d2").plotMetadata;
             var ds5PlotMetadata = stackedPlot._key2PlotDatasetKey.get("d5").plotMetadata;
             assert.strictEqual(ds2PlotMetadata.offsets.get("1"), 1, "positive offset was used");
@@ -3180,10 +3180,10 @@ describe("Plots", function () {
             var data4 = [
                 { x: 1, y: 0 }
             ];
-            stackedPlot.addDataset("d1", data1);
-            stackedPlot.addDataset("d2", data2);
-            stackedPlot.addDataset("d3", data3);
-            stackedPlot.addDataset("d4", data4);
+            stackedPlot.addDataset(data1, "d1");
+            stackedPlot.addDataset(data2, "d2");
+            stackedPlot.addDataset(data3, "d3");
+            stackedPlot.addDataset(data4, "d4");
             var ds2PlotMetadata = stackedPlot._key2PlotDatasetKey.get("d2").plotMetadata;
             var ds4PlotMetadata = stackedPlot._key2PlotDatasetKey.get("d4").plotMetadata;
             assert.strictEqual(ds2PlotMetadata.offsets.get("1"), -2, "positive offset was used");
@@ -3196,8 +3196,8 @@ describe("Plots", function () {
             var data2 = [
                 { a: 1, b: 4 }
             ];
-            stackedPlot.addDataset("d1", data1);
-            stackedPlot.addDataset("d2", data2);
+            stackedPlot.addDataset(data1, "d1");
+            stackedPlot.addDataset(data2, "d2");
             var ds1PlotMetadata = stackedPlot._key2PlotDatasetKey.get("d1").plotMetadata;
             var ds2PlotMetadata = stackedPlot._key2PlotDatasetKey.get("d2").plotMetadata;
             assert.isTrue(isNaN(ds1PlotMetadata.offsets.get("1")), "stacking is initially incorrect");
@@ -3224,12 +3224,12 @@ describe("Plots", function () {
             var data6 = [
                 { x: 1, y: "-1" }
             ];
-            stackedPlot.addDataset("d1", data1);
-            stackedPlot.addDataset("d2", data2);
-            stackedPlot.addDataset("d3", data3);
-            stackedPlot.addDataset("d4", data4);
-            stackedPlot.addDataset("d5", data5);
-            stackedPlot.addDataset("d6", data6);
+            stackedPlot.addDataset(data1, "d1");
+            stackedPlot.addDataset(data2, "d2");
+            stackedPlot.addDataset(data3, "d3");
+            stackedPlot.addDataset(data4, "d4");
+            stackedPlot.addDataset(data5, "d5");
+            stackedPlot.addDataset(data6, "d6");
             var ds3PlotMetadata = stackedPlot._key2PlotDatasetKey.get("d3").plotMetadata;
             var ds4PlotMetadata = stackedPlot._key2PlotDatasetKey.get("d4").plotMetadata;
             var ds5PlotMetadata = stackedPlot._key2PlotDatasetKey.get("d5").plotMetadata;
@@ -3254,7 +3254,7 @@ describe("Plots", function () {
             var data1 = [
                 { x: 1, y: -2 }
             ];
-            stackedPlot.addDataset("a", data1);
+            stackedPlot.addDataset(data1, "a");
             assert.doesNotThrow(function () { return stackedPlot.removeDataset("a"); }, Error);
         });
     });
@@ -3367,8 +3367,8 @@ describe("Plots", function () {
                 { key: "b", value: -2 }
             ];
             var dataset2 = new Plottable.Dataset(data2);
-            stackedBarPlot.addDataset("d1", data1);
-            stackedBarPlot.addDataset("d2", dataset2);
+            stackedBarPlot.addDataset(data1);
+            stackedBarPlot.addDataset(dataset2);
             assert.closeTo(yScale.domain()[0], -6, 1, "min stacked extent is as normal");
             assert.closeTo(yScale.domain()[1], 4, 1, "max stacked extent is as normal");
             dataset2.data(data2_b);
@@ -3502,7 +3502,7 @@ describe("Plots", function () {
                 { x: 1, y: 0, type: "c" },
                 { x: 3, y: 0, type: "c" }
             ];
-            renderer.addDataset("a", new Plottable.Dataset(data));
+            renderer.addDataset(new Plottable.Dataset(data), "a");
             renderer.renderTo(svg);
             assert.strictEqual(oldLowerBound, yScale.domain()[0], "lower bound doesn't change with 0 added");
             assert.strictEqual(oldUpperBound, yScale.domain()[1], "upper bound doesn't change with 0 added");
@@ -3513,7 +3513,7 @@ describe("Plots", function () {
                 { x: 1, y: 10, type: "d" },
                 { x: 3, y: 3, type: "d" }
             ];
-            renderer.addDataset("b", new Plottable.Dataset(data));
+            renderer.addDataset(new Plottable.Dataset(data), "b");
             renderer.renderTo(svg);
             assert.closeTo(oldLowerBound, yScale.domain()[0], 2, "lower bound doesn't change on positive addition");
             assert.closeTo(oldUpperBound + 10, yScale.domain()[1], 2, "upper bound increases");
@@ -3523,7 +3523,7 @@ describe("Plots", function () {
                 { x: 1, y: 0, type: "e" },
                 { x: 3, y: 1, type: "e" }
             ];
-            renderer.addDataset("c", new Plottable.Dataset(data));
+            renderer.addDataset(new Plottable.Dataset(data), "c");
             renderer.renderTo(svg);
             assert.strictEqual(oldUpperBound, yScale.domain()[1], "upper bound doesn't increase since maximum doesn't increase");
             renderer.removeDataset("a");
@@ -3537,17 +3537,17 @@ describe("Plots", function () {
                 { x: 1, y: 0, type: "c" },
                 { x: 3, y: 0, type: "c" }
             ];
-            renderer.addDataset("a", new Plottable.Dataset(data));
+            renderer.addDataset(new Plottable.Dataset(data), "a");
             data = [
                 { x: 1, y: 10, type: "d" },
                 { x: 3, y: 3, type: "d" }
             ];
-            renderer.addDataset("b", new Plottable.Dataset(data));
+            renderer.addDataset(new Plottable.Dataset(data), "b");
             data = [
                 { x: 1, y: 0, type: "e" },
                 { x: 3, y: 1, type: "e" }
             ];
-            renderer.addDataset("c", new Plottable.Dataset(data));
+            renderer.addDataset(new Plottable.Dataset(data), "c");
             renderer.project("x", "x", xScale);
             renderer.project("y", "y", yScale);
             renderer.renderTo(svg);
@@ -4235,7 +4235,7 @@ describe("Metadata", function () {
     });
     it("plot metadata is set properly", function () {
         var d1 = new Plottable.Dataset();
-        var r = new Plottable.Plot.AbstractPlot().addDataset("d1", d1).addDataset(d1).addDataset("d2", []).addDataset([]);
+        var r = new Plottable.Plot.AbstractPlot().addDataset(d1, "d1").addDataset(d1).addDataset([], "d2").addDataset([]);
         r._datasetKeysInOrder.forEach(function (key) {
             var plotMetadata = r._key2PlotDatasetKey.get(key).plotMetadata;
             assert.propertyVal(plotMetadata, "datasetKey", key, "metadata has correct dataset key");
@@ -4383,7 +4383,7 @@ describe("Metadata", function () {
         var dataset1 = new Plottable.Dataset(data1, metadata);
         var dataset2 = new Plottable.Dataset(data2, metadata);
         var checkPlot = function (plot) {
-            plot.addDataset("ds1", dataset1).addDataset("ds2", dataset2).project("x", function (d, i, u, m) { return d.x + u.foo + m.datasetKey.length; }).project("y", function (d, i, u, m) { return d.y + u.foo - m.datasetKey.length; });
+            plot.addDataset(dataset1, "ds1").addDataset(dataset2, "ds2").project("x", function (d, i, u, m) { return d.x + u.foo + m.datasetKey.length; }).project("y", function (d, i, u, m) { return d.y + u.foo - m.datasetKey.length; });
             // This should not crash. If some metadata is not passed, undefined property error will be raised during accessor call.
             plot.renderTo(svg);
             plot.remove();


### PR DESCRIPTION
After interacting with addDataset and even with writing the doc for this signature, I found that having the optional key parameter as the first parameter has been painful.  In general, I think having the optional parameter as the later input arguments just is good style and is easier to interact with.

API-Breaks: Input parameters of addDataset are swapped.