### PR TITLE
[Hotfix][SymbolGenerators] - d3 symbol type verification

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -1016,6 +1016,9 @@ var Plottable;
                     case "triangle-down":
                         sizeFactor = Math.sqrt(3);
                         break;
+                    default:
+                        sizeFactor = 1;
+                        break;
                 }
                 return sizeFactor * Math.pow(SymbolGenerators.SYMBOL_GENERATOR_RADIUS, 2);
             };

--- a/plottable.js
+++ b/plottable.js
@@ -1019,7 +1019,13 @@ var Plottable;
                 }
                 return sizeFactor * Math.pow(SymbolGenerators.SYMBOL_GENERATOR_RADIUS, 2);
             };
-            var symbolSize = typeof (symbolType) === "string" ? typeToSize(symbolType) : function (datum, index) { return typeToSize(symbolType(datum, index)); };
+            function ensureSymbolType(symTypeString) {
+                if (d3.svg.symbolTypes.indexOf(symTypeString) === -1) {
+                    throw new Error(symTypeString + " is an invalid D3 symbol type.  d3.svg.symbolTypes can retrieve the valid symbol types.");
+                }
+                return symTypeString;
+            }
+            var symbolSize = typeof (symbolType) === "string" ? typeToSize(ensureSymbolType(symbolType)) : function (datum, index) { return typeToSize(ensureSymbolType(symbolType(datum, index))); };
             return d3.svg.symbol().type(symbolType).size(symbolSize);
         }
         SymbolGenerators.d3Symbol = d3Symbol;

--- a/src/utils/symbolGenerators.ts
+++ b/src/utils/symbolGenerators.ts
@@ -52,6 +52,9 @@ module Plottable {
           case "triangle-down":
             sizeFactor = Math.sqrt(3);
             break;
+          default:
+            sizeFactor = 1;
+            break;
         }
 
         return sizeFactor * Math.pow(SYMBOL_GENERATOR_RADIUS, 2);

--- a/src/utils/symbolGenerators.ts
+++ b/src/utils/symbolGenerators.ts
@@ -57,9 +57,16 @@ module Plottable {
         return sizeFactor * Math.pow(SYMBOL_GENERATOR_RADIUS, 2);
       };
 
+      function ensureSymbolType(symTypeString: string) {
+        if (d3.svg.symbolTypes.indexOf(symTypeString) === -1) {
+          throw new Error(symTypeString + " is an invalid D3 symbol type.  d3.svg.symbolTypes can retrieve the valid symbol types.");
+        }
+        return symTypeString;
+      }
+
       var symbolSize = typeof(symbolType) === "string" ?
-                         typeToSize(<string> symbolType) :
-                         (datum: any, index: number) => typeToSize((<StringAccessor> symbolType)(datum, index));
+                         typeToSize(ensureSymbolType(<string> symbolType)) :
+                         (datum: any, index: number) => typeToSize(ensureSymbolType((<StringAccessor> symbolType)(datum, index)));
 
       return d3.svg.symbol().type(symbolType).size(symbolSize);
     }

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -51,6 +51,7 @@
 
 ///<reference path="utils/domUtilsTests.ts" />
 ///<reference path="utils/formattersTests.ts" />
+///<reference path="utils/symbolGeneratorsTests.ts" />
 ///<reference path="utils/idCounterTests.ts" />
 ///<reference path="utils/strictEqualityAssociativeArrayTests.ts" />
 ///<reference path="utils/clientToSVGTranslatorTests.ts" />

--- a/test/tests.js
+++ b/test/tests.js
@@ -6962,6 +6962,16 @@ describe("Formatters", function () {
 
 ///<reference path="../testReference.ts" />
 var assert = chai.assert;
+describe("SymbolGenerators", function () {
+    describe("d3Symbol", function () {
+        it("throws an error if invalid symbol type is used", function () {
+            assert.throws(function () { return Plottable.SymbolGenerators.d3Symbol("aaa"); }, Error, "invalid D3 symbol type");
+        });
+    });
+});
+
+///<reference path="../testReference.ts" />
+var assert = chai.assert;
 describe("IDCounter", function () {
     it("IDCounter works as expected", function () {
         var i = new Plottable._Util.IDCounter();

--- a/test/utils/symbolGeneratorsTests.ts
+++ b/test/utils/symbolGeneratorsTests.ts
@@ -1,0 +1,11 @@
+///<reference path="../testReference.ts" />
+
+var assert = chai.assert;
+
+describe("SymbolGenerators", () => {
+  describe("d3Symbol", () => {
+    it("throws an error if invalid symbol type is used", () => {
+      assert.throws(() => Plottable.SymbolGenerators.d3Symbol("aaa"), Error, "invalid D3 symbol type");
+    });
+  });
+});


### PR DESCRIPTION
Throws an error if an invalid symbol type is given.  Default sizeFactor (only will be used after the verification)