### PR TITLE
Add event listeners on registering callbacks

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -510,7 +510,13 @@ declare module Plottable {
              */
             deregisterListener(key: any): Broadcaster<L>;
             /**
-             * Deregisters all listeners and callbacks associated with the broadcaster.
+             * Gets the keys for all listeners attached to the Broadcaster.
+             *
+             * @returns {any[]} An array of the keys.
+             */
+            getListenerKeys(): any[];
+            /**
+             * Deregisters all listeners and callbacks associated with the Broadcaster.
              *
              * @returns {Broadcaster} The calling Broadcaster
              */
@@ -3451,7 +3457,6 @@ declare module Plottable {
 declare module Plottable {
     module Dispatcher {
         class Mouse {
-            broadcaster: Core.Broadcaster;
             /**
              * Get a Dispatcher.Mouse for the <svg> containing elem. If one already exists
              * on that <svg>, it will be returned; otherwise, a new one will be created.
@@ -3484,7 +3489,10 @@ declare module Plottable {
              *
              * @return {Point} The last known mouse position in <svg> coordinate space.
              */
-            getLastMousePosition(): Point;
+            getLastMousePosition(): {
+                x: number;
+                y: number;
+            };
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -8592,7 +8592,7 @@ var Plottable;
             };
             Mouse.prototype._processMoveEvent = function (e) {
                 var newMousePosition = this._computeMousePosition(e.clientX, e.clientY);
-                if (newMousePosition.x == null || newMousePosition.y == null) {
+                if (newMousePosition == null) {
                     return; // couldn't measure
                 }
                 this._lastMousePosition = newMousePosition;
@@ -8615,7 +8615,7 @@ var Plottable;
                 var testPoint = { x: mrBCR.left, y: mrBCR.top };
                 // invalid measurements -- SVG might not be in the DOM
                 if (origin.x === testPoint.x || origin.y === testPoint.y) {
-                    return { x: null, y: null };
+                    return null;
                 }
                 var scaleX = (testPoint.x - origin.x) / sampleDistance;
                 var scaleY = (testPoint.y - origin.y) / sampleDistance;

--- a/src/core/broadcaster.ts
+++ b/src/core/broadcaster.ts
@@ -74,7 +74,16 @@ export module Core {
     }
 
     /**
-     * Deregisters all listeners and callbacks associated with the broadcaster.
+     * Gets the keys for all listeners attached to the Broadcaster.
+     *
+     * @returns {any[]} An array of the keys.
+     */
+    public getListenerKeys() {
+      return this._key2callback.keys();
+    }
+
+    /**
+     * Deregisters all listeners and callbacks associated with the Broadcaster.
      *
      * @returns {Broadcaster} The calling Broadcaster
      */

--- a/src/dispatchers/mouseDispatcher.ts
+++ b/src/dispatchers/mouseDispatcher.ts
@@ -91,7 +91,7 @@ export module Dispatcher {
 
     private _processMoveEvent(e: MouseEvent) {
       var newMousePosition = this._computeMousePosition(e.clientX, e.clientY);
-      if (newMousePosition.x == null || newMousePosition.y == null) {
+      if (newMousePosition == null) {
         return; // couldn't measure
       }
       this._lastMousePosition = newMousePosition;
@@ -117,7 +117,7 @@ export module Dispatcher {
 
       // invalid measurements -- SVG might not be in the DOM
       if (origin.x === testPoint.x || origin.y === testPoint.y) {
-        return { x: null, y: null };
+        return null;
       }
 
       var scaleX = (testPoint.x - origin.x) / sampleDistance;

--- a/test/dispatchers/dispatcherTests.ts
+++ b/test/dispatchers/dispatcherTests.ts
@@ -103,6 +103,71 @@ describe("Dispatchers", () => {
       svg.remove();
     });
 
+    it("can remove callbacks by passing null", () => {
+      var targetWidth = 400, targetHeight = 400;
+      var target = generateSVG(targetWidth, targetHeight);
+      // HACKHACK: PhantomJS can't measure SVGs unless they have something in them occupying space
+      target.append("rect").attr("width", targetWidth).attr("height", targetHeight);
+
+      var targetX = 17;
+      var targetY = 76;
+
+      var md = Plottable.Dispatcher.Mouse.getDispatcher(<SVGElement> target.node());
+
+      var cb1Called = false;
+      var cb1 = function(p: Plottable.Point) {
+        cb1Called = true;
+      };
+      var cb2Called = false;
+      var cb2 = function(p: Plottable.Point) {
+        cb2Called = true;
+      };
+
+      md.onMouseMove("callback1", cb1);
+      md.onMouseMove("callback2", cb2);
+      triggerFakeMouseEvent("mousemove", target, targetX, targetY);
+      assert.isTrue(cb1Called, "callback 1 was called on mousemove");
+      assert.isTrue(cb2Called, "callback 2 was called on mousemove");
+
+      cb1Called = false;
+      cb2Called = false;
+      md.onMouseMove("callback1", null);
+      triggerFakeMouseEvent("mousemove", target, targetX, targetY);
+      assert.isFalse(cb1Called, "callback was not called after blanking");
+      assert.isTrue(cb2Called, "callback 2 was still called");
+
+      target.remove();
+    });
+
+    it("doesn't call callbacks if not in the DOM", () => {
+      var targetWidth = 400, targetHeight = 400;
+      var target = generateSVG(targetWidth, targetHeight);
+      // HACKHACK: PhantomJS can't measure SVGs unless they have something in them occupying space
+      target.append("rect").attr("width", targetWidth).attr("height", targetHeight);
+
+      var targetX = 17;
+      var targetY = 76;
+
+      var md = Plottable.Dispatcher.Mouse.getDispatcher(<SVGElement> target.node());
+
+      var callbackWasCalled = false;
+      var callback = function(p: Plottable.Point) {
+        callbackWasCalled = true;
+      };
+
+      var keyString = "notInDomTest";
+      md.onMouseMove(keyString, callback);
+      triggerFakeMouseEvent("mousemove", target, targetX, targetY);
+      assert.isTrue(callbackWasCalled, "callback was called on mousemove");
+
+      target.remove();
+      callbackWasCalled = false;
+      triggerFakeMouseEvent("mousemove", target, targetX, targetY);
+      assert.isFalse(callbackWasCalled, "callback was not called after <svg> was removed from DOM");
+
+      md.onMouseMove(keyString, null);
+    });
+
     it("calls callbacks on mouseover, mousemove, and mouseout", () => {
       var targetWidth = 400, targetHeight = 400;
       var target = generateSVG(targetWidth, targetHeight);
@@ -129,7 +194,8 @@ describe("Dispatchers", () => {
         assertPointsClose(p, expectedPoint, 0.5, "mouse position is correct");
       };
 
-      md.onMouseMove("unit test", callback);
+      var keyString = "unit test";
+      md.onMouseMove(keyString, callback);
 
       triggerFakeMouseEvent("mouseover", target, targetX, targetY);
       assert.isTrue(callbackWasCalled, "callback was called on mouseover");
@@ -140,36 +206,10 @@ describe("Dispatchers", () => {
       triggerFakeMouseEvent("mouseout", target, targetX, targetY);
       assert.isTrue(callbackWasCalled, "callback was called on mouseout");
 
-      target.remove();
-    });
-
-    it("can remove callbacks by passing null", () => {
-      var targetWidth = 400, targetHeight = 400;
-      var target = generateSVG(targetWidth, targetHeight);
-      // HACKHACK: PhantomJS can't measure SVGs unless they have something in them occupying space
-      target.append("rect").attr("width", targetWidth).attr("height", targetHeight);
-
-      var targetX = 17;
-      var targetY = 76;
-
-      var md = Plottable.Dispatcher.Mouse.getDispatcher(<SVGElement> target.node());
-
-      var callbackWasCalled = false;
-      var callback = function(p: Plottable.Point) {
-        callbackWasCalled = true;
-      };
-
-      var keyString = "callbackTest";
-      md.onMouseMove(keyString, callback);
-      triggerFakeMouseEvent("mousemove", target, targetX, targetY);
-      assert.isTrue(callbackWasCalled, "callback was called on mousemove");
-      callbackWasCalled = false;
       md.onMouseMove(keyString, null);
-      triggerFakeMouseEvent("mousemove", target, targetX, targetY);
-      assert.isFalse(callbackWasCalled, "callback was not called after blanking");
-
       target.remove();
     });
+
   });
 
   describe("Keypress Dispatcher", () => {


### PR DESCRIPTION
And remove them when all callbacks are removed.
Made callbacks not trigger if measurement fails.
Made `Dispatcher.Mouse`'s `Broadcaster` private.