### PR TITLE
[Plot] - Adding generateProjectors() API

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2608,15 +2608,15 @@ declare module Plottable {
             project(attrToSet: string, accessor: any, scale?: Scale.AbstractScale<any, any>): AbstractPlot;
             protected _generateAttrToProjector(): AttributeToProjector;
             /**
-             * Generates a map from a projected attribute to the function to calculate the value of that attribute
+             * Generates a dictionary mapping an attribute to a function that calculate that attribute's value
              * in accordance with the given datasetKey.
              *
              * Note that this will return all of the data attributes, which may not perfectly align to svg attributes
              *
              * @param {datasetKey} the key of the dataset to generate the map for
-             * @returns {AttributeToAppliedProjector} A map from attributes to functions to calculate that attribute
+             * @returns {AttributeToAppliedProjector} A dictionary mapping attributes to functions
              */
-            generateAppliedProjectors(datasetKey: string): AttributeToAppliedProjector;
+            generateProjectors(datasetKey: string): AttributeToAppliedProjector;
             _doRender(): void;
             /**
              * Enables or disables animation.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -672,7 +672,7 @@ declare module Plottable {
     /**
      * Projector with applied user and plot metadata
      */
-    type _AppliedProjector = (datum: any, index: number) => any;
+    type AppliedProjector = (datum: any, index: number) => any;
     /**
      * Defines a way how specific attribute needs be retrieved before rendering.
      */
@@ -692,8 +692,8 @@ declare module Plottable {
     type AttributeToProjector = {
         [attrToSet: string]: _Projector;
     };
-    type _AttributeToAppliedProjector = {
-        [attrToSet: string]: _AppliedProjector;
+    type AttributeToAppliedProjector = {
+        [attrToSet: string]: AppliedProjector;
     };
     /**
      * A simple bounding box.
@@ -1417,13 +1417,13 @@ declare module Plottable {
             animator: Animator.PlotAnimator;
         };
         type AppliedDrawStep = {
-            attrToProjector: _AttributeToAppliedProjector;
+            attrToProjector: AttributeToAppliedProjector;
             animator: Animator.PlotAnimator;
         };
         class AbstractDrawer {
             protected _className: string;
             key: string;
-            protected _attrToProjector: _AttributeToAppliedProjector;
+            protected _attrToProjector: AttributeToAppliedProjector;
             /**
              * Sets the class, which needs to be applied to bound elements.
              *
@@ -2614,9 +2614,9 @@ declare module Plottable {
              * Note that this will return all of the data attributes, which may not perfectly align to svg attributes
              *
              * @param {datasetKey} the key of the dataset to generate the map for
-             * @returns {AttributeToProjector} A map from attributes to functions to calculate that attribute
+             * @returns {AttributeToAppliedProjector} A map from attributes to functions to calculate that attribute
              */
-            generateDataAttrToProjector(datasetKey: string): _AttributeToAppliedProjector;
+            generateAppliedProjections(datasetKey: string): AttributeToAppliedProjector;
             _doRender(): void;
             /**
              * Enables or disables animation.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2607,6 +2607,16 @@ declare module Plottable {
              */
             project(attrToSet: string, accessor: any, scale?: Scale.AbstractScale<any, any>): AbstractPlot;
             protected _generateAttrToProjector(): AttributeToProjector;
+            /**
+             * Generates a map from a projected attribute to the function to calculate the value of that attribute
+             * in accordance with the given datasetKey.
+             *
+             * Note that this will return all of the data attributes, which may not perfectly align to svg attributes
+             *
+             * @param {datasetKey} the key of the dataset to generate the map for
+             * @returns {AttributeToProjector} A map from attributes to functions to calculate that attribute
+             */
+            generateDataAttrToProjector(datasetKey: string): AttributeToProjector;
             _doRender(): void;
             /**
              * Enables or disables animation.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2616,7 +2616,7 @@ declare module Plottable {
              * @param {datasetKey} the key of the dataset to generate the map for
              * @returns {AttributeToProjector} A map from attributes to functions to calculate that attribute
              */
-            generateDataAttrToProjector(datasetKey: string): AttributeToProjector;
+            generateDataAttrToProjector(datasetKey: string): _AttributeToAppliedProjector;
             _doRender(): void;
             /**
              * Enables or disables animation.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2616,7 +2616,7 @@ declare module Plottable {
              * @param {datasetKey} the key of the dataset to generate the map for
              * @returns {AttributeToAppliedProjector} A map from attributes to functions to calculate that attribute
              */
-            generateAppliedProjections(datasetKey: string): AttributeToAppliedProjector;
+            generateAppliedProjectors(datasetKey: string): AttributeToAppliedProjector;
             _doRender(): void;
             /**
              * Enables or disables animation.

--- a/plottable.js
+++ b/plottable.js
@@ -6372,9 +6372,9 @@ var Plottable;
              * Note that this will return all of the data attributes, which may not perfectly align to svg attributes
              *
              * @param {datasetKey} the key of the dataset to generate the map for
-             * @returns {AttributeToProjector} A map from attributes to functions to calculate that attribute
+             * @returns {AttributeToAppliedProjector} A map from attributes to functions to calculate that attribute
              */
-            AbstractPlot.prototype.generateDataAttrToProjector = function (datasetKey) {
+            AbstractPlot.prototype.generateAppliedProjections = function (datasetKey) {
                 return null;
             };
             AbstractPlot.prototype._doRender = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -6374,7 +6374,7 @@ var Plottable;
              * @param {datasetKey} the key of the dataset to generate the map for
              * @returns {AttributeToAppliedProjector} A map from attributes to functions to calculate that attribute
              */
-            AbstractPlot.prototype.generateAppliedProjections = function (datasetKey) {
+            AbstractPlot.prototype.generateAppliedProjectors = function (datasetKey) {
                 return null;
             };
             AbstractPlot.prototype._doRender = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -6365,6 +6365,18 @@ var Plottable;
                 });
                 return h;
             };
+            /**
+             * Generates a map from a projected attribute to the function to calculate the value of that attribute
+             * in accordance with the given datasetKey.
+             *
+             * Note that this will return all of the data attributes, which may not perfectly align to svg attributes
+             *
+             * @param {datasetKey} the key of the dataset to generate the map for
+             * @returns {AttributeToProjector} A map from attributes to functions to calculate that attribute
+             */
+            AbstractPlot.prototype.generateDataAttrToProjector = function (datasetKey) {
+                return null;
+            };
             AbstractPlot.prototype._doRender = function () {
                 if (this._isAnchored) {
                     this._paint();

--- a/plottable.js
+++ b/plottable.js
@@ -6366,15 +6366,15 @@ var Plottable;
                 return h;
             };
             /**
-             * Generates a map from a projected attribute to the function to calculate the value of that attribute
+             * Generates a dictionary mapping an attribute to a function that calculate that attribute's value
              * in accordance with the given datasetKey.
              *
              * Note that this will return all of the data attributes, which may not perfectly align to svg attributes
              *
              * @param {datasetKey} the key of the dataset to generate the map for
-             * @returns {AttributeToAppliedProjector} A map from attributes to functions to calculate that attribute
+             * @returns {AttributeToAppliedProjector} A dictionary mapping attributes to functions
              */
-            AbstractPlot.prototype.generateAppliedProjectors = function (datasetKey) {
+            AbstractPlot.prototype.generateProjectors = function (datasetKey) {
                 var attrToProjector = this._generateAttrToProjector();
                 var plotDatasetKey = this._key2PlotDatasetKey.get(datasetKey);
                 var plotMetadata = plotDatasetKey.plotMetadata;

--- a/plottable.js
+++ b/plottable.js
@@ -6375,7 +6375,15 @@ var Plottable;
              * @returns {AttributeToAppliedProjector} A map from attributes to functions to calculate that attribute
              */
             AbstractPlot.prototype.generateAppliedProjectors = function (datasetKey) {
-                return null;
+                var attrToProjector = this._generateAttrToProjector();
+                var plotDatasetKey = this._key2PlotDatasetKey.get(datasetKey);
+                var plotMetadata = plotDatasetKey.plotMetadata;
+                var userMetadata = plotDatasetKey.dataset.metadata();
+                var attrToAppliedProjector = {};
+                d3.entries(attrToProjector).forEach(function (keyValue) {
+                    attrToAppliedProjector[keyValue.key] = function (datum, index) { return keyValue.value(datum, index, userMetadata, plotMetadata); };
+                });
+                return attrToAppliedProjector;
             };
             AbstractPlot.prototype._doRender = function () {
                 if (this._isAnchored) {

--- a/src/components/plots/abstractPlot.ts
+++ b/src/components/plots/abstractPlot.ts
@@ -209,15 +209,15 @@ export module Plot {
     }
 
     /**
-     * Generates a map from a projected attribute to the function to calculate the value of that attribute
+     * Generates a dictionary mapping an attribute to a function that calculate that attribute's value
      * in accordance with the given datasetKey.
      *
      * Note that this will return all of the data attributes, which may not perfectly align to svg attributes
      *
-     * @param {datasetKey} the key of the dataset to generate the map for
-     * @returns {AttributeToAppliedProjector} A map from attributes to functions to calculate that attribute
+     * @param {datasetKey} the key of the dataset to generate the dictionary for
+     * @returns {AttributeToAppliedProjector} A dictionary mapping attributes to functions
      */
-    public generateAppliedProjectors(datasetKey: string): AttributeToAppliedProjector {
+    public generateProjectors(datasetKey: string): AttributeToAppliedProjector {
       var attrToProjector = this._generateAttrToProjector();
       var plotDatasetKey = this._key2PlotDatasetKey.get(datasetKey);
       var plotMetadata = plotDatasetKey.plotMetadata;

--- a/src/components/plots/abstractPlot.ts
+++ b/src/components/plots/abstractPlot.ts
@@ -218,7 +218,15 @@ export module Plot {
      * @returns {AttributeToAppliedProjector} A map from attributes to functions to calculate that attribute
      */
     public generateAppliedProjectors(datasetKey: string): AttributeToAppliedProjector {
-      return null;
+      var attrToProjector = this._generateAttrToProjector();
+      var plotDatasetKey = this._key2PlotDatasetKey.get(datasetKey);
+      var plotMetadata = plotDatasetKey.plotMetadata;
+      var userMetadata = plotDatasetKey.dataset.metadata();
+      var attrToAppliedProjector: AttributeToAppliedProjector = {};
+      d3.entries(attrToProjector).forEach((keyValue: any) => {
+        attrToAppliedProjector[keyValue.key] = (datum: any, index: number) => keyValue.value(datum, index, userMetadata, plotMetadata);
+      });
+      return attrToAppliedProjector;
     }
 
     public _doRender() {

--- a/src/components/plots/abstractPlot.ts
+++ b/src/components/plots/abstractPlot.ts
@@ -215,9 +215,9 @@ export module Plot {
      * Note that this will return all of the data attributes, which may not perfectly align to svg attributes
      *
      * @param {datasetKey} the key of the dataset to generate the map for
-     * @returns {AttributeToProjector} A map from attributes to functions to calculate that attribute
+     * @returns {AttributeToAppliedProjector} A map from attributes to functions to calculate that attribute
      */
-    public generateDataAttrToProjector(datasetKey: string): _AttributeToAppliedProjector {
+    public generateAppliedProjections(datasetKey: string): AttributeToAppliedProjector {
       return null;
     }
 

--- a/src/components/plots/abstractPlot.ts
+++ b/src/components/plots/abstractPlot.ts
@@ -217,7 +217,7 @@ export module Plot {
      * @param {datasetKey} the key of the dataset to generate the map for
      * @returns {AttributeToProjector} A map from attributes to functions to calculate that attribute
      */
-    public generateDataAttrToProjector(datasetKey: string): AttributeToProjector {
+    public generateDataAttrToProjector(datasetKey: string): _AttributeToAppliedProjector {
       return null;
     }
 

--- a/src/components/plots/abstractPlot.ts
+++ b/src/components/plots/abstractPlot.ts
@@ -208,6 +208,19 @@ export module Plot {
       return h;
     }
 
+    /**
+     * Generates a map from a projected attribute to the function to calculate the value of that attribute
+     * in accordance with the given datasetKey.
+     *
+     * Note that this will return all of the data attributes, which may not perfectly align to svg attributes
+     *
+     * @param {datasetKey} the key of the dataset to generate the map for
+     * @returns {AttributeToProjector} A map from attributes to functions to calculate that attribute
+     */
+    public generateDataAttrToProjector(datasetKey: string): AttributeToProjector {
+      return null;
+    }
+
     public _doRender() {
       if (this._isAnchored) {
         this._paint();

--- a/src/components/plots/abstractPlot.ts
+++ b/src/components/plots/abstractPlot.ts
@@ -217,7 +217,7 @@ export module Plot {
      * @param {datasetKey} the key of the dataset to generate the map for
      * @returns {AttributeToAppliedProjector} A map from attributes to functions to calculate that attribute
      */
-    public generateAppliedProjections(datasetKey: string): AttributeToAppliedProjector {
+    public generateAppliedProjectors(datasetKey: string): AttributeToAppliedProjector {
       return null;
     }
 

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -12,7 +12,7 @@ module Plottable {
   /**
    * Projector with applied user and plot metadata
    */
-  export type _AppliedProjector = (datum: any, index: number) => any;
+  export type AppliedProjector = (datum: any, index: number) => any;
 
   /**
    * Defines a way how specific attribute needs be retrieved before rendering.
@@ -33,7 +33,7 @@ module Plottable {
    */
   export type AttributeToProjector = { [attrToSet: string]: _Projector; };
 
-  export type _AttributeToAppliedProjector = { [attrToSet: string]: _AppliedProjector; };
+  export type AttributeToAppliedProjector = { [attrToSet: string]: AppliedProjector; };
 
   /**
    * A simple bounding box.

--- a/src/drawers/abstractDrawer.ts
+++ b/src/drawers/abstractDrawer.ts
@@ -13,7 +13,7 @@ export module _Drawer {
   }
 
   export type AppliedDrawStep = {
-    attrToProjector: _AttributeToAppliedProjector;
+    attrToProjector: AttributeToAppliedProjector;
     animator: Animator.PlotAnimator;
   }
 
@@ -21,7 +21,7 @@ export module _Drawer {
     private _renderArea: D3.Selection;
     protected _className: string;
     public key: string;
-    protected _attrToProjector: _AttributeToAppliedProjector;
+    protected _attrToProjector: AttributeToAppliedProjector;
 
     /**
      * Sets the class, which needs to be applied to bound elements.
@@ -80,8 +80,8 @@ export module _Drawer {
 
     private _applyMetadata(attrToProjector: AttributeToProjector,
                           userMetadata: any,
-                          plotMetadata: Plot.PlotMetadata): _AttributeToAppliedProjector {
-      var modifiedAttrToProjector: _AttributeToAppliedProjector = {};
+                          plotMetadata: Plot.PlotMetadata): AttributeToAppliedProjector {
+      var modifiedAttrToProjector: AttributeToAppliedProjector = {};
       d3.keys(attrToProjector).forEach((attr: string) => {
         modifiedAttrToProjector[attr] =
           (datum: any, index: number) => attrToProjector[attr](datum, index, userMetadata, plotMetadata);
@@ -109,7 +109,7 @@ export module _Drawer {
     public draw(data: any[], drawSteps: DrawStep[], userMetadata: any, plotMetadata: Plot.PlotMetadata) {
       var appliedDrawSteps: AppliedDrawStep[] = drawSteps.map((dr: DrawStep) => {
         var appliedAttrToProjector = this._applyMetadata(dr.attrToProjector, userMetadata, plotMetadata);
-        this._attrToProjector = <_AttributeToAppliedProjector>_Util.Methods.copyMap(appliedAttrToProjector);
+        this._attrToProjector = <AttributeToAppliedProjector>_Util.Methods.copyMap(appliedAttrToProjector);
         return {
           attrToProjector: appliedAttrToProjector,
           animator: dr.animator

--- a/src/drawers/arcDrawer.ts
+++ b/src/drawers/arcDrawer.ts
@@ -9,14 +9,14 @@ export module _Drawer {
       this._svgElement = "path";
     }
 
-    private _createArc(innerRadiusF: _AppliedProjector, outerRadiusF: _AppliedProjector) {
+    private _createArc(innerRadiusF: AppliedProjector, outerRadiusF: AppliedProjector) {
       return d3.svg.arc()
                    .innerRadius(innerRadiusF)
                    .outerRadius(outerRadiusF);
     }
 
-    private retargetProjectors(attrToProjector: _AttributeToAppliedProjector): _AttributeToAppliedProjector {
-      var retargetedAttrToProjector: _AttributeToAppliedProjector = {};
+    private retargetProjectors(attrToProjector: AttributeToAppliedProjector): AttributeToAppliedProjector {
+      var retargetedAttrToProjector: AttributeToAppliedProjector = {};
       d3.entries(attrToProjector).forEach((entry) => {
         retargetedAttrToProjector[entry.key] = (d: D3.Layout.ArcDescriptor, i: number) => entry.value(d.data, i);
       });
@@ -24,7 +24,7 @@ export module _Drawer {
     }
 
     public _drawStep(step: AppliedDrawStep) {
-      var attrToProjector = <_AttributeToAppliedProjector>_Util.Methods.copyMap(step.attrToProjector);
+      var attrToProjector = <AttributeToAppliedProjector>_Util.Methods.copyMap(step.attrToProjector);
       attrToProjector = this.retargetProjectors(attrToProjector);
       this._attrToProjector = this.retargetProjectors(this._attrToProjector);
       var innerRadiusAccessor = attrToProjector["inner-radius"];

--- a/src/drawers/areaDrawer.ts
+++ b/src/drawers/areaDrawer.ts
@@ -39,10 +39,10 @@ export module _Drawer {
       }
     }
 
-    private _createArea(xFunction: _AppliedProjector,
-                       y0Function: _AppliedProjector,
-                       y1Function: _AppliedProjector,
-                       definedFunction: _AppliedProjector) {
+    private _createArea(xFunction: AppliedProjector,
+                       y0Function: AppliedProjector,
+                       y1Function: AppliedProjector,
+                       definedFunction: AppliedProjector) {
       if(!definedFunction) {
         definedFunction = () => true;
       }
@@ -61,7 +61,7 @@ export module _Drawer {
         // HACKHACK Forced to use anycast to access protected var
         (<any> AbstractDrawer).prototype._drawStep.call(this, step);
       }
-      var attrToProjector = <_AttributeToAppliedProjector>_Util.Methods.copyMap(step.attrToProjector);
+      var attrToProjector = <AttributeToAppliedProjector>_Util.Methods.copyMap(step.attrToProjector);
       var xFunction       = attrToProjector["x"];
       var y0Function      = attrToProjector["y0"];
       var y1Function      = attrToProjector["y"];

--- a/src/drawers/lineDrawer.ts
+++ b/src/drawers/lineDrawer.ts
@@ -22,7 +22,7 @@ export module _Drawer {
       super.setup(area);
     }
 
-    private _createLine(xFunction: _AppliedProjector, yFunction: _AppliedProjector, definedFunction: _AppliedProjector) {
+    private _createLine(xFunction: AppliedProjector, yFunction: AppliedProjector, definedFunction: AppliedProjector) {
       if(!definedFunction) {
         definedFunction = (d, i) => true;
       }
@@ -39,7 +39,7 @@ export module _Drawer {
 
     protected _drawStep(step: AppliedDrawStep) {
       var baseTime = super._drawStep(step);
-      var attrToProjector = <_AttributeToAppliedProjector>_Util.Methods.copyMap(step.attrToProjector);
+      var attrToProjector = <AttributeToAppliedProjector>_Util.Methods.copyMap(step.attrToProjector);
       var definedFunction = attrToProjector["defined"];
 
       var xProjector = attrToProjector["x"];


### PR DESCRIPTION
With the idea of the `project` call, users of Plottable are able to set the attributes of the plot through the use of accessors and scales.  However, the exact way that Plottable computes these attributes is hidden from the user.

For example, consider the call
`plot.project("x", "x", xScale)`
It is hidden from the user that in order to compute the x attribute of the rendered plot the fact that the "x" attribute is queried per datum and scaled with the xScale to find the pixel point that the datum will render to.

This is incredibly important for plots like `Plot.Scatter` to function correctly as there must be a way to map from a datum to a pixel position.

This pull request is an attempt at higher transparency between the user and the plot, letting the user query the following API endpoint to find out how attributes computed on a plot.

This is incredibly important for plots like `Plot.Line` where it is incredibly difficult to see how a datum maps to a single point on a line plot.

This can also reveal the fills on the `Plot.Bar` rectangles without rendering them.

The signature is the following:
```typescript
public generateProjectors(datasetKey: string): AttributeToAppliedProjector
```

Example:  On a `Plot.Scatter` it would be nice to know the pixel positions of each point just from the data / without needing to look through the visuals

http://jsfiddle.net/bluong63/ka5oag2j/2/

Example: `Plot.Bar` example

http://jsfiddle.net/bluong63/pb9rorzv/1/