### PR TITLE
Convert Broadcaster to use generics, remove Listenable.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -461,6 +461,14 @@ declare module Plottable {
 declare module Plottable {
     module Core {
         /**
+         * A callback for a Broadcaster. The callback will be called with the Broadcaster's
+         * "listenable" as the first argument, with subsequent optional arguments depending
+         * on the listenable.
+         */
+        interface BroadcasterCallback<L> {
+            (listenable: L, ...args: any[]): any;
+        }
+        /**
          * The Broadcaster holds a reference to a "listenable" object.
          * Third parties can register and deregister listeners from the Broadcaster.
          * When the broadcaster.broadcast() method is called, all registered callbacks
@@ -474,7 +482,7 @@ declare module Plottable {
              * Constructs a broadcaster, taking a "listenable" object to broadcast about.
              *
              * @constructor
-             * @param {L} listenable The listenable object to broadcast about.
+             * @param {L} listenable The listenable object to broadcast.
              */
             constructor(listenable: L);
             /**
@@ -483,10 +491,10 @@ declare module Plottable {
              * If there is already a callback associated with that key, then the callback will be replaced.
              *
              * @param key The key associated with the callback. Key uniqueness is determined by deep equality.
-             * @param {(listenable: L, ...args: any[]) => any} callback A callback to be called.
+             * @param {BroadcasterCallback<L>} callback A callback to be called.
              * @returns {Broadcaster} The calling Broadcaster
              */
-            registerListener(key: any, callback: (listenable: L, ...args: any[]) => any): Broadcaster<L>;
+            registerListener(key: any, callback: BroadcasterCallback<L>): Broadcaster<L>;
             /**
              * Call all listening callbacks, optionally with arguments passed through.
              *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -461,72 +461,50 @@ declare module Plottable {
 declare module Plottable {
     module Core {
         /**
-         * This interface represents anything in Plottable which can have a listener attached.
-         * Listeners attach by referencing the Listenable's broadcaster, and calling registerListener
-         * on it.
-         *
-         * e.g.:
-         * listenable: Plottable.Listenable;
-         * listenable.broadcaster.registerListener(callbackToCallOnBroadcast)
-         */
-        interface Listenable {
-            broadcaster: Broadcaster;
-        }
-        /**
-         * This interface represents the callback that should be passed to the Broadcaster on a Listenable.
-         *
-         * The callback will be called with the attached Listenable as the first object, and optional arguments
-         * as the subsequent arguments.
-         *
-         * The Listenable is passed as the first argument so that it is easy for the callback to reference the
-         * current state of the Listenable in the resolution logic.
-         */
-        type BroadcasterCallback = (listenable: Listenable, ...args: any[]) => any;
-        /**
-         * The Broadcaster class is owned by an Listenable. Third parties can register and deregister listeners
-         * from the broadcaster. When the broadcaster.broadcast method is activated, all registered callbacks are
-         * called. The registered callbacks are called with the registered Listenable that the broadcaster is attached
-         * to, along with optional arguments passed to the `broadcast` method.
+         * The Broadcaster holds a reference to a "listenable" object.
+         * Third parties can register and deregister listeners from the Broadcaster.
+         * When the broadcaster.broadcast() method is called, all registered callbacks
+         * are called with the Broadcaster's "listenable", along with optional
+         * arguments passed to the `broadcast` method.
          *
          * The listeners are called synchronously.
          */
-        class Broadcaster extends Core.PlottableObject {
-            listenable: Listenable;
+        class Broadcaster<L> extends Core.PlottableObject {
             /**
-             * Constructs a broadcaster, taking the Listenable that the broadcaster will be attached to.
+             * Constructs a broadcaster, taking a "listenable" object to broadcast about.
              *
              * @constructor
-             * @param {Listenable} listenable The Listenable-object that this broadcaster is attached to.
+             * @param {L} listenable The listenable object to broadcast about.
              */
-            constructor(listenable: Listenable);
+            constructor(listenable: L);
             /**
              * Registers a callback to be called when the broadcast method is called. Also takes a key which
              * is used to support deregistering the same callback later, by passing in the same key.
              * If there is already a callback associated with that key, then the callback will be replaced.
              *
              * @param key The key associated with the callback. Key uniqueness is determined by deep equality.
-             * @param {BroadcasterCallback} callback A callback to be called when the Scale's domain changes.
-             * @returns {Broadcaster} this object
+             * @param {(listenable: L, ...args: any[]) => any} callback A callback to be called.
+             * @returns {Broadcaster} The calling Broadcaster
              */
-            registerListener(key: any, callback: BroadcasterCallback): Broadcaster;
+            registerListener(key: any, callback: (listenable: L, ...args: any[]) => any): Broadcaster<L>;
             /**
              * Call all listening callbacks, optionally with arguments passed through.
              *
              * @param ...args A variable number of optional arguments
-             * @returns {Broadcaster} this object
+             * @returns {Broadcaster} The calling Broadcaster
              */
-            broadcast(...args: any[]): Broadcaster;
+            broadcast(...args: any[]): Broadcaster<L>;
             /**
              * Deregisters the callback associated with a key.
              *
              * @param key The key to deregister.
-             * @returns {Broadcaster} this object
+             * @returns {Broadcaster} The calling Broadcaster
              */
-            deregisterListener(key: any): Broadcaster;
+            deregisterListener(key: any): Broadcaster<L>;
             /**
              * Deregisters all listeners and callbacks associated with the broadcaster.
              *
-             * @returns {Broadcaster} this object
+             * @returns {Broadcaster} The calling Broadcaster
              */
             deregisterAllListeners(): void;
         }
@@ -535,8 +513,8 @@ declare module Plottable {
 
 
 declare module Plottable {
-    class Dataset extends Core.PlottableObject implements Core.Listenable {
-        broadcaster: Core.Broadcaster;
+    class Dataset extends Core.PlottableObject {
+        broadcaster: Core.Broadcaster<Dataset>;
         /**
          * Constructs a new set.
          *
@@ -894,9 +872,9 @@ declare module Plottable {
 
 declare module Plottable {
     module Scale {
-        class AbstractScale<D, R> extends Core.PlottableObject implements Core.Listenable {
+        class AbstractScale<D, R> extends Core.PlottableObject {
             protected _d3Scale: D3.Scale.Scale;
-            broadcaster: Core.Broadcaster;
+            broadcaster: Core.Broadcaster<AbstractScale<D, R>>;
             _typeCoercer: (d: any) => any;
             /**
              * Constructs a new Scale.

--- a/plottable.js
+++ b/plottable.js
@@ -1049,25 +1049,26 @@ var Plottable;
     var Core;
     (function (Core) {
         /**
-         * The Broadcaster class is owned by an Listenable. Third parties can register and deregister listeners
-         * from the broadcaster. When the broadcaster.broadcast method is activated, all registered callbacks are
-         * called. The registered callbacks are called with the registered Listenable that the broadcaster is attached
-         * to, along with optional arguments passed to the `broadcast` method.
+         * The Broadcaster holds a reference to a "listenable" object.
+         * Third parties can register and deregister listeners from the Broadcaster.
+         * When the broadcaster.broadcast() method is called, all registered callbacks
+         * are called with the Broadcaster's "listenable", along with optional
+         * arguments passed to the `broadcast` method.
          *
          * The listeners are called synchronously.
          */
         var Broadcaster = (function (_super) {
             __extends(Broadcaster, _super);
             /**
-             * Constructs a broadcaster, taking the Listenable that the broadcaster will be attached to.
+             * Constructs a broadcaster, taking a "listenable" object to broadcast about.
              *
              * @constructor
-             * @param {Listenable} listenable The Listenable-object that this broadcaster is attached to.
+             * @param {L} listenable The listenable object to broadcast about.
              */
             function Broadcaster(listenable) {
                 _super.call(this);
                 this._key2callback = new Plottable._Util.StrictEqualityAssociativeArray();
-                this.listenable = listenable;
+                this._listenable = listenable;
             }
             /**
              * Registers a callback to be called when the broadcast method is called. Also takes a key which
@@ -1075,8 +1076,8 @@ var Plottable;
              * If there is already a callback associated with that key, then the callback will be replaced.
              *
              * @param key The key associated with the callback. Key uniqueness is determined by deep equality.
-             * @param {BroadcasterCallback} callback A callback to be called when the Scale's domain changes.
-             * @returns {Broadcaster} this object
+             * @param {(listenable: L, ...args: any[]) => any} callback A callback to be called.
+             * @returns {Broadcaster} The calling Broadcaster
              */
             Broadcaster.prototype.registerListener = function (key, callback) {
                 this._key2callback.set(key, callback);
@@ -1086,7 +1087,7 @@ var Plottable;
              * Call all listening callbacks, optionally with arguments passed through.
              *
              * @param ...args A variable number of optional arguments
-             * @returns {Broadcaster} this object
+             * @returns {Broadcaster} The calling Broadcaster
              */
             Broadcaster.prototype.broadcast = function () {
                 var _this = this;
@@ -1094,14 +1095,14 @@ var Plottable;
                 for (var _i = 0; _i < arguments.length; _i++) {
                     args[_i - 0] = arguments[_i];
                 }
-                this._key2callback.values().forEach(function (callback) { return callback(_this.listenable, args); });
+                this._key2callback.values().forEach(function (callback) { return callback(_this._listenable, args); });
                 return this;
             };
             /**
              * Deregisters the callback associated with a key.
              *
              * @param key The key to deregister.
-             * @returns {Broadcaster} this object
+             * @returns {Broadcaster} The calling Broadcaster
              */
             Broadcaster.prototype.deregisterListener = function (key) {
                 this._key2callback.delete(key);
@@ -1110,7 +1111,7 @@ var Plottable;
             /**
              * Deregisters all listeners and callbacks associated with the broadcaster.
              *
-             * @returns {Broadcaster} this object
+             * @returns {Broadcaster} The calling Broadcaster
              */
             Broadcaster.prototype.deregisterAllListeners = function () {
                 this._key2callback = new Plottable._Util.StrictEqualityAssociativeArray();

--- a/plottable.js
+++ b/plottable.js
@@ -1063,7 +1063,7 @@ var Plottable;
              * Constructs a broadcaster, taking a "listenable" object to broadcast about.
              *
              * @constructor
-             * @param {L} listenable The listenable object to broadcast about.
+             * @param {L} listenable The listenable object to broadcast.
              */
             function Broadcaster(listenable) {
                 _super.call(this);
@@ -1076,7 +1076,7 @@ var Plottable;
              * If there is already a callback associated with that key, then the callback will be replaced.
              *
              * @param key The key associated with the callback. Key uniqueness is determined by deep equality.
-             * @param {(listenable: L, ...args: any[]) => any} callback A callback to be called.
+             * @param {BroadcasterCallback<L>} callback A callback to be called.
              * @returns {Broadcaster} The calling Broadcaster
              */
             Broadcaster.prototype.registerListener = function (key, callback) {

--- a/src/core/broadcaster.ts
+++ b/src/core/broadcaster.ts
@@ -3,50 +3,27 @@
 module Plottable {
 export module Core {
   /**
-   * This interface represents anything in Plottable which can have a listener attached.
-   * Listeners attach by referencing the Listenable's broadcaster, and calling registerListener
-   * on it.
-   *
-   * e.g.:
-   * listenable: Plottable.Listenable;
-   * listenable.broadcaster.registerListener(callbackToCallOnBroadcast)
-   */
-  export interface Listenable {
-    broadcaster: Broadcaster;
-  }
-
-  /**
-   * This interface represents the callback that should be passed to the Broadcaster on a Listenable.
-   *
-   * The callback will be called with the attached Listenable as the first object, and optional arguments
-   * as the subsequent arguments.
-   *
-   * The Listenable is passed as the first argument so that it is easy for the callback to reference the
-   * current state of the Listenable in the resolution logic.
-   */
-  export type BroadcasterCallback = (listenable: Listenable, ...args: any[]) => any;
-
-  /**
-   * The Broadcaster class is owned by an Listenable. Third parties can register and deregister listeners
-   * from the broadcaster. When the broadcaster.broadcast method is activated, all registered callbacks are
-   * called. The registered callbacks are called with the registered Listenable that the broadcaster is attached
-   * to, along with optional arguments passed to the `broadcast` method.
+   * The Broadcaster holds a reference to a "listenable" object.
+   * Third parties can register and deregister listeners from the Broadcaster.
+   * When the broadcaster.broadcast() method is called, all registered callbacks
+   * are called with the Broadcaster's "listenable", along with optional
+   * arguments passed to the `broadcast` method.
    *
    * The listeners are called synchronously.
    */
-  export class Broadcaster extends Core.PlottableObject {
+  export class Broadcaster<L> extends Core.PlottableObject {
     private _key2callback = new _Util.StrictEqualityAssociativeArray();
-    public listenable: Listenable;
+    private _listenable: L;
 
     /**
-     * Constructs a broadcaster, taking the Listenable that the broadcaster will be attached to.
+     * Constructs a broadcaster, taking a "listenable" object to broadcast about.
      *
      * @constructor
-     * @param {Listenable} listenable The Listenable-object that this broadcaster is attached to.
+     * @param {L} listenable The listenable object to broadcast about.
      */
-    constructor(listenable: Listenable) {
+    constructor(listenable: L) {
       super();
-      this.listenable = listenable;
+      this._listenable = listenable;
     }
 
     /**
@@ -55,10 +32,10 @@ export module Core {
      * If there is already a callback associated with that key, then the callback will be replaced.
      *
      * @param key The key associated with the callback. Key uniqueness is determined by deep equality.
-     * @param {BroadcasterCallback} callback A callback to be called when the Scale's domain changes.
-     * @returns {Broadcaster} this object
+     * @param {(listenable: L, ...args: any[]) => any} callback A callback to be called.
+     * @returns {Broadcaster} The calling Broadcaster
      */
-    public registerListener(key: any, callback: BroadcasterCallback) {
+    public registerListener(key: any, callback: (listenable: L, ...args: any[]) => any) {
       this._key2callback.set(key, callback);
       return this;
     }
@@ -67,10 +44,10 @@ export module Core {
      * Call all listening callbacks, optionally with arguments passed through.
      *
      * @param ...args A variable number of optional arguments
-     * @returns {Broadcaster} this object
+     * @returns {Broadcaster} The calling Broadcaster
      */
     public broadcast(...args: any[]) {
-      this._key2callback.values().forEach((callback) => callback(this.listenable, args));
+      this._key2callback.values().forEach((callback) => callback(this._listenable, args));
       return this;
     }
 
@@ -78,7 +55,7 @@ export module Core {
      * Deregisters the callback associated with a key.
      *
      * @param key The key to deregister.
-     * @returns {Broadcaster} this object
+     * @returns {Broadcaster} The calling Broadcaster
      */
     public deregisterListener(key: any) {
       this._key2callback.delete(key);
@@ -88,7 +65,7 @@ export module Core {
     /**
      * Deregisters all listeners and callbacks associated with the broadcaster.
      *
-     * @returns {Broadcaster} this object
+     * @returns {Broadcaster} The calling Broadcaster
      */
     public deregisterAllListeners() {
       this._key2callback = new _Util.StrictEqualityAssociativeArray();

--- a/src/core/broadcaster.ts
+++ b/src/core/broadcaster.ts
@@ -2,6 +2,17 @@
 
 module Plottable {
 export module Core {
+
+  /**
+   * A callback for a Broadcaster. The callback will be called with the Broadcaster's
+   * "listenable" as the first argument, with subsequent optional arguments depending
+   * on the listenable.
+   */
+  // HACKHACK: An interface because the "type" keyword doesn't work with generics.
+  export interface BroadcasterCallback<L> {
+    (listenable: L, ...args: any[]): any;
+  }
+
   /**
    * The Broadcaster holds a reference to a "listenable" object.
    * Third parties can register and deregister listeners from the Broadcaster.
@@ -19,7 +30,7 @@ export module Core {
      * Constructs a broadcaster, taking a "listenable" object to broadcast about.
      *
      * @constructor
-     * @param {L} listenable The listenable object to broadcast about.
+     * @param {L} listenable The listenable object to broadcast.
      */
     constructor(listenable: L) {
       super();
@@ -32,10 +43,10 @@ export module Core {
      * If there is already a callback associated with that key, then the callback will be replaced.
      *
      * @param key The key associated with the callback. Key uniqueness is determined by deep equality.
-     * @param {(listenable: L, ...args: any[]) => any} callback A callback to be called.
+     * @param {BroadcasterCallback<L>} callback A callback to be called.
      * @returns {Broadcaster} The calling Broadcaster
      */
-    public registerListener(key: any, callback: (listenable: L, ...args: any[]) => any) {
+    public registerListener(key: any, callback: BroadcasterCallback<L>) {
       this._key2callback.set(key, callback);
       return this;
     }

--- a/src/core/dataset.ts
+++ b/src/core/dataset.ts
@@ -5,11 +5,11 @@ module Plottable {
     accessor: _Accessor;
     extent: any[];
   }
-  export class Dataset extends Core.PlottableObject implements Core.Listenable {
+  export class Dataset extends Core.PlottableObject {
     private _data: any[];
     private _metadata: any;
     private _accessor2cachedExtent: _Util.StrictEqualityAssociativeArray;
-    public broadcaster: Core.Broadcaster;
+    public broadcaster: Core.Broadcaster<Dataset>;
 
     /**
      * Constructs a new set.

--- a/src/core/resizeBroadcaster.ts
+++ b/src/core/resizeBroadcaster.ts
@@ -14,12 +14,12 @@ export module Core {
    * animations during resize.
    */
   export module ResizeBroadcaster {
-    var broadcaster: Core.Broadcaster;
+    var broadcaster: Core.Broadcaster<any>;
     var _resizing: boolean = false;
 
     function _lazyInitialize() {
       if (broadcaster === undefined) {
-        broadcaster = new Core.Broadcaster(<any> ResizeBroadcaster);
+        broadcaster = new Core.Broadcaster<any>(<any> ResizeBroadcaster);
         window.addEventListener("resize", _onResize);
       }
     }

--- a/src/core/resizeBroadcaster.ts
+++ b/src/core/resizeBroadcaster.ts
@@ -19,7 +19,7 @@ export module Core {
 
     function _lazyInitialize() {
       if (broadcaster === undefined) {
-        broadcaster = new Core.Broadcaster<any>(<any> ResizeBroadcaster);
+        broadcaster = new Core.Broadcaster<any>(ResizeBroadcaster);
         window.addEventListener("resize", _onResize);
       }
     }

--- a/src/scales/abstractScale.ts
+++ b/src/scales/abstractScale.ts
@@ -2,10 +2,10 @@
 
 module Plottable {
 export module Scale {
-  export class AbstractScale<D,R> extends Core.PlottableObject implements Core.Listenable {
+  export class AbstractScale<D,R> extends Core.PlottableObject {
     protected _d3Scale: D3.Scale.Scale;
     private _autoDomainAutomatically = true;
-    public broadcaster: Core.Broadcaster;
+    public broadcaster: Core.Broadcaster<AbstractScale<D, R>>;
     private _rendererAttrID2Extent: {[rendererAttrID: string]: D[]} = {};
     public _typeCoercer: (d: any) => any = (d: any) => d;
     private _domainModificationInProgress: boolean = false;

--- a/test/components/plots/plotTests.ts
+++ b/test/components/plots/plotTests.ts
@@ -69,11 +69,11 @@ describe("Plots", () => {
       r.project("x", "x", xScale);
       r.project("y", "y", yScale);
       r.project("meta", metadataProjector);
-      xScale.broadcaster.registerListener(null, (listenable: Plottable.Core.Listenable) => {
+      xScale.broadcaster.registerListener("unitTest", (listenable: Plottable.Scale.Linear) => {
         assert.equal(listenable, xScale, "Callback received the calling scale as the first argument");
         ++xScaleCalls;
       });
-      yScale.broadcaster.registerListener(null, (listenable: Plottable.Core.Listenable) => {
+      yScale.broadcaster.registerListener("unitTest", (listenable: Plottable.Scale.Linear) => {
         assert.equal(listenable, yScale, "Callback received the calling scale as the first argument");
         ++yScaleCalls;
       });

--- a/test/core/broadcasterTests.ts
+++ b/test/core/broadcasterTests.ts
@@ -3,14 +3,13 @@
 var assert = chai.assert;
 
 describe("Broadcasters", () => {
-  var b: Plottable.Core.Broadcaster;
+  var b: Plottable.Core.Broadcaster<any>;
   var called: boolean;
   var cb: any;
-  var listenable: Plottable.Core.Listenable = {broadcaster: null};
+  var listenable: Object = {};
 
   beforeEach(() => {
     b = new Plottable.Core.Broadcaster(listenable);
-    listenable.broadcaster = b;
     called = false;
     cb = () => {called = true;};
   });
@@ -54,7 +53,7 @@ describe("Broadcasters", () => {
   it("arguments are passed through to callback", () => {
     var g2 = {};
     var g3 = "foo";
-    var cb = (a1: Plottable.Core.Listenable, rest: any[]) => {
+    var cb = (a1: any, rest: any[]) => {
       assert.equal(listenable, a1, "broadcaster passed through");
       assert.equal(g2, rest[0], "arg1 passed through");
       assert.equal(g3, rest[1], "arg2 passed through");

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -318,22 +318,11 @@ describe("Component behavior", () => {
   });
 
   it("detach() works as expected", () => {
-    var cbCalled = 0;
-    var cb = (b: Plottable.Core.Listenable) => cbCalled++;
-    var b = new Plottable.Core.Broadcaster(null);
-
     var c1 = new Plottable.Component.AbstractComponent();
 
-    b.registerListener(c1, cb);
-
     c1.renderTo(svg);
-    b.broadcast();
-    assert.equal(cbCalled, 1, "the callback was called");
     assert.isTrue(svg.node().hasChildNodes(), "the svg has children");
     c1.detach();
-
-    b.broadcast();
-    assert.equal(cbCalled, 2, "the callback is still attached to the component");
     assert.isFalse(svg.node().hasChildNodes(), "the svg has no children");
 
     svg.remove();

--- a/test/core/datasetTests.ts
+++ b/test/core/datasetTests.ts
@@ -9,7 +9,7 @@ describe("Dataset", () => {
     var newData = [ 1, 2, 3 ];
 
     var callbackCalled = false;
-    var callback: Plottable.Core.BroadcasterCallback = (listenable: Plottable.Core.Listenable) => {
+    var callback = (listenable: Plottable.Dataset) => {
       assert.equal(listenable, ds, "Callback received the Dataset as the first argument");
       assert.deepEqual(ds.data(), newData, "Dataset arrives with correct data");
       callbackCalled = true;
@@ -26,7 +26,7 @@ describe("Dataset", () => {
     var newMetadata = "blargh";
 
     var callbackCalled = false;
-    var callback: Plottable.Core.BroadcasterCallback = (listenable: Plottable.Core.Listenable) => {
+    var callback = (listenable: Plottable.Dataset) => {
       assert.equal(listenable, ds, "Callback received the Dataset as the first argument");
       assert.deepEqual(ds.metadata(), newMetadata, "Dataset arrives with correct metadata");
       callbackCalled = true;

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -4,7 +4,7 @@ var assert = chai.assert;
 
 describe("Scales", () => {
   it("Scale's copy() works correctly", () => {
-    var testCallback: Plottable.Core.BroadcasterCallback = (broadcaster: Plottable.Core.Listenable) => {
+    var testCallback = (listenable: any) => {
       return true; // doesn't do anything
     };
     var scale = new Plottable.Scale.Linear();
@@ -19,7 +19,7 @@ describe("Scales", () => {
   it("Scale alerts listeners when its domain is updated", () => {
     var scale = new Plottable.Scale.Linear();
     var callbackWasCalled = false;
-    var testCallback: Plottable.Core.BroadcasterCallback = (listenable: Plottable.Core.Listenable) => {
+    var testCallback = (listenable: Plottable.Scale.Linear) => {
       assert.equal(listenable, scale, "Callback received the calling scale as the first argument");
       callbackWasCalled = true;
     };

--- a/test/tests.js
+++ b/test/tests.js
@@ -1655,11 +1655,11 @@ describe("Plots", function () {
             r.project("x", "x", xScale);
             r.project("y", "y", yScale);
             r.project("meta", metadataProjector);
-            xScale.broadcaster.registerListener(null, function (listenable) {
+            xScale.broadcaster.registerListener("unitTest", function (listenable) {
                 assert.equal(listenable, xScale, "Callback received the calling scale as the first argument");
                 ++xScaleCalls;
             });
-            yScale.broadcaster.registerListener(null, function (listenable) {
+            yScale.broadcaster.registerListener("unitTest", function (listenable) {
                 assert.equal(listenable, yScale, "Callback received the calling scale as the first argument");
                 ++yScaleCalls;
             });
@@ -4159,10 +4159,9 @@ describe("Broadcasters", function () {
     var b;
     var called;
     var cb;
-    var listenable = { broadcaster: null };
+    var listenable = {};
     beforeEach(function () {
         b = new Plottable.Core.Broadcaster(listenable);
-        listenable.broadcaster = b;
         called = false;
         cb = function () {
             called = true;
@@ -4924,18 +4923,10 @@ describe("Component behavior", function () {
         svg.remove();
     });
     it("detach() works as expected", function () {
-        var cbCalled = 0;
-        var cb = function (b) { return cbCalled++; };
-        var b = new Plottable.Core.Broadcaster(null);
         var c1 = new Plottable.Component.AbstractComponent();
-        b.registerListener(c1, cb);
         c1.renderTo(svg);
-        b.broadcast();
-        assert.equal(cbCalled, 1, "the callback was called");
         assert.isTrue(svg.node().hasChildNodes(), "the svg has children");
         c1.detach();
-        b.broadcast();
-        assert.equal(cbCalled, 2, "the callback is still attached to the component");
         assert.isFalse(svg.node().hasChildNodes(), "the svg has no children");
         svg.remove();
     });
@@ -5700,7 +5691,7 @@ describe("Coordinators", function () {
 var assert = chai.assert;
 describe("Scales", function () {
     it("Scale's copy() works correctly", function () {
-        var testCallback = function (broadcaster) {
+        var testCallback = function (listenable) {
             return true; // doesn't do anything
         };
         var scale = new Plottable.Scale.Linear();


### PR DESCRIPTION
Previously: `Broadcasters` had-a `Listenable`, which had-a reference to the same `Broadcaster`. This was silly and prevented the use of multiple
`Broadcasters` on the same object.

Now we can use generic typing to convey more information about what the `Broadcaster` is broadcasting.

Close #1604.