### PR TITLE
[BarPlot] - Domainer Constructor fixes

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2814,7 +2814,6 @@ declare module Plottable {
             _computeLayout(offeredXOrigin?: number, offeredYOffset?: number, availableWidth?: number, availableHeight?: number): void;
             protected _updateXDomainer(): void;
             protected _updateYDomainer(): void;
-            protected static updateScaleDomainer(scale: Scale.AbstractScale<any, number>): void;
             /**
              * Adjusts both domains' extents to show all datasets.
              *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -452,6 +452,7 @@ declare module Plottable {
          * unique ID.
          */
         class PlottableObject {
+            protected _plottableID: number;
             getID(): number;
         }
     }
@@ -2813,6 +2814,7 @@ declare module Plottable {
             _computeLayout(offeredXOrigin?: number, offeredYOffset?: number, availableWidth?: number, availableHeight?: number): void;
             protected _updateXDomainer(): void;
             protected _updateYDomainer(): void;
+            protected static updateScaleDomainer(scale: Scale.AbstractScale<any, number>): void;
             /**
              * Adjusts both domains' extents to show all datasets.
              *

--- a/plottable.js
+++ b/plottable.js
@@ -6679,9 +6679,9 @@ var Plottable;
                 Plottable._Util.Methods.uniqPush(this._cssClasses, "xy-plot");
                 this._xScale = xScale;
                 this._yScale = yScale;
-                AbstractXYPlot.updateScaleDomainer(xScale);
+                AbstractXYPlot._updateScaleDomainer(xScale);
                 xScale.broadcaster.registerListener("yDomainAdjustment" + this.getID(), function () { return _this._adjustYDomainOnChangeFromX(); });
-                AbstractXYPlot.updateScaleDomainer(yScale);
+                AbstractXYPlot._updateScaleDomainer(yScale);
                 yScale.broadcaster.registerListener("xDomainAdjustment" + this.getID(), function () { return _this._adjustXDomainOnChangeFromY(); });
                 this._autoAdjustXScaleDomain = false;
                 this._autoAdjustYScaleDomain = false;
@@ -6771,12 +6771,12 @@ var Plottable;
                 }
             };
             AbstractXYPlot.prototype._updateXDomainer = function () {
-                AbstractXYPlot.updateScaleDomainer(this._xScale);
+                AbstractXYPlot._updateScaleDomainer(this._xScale);
             };
             AbstractXYPlot.prototype._updateYDomainer = function () {
-                AbstractXYPlot.updateScaleDomainer(this._yScale);
+                AbstractXYPlot._updateScaleDomainer(this._yScale);
             };
-            AbstractXYPlot.updateScaleDomainer = function (scale) {
+            AbstractXYPlot._updateScaleDomainer = function (scale) {
                 if (scale instanceof Plottable.Scale.AbstractQuantitative) {
                     var qScale = scale;
                     if (!qScale._userSetDomainer) {

--- a/plottable.js
+++ b/plottable.js
@@ -7113,7 +7113,13 @@ var Plottable;
                 this._animators["bars"] = new Plottable.Animator.Base();
                 this._animators["baseline"] = new Plottable.Animator.Null();
                 this._isVertical = isVertical;
-                this._baselineValue = 0;
+                this.baseline(0);
+                if (isVertical) {
+                    Bar._updateDomainerBaseline(yScale, 0, this._plottableID);
+                }
+                else {
+                    Bar._updateDomainerBaseline(xScale, 0, this._plottableID);
+                }
             }
             Bar.prototype._getDrawer = function (key) {
                 return new Plottable._Drawer.Rect(key, this._isVertical);
@@ -7218,21 +7224,24 @@ var Plottable;
                 });
                 return bars;
             };
-            Bar.prototype._updateDomainer = function (scale) {
+            Bar._updateDomainerBaseline = function (scale, baselineValue, id) {
                 if (scale instanceof Plottable.Scale.AbstractQuantitative) {
                     var qscale = scale;
                     if (!qscale._userSetDomainer) {
-                        if (this._baselineValue != null) {
-                            qscale.domainer().addPaddingException(this._baselineValue, "BAR_PLOT+" + this.getID()).addIncludedValue(this._baselineValue, "BAR_PLOT+" + this.getID());
+                        if (baselineValue != null) {
+                            qscale.domainer().addPaddingException(baselineValue, "BAR_PLOT+" + id).addIncludedValue(baselineValue, "BAR_PLOT+" + id);
                         }
                         else {
-                            qscale.domainer().removePaddingException("BAR_PLOT+" + this.getID()).removeIncludedValue("BAR_PLOT+" + this.getID());
+                            qscale.domainer().removePaddingException("BAR_PLOT+" + id).removeIncludedValue("BAR_PLOT+" + id);
                         }
                         qscale.domainer().pad().nice();
                     }
                     // prepending "BAR_PLOT" is unnecessary but reduces likely of user accidentally creating collisions
                     qscale._autoDomainIfAutomaticMode();
                 }
+            };
+            Bar.prototype._updateDomainer = function (scale) {
+                Bar._updateDomainerBaseline(scale, this.baseline(), this.getID());
             };
             Bar.prototype._updateYDomainer = function () {
                 if (this._isVertical) {

--- a/plottable.js
+++ b/plottable.js
@@ -7113,7 +7113,7 @@ var Plottable;
                 this._animators["bars"] = new Plottable.Animator.Base();
                 this._animators["baseline"] = new Plottable.Animator.Null();
                 this._isVertical = isVertical;
-                this.baseline(0);
+                this._baselineValue = 0;
                 if (isVertical) {
                     Bar._updateDomainerBaseline(yScale, 0, this._plottableID);
                 }

--- a/src/components/plots/abstractXYPlot.ts
+++ b/src/components/plots/abstractXYPlot.ts
@@ -30,9 +30,9 @@ export module Plot {
       this._xScale = xScale;
       this._yScale = yScale;
 
-      AbstractXYPlot.updateScaleDomainer(xScale);
+      AbstractXYPlot._updateScaleDomainer(xScale);
       xScale.broadcaster.registerListener("yDomainAdjustment" + this.getID(), () => this._adjustYDomainOnChangeFromX());
-      AbstractXYPlot.updateScaleDomainer(yScale);
+      AbstractXYPlot._updateScaleDomainer(yScale);
       yScale.broadcaster.registerListener("xDomainAdjustment" + this.getID(), () => this._adjustXDomainOnChangeFromY());
 
       this._autoAdjustXScaleDomain = false;
@@ -132,14 +132,14 @@ export module Plot {
     }
 
     protected _updateXDomainer() {
-      AbstractXYPlot.updateScaleDomainer(this._xScale);
+      AbstractXYPlot._updateScaleDomainer(this._xScale);
     }
 
     protected _updateYDomainer() {
-      AbstractXYPlot.updateScaleDomainer(this._yScale);
+      AbstractXYPlot._updateScaleDomainer(this._yScale);
     }
 
-    protected static updateScaleDomainer(scale: Scale.AbstractScale<any, number>) {
+    private static _updateScaleDomainer(scale: Scale.AbstractScale<any, number>) {
       if (scale instanceof Scale.AbstractQuantitative) {
         var qScale = <Scale.AbstractQuantitative<any>> scale;
         if (!qScale._userSetDomainer) {

--- a/src/components/plots/abstractXYPlot.ts
+++ b/src/components/plots/abstractXYPlot.ts
@@ -139,7 +139,7 @@ export module Plot {
       AbstractXYPlot.updateScaleDomainer(this._yScale);
     }
 
-    private static updateScaleDomainer(scale: Scale.AbstractScale<any, number>) {
+    protected static updateScaleDomainer(scale: Scale.AbstractScale<any, number>) {
       if (scale instanceof Scale.AbstractQuantitative) {
         var qScale = <Scale.AbstractQuantitative<any>> scale;
         if (!qScale._userSetDomainer) {

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -33,7 +33,7 @@ export module Plot {
       this._animators["bars"] = new Animator.Base();
       this._animators["baseline"] = new Animator.Null();
       this._isVertical = isVertical;
-      this.baseline(0);
+      this._baselineValue = 0;
 
       if (isVertical) {
         Bar._updateDomainerBaseline(yScale, 0, this._plottableID);

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -33,7 +33,13 @@ export module Plot {
       this._animators["bars"] = new Animator.Base();
       this._animators["baseline"] = new Animator.Null();
       this._isVertical = isVertical;
-      this._baselineValue = 0;
+      this.baseline(0);
+
+      if (isVertical) {
+        Bar._updateDomainerBaseline(yScale, 0, this._plottableID);
+      } else {
+        Bar._updateDomainerBaseline(xScale, 0, this._plottableID);
+      }
     }
 
     protected _getDrawer(key: string) {
@@ -195,24 +201,28 @@ export module Plot {
       return bars;
     }
 
-    protected _updateDomainer(scale: Scale.AbstractScale<any, number>) {
+    private static _updateDomainerBaseline(scale: Scale.AbstractScale<any, number>, baselineValue: number, id: number) {
       if (scale instanceof Scale.AbstractQuantitative) {
         var qscale = <Scale.AbstractQuantitative<any>> scale;
         if (!qscale._userSetDomainer) {
-          if (this._baselineValue != null) {
+          if (baselineValue != null) {
             qscale.domainer()
-              .addPaddingException(this._baselineValue, "BAR_PLOT+" + this.getID())
-              .addIncludedValue(this._baselineValue, "BAR_PLOT+" + this.getID());
+              .addPaddingException(baselineValue, "BAR_PLOT+" + id)
+              .addIncludedValue(baselineValue, "BAR_PLOT+" + id);
           } else {
             qscale.domainer()
-              .removePaddingException("BAR_PLOT+" + this.getID())
-              .removeIncludedValue("BAR_PLOT+" + this.getID());
+              .removePaddingException("BAR_PLOT+" + id)
+              .removeIncludedValue("BAR_PLOT+" + id);
           }
           qscale.domainer().pad().nice();
         }
             // prepending "BAR_PLOT" is unnecessary but reduces likely of user accidentally creating collisions
         qscale._autoDomainIfAutomaticMode();
       }
+    }
+
+    protected _updateDomainer(scale: Scale.AbstractScale<any, number>) {
+      Bar._updateDomainerBaseline(scale, this.baseline(), this.getID());
     }
 
     protected _updateYDomainer() {

--- a/src/core/plottableObject.ts
+++ b/src/core/plottableObject.ts
@@ -8,7 +8,7 @@ export module Core {
    */
   export class PlottableObject {
     private static _nextID = 0;
-    private _plottableID = PlottableObject._nextID++;
+    protected _plottableID = PlottableObject._nextID++;
 
     public getID() {
       return this._plottableID;


### PR DESCRIPTION
The barPlot called baseline in its constructor previously which enacted a domainer updating that the constructor does not catch.  Note that one possible issue that is arising is when the scales are attached to the plot, we are instantly updating the scale... even when the plot isn't rendered...