### PR TITLE
Pass arguments to Broadcaster callbacks one at a time

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -488,6 +488,7 @@ declare module Plottable {
              * Registers a callback to be called when the broadcast method is called. Also takes a key which
              * is used to support deregistering the same callback later, by passing in the same key.
              * If there is already a callback associated with that key, then the callback will be replaced.
+             * The callback will be passed the Broadcaster's "listenable" as the `this` context.
              *
              * @param key The key associated with the callback. Key uniqueness is determined by deep equality.
              * @param {BroadcasterCallback<L>} callback A callback to be called.

--- a/plottable.js
+++ b/plottable.js
@@ -1081,6 +1081,7 @@ var Plottable;
              * Registers a callback to be called when the broadcast method is called. Also takes a key which
              * is used to support deregistering the same callback later, by passing in the same key.
              * If there is already a callback associated with that key, then the callback will be replaced.
+             * The callback will be passed the Broadcaster's "listenable" as the `this` context.
              *
              * @param key The key associated with the callback. Key uniqueness is determined by deep equality.
              * @param {BroadcasterCallback<L>} callback A callback to be called.
@@ -1102,7 +1103,10 @@ var Plottable;
                 for (var _i = 0; _i < arguments.length; _i++) {
                     args[_i - 0] = arguments[_i];
                 }
-                this._key2callback.values().forEach(function (callback) { return callback(_this._listenable, args); });
+                args.unshift(this._listenable);
+                this._key2callback.values().forEach(function (callback) {
+                    callback.apply(_this.listenable, args);
+                });
                 return this;
             };
             /**

--- a/plottable.js
+++ b/plottable.js
@@ -1105,7 +1105,7 @@ var Plottable;
                 }
                 args.unshift(this._listenable);
                 this._key2callback.values().forEach(function (callback) {
-                    callback.apply(_this.listenable, args);
+                    callback.apply(_this._listenable, args);
                 });
                 return this;
             };

--- a/src/core/broadcaster.ts
+++ b/src/core/broadcaster.ts
@@ -61,7 +61,7 @@ export module Core {
     public broadcast(...args: any[]) {
       args.unshift(this._listenable);
       this._key2callback.values().forEach((callback) => {
-        callback.apply(this.listenable, args);
+        callback.apply(this._listenable, args);
       });
       return this;
     }

--- a/src/core/broadcaster.ts
+++ b/src/core/broadcaster.ts
@@ -41,6 +41,7 @@ export module Core {
      * Registers a callback to be called when the broadcast method is called. Also takes a key which
      * is used to support deregistering the same callback later, by passing in the same key.
      * If there is already a callback associated with that key, then the callback will be replaced.
+     * The callback will be passed the Broadcaster's "listenable" as the `this` context.
      *
      * @param key The key associated with the callback. Key uniqueness is determined by deep equality.
      * @param {BroadcasterCallback<L>} callback A callback to be called.
@@ -58,7 +59,10 @@ export module Core {
      * @returns {Broadcaster} The calling Broadcaster
      */
     public broadcast(...args: any[]) {
-      this._key2callback.values().forEach((callback) => callback(this._listenable, args));
+      args.unshift(this._listenable);
+      this._key2callback.values().forEach((callback) => {
+        callback.apply(this.listenable, args);
+      });
       return this;
     }
 

--- a/test/core/broadcasterTests.ts
+++ b/test/core/broadcasterTests.ts
@@ -53,10 +53,10 @@ describe("Broadcasters", () => {
   it("arguments are passed through to callback", () => {
     var g2 = {};
     var g3 = "foo";
-    var cb = (a1: any, rest: any[]) => {
-      assert.equal(listenable, a1, "broadcaster passed through");
-      assert.equal(g2, rest[0], "arg1 passed through");
-      assert.equal(g3, rest[1], "arg2 passed through");
+    var cb = (arg1: any, arg2: any, arg3: any) => {
+      assert.equal(listenable, arg1, "broadcaster passed through");
+      assert.equal(g2, arg2, "g2 passed through");
+      assert.equal(g3, arg3, "g3 passed through");
       called = true;
     };
     b.registerListener(null, cb);

--- a/test/core/broadcasterTests.ts
+++ b/test/core/broadcasterTests.ts
@@ -54,9 +54,9 @@ describe("Broadcasters", () => {
     var g2 = {};
     var g3 = "foo";
     var cb = (arg1: any, arg2: any, arg3: any) => {
-      assert.equal(listenable, arg1, "broadcaster passed through");
-      assert.equal(g2, arg2, "g2 passed through");
-      assert.equal(g3, arg3, "g3 passed through");
+      assert.strictEqual(listenable, arg1, "broadcaster passed through");
+      assert.strictEqual(g2, arg2, "g2 passed through");
+      assert.strictEqual(g3, arg3, "g3 passed through");
       called = true;
     };
     b.registerListener(null, cb);

--- a/test/tests.js
+++ b/test/tests.js
@@ -4222,9 +4222,9 @@ describe("Broadcasters", function () {
         var g2 = {};
         var g3 = "foo";
         var cb = function (arg1, arg2, arg3) {
-            assert.equal(listenable, arg1, "broadcaster passed through");
-            assert.equal(g2, arg2, "g2 passed through");
-            assert.equal(g3, arg3, "g3 passed through");
+            assert.strictEqual(listenable, arg1, "broadcaster passed through");
+            assert.strictEqual(g2, arg2, "g2 passed through");
+            assert.strictEqual(g3, arg3, "g3 passed through");
             called = true;
         };
         b.registerListener(null, cb);

--- a/test/tests.js
+++ b/test/tests.js
@@ -4221,10 +4221,10 @@ describe("Broadcasters", function () {
     it("arguments are passed through to callback", function () {
         var g2 = {};
         var g3 = "foo";
-        var cb = function (a1, rest) {
-            assert.equal(listenable, a1, "broadcaster passed through");
-            assert.equal(g2, rest[0], "arg1 passed through");
-            assert.equal(g3, rest[1], "arg2 passed through");
+        var cb = function (arg1, arg2, arg3) {
+            assert.equal(listenable, arg1, "broadcaster passed through");
+            assert.equal(g2, arg2, "g2 passed through");
+            assert.equal(g3, arg3, "g3 passed through");
             called = true;
         };
         b.registerListener(null, cb);


### PR DESCRIPTION
... instead of as an array. This change forces us to choose a `this`-context for the callbacks; The `this`-context passed to the callbacks is the `Broadcaster`'s "listenable".

Close #1583.