### PR TITLE
[CategoryAxis] Make rotated ticks wrap less aggressively

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -5056,6 +5056,7 @@ var Plottable;
                 var _this = this;
                 var wrappingResults = ticks.map(function (s) {
                     var bandWidth = scale.stepWidth();
+                    // HACKHACK: https://github.com/palantir/svg-typewriter/issues/25
                     var width = bandWidth;
                     if (_this._isHorizontal()) {
                         if (_this._tickLabelAngle !== 0) {
@@ -5084,14 +5085,6 @@ var Plottable;
                     usedWidth: usedWidth,
                     usedHeight: usedHeight
                 };
-                // return {
-                //   textFits: wrappingResults.every((t: SVGTypewriter.Wrappers.WrappingResult) =>
-                //               SVGTypewriter.Utils.StringMethods.isNotEmptyString(t.truncatedText) && t.noLines === 1),
-                //   usedWidth : widthFn<SVGTypewriter.Wrappers.WrappingResult, number>(wrappingResults,
-                //                 (t: SVGTypewriter.Wrappers.WrappingResult) => this._measurer.measure(t.wrappedText).width, 0),
-                //   usedHeight: heightFn<SVGTypewriter.Wrappers.WrappingResult, number>(wrappingResults,
-                //                 (t: SVGTypewriter.Wrappers.WrappingResult) => this._measurer.measure(t.wrappedText).height, 0)
-                // };
             };
             Category.prototype._doRender = function () {
                 var _this = this;

--- a/plottable.js
+++ b/plottable.js
@@ -5075,6 +5075,7 @@ var Plottable;
                 var usedWidth = widthFn(wrappingResults, function (t) { return _this._measurer.measure(t.wrappedText).width; }, 0);
                 var usedHeight = heightFn(wrappingResults, function (t) { return _this._measurer.measure(t.wrappedText).height; }, 0);
                 // If the tick labels are rotated, reverse usedWidth and usedHeight
+                // HACKHACK: https://github.com/palantir/svg-typewriter/issues/25
                 if (this._tickLabelAngle !== 0) {
                     var tempHeight = usedHeight;
                     usedHeight = usedWidth;

--- a/plottable.js
+++ b/plottable.js
@@ -5057,20 +5057,26 @@ var Plottable;
                 var wrappingResults = ticks.map(function (s) {
                     var bandWidth = scale.stepWidth();
                     // HACKHACK: https://github.com/palantir/svg-typewriter/issues/25
-                    var width = bandWidth;
+                    var width = axisWidth - _this._maxLabelTickLength() - _this.tickLabelPadding(); // default for left/right
                     if (_this._isHorizontal()) {
+                        width = bandWidth; // defaults to the band width
                         if (_this._tickLabelAngle !== 0) {
-                            width = bandWidth - _this._maxLabelTickLength() - _this.tickLabelPadding();
-                        }
-                        else {
-                            width = axisWidth - _this._maxLabelTickLength() - _this.tickLabelPadding();
+                            width = axisHeight - _this._maxLabelTickLength() - _this.tickLabelPadding(); // use the axis height
                         }
                     }
-                    var height = _this._isHorizontal() ? axisHeight - _this._maxLabelTickLength() - _this.tickLabelPadding() : bandWidth;
+                    // HACKHACK: https://github.com/palantir/svg-typewriter/issues/25
+                    var height = bandWidth; // default for left/right
+                    if (_this._isHorizontal()) {
+                        height = axisHeight;
+                        if (_this._tickLabelAngle !== 0) {
+                            height = axisWidth - _this._maxLabelTickLength() - _this.tickLabelPadding();
+                        }
+                    }
                     return _this._wrapper.wrap(_this.formatter()(s), _this._measurer, width, height);
                 });
-                var widthFn = this._isHorizontal() ? d3.sum : Plottable._Util.Methods.max;
-                var heightFn = this._isHorizontal() ? Plottable._Util.Methods.max : d3.sum;
+                // HACKHACK: https://github.com/palantir/svg-typewriter/issues/25
+                var widthFn = (this._isHorizontal() && this._tickLabelAngle === 0) ? d3.sum : Plottable._Util.Methods.max;
+                var heightFn = (this._isHorizontal() && this._tickLabelAngle === 0) ? Plottable._Util.Methods.max : d3.sum;
                 var textFits = wrappingResults.every(function (t) { return SVGTypewriter.Utils.StringMethods.isNotEmptyString(t.truncatedText) && t.noLines === 1; });
                 var usedWidth = widthFn(wrappingResults, function (t) { return _this._measurer.measure(t.wrappedText).width; }, 0);
                 var usedHeight = heightFn(wrappingResults, function (t) { return _this._measurer.measure(t.wrappedText).height; }, 0);

--- a/plottable.js
+++ b/plottable.js
@@ -5056,17 +5056,42 @@ var Plottable;
                 var _this = this;
                 var wrappingResults = ticks.map(function (s) {
                     var bandWidth = scale.stepWidth();
-                    var width = _this._isHorizontal() ? bandWidth : axisWidth - _this._maxLabelTickLength() - _this.tickLabelPadding();
+                    var width = bandWidth;
+                    if (_this._isHorizontal()) {
+                        if (_this._tickLabelAngle !== 0) {
+                            width = bandWidth - _this._maxLabelTickLength() - _this.tickLabelPadding();
+                        }
+                        else {
+                            width = axisWidth - _this._maxLabelTickLength() - _this.tickLabelPadding();
+                        }
+                    }
                     var height = _this._isHorizontal() ? axisHeight - _this._maxLabelTickLength() - _this.tickLabelPadding() : bandWidth;
                     return _this._wrapper.wrap(_this.formatter()(s), _this._measurer, width, height);
                 });
                 var widthFn = this._isHorizontal() ? d3.sum : Plottable._Util.Methods.max;
                 var heightFn = this._isHorizontal() ? Plottable._Util.Methods.max : d3.sum;
+                var textFits = wrappingResults.every(function (t) { return SVGTypewriter.Utils.StringMethods.isNotEmptyString(t.truncatedText) && t.noLines === 1; });
+                var usedWidth = widthFn(wrappingResults, function (t) { return _this._measurer.measure(t.wrappedText).width; }, 0);
+                var usedHeight = heightFn(wrappingResults, function (t) { return _this._measurer.measure(t.wrappedText).height; }, 0);
+                // If the tick labels are rotated, reverse usedWidth and usedHeight
+                if (this._tickLabelAngle !== 0) {
+                    var tempHeight = usedHeight;
+                    usedHeight = usedWidth;
+                    usedWidth = tempHeight;
+                }
                 return {
-                    textFits: wrappingResults.every(function (t) { return SVGTypewriter.Utils.StringMethods.isNotEmptyString(t.truncatedText) && t.noLines === 1; }),
-                    usedWidth: widthFn(wrappingResults, function (t) { return _this._measurer.measure(t.wrappedText).width; }, 0),
-                    usedHeight: heightFn(wrappingResults, function (t) { return _this._measurer.measure(t.wrappedText).height; }, 0)
+                    textFits: textFits,
+                    usedWidth: usedWidth,
+                    usedHeight: usedHeight
                 };
+                // return {
+                //   textFits: wrappingResults.every((t: SVGTypewriter.Wrappers.WrappingResult) =>
+                //               SVGTypewriter.Utils.StringMethods.isNotEmptyString(t.truncatedText) && t.noLines === 1),
+                //   usedWidth : widthFn<SVGTypewriter.Wrappers.WrappingResult, number>(wrappingResults,
+                //                 (t: SVGTypewriter.Wrappers.WrappingResult) => this._measurer.measure(t.wrappedText).width, 0),
+                //   usedHeight: heightFn<SVGTypewriter.Wrappers.WrappingResult, number>(wrappingResults,
+                //                 (t: SVGTypewriter.Wrappers.WrappingResult) => this._measurer.measure(t.wrappedText).height, 0)
+                // };
             };
             Category.prototype._doRender = function () {
                 var _this = this;

--- a/src/components/axes/categoryAxis.ts
+++ b/src/components/axes/categoryAxis.ts
@@ -139,6 +139,7 @@ export module Axis {
       var wrappingResults = ticks.map((s: string) => {
         var bandWidth = scale.stepWidth();
 
+        // HACKHACK: https://github.com/palantir/svg-typewriter/issues/25
         var width = bandWidth;
         if (this._isHorizontal()) {
           if (this._tickLabelAngle !== 0) {
@@ -174,15 +175,6 @@ export module Axis {
         usedWidth: usedWidth,
         usedHeight: usedHeight
       };
-
-      // return {
-      //   textFits: wrappingResults.every((t: SVGTypewriter.Wrappers.WrappingResult) =>
-      //               SVGTypewriter.Utils.StringMethods.isNotEmptyString(t.truncatedText) && t.noLines === 1),
-      //   usedWidth : widthFn<SVGTypewriter.Wrappers.WrappingResult, number>(wrappingResults,
-      //                 (t: SVGTypewriter.Wrappers.WrappingResult) => this._measurer.measure(t.wrappedText).width, 0),
-      //   usedHeight: heightFn<SVGTypewriter.Wrappers.WrappingResult, number>(wrappingResults,
-      //                 (t: SVGTypewriter.Wrappers.WrappingResult) => this._measurer.measure(t.wrappedText).height, 0)
-      // };
     }
 
     public _doRender() {

--- a/src/components/axes/categoryAxis.ts
+++ b/src/components/axes/categoryAxis.ts
@@ -164,6 +164,7 @@ export module Axis {
                       (t: SVGTypewriter.Wrappers.WrappingResult) => this._measurer.measure(t.wrappedText).height, 0);
 
       // If the tick labels are rotated, reverse usedWidth and usedHeight
+      // HACKHACK: https://github.com/palantir/svg-typewriter/issues/25
       if (this._tickLabelAngle !== 0) {
         var tempHeight = usedHeight;
         usedHeight = usedWidth;

--- a/src/components/axes/categoryAxis.ts
+++ b/src/components/axes/categoryAxis.ts
@@ -140,21 +140,29 @@ export module Axis {
         var bandWidth = scale.stepWidth();
 
         // HACKHACK: https://github.com/palantir/svg-typewriter/issues/25
-        var width = bandWidth;
-        if (this._isHorizontal()) {
-          if (this._tickLabelAngle !== 0) {
-            width = bandWidth - this._maxLabelTickLength() - this.tickLabelPadding();
-          } else {
-            width = axisWidth - this._maxLabelTickLength() - this.tickLabelPadding();
+        var width = axisWidth - this._maxLabelTickLength() - this.tickLabelPadding(); // default for left/right
+        if (this._isHorizontal()) { // case for top/bottom
+          width = bandWidth; // defaults to the band width
+          if (this._tickLabelAngle !== 0) { // rotated label
+            width = axisHeight - this._maxLabelTickLength() - this.tickLabelPadding(); // use the axis height
           }
         }
-        var height = this._isHorizontal() ? axisHeight - this._maxLabelTickLength() - this.tickLabelPadding() : bandWidth;
+
+        // HACKHACK: https://github.com/palantir/svg-typewriter/issues/25
+        var height = bandWidth; // default for left/right
+        if (this._isHorizontal()) { // case for top/bottom
+          height = axisHeight;
+          if (this._tickLabelAngle !== 0) { // rotated label
+            height = axisWidth - this._maxLabelTickLength() - this.tickLabelPadding();
+          }
+        }
 
         return this._wrapper.wrap(this.formatter()(s), this._measurer, width, height);
       });
 
-      var widthFn  = this._isHorizontal() ? d3.sum : _Util.Methods.max;
-      var heightFn = this._isHorizontal() ? _Util.Methods.max : d3.sum;
+      // HACKHACK: https://github.com/palantir/svg-typewriter/issues/25
+      var widthFn = (this._isHorizontal() && this._tickLabelAngle === 0) ? d3.sum : _Util.Methods.max;
+      var heightFn = (this._isHorizontal() && this._tickLabelAngle === 0) ? _Util.Methods.max : d3.sum;
 
       var textFits = wrappingResults.every((t: SVGTypewriter.Wrappers.WrappingResult) =>
                     SVGTypewriter.Utils.StringMethods.isNotEmptyString(t.truncatedText) && t.noLines === 1);

--- a/test/components/categoryAxisTests.ts
+++ b/test/components/categoryAxisTests.ts
@@ -145,6 +145,22 @@ describe("Category Axes", () => {
     verifyTickLabelOverlaps(tickLabels, tickMarks);
     axis.orient("right");
     verifyTickLabelOverlaps(tickLabels, tickMarks);
+    svg.remove();
+  });
+
+  it("axis should request more space when rotated than not rotated", () => {
+    var svg = generateSVG(300, 300);
+    var labels = ["label1", "label2", "label100"];
+    var scale = new Plottable.Scale.Ordinal().domain(labels);
+    var axis = new Plottable.Axis.Category(scale, "bottom");
+    axis.renderTo(svg);
+
+    var requestedSpace = axis._requestedSpace(300, 50);
+    var flatHeight = requestedSpace.height;
+
+    axis.tickLabelAngle(-90);
+    requestedSpace = axis._requestedSpace(300, 50);
+    assert.isTrue(flatHeight < requestedSpace.height, "axis should request more height when tick labels are rotated");
 
     svg.remove();
   });

--- a/test/tests.js
+++ b/test/tests.js
@@ -1255,6 +1255,19 @@ describe("Category Axes", function () {
         verifyTickLabelOverlaps(tickLabels, tickMarks);
         svg.remove();
     });
+    it("axis should request more space when rotated than not rotated", function () {
+        var svg = generateSVG(300, 300);
+        var labels = ["label1", "label2", "label100"];
+        var scale = new Plottable.Scale.Ordinal().domain(labels);
+        var axis = new Plottable.Axis.Category(scale, "bottom");
+        axis.renderTo(svg);
+        var requestedSpace = axis._requestedSpace(300, 50);
+        var flatHeight = requestedSpace.height;
+        axis.tickLabelAngle(-90);
+        requestedSpace = axis._requestedSpace(300, 50);
+        assert.isTrue(flatHeight < requestedSpace.height, "axis should request more height when tick labels are rotated");
+        svg.remove();
+    });
 });
 
 ///<reference path="../testReference.ts" />


### PR DESCRIPTION
It appears that the crux of the matter is that SVGTypewriter does not really work for rotated text as far as I know, so in cases where the text is rotated, I am taking an approach where adjustments to width requested are made based on the angle of the tick label, and then flipping the width and height results at the end of _measureTicks.

JSFiddle of fix: http://jsfiddle.net/xcgjf426/3/

Fix #1526 