### PR TITLE
Upgrading grunt-mocha-phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "grunt-ts": "~1.12.1",
     "grunt-tslint": "2.0.0",
     "grunt-contrib-concat": "~0.3.0",
-    "grunt-mocha-phantomjs": "~0.4.0",
+    "grunt-mocha-phantomjs": "0.6.1",
     "grunt-contrib-connect": "~0.6.0",
     "grunt-blanket-mocha": "~0.4.0",
     "grunt-saucelabs": "8.6.0",


### PR DESCRIPTION
PhantomJS results sometimes in a cyclical structure error when attempting to use assert.includeMembers in mocha.  Upgrading should solve the issue.