### PR TITLE
[CategoryAxis] - Correcting textFits parameter for space calculations

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -5073,7 +5073,7 @@ var Plottable;
                 var widthFn = this._isHorizontal() ? d3.sum : Plottable._Util.Methods.max;
                 var heightFn = this._isHorizontal() ? Plottable._Util.Methods.max : d3.sum;
                 return {
-                    textFits: wrappingResults.every(function (t) { return !SVGTypewriter.Utils.StringMethods.isNotEmptyString(t.truncatedText) && t.noLines === 1; }),
+                    textFits: wrappingResults.every(function (t) { return SVGTypewriter.Utils.StringMethods.isNotEmptyString(t.truncatedText) && t.noLines === 1; }),
                     usedWidth: widthFn(wrappingResults, function (t) { return _this._measurer.measure(t.wrappedText).width; }, 0),
                     usedHeight: heightFn(wrappingResults, function (t) { return _this._measurer.measure(t.wrappedText).height; }, 0)
                 };

--- a/src/components/axes/categoryAxis.ts
+++ b/src/components/axes/categoryAxis.ts
@@ -148,7 +148,7 @@ export module Axis {
 
       return {
         textFits: wrappingResults.every((t: SVGTypewriter.Wrappers.WrappingResult) =>
-                    !SVGTypewriter.Utils.StringMethods.isNotEmptyString(t.truncatedText) && t.noLines === 1),
+                    SVGTypewriter.Utils.StringMethods.isNotEmptyString(t.truncatedText) && t.noLines === 1),
         usedWidth : widthFn<SVGTypewriter.Wrappers.WrappingResult, number>(wrappingResults,
                       (t: SVGTypewriter.Wrappers.WrappingResult) => this._measurer.measure(t.wrappedText).width, 0),
         usedHeight: heightFn<SVGTypewriter.Wrappers.WrappingResult, number>(wrappingResults,

--- a/test/components/categoryAxisTests.ts
+++ b/test/components/categoryAxisTests.ts
@@ -109,20 +109,14 @@ describe("Category Axes", () => {
     svg.remove();
   });
 
-  it("layout calculated correctly under 0 width/height surrounding component conditions", () => {
+  it("axis should request more space if there's not enough space to fit the text", () => {
     var svg = generateSVG(300, 300);
     var years = ["2000", "2001", "2002", "2003"];
     var scale = new Plottable.Scale.Ordinal().domain(years);
     var axis = new Plottable.Axis.Category(scale, "bottom");
-    var table = new Plottable.Component.Table([
-                                               [null],
-                                               [axis],
-                                               [null],
-                                               [new Plottable.Component.Label("")]
-                                                                                  ]);
-    table.renderTo(svg);
-    assert.closeTo(axis.height(), 44, 2, "height is calculated correctly");
-    assert.strictEqual(axis.width(), 300, "width is calculated correctly");
+    axis.renderTo(svg);
+    var requestedSpace = axis._requestedSpace(300, 10);
+    assert.isTrue(requestedSpace.wantsHeight, "axis should want to ask for more space");
 
     svg.remove();
   });

--- a/test/components/categoryAxisTests.ts
+++ b/test/components/categoryAxisTests.ts
@@ -121,7 +121,7 @@ describe("Category Axes", () => {
                                                [new Plottable.Component.Label("")]
                                                                                   ]);
     table.renderTo(svg);
-    assert.closeTo(axis.height(), 44, 1, "height is calculated correctly");
+    assert.closeTo(axis.height(), 44, 2, "height is calculated correctly");
     assert.strictEqual(axis.width(), 300, "width is calculated correctly");
 
     svg.remove();

--- a/test/components/categoryAxisTests.ts
+++ b/test/components/categoryAxisTests.ts
@@ -108,4 +108,22 @@ describe("Category Axes", () => {
 
     svg.remove();
   });
+
+  it("layout calculated correctly under 0 width/height surrounding component conditions", () => {
+    var svg = generateSVG(300, 300);
+    var years = ["2000", "2001", "2002", "2003"];
+    var scale = new Plottable.Scale.Ordinal().domain(years);
+    var axis = new Plottable.Axis.Category(scale, "bottom");
+    var table = new Plottable.Component.Table([
+                                               [null],
+                                               [axis],
+                                               [null],
+                                               [new Plottable.Component.Label("")]
+                                                                                  ]);
+    table.renderTo(svg);
+    assert.strictEqual(axis.height(), 44, "height is calculated correctly");
+    assert.strictEqual(axis.width(), 300, "width is calculated correctly");
+
+    svg.remove();
+  });
 });

--- a/test/components/categoryAxisTests.ts
+++ b/test/components/categoryAxisTests.ts
@@ -116,10 +116,10 @@ describe("Category Axes", () => {
     var axis = new Plottable.Axis.Category(scale, "bottom");
     axis.renderTo(svg);
     var requestedSpace = axis._requestedSpace(300, 10);
-    assert.isTrue(requestedSpace.wantsHeight, "axis should ask for more space");
+    assert.isTrue(requestedSpace.wantsHeight, "axis should ask for more space (horizontal orientation)");
     axis.orient("left");
     requestedSpace = axis._requestedSpace(10, 300);
-    assert.isTrue(requestedSpace.wantsWidth, "axis should ask for more space");
+    assert.isTrue(requestedSpace.wantsWidth, "axis should ask for more space (vertical orientation)");
 
     svg.remove();
   });

--- a/test/components/categoryAxisTests.ts
+++ b/test/components/categoryAxisTests.ts
@@ -121,7 +121,7 @@ describe("Category Axes", () => {
                                                [new Plottable.Component.Label("")]
                                                                                   ]);
     table.renderTo(svg);
-    assert.strictEqual(axis.height(), 44, "height is calculated correctly");
+    assert.closeTo(axis.height(), 44, 1, "height is calculated correctly");
     assert.strictEqual(axis.width(), 300, "width is calculated correctly");
 
     svg.remove();

--- a/test/components/categoryAxisTests.ts
+++ b/test/components/categoryAxisTests.ts
@@ -116,7 +116,10 @@ describe("Category Axes", () => {
     var axis = new Plottable.Axis.Category(scale, "bottom");
     axis.renderTo(svg);
     var requestedSpace = axis._requestedSpace(300, 10);
-    assert.isTrue(requestedSpace.wantsHeight, "axis should want to ask for more space");
+    assert.isTrue(requestedSpace.wantsHeight, "axis should ask for more space");
+    axis.orient("left");
+    requestedSpace = axis._requestedSpace(10, 300);
+    assert.isTrue(requestedSpace.wantsWidth, "axis should ask for more space");
 
     svg.remove();
   });

--- a/test/tests.js
+++ b/test/tests.js
@@ -1011,6 +1011,22 @@ describe("Category Axes", function () {
         assert.include(axis._content.selectAll(".text-area").attr("transform"), -90, "the ticks were rotated left");
         svg.remove();
     });
+    it("layout calculated correctly under 0 width/height surrounding component conditions", function () {
+        var svg = generateSVG(300, 300);
+        var years = ["2000", "2001", "2002", "2003"];
+        var scale = new Plottable.Scale.Ordinal().domain(years);
+        var axis = new Plottable.Axis.Category(scale, "bottom");
+        var table = new Plottable.Component.Table([
+            [null],
+            [axis],
+            [null],
+            [new Plottable.Component.Label("")]
+        ]);
+        table.renderTo(svg);
+        assert.strictEqual(axis.height(), 44, "height is calculated correctly");
+        assert.strictEqual(axis.width(), 300, "width is calculated correctly");
+        svg.remove();
+    });
 });
 
 ///<reference path="../testReference.ts" />

--- a/test/tests.js
+++ b/test/tests.js
@@ -1018,10 +1018,10 @@ describe("Category Axes", function () {
         var axis = new Plottable.Axis.Category(scale, "bottom");
         axis.renderTo(svg);
         var requestedSpace = axis._requestedSpace(300, 10);
-        assert.isTrue(requestedSpace.wantsHeight, "axis should ask for more space");
+        assert.isTrue(requestedSpace.wantsHeight, "axis should ask for more space (horizontal orientation)");
         axis.orient("left");
         requestedSpace = axis._requestedSpace(10, 300);
-        assert.isTrue(requestedSpace.wantsWidth, "axis should ask for more space");
+        assert.isTrue(requestedSpace.wantsWidth, "axis should ask for more space (vertical orientation)");
         svg.remove();
     });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -1023,7 +1023,7 @@ describe("Category Axes", function () {
             [new Plottable.Component.Label("")]
         ]);
         table.renderTo(svg);
-        assert.closeTo(axis.height(), 44, 1, "height is calculated correctly");
+        assert.closeTo(axis.height(), 44, 2, "height is calculated correctly");
         assert.strictEqual(axis.width(), 300, "width is calculated correctly");
         svg.remove();
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -1018,7 +1018,10 @@ describe("Category Axes", function () {
         var axis = new Plottable.Axis.Category(scale, "bottom");
         axis.renderTo(svg);
         var requestedSpace = axis._requestedSpace(300, 10);
-        assert.isTrue(requestedSpace.wantsHeight, "axis should want to ask for more space");
+        assert.isTrue(requestedSpace.wantsHeight, "axis should ask for more space");
+        axis.orient("left");
+        requestedSpace = axis._requestedSpace(10, 300);
+        assert.isTrue(requestedSpace.wantsWidth, "axis should ask for more space");
         svg.remove();
     });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -1023,7 +1023,7 @@ describe("Category Axes", function () {
             [new Plottable.Component.Label("")]
         ]);
         table.renderTo(svg);
-        assert.strictEqual(axis.height(), 44, "height is calculated correctly");
+        assert.closeTo(axis.height(), 44, 1, "height is calculated correctly");
         assert.strictEqual(axis.width(), 300, "width is calculated correctly");
         svg.remove();
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -1011,20 +1011,14 @@ describe("Category Axes", function () {
         assert.include(axis._content.selectAll(".text-area").attr("transform"), -90, "the ticks were rotated left");
         svg.remove();
     });
-    it("layout calculated correctly under 0 width/height surrounding component conditions", function () {
+    it("axis should request more space if there's not enough space to fit the text", function () {
         var svg = generateSVG(300, 300);
         var years = ["2000", "2001", "2002", "2003"];
         var scale = new Plottable.Scale.Ordinal().domain(years);
         var axis = new Plottable.Axis.Category(scale, "bottom");
-        var table = new Plottable.Component.Table([
-            [null],
-            [axis],
-            [null],
-            [new Plottable.Component.Label("")]
-        ]);
-        table.renderTo(svg);
-        assert.closeTo(axis.height(), 44, 2, "height is calculated correctly");
-        assert.strictEqual(axis.width(), 300, "width is calculated correctly");
+        axis.renderTo(svg);
+        var requestedSpace = axis._requestedSpace(300, 10);
+        assert.isTrue(requestedSpace.wantsHeight, "axis should want to ask for more space");
         svg.remove();
     });
 });


### PR DESCRIPTION
The textFits parameter currently determines if the text labels on a categoryAxis can fit there.  However the calculation is... incorrect.

It used to read - If I have 1 wrapped line and I am not not an empty string, then I fit
It should read - If I have 1 wrapped line and I am not an empty string, then I fit

In short, confusing double negative is confusing

Fixes #1511 