### PR TITLE
[Plot] - Adding exclude argument to getAllSelections

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2679,7 +2679,7 @@ declare module Plottable {
              * If not provided, all selections will be retrieved.
              * @returns {D3.Selection} The retrieved selections.
              */
-            getAllSelections(datasetKeys?: string | string[]): D3.Selection;
+            getAllSelections(datasetKeys?: string | string[], exclude?: boolean): D3.Selection;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2677,6 +2677,8 @@ declare module Plottable {
              *
              * @param {string | string[]} datasetKeys The dataset(s) to retrieve the selections from.
              * If not provided, all selections will be retrieved.
+             * @param {boolean} exclude If set to true, all datasets will be queried excluding the keys referenced
+             * in the previous datasetKeys argument (default = false).
              * @returns {D3.Selection} The retrieved selections.
              */
             getAllSelections(datasetKeys?: string | string[], exclude?: boolean): D3.Selection;

--- a/plottable.js
+++ b/plottable.js
@@ -6536,6 +6536,8 @@ var Plottable;
              *
              * @param {string | string[]} datasetKeys The dataset(s) to retrieve the selections from.
              * If not provided, all selections will be retrieved.
+             * @param {boolean} exclude If set to true, all datasets will be queried excluding the keys referenced
+             * in the previous datasetKeys argument (default = false).
              * @returns {D3.Selection} The retrieved selections.
              */
             AbstractPlot.prototype.getAllSelections = function (datasetKeys, exclude) {

--- a/plottable.js
+++ b/plottable.js
@@ -6538,17 +6538,22 @@ var Plottable;
              * If not provided, all selections will be retrieved.
              * @returns {D3.Selection} The retrieved selections.
              */
-            AbstractPlot.prototype.getAllSelections = function (datasetKeys) {
+            AbstractPlot.prototype.getAllSelections = function (datasetKeys, exclude) {
                 var _this = this;
+                if (exclude === void 0) { exclude = false; }
                 var datasetKeyArray = [];
                 if (datasetKeys == null) {
-                    datasetKeyArray = this._datasetKeysInOrder;
+                    datasetKeyArray = this.datasetOrder();
                 }
                 else if (typeof (datasetKeys) === "string") {
                     datasetKeyArray = [datasetKeys];
                 }
                 else {
                     datasetKeyArray = datasetKeys;
+                }
+                if (exclude) {
+                    var excludedDatasetKeys = d3.set(datasetKeyArray);
+                    datasetKeyArray = this.datasetOrder().filter(function (datasetKey) { return !excludedDatasetKeys.has(datasetKey); });
                 }
                 var allSelections = [];
                 datasetKeyArray.forEach(function (datasetKey) {

--- a/src/components/plots/abstractPlot.ts
+++ b/src/components/plots/abstractPlot.ts
@@ -426,16 +426,23 @@ export module Plot {
      *
      * @param {string | string[]} datasetKeys The dataset(s) to retrieve the selections from.
      * If not provided, all selections will be retrieved.
+     * @param {boolean} exclude If set to true, all datasets will be queried excluding the keys referenced
+     * in the previous datasetKeys argument (default = false).
      * @returns {D3.Selection} The retrieved selections.
      */
-    public getAllSelections(datasetKeys?: string | string[]): D3.Selection {
+    public getAllSelections(datasetKeys?: string | string[], exclude = false): D3.Selection {
       var datasetKeyArray: string[] = [];
       if (datasetKeys == null) {
-        datasetKeyArray = this._datasetKeysInOrder;
+        datasetKeyArray = this.datasetOrder();
       } else if (typeof(datasetKeys) === "string") {
         datasetKeyArray = [<string> datasetKeys];
       } else {
         datasetKeyArray = <string[]> datasetKeys;
+      }
+
+      if (exclude) {
+        var excludedDatasetKeys = d3.set(datasetKeyArray);
+        datasetKeyArray = this.datasetOrder().filter((datasetKey) => !excludedDatasetKeys.has(datasetKey));
       }
 
       var allSelections: EventTarget[] = [];

--- a/test/components/plots/plotTests.ts
+++ b/test/components/plots/plotTests.ts
@@ -178,7 +178,11 @@ describe("Plots", () => {
 
       var oneElementSelection = plot.getAllSelections(["ds2"]);
       assert.strictEqual(oneElementSelection.size(), 1);
-      assert.strictEqual(numAttr(oneElementSelection, "cy"), 10, "retreieved selection in renderArea2");
+      assert.strictEqual(numAttr(oneElementSelection, "cy"), 10, "retreived selection in renderArea2");
+
+      var nonExcludedSelection = plot.getAllSelections(["ds1"], true);
+      assert.strictEqual(nonExcludedSelection.size(), 1);
+      assert.strictEqual(numAttr(nonExcludedSelection, "cy"), 10, "retreived non-excluded selection in renderArea2");
       svg.remove();
     });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1999,7 +1999,10 @@ describe("Plots", function () {
             assert.strictEqual(numAttr(oneSelection, "cx"), 100, "retrieved selection in renderArea1");
             var oneElementSelection = plot.getAllSelections(["ds2"]);
             assert.strictEqual(oneElementSelection.size(), 1);
-            assert.strictEqual(numAttr(oneElementSelection, "cy"), 10, "retreieved selection in renderArea2");
+            assert.strictEqual(numAttr(oneElementSelection, "cy"), 10, "retreived selection in renderArea2");
+            var nonExcludedSelection = plot.getAllSelections(["ds1"], true);
+            assert.strictEqual(nonExcludedSelection.size(), 1);
+            assert.strictEqual(numAttr(nonExcludedSelection, "cy"), 10, "retreived non-excluded selection in renderArea2");
             svg.remove();
         });
         describe("Dataset removal", function () {


### PR DESCRIPTION
The new signature for getAllSelections after this pull request should be
```typescript
public getAllSelections(datasetKeys?: string | string[], exclude = false): D3.Selection
```

An exclude argument is added as a parameter that defaults to false that can be set to true if the user wants to retrieve all selections excluding the ones specified in datasetKeys.