### PR TITLE
[GridPlot] - getDrawer now returns a RectDrawer

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2808,7 +2808,7 @@ declare module Plottable {
              */
             constructor(xScale: Scale.Ordinal, yScale: Scale.Ordinal, colorScale: Scale.AbstractScale<any, string>);
             addDataset(keyOrDataset: any, dataset?: any): Grid;
-            protected _getDrawer(key: string): _Drawer.Element;
+            protected _getDrawer(key: string): _Drawer.Rect;
             /**
              * @param {string} attrToSet One of ["x", "y", "fill"]. If "fill" is used,
              * the data should return a valid CSS color.

--- a/plottable.js
+++ b/plottable.js
@@ -6985,7 +6985,7 @@ var Plottable;
                 return this;
             };
             Grid.prototype._getDrawer = function (key) {
-                return new Plottable._Drawer.Element(key).svgElement("rect");
+                return new Plottable._Drawer.Rect(key, true);
             };
             /**
              * @param {string} attrToSet One of ["x", "y", "fill"]. If "fill" is used,

--- a/src/components/plots/gridPlot.ts
+++ b/src/components/plots/gridPlot.ts
@@ -39,7 +39,7 @@ export module Plot {
     }
 
     protected _getDrawer(key: string) {
-      return new _Drawer.Element(key).svgElement("rect");
+      return new _Drawer.Rect(key, true);
     }
 
     /**


### PR DESCRIPTION
Used to create an ElementDrawer that sets its own svgElement to "rect"