### PR TITLE
Add Interaction.Pointer.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3734,6 +3734,54 @@ declare module Plottable {
 
 declare module Plottable {
     module Interaction {
+        class Pointer extends Interaction.AbstractInteraction {
+            _anchor(component: Component.AbstractComponent, hitBox: D3.Selection): void;
+            /**
+             * Gets the callback called when the pointer enters the Component.
+             *
+             * @return {(p: Point) => any} The current callback.
+             */
+            onPointerEnter(): (p: Point) => any;
+            /**
+             * Sets the callback called when the pointer enters the Component.
+             *
+             * @param {(p: Point) => any} callback The callback to set.
+             * @return {Interaction.Pointer} The calling Interaction.Pointer.
+             */
+            onPointerEnter(callback: (p: Point) => any): Interaction.Pointer;
+            /**
+             * Gets the callback called when the pointer moves.
+             *
+             * @return {(p: Point) => any} The current callback.
+             */
+            onPointerMove(): (p: Point) => any;
+            /**
+             * Sets the callback called when the pointer moves.
+             *
+             * @param {(p: Point) => any} callback The callback to set.
+             * @return {Interaction.Pointer} The calling Interaction.Pointer.
+             */
+            onPointerMove(callback: (p: Point) => any): Interaction.Pointer;
+            /**
+             * Gets the callback called when the pointer exits the Component.
+             *
+             * @return {(p: Point) => any} The current callback.
+             */
+            onPointerExit(): (p: Point) => any;
+            /**
+             * Sets the callback called when the pointer exits the Component.
+             *
+             * @param {(p: Point) => any} callback The callback to set.
+             * @return {Interaction.Pointer} The calling Interaction.Pointer.
+             */
+            onPointerExit(callback: (p: Point) => any): Interaction.Pointer;
+        }
+    }
+}
+
+
+declare module Plottable {
+    module Interaction {
         class PanZoom extends AbstractInteraction {
             /**
              * Creates a PanZoomInteraction.

--- a/plottable.js
+++ b/plottable.js
@@ -9350,7 +9350,7 @@ var Plottable;
                 this._mouseDispatcher = Plottable.Dispatcher.Mouse.getDispatcher(this._componentToListenTo.content().node());
                 this._mouseDispatcher.onMouseMove("Interaction.Pointer" + this.getID(), function (p) { return _this._handlePointerEvent(p); });
                 this._touchDispatcher = Plottable.Dispatcher.Touch.getDispatcher(this._componentToListenTo.content().node());
-                this._touchDispatcher.onTouchStart("Interaction.Pointer" + this.getID(), function (p, e) { return _this._handlePointerEvent(p); });
+                this._touchDispatcher.onTouchStart("Interaction.Pointer" + this.getID(), function (p) { return _this._handlePointerEvent(p); });
             };
             Pointer.prototype._handlePointerEvent = function (p) {
                 var translatedP = this._translateToComponentSpace(p);
@@ -9372,21 +9372,21 @@ var Plottable;
                 }
             };
             Pointer.prototype.onPointerEnter = function (callback) {
-                if (callback == null) {
+                if (callback === undefined) {
                     return this._pointerEnterCallback;
                 }
                 this._pointerEnterCallback = callback;
                 return this;
             };
             Pointer.prototype.onPointerMove = function (callback) {
-                if (callback == null) {
+                if (callback === undefined) {
                     return this._pointerMoveCallback;
                 }
                 this._pointerMoveCallback = callback;
                 return this;
             };
             Pointer.prototype.onPointerExit = function (callback) {
-                if (callback == null) {
+                if (callback === undefined) {
                     return this._pointerExitCallback;
                 }
                 this._pointerExitCallback = callback;

--- a/plottable.js
+++ b/plottable.js
@@ -9338,6 +9338,77 @@ var Plottable;
 (function (Plottable) {
     var Interaction;
     (function (Interaction) {
+        var Pointer = (function (_super) {
+            __extends(Pointer, _super);
+            function Pointer() {
+                _super.apply(this, arguments);
+                this._overComponent = false;
+            }
+            Pointer.prototype._anchor = function (component, hitBox) {
+                var _this = this;
+                _super.prototype._anchor.call(this, component, hitBox);
+                this._mouseDispatcher = Plottable.Dispatcher.Mouse.getDispatcher(this._componentToListenTo.content().node());
+                this._mouseDispatcher.onMouseMove("Interaction.Pointer" + this.getID(), function (p) { return _this._handlePointerEvent(p); });
+                this._touchDispatcher = Plottable.Dispatcher.Touch.getDispatcher(this._componentToListenTo.content().node());
+                this._touchDispatcher.onTouchStart("Interaction.Pointer" + this.getID(), function (p, e) { return _this._handlePointerEvent(p); });
+            };
+            Pointer.prototype._handlePointerEvent = function (p) {
+                var translatedP = this._translateToComponentSpace(p);
+                if (this._isInsideComponent(translatedP)) {
+                    var wasOverComponent = this._overComponent;
+                    this._overComponent = true;
+                    if (!wasOverComponent && this._pointerEnterCallback) {
+                        this._pointerEnterCallback(translatedP);
+                    }
+                    if (this._pointerMoveCallback) {
+                        this._pointerMoveCallback(translatedP);
+                    }
+                }
+                else if (this._overComponent) {
+                    this._overComponent = false;
+                    if (this._pointerExitCallback) {
+                        this._pointerExitCallback(translatedP);
+                    }
+                }
+            };
+            Pointer.prototype.onPointerEnter = function (callback) {
+                if (callback == null) {
+                    return this._pointerEnterCallback;
+                }
+                this._pointerEnterCallback = callback;
+                return this;
+            };
+            Pointer.prototype.onPointerMove = function (callback) {
+                if (callback == null) {
+                    return this._pointerMoveCallback;
+                }
+                this._pointerMoveCallback = callback;
+                return this;
+            };
+            Pointer.prototype.onPointerExit = function (callback) {
+                if (callback == null) {
+                    return this._pointerExitCallback;
+                }
+                this._pointerExitCallback = callback;
+                return this;
+            };
+            return Pointer;
+        })(Interaction.AbstractInteraction);
+        Interaction.Pointer = Pointer;
+    })(Interaction = Plottable.Interaction || (Plottable.Interaction = {}));
+})(Plottable || (Plottable = {}));
+
+///<reference path="../reference.ts" />
+var __extends = this.__extends || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    __.prototype = b.prototype;
+    d.prototype = new __();
+};
+var Plottable;
+(function (Plottable) {
+    var Interaction;
+    (function (Interaction) {
         var PanZoom = (function (_super) {
             __extends(PanZoom, _super);
             /**

--- a/src/interactions/pointerInteraction.ts
+++ b/src/interactions/pointerInteraction.ts
@@ -1,0 +1,105 @@
+///<reference path="../reference.ts" />
+
+module Plottable {
+export module Interaction {
+  export class Pointer extends Interaction.AbstractInteraction {
+    private _mouseDispatcher: Dispatcher.Mouse;
+    private _touchDispatcher: Dispatcher.Touch;
+    private _overComponent = false;
+    private _pointerEnterCallback: (p: Point) => any;
+    private _pointerMoveCallback: (p: Point) => any;
+    private _pointerExitCallback: (p: Point) => any;
+
+    public _anchor(component: Component.AbstractComponent, hitBox: D3.Selection) {
+      super._anchor(component, hitBox);
+      this._mouseDispatcher = Dispatcher.Mouse.getDispatcher(<SVGElement> this._componentToListenTo.content().node());
+      this._mouseDispatcher.onMouseMove("Interaction.Pointer" + this.getID(), (p: Point) => this._handlePointerEvent(p));
+
+      this._touchDispatcher = Dispatcher.Touch.getDispatcher(<SVGElement> this._componentToListenTo.content().node());
+      this._touchDispatcher.onTouchStart("Interaction.Pointer" + this.getID(), (p: Point, e: TouchEvent) => this._handlePointerEvent(p));
+    }
+
+    private _handlePointerEvent(p: Point) {
+      var translatedP = this._translateToComponentSpace(p);
+      if (this._isInsideComponent(translatedP)) {
+        var wasOverComponent = this._overComponent;
+        this._overComponent = true;
+        if (!wasOverComponent && this._pointerEnterCallback) {
+          this._pointerEnterCallback(translatedP);
+        }
+        if (this._pointerMoveCallback) {
+          this._pointerMoveCallback(translatedP);
+        }
+      } else if (this._overComponent) {
+        this._overComponent = false;
+        if (this._pointerExitCallback) {
+          this._pointerExitCallback(translatedP);
+        }
+      }
+    }
+
+    /**
+     * Gets the callback called when the pointer enters the Component.
+     *
+     * @return {(p: Point) => any} The current callback.
+     */
+    public onPointerEnter(): (p: Point) => any;
+    /**
+     * Sets the callback called when the pointer enters the Component.
+     *
+     * @param {(p: Point) => any} callback The callback to set.
+     * @return {Interaction.Pointer} The calling Interaction.Pointer.
+     */
+    public onPointerEnter(callback: (p: Point) => any): Interaction.Pointer;
+    public onPointerEnter(callback?: (p: Point) => any): any {
+      if (callback == null) {
+        return this._pointerEnterCallback;
+      }
+      this._pointerEnterCallback = callback;
+      return this;
+    }
+
+    /**
+     * Gets the callback called when the pointer moves.
+     *
+     * @return {(p: Point) => any} The current callback.
+     */
+    public onPointerMove(): (p: Point) => any;
+    /**
+     * Sets the callback called when the pointer moves.
+     *
+     * @param {(p: Point) => any} callback The callback to set.
+     * @return {Interaction.Pointer} The calling Interaction.Pointer.
+     */
+    public onPointerMove(callback: (p: Point) => any): Interaction.Pointer;
+    public onPointerMove(callback?: (p: Point) => any): any {
+      if (callback == null) {
+        return this._pointerMoveCallback;
+      }
+      this._pointerMoveCallback = callback;
+      return this;
+    }
+
+    /**
+     * Gets the callback called when the pointer exits the Component.
+     *
+     * @return {(p: Point) => any} The current callback.
+     */
+    public onPointerExit(): (p: Point) => any;
+    /**
+     * Sets the callback called when the pointer exits the Component.
+     *
+     * @param {(p: Point) => any} callback The callback to set.
+     * @return {Interaction.Pointer} The calling Interaction.Pointer.
+     */
+    public onPointerExit(callback: (p: Point) => any): Interaction.Pointer;
+    public onPointerExit(callback?: (p: Point) => any): any {
+      if (callback == null) {
+        return this._pointerExitCallback;
+      }
+      this._pointerExitCallback = callback;
+      return this;
+    }
+  }
+}
+}

--- a/src/interactions/pointerInteraction.ts
+++ b/src/interactions/pointerInteraction.ts
@@ -16,7 +16,7 @@ export module Interaction {
       this._mouseDispatcher.onMouseMove("Interaction.Pointer" + this.getID(), (p: Point) => this._handlePointerEvent(p));
 
       this._touchDispatcher = Dispatcher.Touch.getDispatcher(<SVGElement> this._componentToListenTo.content().node());
-      this._touchDispatcher.onTouchStart("Interaction.Pointer" + this.getID(), (p: Point, e: TouchEvent) => this._handlePointerEvent(p));
+      this._touchDispatcher.onTouchStart("Interaction.Pointer" + this.getID(), (p: Point) => this._handlePointerEvent(p));
     }
 
     private _handlePointerEvent(p: Point) {
@@ -52,7 +52,7 @@ export module Interaction {
      */
     public onPointerEnter(callback: (p: Point) => any): Interaction.Pointer;
     public onPointerEnter(callback?: (p: Point) => any): any {
-      if (callback == null) {
+      if (callback === undefined) {
         return this._pointerEnterCallback;
       }
       this._pointerEnterCallback = callback;
@@ -73,7 +73,7 @@ export module Interaction {
      */
     public onPointerMove(callback: (p: Point) => any): Interaction.Pointer;
     public onPointerMove(callback?: (p: Point) => any): any {
-      if (callback == null) {
+      if (callback === undefined) {
         return this._pointerMoveCallback;
       }
       this._pointerMoveCallback = callback;
@@ -94,7 +94,7 @@ export module Interaction {
      */
     public onPointerExit(callback: (p: Point) => any): Interaction.Pointer;
     public onPointerExit(callback?: (p: Point) => any): any {
-      if (callback == null) {
+      if (callback === undefined) {
         return this._pointerExitCallback;
       }
       this._pointerExitCallback = callback;

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -87,6 +87,7 @@
 /// <reference path="interactions/abstractInteraction.ts" />
 /// <reference path="interactions/clickInteraction.ts" />
 /// <reference path="interactions/keyInteraction.ts" />
+/// <reference path="interactions/pointerInteraction.ts" />
 /// <reference path="interactions/panZoomInteraction.ts" />
 /// <reference path="interactions/drag/dragInteraction.ts" />
 /// <reference path="interactions/drag/dragBoxInteraction.ts" />

--- a/test/interactions/pointerInteractionTests.ts
+++ b/test/interactions/pointerInteractionTests.ts
@@ -1,0 +1,147 @@
+///<reference path="../testReference.ts" />
+
+var assert = chai.assert;
+
+describe("Interactions", () => {
+  describe("Pointer", () => {
+    var SVG_WIDTH = 400;
+    var SVG_HEIGHT = 400;
+
+    it("onPointerEnter", () => {
+      var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      var c = new Plottable.Component.AbstractComponent();
+      c.renderTo(svg);
+
+      var pointerInteraction = new Plottable.Interaction.Pointer();
+      c.registerInteraction(pointerInteraction);
+
+      var callbackCalled = false;
+      var lastPoint: Plottable.Point;
+      var callback = function(p: Plottable.Point) {
+        callbackCalled = true;
+        lastPoint = p;
+      };
+      pointerInteraction.onPointerEnter(callback);
+      assert.strictEqual(pointerInteraction.onPointerEnter(), callback, "callback can be retrieved");
+
+      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
+      assert.isTrue(callbackCalled, "callback called on entering Component (mouse)");
+      assert.deepEqual(lastPoint, { x: SVG_WIDTH/2, y: SVG_HEIGHT/2 }, "was passed correct point (mouse)");
+
+      callbackCalled = false;
+      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH/4, SVG_HEIGHT/4);
+      assert.isFalse(callbackCalled, "callback not called again if already in Component (mouse)");
+
+      triggerFakeMouseEvent("mousemove", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
+      assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
+
+      callbackCalled = false;
+      lastPoint = null;
+      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
+      assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
+      assert.deepEqual(lastPoint, { x: SVG_WIDTH/2, y: SVG_HEIGHT/2 }, "was passed correct point (touch)");
+
+      callbackCalled = false;
+      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH/4, SVG_HEIGHT/4);
+      assert.isFalse(callbackCalled, "callback not called again if already in Component (touch)");
+
+      triggerFakeTouchEvent("touchstart", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
+      assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
+
+      svg.remove();
+    });
+
+    it("onPointerMove", () => {
+      var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      var c = new Plottable.Component.AbstractComponent();
+      c.renderTo(svg);
+
+      var pointerInteraction = new Plottable.Interaction.Pointer();
+      c.registerInteraction(pointerInteraction);
+
+      var callbackCalled = false;
+      var lastPoint: Plottable.Point;
+      var callback = function(p: Plottable.Point) {
+        callbackCalled = true;
+        lastPoint = p;
+      };
+      pointerInteraction.onPointerMove(callback);
+      assert.strictEqual(pointerInteraction.onPointerMove(), callback, "callback can be retrieved");
+
+      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
+      assert.isTrue(callbackCalled, "callback called on entering Component (mouse)");
+      assert.deepEqual(lastPoint, { x: SVG_WIDTH/2, y: SVG_HEIGHT/2 }, "was passed correct point (mouse)");
+
+      callbackCalled = false;
+      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH/4, SVG_HEIGHT/4);
+      assert.isTrue(callbackCalled, "callback on moving inside Component (mouse)");
+      assert.deepEqual(lastPoint, { x: SVG_WIDTH/4, y: SVG_HEIGHT/4 }, "was passed correct point (mouse)");
+
+      callbackCalled = false;
+      triggerFakeMouseEvent("mousemove", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
+      assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
+
+      callbackCalled = false;
+      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
+      assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
+      assert.deepEqual(lastPoint, { x: SVG_WIDTH/2, y: SVG_HEIGHT/2 }, "was passed correct point (touch)");
+
+      callbackCalled = false;
+      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH/4, SVG_HEIGHT/4);
+      assert.isTrue(callbackCalled, "callback on moving inside Component (touch)");
+      assert.deepEqual(lastPoint, { x: SVG_WIDTH/4, y: SVG_HEIGHT/4 }, "was passed correct point (touch)");
+
+      callbackCalled = false;
+      triggerFakeTouchEvent("touchstart", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
+      assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
+
+      svg.remove();
+    });
+
+    it("onPointerExit", () => {
+      var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      var c = new Plottable.Component.AbstractComponent();
+      c.renderTo(svg);
+
+      var pointerInteraction = new Plottable.Interaction.Pointer();
+      c.registerInteraction(pointerInteraction);
+
+      var callbackCalled = false;
+      var lastPoint: Plottable.Point;
+      var callback = function(p: Plottable.Point) {
+        callbackCalled = true;
+        lastPoint = p;
+      };
+      pointerInteraction.onPointerExit(callback);
+      assert.strictEqual(pointerInteraction.onPointerExit(), callback, "callback can be retrieved");
+
+      triggerFakeMouseEvent("mousemove", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
+      assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
+
+      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
+      triggerFakeMouseEvent("mousemove", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
+      assert.isTrue(callbackCalled, "callback called on exiting Component (mouse)");
+      assert.deepEqual(lastPoint, { x: 2*SVG_WIDTH, y: 2*SVG_HEIGHT }, "was passed correct point (mouse)");
+
+      callbackCalled = false;
+      triggerFakeMouseEvent("mousemove", c.content(), 3*SVG_WIDTH, 3*SVG_HEIGHT);
+      assert.isFalse(callbackCalled, "callback not called again if already outside of Component (mouse)");
+
+      callbackCalled = false;
+      lastPoint = null;
+      triggerFakeTouchEvent("touchstart", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
+      assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
+
+      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
+      triggerFakeTouchEvent("touchstart", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
+      assert.isTrue(callbackCalled, "callback called on exiting Component (touch)");
+      assert.deepEqual(lastPoint, { x: 2*SVG_WIDTH, y: 2*SVG_HEIGHT }, "was passed correct point (touch)");
+
+      callbackCalled = false;
+      triggerFakeTouchEvent("touchstart", c.content(), 3*SVG_WIDTH, 3*SVG_HEIGHT);
+      assert.isFalse(callbackCalled, "callback not called again if already outside of Component (touch)");
+
+      svg.remove();
+    });
+  });
+});

--- a/test/interactions/pointerInteractionTests.ts
+++ b/test/interactions/pointerInteractionTests.ts
@@ -48,6 +48,10 @@ describe("Interactions", () => {
       triggerFakeTouchEvent("touchstart", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
       assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
 
+      pointerInteraction.onPointerEnter(null);
+      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
+      assert.isFalse(callbackCalled, "callback removed by passing null");
+
       svg.remove();
     });
 
@@ -95,6 +99,10 @@ describe("Interactions", () => {
       triggerFakeTouchEvent("touchstart", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
       assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
 
+      pointerInteraction.onPointerMove(null);
+      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
+      assert.isFalse(callbackCalled, "callback removed by passing null");
+
       svg.remove();
     });
 
@@ -140,6 +148,11 @@ describe("Interactions", () => {
       callbackCalled = false;
       triggerFakeTouchEvent("touchstart", c.content(), 3*SVG_WIDTH, 3*SVG_HEIGHT);
       assert.isFalse(callbackCalled, "callback not called again if already outside of Component (touch)");
+
+      pointerInteraction.onPointerExit(null);
+      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
+      triggerFakeMouseEvent("mousemove", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
+      assert.isFalse(callbackCalled, "callback removed by passing null");
 
       svg.remove();
     });

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -59,6 +59,7 @@
 ///<reference path="utils/utilsTests.ts" />
 
 ///<reference path="interactions/interactionTests.ts" />
+///<reference path="interactions/pointerInteractionTests.ts" />
 ///<reference path="interactions/dragBoxTests.ts" />
 ///<reference path="interactions/hoverInteractionTests.ts" />
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -7386,6 +7386,9 @@ describe("Interactions", function () {
             assert.isFalse(callbackCalled, "callback not called again if already in Component (touch)");
             triggerFakeTouchEvent("touchstart", c.content(), 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
             assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
+            pointerInteraction.onPointerEnter(null);
+            triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            assert.isFalse(callbackCalled, "callback removed by passing null");
             svg.remove();
         });
         it("onPointerMove", function () {
@@ -7423,6 +7426,9 @@ describe("Interactions", function () {
             callbackCalled = false;
             triggerFakeTouchEvent("touchstart", c.content(), 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
             assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
+            pointerInteraction.onPointerMove(null);
+            triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            assert.isFalse(callbackCalled, "callback removed by passing null");
             svg.remove();
         });
         it("onPointerExit", function () {
@@ -7459,6 +7465,10 @@ describe("Interactions", function () {
             callbackCalled = false;
             triggerFakeTouchEvent("touchstart", c.content(), 3 * SVG_WIDTH, 3 * SVG_HEIGHT);
             assert.isFalse(callbackCalled, "callback not called again if already outside of Component (touch)");
+            pointerInteraction.onPointerExit(null);
+            triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            triggerFakeMouseEvent("mousemove", c.content(), 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
+            assert.isFalse(callbackCalled, "callback removed by passing null");
             svg.remove();
         });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -7350,6 +7350,122 @@ describe("Interactions", function () {
 
 ///<reference path="../testReference.ts" />
 var assert = chai.assert;
+describe("Interactions", function () {
+    describe("Pointer", function () {
+        var SVG_WIDTH = 400;
+        var SVG_HEIGHT = 400;
+        it("onPointerEnter", function () {
+            var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+            var c = new Plottable.Component.AbstractComponent();
+            c.renderTo(svg);
+            var pointerInteraction = new Plottable.Interaction.Pointer();
+            c.registerInteraction(pointerInteraction);
+            var callbackCalled = false;
+            var lastPoint;
+            var callback = function (p) {
+                callbackCalled = true;
+                lastPoint = p;
+            };
+            pointerInteraction.onPointerEnter(callback);
+            assert.strictEqual(pointerInteraction.onPointerEnter(), callback, "callback can be retrieved");
+            triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            assert.isTrue(callbackCalled, "callback called on entering Component (mouse)");
+            assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (mouse)");
+            callbackCalled = false;
+            triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH / 4, SVG_HEIGHT / 4);
+            assert.isFalse(callbackCalled, "callback not called again if already in Component (mouse)");
+            triggerFakeMouseEvent("mousemove", c.content(), 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
+            assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
+            callbackCalled = false;
+            lastPoint = null;
+            triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
+            assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (touch)");
+            callbackCalled = false;
+            triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 4, SVG_HEIGHT / 4);
+            assert.isFalse(callbackCalled, "callback not called again if already in Component (touch)");
+            triggerFakeTouchEvent("touchstart", c.content(), 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
+            assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
+            svg.remove();
+        });
+        it("onPointerMove", function () {
+            var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+            var c = new Plottable.Component.AbstractComponent();
+            c.renderTo(svg);
+            var pointerInteraction = new Plottable.Interaction.Pointer();
+            c.registerInteraction(pointerInteraction);
+            var callbackCalled = false;
+            var lastPoint;
+            var callback = function (p) {
+                callbackCalled = true;
+                lastPoint = p;
+            };
+            pointerInteraction.onPointerMove(callback);
+            assert.strictEqual(pointerInteraction.onPointerMove(), callback, "callback can be retrieved");
+            triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            assert.isTrue(callbackCalled, "callback called on entering Component (mouse)");
+            assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (mouse)");
+            callbackCalled = false;
+            triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH / 4, SVG_HEIGHT / 4);
+            assert.isTrue(callbackCalled, "callback on moving inside Component (mouse)");
+            assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed correct point (mouse)");
+            callbackCalled = false;
+            triggerFakeMouseEvent("mousemove", c.content(), 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
+            assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
+            callbackCalled = false;
+            triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
+            assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (touch)");
+            callbackCalled = false;
+            triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 4, SVG_HEIGHT / 4);
+            assert.isTrue(callbackCalled, "callback on moving inside Component (touch)");
+            assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed correct point (touch)");
+            callbackCalled = false;
+            triggerFakeTouchEvent("touchstart", c.content(), 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
+            assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
+            svg.remove();
+        });
+        it("onPointerExit", function () {
+            var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+            var c = new Plottable.Component.AbstractComponent();
+            c.renderTo(svg);
+            var pointerInteraction = new Plottable.Interaction.Pointer();
+            c.registerInteraction(pointerInteraction);
+            var callbackCalled = false;
+            var lastPoint;
+            var callback = function (p) {
+                callbackCalled = true;
+                lastPoint = p;
+            };
+            pointerInteraction.onPointerExit(callback);
+            assert.strictEqual(pointerInteraction.onPointerExit(), callback, "callback can be retrieved");
+            triggerFakeMouseEvent("mousemove", c.content(), 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
+            assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
+            triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            triggerFakeMouseEvent("mousemove", c.content(), 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
+            assert.isTrue(callbackCalled, "callback called on exiting Component (mouse)");
+            assert.deepEqual(lastPoint, { x: 2 * SVG_WIDTH, y: 2 * SVG_HEIGHT }, "was passed correct point (mouse)");
+            callbackCalled = false;
+            triggerFakeMouseEvent("mousemove", c.content(), 3 * SVG_WIDTH, 3 * SVG_HEIGHT);
+            assert.isFalse(callbackCalled, "callback not called again if already outside of Component (mouse)");
+            callbackCalled = false;
+            lastPoint = null;
+            triggerFakeTouchEvent("touchstart", c.content(), 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
+            assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
+            triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            triggerFakeTouchEvent("touchstart", c.content(), 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
+            assert.isTrue(callbackCalled, "callback called on exiting Component (touch)");
+            assert.deepEqual(lastPoint, { x: 2 * SVG_WIDTH, y: 2 * SVG_HEIGHT }, "was passed correct point (touch)");
+            callbackCalled = false;
+            triggerFakeTouchEvent("touchstart", c.content(), 3 * SVG_WIDTH, 3 * SVG_HEIGHT);
+            assert.isFalse(callbackCalled, "callback not called again if already outside of Component (touch)");
+            svg.remove();
+        });
+    });
+});
+
+///<reference path="../testReference.ts" />
+var assert = chai.assert;
 describe("DragBoxInteractions", function () {
     var svgWidth = 400;
     var svgHeight = 400;


### PR DESCRIPTION
Similar to the old `Interaction.Mousemove`, produces pixels whenever the pointer (mouse or touch), enters the `Component`, moves, or exits the `Component`.