### PR TITLE
[Component] - Replace `merge` with `above`/`below`

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1746,21 +1746,34 @@ declare module Plottable {
              * @returns {boolean} Whether the component has a fixed height.
              */
             _isFixedHeight(): boolean;
+            _merge(c: AbstractComponent, below: boolean): Component.Group;
             /**
-             * Merges this Component with another Component, returning a
+             * Merges this Component below another Component, returning a
              * ComponentGroup. This is used to layer Components on top of each other.
              *
              * There are four cases:
-             * Component + Component: Returns a ComponentGroup with both components inside it.
+             * Component + Component: Returns a ComponentGroup with the first component before the second component.
              * ComponentGroup + Component: Returns the ComponentGroup with the Component appended.
              * Component + ComponentGroup: Returns the ComponentGroup with the Component prepended.
-             * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with two ComponentGroups inside it.
+             * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with the first group before the second group.
              *
              * @param {Component} c The component to merge in.
              * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
              */
-            _merge(c: AbstractComponent, below: boolean): Component.Group;
             above(c: AbstractComponent): Component.Group;
+            /**
+             * Merges this Component above another Component, returning a
+             * ComponentGroup. This is used to layer Components on top of each other.
+             *
+             * There are four cases:
+             * Component + Component: Returns a ComponentGroup with the first component after the second component.
+             * ComponentGroup + Component: Returns the ComponentGroup with the Component prepended.
+             * Component + ComponentGroup: Returns the ComponentGroup with the Component appended.
+             * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with the first group after the second group.
+             *
+             * @param {Component} c The component to merge in.
+             * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
+             */
             below(c: AbstractComponent): Component.Group;
             /**
              * Detaches a Component from the DOM. The component can be reused.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1892,17 +1892,17 @@ declare module Plottable {
     module Component {
         class Group extends AbstractComponentContainer {
             /**
-             * Constructs a GroupComponent.
+             * Constructs a Component.Group.
              *
-             * A GroupComponent is a set of Components that will be rendered on top of
+             * A Component.Group is a set of Components that will be rendered on top of
              * each other. When you call Component.above(Component) or Component.below(Component),
-             * it creates and returns a GroupComponent.
+             * it creates and returns a Component.Group.
              *
              * Note that the order of the components will determine placement on the z-axis,
              * with the previous items rendered below the later items.
              *
              * @constructor
-             * @param {Component[]} components The Components in the Group (default = []).
+             * @param {Component[]} components The Components in the resultant Component.Group (default = []).
              */
             constructor(components?: AbstractComponent[]);
             _requestedSpace(offeredWidth: number, offeredHeight: number): _SpaceRequest;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1895,8 +1895,11 @@ declare module Plottable {
              * Constructs a GroupComponent.
              *
              * A GroupComponent is a set of Components that will be rendered on top of
-             * each other. When you call Component.merge(Component), it creates and
-             * returns a GroupComponent.
+             * each other. When you call Component.above(Component) or Component.below(Component),
+             * it creates and returns a GroupComponent.
+             *
+             * Note that the order of the components will determine placement on the z-axis,
+             * with the previous items rendered below the later items.
              *
              * @constructor
              * @param {Component[]} components The Components in the Group (default = []).

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1748,20 +1748,6 @@ declare module Plottable {
             _isFixedHeight(): boolean;
             _merge(c: AbstractComponent, below: boolean): Component.Group;
             /**
-             * Merges this Component below another Component, returning a
-             * ComponentGroup. This is used to layer Components on top of each other.
-             *
-             * There are four cases:
-             * Component + Component: Returns a ComponentGroup with the first component before the second component.
-             * ComponentGroup + Component: Returns the ComponentGroup with the Component appended.
-             * Component + ComponentGroup: Returns the ComponentGroup with the Component prepended.
-             * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with the first group before the second group.
-             *
-             * @param {Component} c The component to merge in.
-             * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
-             */
-            above(c: AbstractComponent): Component.Group;
-            /**
              * Merges this Component above another Component, returning a
              * ComponentGroup. This is used to layer Components on top of each other.
              *
@@ -1770,6 +1756,20 @@ declare module Plottable {
              * ComponentGroup + Component: Returns the ComponentGroup with the Component prepended.
              * Component + ComponentGroup: Returns the ComponentGroup with the Component appended.
              * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with the first group after the second group.
+             *
+             * @param {Component} c The component to merge in.
+             * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
+             */
+            above(c: AbstractComponent): Component.Group;
+            /**
+             * Merges this Component below another Component, returning a
+             * ComponentGroup. This is used to layer Components on top of each other.
+             *
+             * There are four cases:
+             * Component + Component: Returns a ComponentGroup with the first component before the second component.
+             * ComponentGroup + Component: Returns the ComponentGroup with the Component appended.
+             * Component + ComponentGroup: Returns the ComponentGroup with the Component prepended.
+             * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with the first group before the second group.
              *
              * @param {Component} c The component to merge in.
              * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1759,7 +1759,7 @@ declare module Plottable {
              * @param {Component} c The component to merge in.
              * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
              */
-            merge(c: AbstractComponent, below?: boolean): Component.Group;
+            _merge(c: AbstractComponent, below: boolean): Component.Group;
             above(c: AbstractComponent): Component.Group;
             below(c: AbstractComponent): Component.Group;
             /**
@@ -1890,7 +1890,7 @@ declare module Plottable {
              */
             constructor(components?: AbstractComponent[]);
             _requestedSpace(offeredWidth: number, offeredHeight: number): _SpaceRequest;
-            merge(c: AbstractComponent): Group;
+            _merge(c: AbstractComponent, below: boolean): Group;
             _computeLayout(offeredXOrigin?: number, offeredYOrigin?: number, availableWidth?: number, availableHeight?: number): Group;
             _isFixedWidth(): boolean;
             _isFixedHeight(): boolean;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1759,7 +1759,7 @@ declare module Plottable {
              * @param {Component} c The component to merge in.
              * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
              */
-            merge(c: AbstractComponent): Component.Group;
+            merge(c: AbstractComponent, below?: boolean): Component.Group;
             /**
              * Detaches a Component from the DOM. The component can be reused.
              *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1760,6 +1760,8 @@ declare module Plottable {
              * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
              */
             merge(c: AbstractComponent, below?: boolean): Component.Group;
+            above(c: AbstractComponent): Component.Group;
+            below(c: AbstractComponent): Component.Group;
             /**
              * Detaches a Component from the DOM. The component can be reused.
              *

--- a/plottable.js
+++ b/plottable.js
@@ -3812,35 +3812,11 @@ var Plottable;
                     return cg;
                 }
             };
-            /**
-             * Merges this Component with another Component, returning a
-             * ComponentGroup. This is used to layer Components on top of each other.
-             *
-             * There are four cases:
-             * Component + Component: Returns a ComponentGroup with both components inside it.
-             * ComponentGroup + Component: Returns the ComponentGroup with the Component appended.
-             * Component + ComponentGroup: Returns the ComponentGroup with the Component prepended.
-             * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with two ComponentGroups inside it.
-             *
-             * @param {Component} c The component to merge in.
-             * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
-             */
-            AbstractComponent.prototype.merge = function (c, below) {
-                if (below === void 0) { below = true; }
-                var cg;
-                if (this._isSetup || this._isAnchored) {
-                    throw new Error("Can't presently merge a component that's already been anchored");
-                }
-                if (Plottable.Component.Group.prototype.isPrototypeOf(c)) {
-                    cg = c;
-                    cg._addComponent(this, below);
-                    return cg;
-                }
-                else {
-                    var mergedComponents = below ? [this, c] : [c, this];
-                    cg = new Plottable.Component.Group(mergedComponents);
-                    return cg;
-                }
+            AbstractComponent.prototype.above = function (c) {
+                return this.merge(c, false);
+            };
+            AbstractComponent.prototype.below = function (c) {
+                return this.merge(c, true);
             };
             /**
              * Detaches a Component from the DOM. The component can be reused.

--- a/plottable.js
+++ b/plottable.js
@@ -4062,17 +4062,17 @@ var Plottable;
         var Group = (function (_super) {
             __extends(Group, _super);
             /**
-             * Constructs a GroupComponent.
+             * Constructs a Component.Group.
              *
-             * A GroupComponent is a set of Components that will be rendered on top of
+             * A Component.Group is a set of Components that will be rendered on top of
              * each other. When you call Component.above(Component) or Component.below(Component),
-             * it creates and returns a GroupComponent.
+             * it creates and returns a Component.Group.
              *
              * Note that the order of the components will determine placement on the z-axis,
              * with the previous items rendered below the later items.
              *
              * @constructor
-             * @param {Component[]} components The Components in the Group (default = []).
+             * @param {Component[]} components The Components in the resultant Component.Group (default = []).
              */
             function Group(components) {
                 var _this = this;

--- a/plottable.js
+++ b/plottable.js
@@ -3795,8 +3795,7 @@ var Plottable;
              * @param {Component} c The component to merge in.
              * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
              */
-            AbstractComponent.prototype.merge = function (c, below) {
-                if (below === void 0) { below = true; }
+            AbstractComponent.prototype._merge = function (c, below) {
                 var cg;
                 if (this._isSetup || this._isAnchored) {
                     throw new Error("Can't presently merge a component that's already been anchored");
@@ -3813,10 +3812,10 @@ var Plottable;
                 }
             };
             AbstractComponent.prototype.above = function (c) {
-                return this.merge(c, false);
+                return this._merge(c, false);
             };
             AbstractComponent.prototype.below = function (c) {
-                return this.merge(c, true);
+                return this._merge(c, true);
             };
             /**
              * Detaches a Component from the DOM. The component can be reused.
@@ -4075,8 +4074,8 @@ var Plottable;
                     wantsHeight: requests.map(function (r) { return r.wantsHeight; }).some(function (x) { return x; })
                 };
             };
-            Group.prototype.merge = function (c) {
-                this._addComponent(c);
+            Group.prototype._merge = function (c, below) {
+                this._addComponent(c, !below);
                 return this;
             };
             Group.prototype._computeLayout = function (offeredXOrigin, offeredYOrigin, availableWidth, availableHeight) {

--- a/plottable.js
+++ b/plottable.js
@@ -4065,8 +4065,11 @@ var Plottable;
              * Constructs a GroupComponent.
              *
              * A GroupComponent is a set of Components that will be rendered on top of
-             * each other. When you call Component.merge(Component), it creates and
-             * returns a GroupComponent.
+             * each other. When you call Component.above(Component) or Component.below(Component),
+             * it creates and returns a GroupComponent.
+             *
+             * Note that the order of the components will determine placement on the z-axis,
+             * with the previous items rendered below the later items.
              *
              * @constructor
              * @param {Component[]} components The Components in the Group (default = []).

--- a/plottable.js
+++ b/plottable.js
@@ -3795,18 +3795,50 @@ var Plottable;
              * @param {Component} c The component to merge in.
              * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
              */
-            AbstractComponent.prototype.merge = function (c) {
+            AbstractComponent.prototype.merge = function (c, below) {
+                if (below === void 0) { below = true; }
                 var cg;
                 if (this._isSetup || this._isAnchored) {
                     throw new Error("Can't presently merge a component that's already been anchored");
                 }
                 if (Plottable.Component.Group.prototype.isPrototypeOf(c)) {
                     cg = c;
-                    cg._addComponent(this, true);
+                    cg._addComponent(this, below);
                     return cg;
                 }
                 else {
-                    cg = new Plottable.Component.Group([this, c]);
+                    var mergedComponents = below ? [this, c] : [c, this];
+                    cg = new Plottable.Component.Group(mergedComponents);
+                    return cg;
+                }
+            };
+            /**
+             * Merges this Component with another Component, returning a
+             * ComponentGroup. This is used to layer Components on top of each other.
+             *
+             * There are four cases:
+             * Component + Component: Returns a ComponentGroup with both components inside it.
+             * ComponentGroup + Component: Returns the ComponentGroup with the Component appended.
+             * Component + ComponentGroup: Returns the ComponentGroup with the Component prepended.
+             * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with two ComponentGroups inside it.
+             *
+             * @param {Component} c The component to merge in.
+             * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
+             */
+            AbstractComponent.prototype.merge = function (c, below) {
+                if (below === void 0) { below = true; }
+                var cg;
+                if (this._isSetup || this._isAnchored) {
+                    throw new Error("Can't presently merge a component that's already been anchored");
+                }
+                if (Plottable.Component.Group.prototype.isPrototypeOf(c)) {
+                    cg = c;
+                    cg._addComponent(this, below);
+                    return cg;
+                }
+                else {
+                    var mergedComponents = below ? [this, c] : [c, this];
+                    cg = new Plottable.Component.Group(mergedComponents);
                     return cg;
                 }
             };

--- a/plottable.js
+++ b/plottable.js
@@ -3782,19 +3782,6 @@ var Plottable;
             AbstractComponent.prototype._isFixedHeight = function () {
                 return this._fixedHeightFlag;
             };
-            /**
-             * Merges this Component with another Component, returning a
-             * ComponentGroup. This is used to layer Components on top of each other.
-             *
-             * There are four cases:
-             * Component + Component: Returns a ComponentGroup with both components inside it.
-             * ComponentGroup + Component: Returns the ComponentGroup with the Component appended.
-             * Component + ComponentGroup: Returns the ComponentGroup with the Component prepended.
-             * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with two ComponentGroups inside it.
-             *
-             * @param {Component} c The component to merge in.
-             * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
-             */
             AbstractComponent.prototype._merge = function (c, below) {
                 var cg;
                 if (this._isSetup || this._isAnchored) {
@@ -3811,9 +3798,35 @@ var Plottable;
                     return cg;
                 }
             };
+            /**
+             * Merges this Component below another Component, returning a
+             * ComponentGroup. This is used to layer Components on top of each other.
+             *
+             * There are four cases:
+             * Component + Component: Returns a ComponentGroup with the first component before the second component.
+             * ComponentGroup + Component: Returns the ComponentGroup with the Component appended.
+             * Component + ComponentGroup: Returns the ComponentGroup with the Component prepended.
+             * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with the first group before the second group.
+             *
+             * @param {Component} c The component to merge in.
+             * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
+             */
             AbstractComponent.prototype.above = function (c) {
                 return this._merge(c, false);
             };
+            /**
+             * Merges this Component above another Component, returning a
+             * ComponentGroup. This is used to layer Components on top of each other.
+             *
+             * There are four cases:
+             * Component + Component: Returns a ComponentGroup with the first component after the second component.
+             * ComponentGroup + Component: Returns the ComponentGroup with the Component prepended.
+             * Component + ComponentGroup: Returns the ComponentGroup with the Component appended.
+             * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with the first group after the second group.
+             *
+             * @param {Component} c The component to merge in.
+             * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
+             */
             AbstractComponent.prototype.below = function (c) {
                 return this._merge(c, true);
             };

--- a/plottable.js
+++ b/plottable.js
@@ -3799,22 +3799,6 @@ var Plottable;
                 }
             };
             /**
-             * Merges this Component below another Component, returning a
-             * ComponentGroup. This is used to layer Components on top of each other.
-             *
-             * There are four cases:
-             * Component + Component: Returns a ComponentGroup with the first component before the second component.
-             * ComponentGroup + Component: Returns the ComponentGroup with the Component appended.
-             * Component + ComponentGroup: Returns the ComponentGroup with the Component prepended.
-             * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with the first group before the second group.
-             *
-             * @param {Component} c The component to merge in.
-             * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
-             */
-            AbstractComponent.prototype.above = function (c) {
-                return this._merge(c, false);
-            };
-            /**
              * Merges this Component above another Component, returning a
              * ComponentGroup. This is used to layer Components on top of each other.
              *
@@ -3823,6 +3807,22 @@ var Plottable;
              * ComponentGroup + Component: Returns the ComponentGroup with the Component prepended.
              * Component + ComponentGroup: Returns the ComponentGroup with the Component appended.
              * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with the first group after the second group.
+             *
+             * @param {Component} c The component to merge in.
+             * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
+             */
+            AbstractComponent.prototype.above = function (c) {
+                return this._merge(c, false);
+            };
+            /**
+             * Merges this Component below another Component, returning a
+             * ComponentGroup. This is used to layer Components on top of each other.
+             *
+             * There are four cases:
+             * Component + Component: Returns a ComponentGroup with the first component before the second component.
+             * ComponentGroup + Component: Returns the ComponentGroup with the Component appended.
+             * Component + ComponentGroup: Returns the ComponentGroup with the Component prepended.
+             * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with the first group before the second group.
              *
              * @param {Component} c The component to merge in.
              * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -423,7 +423,7 @@ export module Component {
      * @param {Component} c The component to merge in.
      * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
      */
-    public merge(c: AbstractComponent, below = true): Component.Group {
+    public _merge(c: AbstractComponent, below: boolean): Component.Group {
       var cg: Component.Group;
       if (this._isSetup || this._isAnchored) {
         throw new Error("Can't presently merge a component that's already been anchored");
@@ -440,11 +440,11 @@ export module Component {
     }
 
     public above(c: AbstractComponent): Component.Group {
-      return this.merge(c, false);
+      return this._merge(c, false);
     }
 
     public below(c: AbstractComponent): Component.Group {
-      return this.merge(c, true);
+      return this._merge(c, true);
     }
 
     /**

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -427,14 +427,14 @@ export module Component {
     }
 
     /**
-     * Merges this Component below another Component, returning a
+     * Merges this Component above another Component, returning a
      * ComponentGroup. This is used to layer Components on top of each other.
      *
      * There are four cases:
-     * Component + Component: Returns a ComponentGroup with the first component before the second component.
-     * ComponentGroup + Component: Returns the ComponentGroup with the Component appended.
-     * Component + ComponentGroup: Returns the ComponentGroup with the Component prepended.
-     * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with the first group before the second group.
+     * Component + Component: Returns a ComponentGroup with the first component after the second component.
+     * ComponentGroup + Component: Returns the ComponentGroup with the Component prepended.
+     * Component + ComponentGroup: Returns the ComponentGroup with the Component appended.
+     * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with the first group after the second group.
      *
      * @param {Component} c The component to merge in.
      * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
@@ -444,14 +444,14 @@ export module Component {
     }
 
     /**
-     * Merges this Component above another Component, returning a
+     * Merges this Component below another Component, returning a
      * ComponentGroup. This is used to layer Components on top of each other.
      *
      * There are four cases:
-     * Component + Component: Returns a ComponentGroup with the first component after the second component.
-     * ComponentGroup + Component: Returns the ComponentGroup with the Component prepended.
-     * Component + ComponentGroup: Returns the ComponentGroup with the Component appended.
-     * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with the first group after the second group.
+     * Component + Component: Returns a ComponentGroup with the first component before the second component.
+     * ComponentGroup + Component: Returns the ComponentGroup with the Component appended.
+     * Component + ComponentGroup: Returns the ComponentGroup with the Component prepended.
+     * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with the first group before the second group.
      *
      * @param {Component} c The component to merge in.
      * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -439,33 +439,12 @@ export module Component {
       }
     }
 
-    /**
-     * Merges this Component with another Component, returning a
-     * ComponentGroup. This is used to layer Components on top of each other.
-     *
-     * There are four cases:
-     * Component + Component: Returns a ComponentGroup with both components inside it.
-     * ComponentGroup + Component: Returns the ComponentGroup with the Component appended.
-     * Component + ComponentGroup: Returns the ComponentGroup with the Component prepended.
-     * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with two ComponentGroups inside it.
-     *
-     * @param {Component} c The component to merge in.
-     * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
-     */
-    public merge(c: AbstractComponent, below = true): Component.Group {
-      var cg: Component.Group;
-      if (this._isSetup || this._isAnchored) {
-        throw new Error("Can't presently merge a component that's already been anchored");
-      }
-      if (Plottable.Component.Group.prototype.isPrototypeOf(c)) {
-        cg = (<Plottable.Component.Group> c);
-        cg._addComponent(this, below);
-        return cg;
-      } else {
-        var mergedComponents = below ? [this, c] : [c, this];
-        cg = new Plottable.Component.Group(mergedComponents);
-        return cg;
-      }
+    public above(c: AbstractComponent): Component.Group {
+      return this.merge(c, false);
+    }
+
+    public below(c: AbstractComponent): Component.Group {
+      return this.merge(c, true);
     }
 
     /**

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -423,17 +423,47 @@ export module Component {
      * @param {Component} c The component to merge in.
      * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
      */
-    public merge(c: AbstractComponent): Component.Group {
+    public merge(c: AbstractComponent, below = true): Component.Group {
       var cg: Component.Group;
       if (this._isSetup || this._isAnchored) {
         throw new Error("Can't presently merge a component that's already been anchored");
       }
       if (Plottable.Component.Group.prototype.isPrototypeOf(c)) {
         cg = (<Plottable.Component.Group> c);
-        cg._addComponent(this, true);
+        cg._addComponent(this, below);
         return cg;
       } else {
-        cg = new Plottable.Component.Group([this, c]);
+        var mergedComponents = below ? [this, c] : [c, this];
+        cg = new Plottable.Component.Group(mergedComponents);
+        return cg;
+      }
+    }
+
+    /**
+     * Merges this Component with another Component, returning a
+     * ComponentGroup. This is used to layer Components on top of each other.
+     *
+     * There are four cases:
+     * Component + Component: Returns a ComponentGroup with both components inside it.
+     * ComponentGroup + Component: Returns the ComponentGroup with the Component appended.
+     * Component + ComponentGroup: Returns the ComponentGroup with the Component prepended.
+     * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with two ComponentGroups inside it.
+     *
+     * @param {Component} c The component to merge in.
+     * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
+     */
+    public merge(c: AbstractComponent, below = true): Component.Group {
+      var cg: Component.Group;
+      if (this._isSetup || this._isAnchored) {
+        throw new Error("Can't presently merge a component that's already been anchored");
+      }
+      if (Plottable.Component.Group.prototype.isPrototypeOf(c)) {
+        cg = (<Plottable.Component.Group> c);
+        cg._addComponent(this, below);
+        return cg;
+      } else {
+        var mergedComponents = below ? [this, c] : [c, this];
+        cg = new Plottable.Component.Group(mergedComponents);
         return cg;
       }
     }

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -410,19 +410,6 @@ export module Component {
       return this._fixedHeightFlag;
     }
 
-    /**
-     * Merges this Component with another Component, returning a
-     * ComponentGroup. This is used to layer Components on top of each other.
-     *
-     * There are four cases:
-     * Component + Component: Returns a ComponentGroup with both components inside it.
-     * ComponentGroup + Component: Returns the ComponentGroup with the Component appended.
-     * Component + ComponentGroup: Returns the ComponentGroup with the Component prepended.
-     * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with two ComponentGroups inside it.
-     *
-     * @param {Component} c The component to merge in.
-     * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
-     */
     public _merge(c: AbstractComponent, below: boolean): Component.Group {
       var cg: Component.Group;
       if (this._isSetup || this._isAnchored) {
@@ -439,10 +426,36 @@ export module Component {
       }
     }
 
+    /**
+     * Merges this Component below another Component, returning a
+     * ComponentGroup. This is used to layer Components on top of each other.
+     *
+     * There are four cases:
+     * Component + Component: Returns a ComponentGroup with the first component before the second component.
+     * ComponentGroup + Component: Returns the ComponentGroup with the Component appended.
+     * Component + ComponentGroup: Returns the ComponentGroup with the Component prepended.
+     * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with the first group before the second group.
+     *
+     * @param {Component} c The component to merge in.
+     * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
+     */
     public above(c: AbstractComponent): Component.Group {
       return this._merge(c, false);
     }
 
+    /**
+     * Merges this Component above another Component, returning a
+     * ComponentGroup. This is used to layer Components on top of each other.
+     *
+     * There are four cases:
+     * Component + Component: Returns a ComponentGroup with the first component after the second component.
+     * ComponentGroup + Component: Returns the ComponentGroup with the Component prepended.
+     * Component + ComponentGroup: Returns the ComponentGroup with the Component appended.
+     * ComponentGroup + ComponentGroup: Returns a new ComponentGroup with the first group after the second group.
+     *
+     * @param {Component} c The component to merge in.
+     * @returns {ComponentGroup} The relevant ComponentGroup out of the above four cases.
+     */
     public below(c: AbstractComponent): Component.Group {
       return this._merge(c, true);
     }

--- a/src/components/componentGroup.ts
+++ b/src/components/componentGroup.ts
@@ -5,17 +5,17 @@ export module Component {
   export class Group extends AbstractComponentContainer {
 
     /**
-     * Constructs a GroupComponent.
+     * Constructs a Component.Group.
      *
-     * A GroupComponent is a set of Components that will be rendered on top of
+     * A Component.Group is a set of Components that will be rendered on top of
      * each other. When you call Component.above(Component) or Component.below(Component),
-     * it creates and returns a GroupComponent.
+     * it creates and returns a Component.Group.
      *
      * Note that the order of the components will determine placement on the z-axis,
      * with the previous items rendered below the later items.
      *
      * @constructor
-     * @param {Component[]} components The Components in the Group (default = []).
+     * @param {Component[]} components The Components in the resultant Component.Group (default = []).
      */
     constructor(components: AbstractComponent[] = []){
       super();

--- a/src/components/componentGroup.ts
+++ b/src/components/componentGroup.ts
@@ -8,8 +8,11 @@ export module Component {
      * Constructs a GroupComponent.
      *
      * A GroupComponent is a set of Components that will be rendered on top of
-     * each other. When you call Component.merge(Component), it creates and
-     * returns a GroupComponent.
+     * each other. When you call Component.above(Component) or Component.below(Component),
+     * it creates and returns a GroupComponent.
+     *
+     * Note that the order of the components will determine placement on the z-axis,
+     * with the previous items rendered below the later items.
      *
      * @constructor
      * @param {Component[]} components The Components in the Group (default = []).

--- a/src/components/componentGroup.ts
+++ b/src/components/componentGroup.ts
@@ -30,8 +30,8 @@ export module Component {
       };
     }
 
-    public merge(c: AbstractComponent): Group {
-      this._addComponent(c);
+    public _merge(c: AbstractComponent, below: boolean): Group {
+      this._addComponent(c, !below);
       return this;
     }
 

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -193,51 +193,101 @@ describe("ComponentGroups", () => {
     });
   });
 
-    describe("Component.merge works as expected", () => {
+    describe("Merging components works as expected", () => {
       var c1 = new Plottable.Component.AbstractComponent();
       var c2 = new Plottable.Component.AbstractComponent();
       var c3 = new Plottable.Component.AbstractComponent();
       var c4 = new Plottable.Component.AbstractComponent();
 
-      it("Component.merge works as expected (Component.merge Component)", () => {
-        var cg: Plottable.Component.Group = c1.below(c2);
-        var innerComponents: Plottable.Component.AbstractComponent[] = cg.components();
-        assert.lengthOf(innerComponents, 2, "There are two components");
-        assert.equal(innerComponents[0], c1, "first component correct");
-        assert.equal(innerComponents[1], c2, "second component correct");
-      });
+      describe("above()", () => {
 
-      it("Component.merge works as expected (Component.merge ComponentGroup)", () => {
-        var cg = new Plottable.Component.Group([c2,c3,c4]);
-        var cg2 = c1.below(cg);
-        assert.equal(cg, cg2, "c.merge(cg) returns cg");
-        var components: Plottable.Component.AbstractComponent[] = cg.components();
-        assert.lengthOf(components, 4, "four components");
-        assert.equal(components[0], c1, "first component in front");
-        assert.equal(components[1], c2, "second component is second");
-      });
-
-      it("Component.merge works as expected (ComponentGroup.merge Component)", () => {
-        var cg = new Plottable.Component.Group([c1,c2,c3]);
-        var cg2 = cg.below(c4);
-        assert.equal(cg, cg2, "cg.merge(c) returns cg");
-        var components: Plottable.Component.AbstractComponent[] = cg.components();
-        assert.lengthOf(components, 4, "there are four components");
-        assert.equal(components[0], c1, "first is first");
-        assert.equal(components[3], c4, "fourth is fourth");
+        it("Component.merge works as expected (Component.merge Component)",() => {
+          var cg: Plottable.Component.Group = c1.below(c2);
+          var innerComponents: Plottable.Component.AbstractComponent[] = cg.components();
+          assert.lengthOf(innerComponents, 2, "There are two components");
+          assert.equal(innerComponents[0], c1, "first component correct");
+          assert.equal(innerComponents[1], c2, "second component correct");
         });
 
-      it("Component.merge works as expected (ComponentGroup.merge ComponentGroup)", () => {
-        var cg1 = new Plottable.Component.Group([c1,c2]);
-        var cg2 = new Plottable.Component.Group([c3,c4]);
-        var cg = cg1.below(cg2);
-        assert.equal(cg, cg1, "merged == cg1");
-        assert.notEqual(cg, cg2, "merged != cg2");
-        var components: Plottable.Component.AbstractComponent[] = cg.components();
-        assert.lengthOf(components, 3, "there are three inner components");
-        assert.equal(components[0], c1, "components are inside");
-        assert.equal(components[1], c2, "components are inside");
-        assert.equal(components[2], cg2, "componentGroup2 inside componentGroup1");
+        it("Component.merge works as expected (Component.merge ComponentGroup)",() => {
+          var cg = new Plottable.Component.Group([c2, c3, c4]);
+          var cg2 = c1.below(cg);
+          assert.equal(cg, cg2, "c.merge(cg) returns cg");
+          var components: Plottable.Component.AbstractComponent[] = cg.components();
+          assert.lengthOf(components, 4, "four components");
+          assert.equal(components[0], c1, "first component in front");
+          assert.equal(components[1], c2, "second component is second");
+        });
+
+        it("Component.merge works as expected (ComponentGroup.merge Component)",() => {
+          var cg = new Plottable.Component.Group([c1, c2, c3]);
+          var cg2 = cg.below(c4);
+          assert.equal(cg, cg2, "cg.merge(c) returns cg");
+          var components: Plottable.Component.AbstractComponent[] = cg.components();
+          assert.lengthOf(components, 4, "there are four components");
+          assert.equal(components[0], c1, "first is first");
+          assert.equal(components[3], c4, "fourth is fourth");
+        });
+
+        it("Component.merge works as expected (ComponentGroup.merge ComponentGroup)",() => {
+          var cg1 = new Plottable.Component.Group([c1, c2]);
+          var cg2 = new Plottable.Component.Group([c3, c4]);
+          var cg = cg1.below(cg2);
+          assert.equal(cg, cg1, "merged == cg1");
+          assert.notEqual(cg, cg2, "merged != cg2");
+          var components: Plottable.Component.AbstractComponent[] = cg.components();
+          assert.lengthOf(components, 3, "there are three inner components");
+          assert.equal(components[0], c1, "components are inside");
+          assert.equal(components[1], c2, "components are inside");
+          assert.equal(components[2], cg2, "componentGroup2 inside componentGroup1");
+        });
+
       });
+
+      describe("below()",() => {
+
+        it("Component.below works as expected (Component.below Component)",() => {
+          var cg: Plottable.Component.Group = c1.below(c2);
+          var innerComponents: Plottable.Component.AbstractComponent[] = cg.components();
+          assert.lengthOf(innerComponents, 2, "There are two components");
+          assert.equal(innerComponents[0], c1, "first component correct");
+          assert.equal(innerComponents[1], c2, "second component correct");
+        });
+
+        it("Component.below works as expected (Component.below ComponentGroup)",() => {
+          var cg = new Plottable.Component.Group([c2, c3, c4]);
+          var cg2 = c1.below(cg);
+          assert.equal(cg, cg2, "c1.below(cg) returns cg");
+          var components: Plottable.Component.AbstractComponent[] = cg.components();
+          assert.lengthOf(components, 4, "four components");
+          assert.equal(components[0], c1, "first component in front");
+          assert.equal(components[1], c2, "second component is second");
+        });
+
+        it("Component.below works as expected (ComponentGroup.below Component)",() => {
+          var cg = new Plottable.Component.Group([c1, c2, c3]);
+          var cg2 = cg.below(c4);
+          assert.equal(cg, cg2, "cg.merge(c4) returns cg");
+          var components: Plottable.Component.AbstractComponent[] = cg.components();
+          assert.lengthOf(components, 4, "there are four components");
+          assert.equal(components[0], c1, "first is first");
+          assert.equal(components[3], c4, "fourth is fourth");
+        });
+
+        it("Component.below works as expected (ComponentGroup.below ComponentGroup)",() => {
+          var cg1 = new Plottable.Component.Group([c1, c2]);
+          var cg2 = new Plottable.Component.Group([c3, c4]);
+          var cg = cg1.below(cg2);
+          assert.equal(cg, cg1, "merged group == cg1");
+          assert.notEqual(cg, cg2, "merged group != cg2");
+          var components: Plottable.Component.AbstractComponent[] = cg.components();
+          assert.lengthOf(components, 3, "there are three inner components");
+          assert.equal(components[0], c1, "components are inside");
+          assert.equal(components[1], c2, "components are inside");
+          assert.equal(components[2], cg2, "componentGroup2 inside componentGroup1");
+        });
+
+      });
+
     });
 });

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -201,45 +201,45 @@ describe("ComponentGroups", () => {
 
       describe("above()", () => {
 
-        it("Component.merge works as expected (Component.merge Component)",() => {
-          var cg: Plottable.Component.Group = c1.below(c2);
+        it("Component.above works as expected (Component.above Component)",() => {
+          var cg: Plottable.Component.Group = c2.above(c1);
           var innerComponents: Plottable.Component.AbstractComponent[] = cg.components();
           assert.lengthOf(innerComponents, 2, "There are two components");
           assert.equal(innerComponents[0], c1, "first component correct");
           assert.equal(innerComponents[1], c2, "second component correct");
         });
 
-        it("Component.merge works as expected (Component.merge ComponentGroup)",() => {
-          var cg = new Plottable.Component.Group([c2, c3, c4]);
-          var cg2 = c1.below(cg);
-          assert.equal(cg, cg2, "c.merge(cg) returns cg");
+        it("Component.above works as expected (Component.above ComponentGroup)",() => {
+          var cg = new Plottable.Component.Group([c1, c2, c3]);
+          var cg2 = c4.above(cg);
+          assert.equal(cg, cg2, "c4.above(cg) returns cg");
           var components: Plottable.Component.AbstractComponent[] = cg.components();
           assert.lengthOf(components, 4, "four components");
-          assert.equal(components[0], c1, "first component in front");
-          assert.equal(components[1], c2, "second component is second");
+          assert.equal(components[2], c3, "third component in third");
+          assert.equal(components[3], c4, "fourth component is last");
         });
 
-        it("Component.merge works as expected (ComponentGroup.merge Component)",() => {
-          var cg = new Plottable.Component.Group([c1, c2, c3]);
-          var cg2 = cg.below(c4);
-          assert.equal(cg, cg2, "cg.merge(c) returns cg");
+        it("Component.above works as expected (ComponentGroup.above Component)",() => {
+          var cg = new Plottable.Component.Group([c2, c3, c4]);
+          var cg2 = cg.above(c1);
+          assert.equal(cg, cg2, "cg.merge(c1) returns cg");
           var components: Plottable.Component.AbstractComponent[] = cg.components();
           assert.lengthOf(components, 4, "there are four components");
           assert.equal(components[0], c1, "first is first");
           assert.equal(components[3], c4, "fourth is fourth");
         });
 
-        it("Component.merge works as expected (ComponentGroup.merge ComponentGroup)",() => {
+        it("Component.above works as expected (ComponentGroup.above ComponentGroup)",() => {
           var cg1 = new Plottable.Component.Group([c1, c2]);
           var cg2 = new Plottable.Component.Group([c3, c4]);
-          var cg = cg1.below(cg2);
+          var cg = cg1.above(cg2);
           assert.equal(cg, cg1, "merged == cg1");
           assert.notEqual(cg, cg2, "merged != cg2");
           var components: Plottable.Component.AbstractComponent[] = cg.components();
           assert.lengthOf(components, 3, "there are three inner components");
-          assert.equal(components[0], c1, "components are inside");
-          assert.equal(components[1], c2, "components are inside");
-          assert.equal(components[2], cg2, "componentGroup2 inside componentGroup1");
+          assert.equal(components[0], cg2, "componentGroup2 inside componentGroup1");
+          assert.equal(components[1], c1, "components are inside");
+          assert.equal(components[2], c2, "components are inside");
         });
 
       });

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -52,7 +52,7 @@ describe("ComponentGroups", () => {
 
     var cg = new Plottable.Component.Group([c1]);
     var svg = generateSVG(400, 400);
-    cg.merge(c2)._anchor(svg);
+    cg.below(c2)._anchor(svg);
     (<any> c1)._addBox("test-box1");
     (<any> c2)._addBox("test-box2");
     cg._computeLayout()._render();
@@ -60,7 +60,7 @@ describe("ComponentGroups", () => {
     var t2 = svg.select(".test-box2");
     assertWidthHeight(t1, 10, 10, "rect1 sized correctly");
     assertWidthHeight(t2, 20, 20, "rect2 sized correctly");
-    cg.merge(c3);
+    cg.below(c3);
     (<any> c3)._addBox("test-box3");
     cg._computeLayout()._render();
     var t3 = svg.select(".test-box3");
@@ -73,7 +73,7 @@ describe("ComponentGroups", () => {
     var c1 = new Plottable.Component.AbstractComponent();
     var c2 = new Plottable.Component.AbstractComponent();
 
-    cg.merge(c1).merge(c2);
+    cg.below(c1).below(c2);
     assert.isFalse(cg._isFixedHeight(), "height not fixed when both components unfixed");
     assert.isFalse(cg._isFixedWidth(), "width not fixed when both components unfixed");
 
@@ -90,7 +90,7 @@ describe("ComponentGroups", () => {
     var cg = new Plottable.Component.Group();
     var c1 = new Plottable.Component.AbstractComponent();
     var c2 = new Plottable.Component.AbstractComponent();
-    cg.merge(c1).merge(c2);
+    cg.below(c1).below(c2);
 
     var svg = generateSVG();
     cg._anchor(svg);
@@ -153,7 +153,7 @@ describe("ComponentGroups", () => {
     var c2 = new Plottable.Component.AbstractComponent();
     var c3 = new Plottable.Component.AbstractComponent();
     assert.isTrue(cg.empty(), "cg initially empty");
-    cg.merge(c1).merge(c2).merge(c3);
+    cg.below(c1).below(c2).below(c3);
     assert.isFalse(cg.empty(), "cg not empty after merging components");
     cg.detachAll();
     assert.isTrue(cg.empty(), "cg empty after detachAll()");
@@ -175,7 +175,7 @@ describe("ComponentGroups", () => {
       var cg = new Plottable.Component.Group();
       var c1 = new Plottable.Component.AbstractComponent();
       var c2 = new Plottable.Component.AbstractComponent();
-      cg.merge(c1).merge(c2);
+      cg.below(c1).below(c2);
       var request = cg._requestedSpace(10, 10);
       verifySpaceRequest(request, 0, 0, false, false, "");
     });
@@ -185,7 +185,7 @@ describe("ComponentGroups", () => {
       var c1 = new Plottable.Component.AbstractComponent();
       var c2 = new Plottable.Component.AbstractComponent();
       var c3 = new Plottable.Component.AbstractComponent();
-      cg.merge(c1).merge(c2).merge(c3);
+      cg.below(c1).below(c2).below(c3);
       fixComponentSize(c1, null, 10);
       fixComponentSize(c2, null, 50);
       var request = cg._requestedSpace(10, 10);
@@ -200,7 +200,7 @@ describe("ComponentGroups", () => {
       var c4 = new Plottable.Component.AbstractComponent();
 
       it("Component.merge works as expected (Component.merge Component)", () => {
-        var cg: Plottable.Component.Group = c1.merge(c2);
+        var cg: Plottable.Component.Group = c1.below(c2);
         var innerComponents: Plottable.Component.AbstractComponent[] = cg.components();
         assert.lengthOf(innerComponents, 2, "There are two components");
         assert.equal(innerComponents[0], c1, "first component correct");
@@ -209,7 +209,7 @@ describe("ComponentGroups", () => {
 
       it("Component.merge works as expected (Component.merge ComponentGroup)", () => {
         var cg = new Plottable.Component.Group([c2,c3,c4]);
-        var cg2 = c1.merge(cg);
+        var cg2 = c1.below(cg);
         assert.equal(cg, cg2, "c.merge(cg) returns cg");
         var components: Plottable.Component.AbstractComponent[] = cg.components();
         assert.lengthOf(components, 4, "four components");
@@ -219,7 +219,7 @@ describe("ComponentGroups", () => {
 
       it("Component.merge works as expected (ComponentGroup.merge Component)", () => {
         var cg = new Plottable.Component.Group([c1,c2,c3]);
-        var cg2 = cg.merge(c4);
+        var cg2 = cg.below(c4);
         assert.equal(cg, cg2, "cg.merge(c) returns cg");
         var components: Plottable.Component.AbstractComponent[] = cg.components();
         assert.lengthOf(components, 4, "there are four components");
@@ -230,7 +230,7 @@ describe("ComponentGroups", () => {
       it("Component.merge works as expected (ComponentGroup.merge ComponentGroup)", () => {
         var cg1 = new Plottable.Component.Group([c1,c2]);
         var cg2 = new Plottable.Component.Group([c3,c4]);
-        var cg = cg1.merge(cg2);
+        var cg = cg1.below(cg2);
         assert.equal(cg, cg1, "merged == cg1");
         assert.notEqual(cg, cg2, "merged != cg2");
         var components: Plottable.Component.AbstractComponent[] = cg.components();

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -128,12 +128,12 @@ describe("Scales", () => {
       renderAreaD2.addDataset(ds2);
       renderAreaD2.project("x", "x", xScale);
       renderAreaD2.project("y", "y", yScale);
-      var renderAreas = renderAreaD1.merge(renderAreaD2);
+      var renderAreas = renderAreaD1.below(renderAreaD2);
       renderAreas.renderTo(svg);
       assert.deepEqual(xScale.domain(), [0, 2]);
       renderAreaD1.detach();
       assert.deepEqual(xScale.domain(), [1, 2], "resize on plot.detach()");
-      renderAreas.merge(renderAreaD1);
+      renderAreas.below(renderAreaD1);
       assert.deepEqual(xScale.domain(), [0, 2], "resize on plot.merge()");
       svg.remove();
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -5072,7 +5072,7 @@ describe("ComponentGroups", function () {
         var c3 = new Plottable.Component.AbstractComponent();
         var cg = new Plottable.Component.Group([c1]);
         var svg = generateSVG(400, 400);
-        cg.merge(c2)._anchor(svg);
+        cg.below(c2)._anchor(svg);
         c1._addBox("test-box1");
         c2._addBox("test-box2");
         cg._computeLayout()._render();
@@ -5080,7 +5080,7 @@ describe("ComponentGroups", function () {
         var t2 = svg.select(".test-box2");
         assertWidthHeight(t1, 10, 10, "rect1 sized correctly");
         assertWidthHeight(t2, 20, 20, "rect2 sized correctly");
-        cg.merge(c3);
+        cg.below(c3);
         c3._addBox("test-box3");
         cg._computeLayout()._render();
         var t3 = svg.select(".test-box3");
@@ -5091,7 +5091,7 @@ describe("ComponentGroups", function () {
         var cg = new Plottable.Component.Group();
         var c1 = new Plottable.Component.AbstractComponent();
         var c2 = new Plottable.Component.AbstractComponent();
-        cg.merge(c1).merge(c2);
+        cg.below(c1).below(c2);
         assert.isFalse(cg._isFixedHeight(), "height not fixed when both components unfixed");
         assert.isFalse(cg._isFixedWidth(), "width not fixed when both components unfixed");
         fixComponentSize(c1, 10, 10);
@@ -5105,7 +5105,7 @@ describe("ComponentGroups", function () {
         var cg = new Plottable.Component.Group();
         var c1 = new Plottable.Component.AbstractComponent();
         var c2 = new Plottable.Component.AbstractComponent();
-        cg.merge(c1).merge(c2);
+        cg.below(c1).below(c2);
         var svg = generateSVG();
         cg._anchor(svg);
         cg._computeLayout(50, 50, 350, 350);
@@ -5153,7 +5153,7 @@ describe("ComponentGroups", function () {
         var c2 = new Plottable.Component.AbstractComponent();
         var c3 = new Plottable.Component.AbstractComponent();
         assert.isTrue(cg.empty(), "cg initially empty");
-        cg.merge(c1).merge(c2).merge(c3);
+        cg.below(c1).below(c2).below(c3);
         assert.isFalse(cg.empty(), "cg not empty after merging components");
         cg.detachAll();
         assert.isTrue(cg.empty(), "cg empty after detachAll()");
@@ -5172,7 +5172,7 @@ describe("ComponentGroups", function () {
             var cg = new Plottable.Component.Group();
             var c1 = new Plottable.Component.AbstractComponent();
             var c2 = new Plottable.Component.AbstractComponent();
-            cg.merge(c1).merge(c2);
+            cg.below(c1).below(c2);
             var request = cg._requestedSpace(10, 10);
             verifySpaceRequest(request, 0, 0, false, false, "");
         });
@@ -5181,7 +5181,7 @@ describe("ComponentGroups", function () {
             var c1 = new Plottable.Component.AbstractComponent();
             var c2 = new Plottable.Component.AbstractComponent();
             var c3 = new Plottable.Component.AbstractComponent();
-            cg.merge(c1).merge(c2).merge(c3);
+            cg.below(c1).below(c2).below(c3);
             fixComponentSize(c1, null, 10);
             fixComponentSize(c2, null, 50);
             var request = cg._requestedSpace(10, 10);
@@ -5194,7 +5194,7 @@ describe("ComponentGroups", function () {
         var c3 = new Plottable.Component.AbstractComponent();
         var c4 = new Plottable.Component.AbstractComponent();
         it("Component.merge works as expected (Component.merge Component)", function () {
-            var cg = c1.merge(c2);
+            var cg = c1.below(c2);
             var innerComponents = cg.components();
             assert.lengthOf(innerComponents, 2, "There are two components");
             assert.equal(innerComponents[0], c1, "first component correct");
@@ -5202,7 +5202,7 @@ describe("ComponentGroups", function () {
         });
         it("Component.merge works as expected (Component.merge ComponentGroup)", function () {
             var cg = new Plottable.Component.Group([c2, c3, c4]);
-            var cg2 = c1.merge(cg);
+            var cg2 = c1.below(cg);
             assert.equal(cg, cg2, "c.merge(cg) returns cg");
             var components = cg.components();
             assert.lengthOf(components, 4, "four components");
@@ -5211,7 +5211,7 @@ describe("ComponentGroups", function () {
         });
         it("Component.merge works as expected (ComponentGroup.merge Component)", function () {
             var cg = new Plottable.Component.Group([c1, c2, c3]);
-            var cg2 = cg.merge(c4);
+            var cg2 = cg.below(c4);
             assert.equal(cg, cg2, "cg.merge(c) returns cg");
             var components = cg.components();
             assert.lengthOf(components, 4, "there are four components");
@@ -5221,7 +5221,7 @@ describe("ComponentGroups", function () {
         it("Component.merge works as expected (ComponentGroup.merge ComponentGroup)", function () {
             var cg1 = new Plottable.Component.Group([c1, c2]);
             var cg2 = new Plottable.Component.Group([c3, c4]);
-            var cg = cg1.merge(cg2);
+            var cg = cg1.below(cg2);
             assert.equal(cg, cg1, "merged == cg1");
             assert.notEqual(cg, cg2, "merged != cg2");
             var components = cg.components();
@@ -6323,12 +6323,12 @@ describe("Scales", function () {
             renderAreaD2.addDataset(ds2);
             renderAreaD2.project("x", "x", xScale);
             renderAreaD2.project("y", "y", yScale);
-            var renderAreas = renderAreaD1.merge(renderAreaD2);
+            var renderAreas = renderAreaD1.below(renderAreaD2);
             renderAreas.renderTo(svg);
             assert.deepEqual(xScale.domain(), [0, 2]);
             renderAreaD1.detach();
             assert.deepEqual(xScale.domain(), [1, 2], "resize on plot.detach()");
-            renderAreas.merge(renderAreaD1);
+            renderAreas.below(renderAreaD1);
             assert.deepEqual(xScale.domain(), [0, 2], "resize on plot.merge()");
             svg.remove();
         });

--- a/test/tests.js
+++ b/test/tests.js
@@ -5188,47 +5188,88 @@ describe("ComponentGroups", function () {
             verifySpaceRequest(request, 0, 50, false, true, "");
         });
     });
-    describe("Component.merge works as expected", function () {
+    describe("Merging components works as expected", function () {
         var c1 = new Plottable.Component.AbstractComponent();
         var c2 = new Plottable.Component.AbstractComponent();
         var c3 = new Plottable.Component.AbstractComponent();
         var c4 = new Plottable.Component.AbstractComponent();
-        it("Component.merge works as expected (Component.merge Component)", function () {
-            var cg = c1.below(c2);
-            var innerComponents = cg.components();
-            assert.lengthOf(innerComponents, 2, "There are two components");
-            assert.equal(innerComponents[0], c1, "first component correct");
-            assert.equal(innerComponents[1], c2, "second component correct");
+        describe("above()", function () {
+            it("Component.merge works as expected (Component.merge Component)", function () {
+                var cg = c1.below(c2);
+                var innerComponents = cg.components();
+                assert.lengthOf(innerComponents, 2, "There are two components");
+                assert.equal(innerComponents[0], c1, "first component correct");
+                assert.equal(innerComponents[1], c2, "second component correct");
+            });
+            it("Component.merge works as expected (Component.merge ComponentGroup)", function () {
+                var cg = new Plottable.Component.Group([c2, c3, c4]);
+                var cg2 = c1.below(cg);
+                assert.equal(cg, cg2, "c.merge(cg) returns cg");
+                var components = cg.components();
+                assert.lengthOf(components, 4, "four components");
+                assert.equal(components[0], c1, "first component in front");
+                assert.equal(components[1], c2, "second component is second");
+            });
+            it("Component.merge works as expected (ComponentGroup.merge Component)", function () {
+                var cg = new Plottable.Component.Group([c1, c2, c3]);
+                var cg2 = cg.below(c4);
+                assert.equal(cg, cg2, "cg.merge(c) returns cg");
+                var components = cg.components();
+                assert.lengthOf(components, 4, "there are four components");
+                assert.equal(components[0], c1, "first is first");
+                assert.equal(components[3], c4, "fourth is fourth");
+            });
+            it("Component.merge works as expected (ComponentGroup.merge ComponentGroup)", function () {
+                var cg1 = new Plottable.Component.Group([c1, c2]);
+                var cg2 = new Plottable.Component.Group([c3, c4]);
+                var cg = cg1.below(cg2);
+                assert.equal(cg, cg1, "merged == cg1");
+                assert.notEqual(cg, cg2, "merged != cg2");
+                var components = cg.components();
+                assert.lengthOf(components, 3, "there are three inner components");
+                assert.equal(components[0], c1, "components are inside");
+                assert.equal(components[1], c2, "components are inside");
+                assert.equal(components[2], cg2, "componentGroup2 inside componentGroup1");
+            });
         });
-        it("Component.merge works as expected (Component.merge ComponentGroup)", function () {
-            var cg = new Plottable.Component.Group([c2, c3, c4]);
-            var cg2 = c1.below(cg);
-            assert.equal(cg, cg2, "c.merge(cg) returns cg");
-            var components = cg.components();
-            assert.lengthOf(components, 4, "four components");
-            assert.equal(components[0], c1, "first component in front");
-            assert.equal(components[1], c2, "second component is second");
-        });
-        it("Component.merge works as expected (ComponentGroup.merge Component)", function () {
-            var cg = new Plottable.Component.Group([c1, c2, c3]);
-            var cg2 = cg.below(c4);
-            assert.equal(cg, cg2, "cg.merge(c) returns cg");
-            var components = cg.components();
-            assert.lengthOf(components, 4, "there are four components");
-            assert.equal(components[0], c1, "first is first");
-            assert.equal(components[3], c4, "fourth is fourth");
-        });
-        it("Component.merge works as expected (ComponentGroup.merge ComponentGroup)", function () {
-            var cg1 = new Plottable.Component.Group([c1, c2]);
-            var cg2 = new Plottable.Component.Group([c3, c4]);
-            var cg = cg1.below(cg2);
-            assert.equal(cg, cg1, "merged == cg1");
-            assert.notEqual(cg, cg2, "merged != cg2");
-            var components = cg.components();
-            assert.lengthOf(components, 3, "there are three inner components");
-            assert.equal(components[0], c1, "components are inside");
-            assert.equal(components[1], c2, "components are inside");
-            assert.equal(components[2], cg2, "componentGroup2 inside componentGroup1");
+        describe("below()", function () {
+            it("Component.below works as expected (Component.below Component)", function () {
+                var cg = c1.below(c2);
+                var innerComponents = cg.components();
+                assert.lengthOf(innerComponents, 2, "There are two components");
+                assert.equal(innerComponents[0], c1, "first component correct");
+                assert.equal(innerComponents[1], c2, "second component correct");
+            });
+            it("Component.below works as expected (Component.below ComponentGroup)", function () {
+                var cg = new Plottable.Component.Group([c2, c3, c4]);
+                var cg2 = c1.below(cg);
+                assert.equal(cg, cg2, "c1.below(cg) returns cg");
+                var components = cg.components();
+                assert.lengthOf(components, 4, "four components");
+                assert.equal(components[0], c1, "first component in front");
+                assert.equal(components[1], c2, "second component is second");
+            });
+            it("Component.below works as expected (ComponentGroup.below Component)", function () {
+                var cg = new Plottable.Component.Group([c1, c2, c3]);
+                var cg2 = cg.below(c4);
+                assert.equal(cg, cg2, "cg.merge(c4) returns cg");
+                var components = cg.components();
+                assert.lengthOf(components, 4, "there are four components");
+                assert.equal(components[0], c1, "first is first");
+                assert.equal(components[3], c4, "fourth is fourth");
+            });
+            it("Component.below works as expected (ComponentGroup.below ComponentGroup)", function () {
+                var cg1 = new Plottable.Component.Group([c1, c2]);
+                var cg2 = new Plottable.Component.Group([c3, c4]);
+                var cg = cg1.below(cg2);
+                assert.equal(cg, cg1, "merged group == cg1");
+                assert.notEqual(cg, cg2, "merged group != cg2");
+                var components = cg.components();
+                assert.lengthOf(components, 3, "there are three inner components");
+                assert.equal(components[0], c1, "components are inside");
+                assert.equal(components[1], c2, "components are inside");
+                assert.equal(components[2], cg2, "componentGroup2 inside componentGroup1");
+            });
         });
     });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -5194,42 +5194,42 @@ describe("ComponentGroups", function () {
         var c3 = new Plottable.Component.AbstractComponent();
         var c4 = new Plottable.Component.AbstractComponent();
         describe("above()", function () {
-            it("Component.merge works as expected (Component.merge Component)", function () {
-                var cg = c1.below(c2);
+            it("Component.above works as expected (Component.above Component)", function () {
+                var cg = c2.above(c1);
                 var innerComponents = cg.components();
                 assert.lengthOf(innerComponents, 2, "There are two components");
                 assert.equal(innerComponents[0], c1, "first component correct");
                 assert.equal(innerComponents[1], c2, "second component correct");
             });
-            it("Component.merge works as expected (Component.merge ComponentGroup)", function () {
-                var cg = new Plottable.Component.Group([c2, c3, c4]);
-                var cg2 = c1.below(cg);
-                assert.equal(cg, cg2, "c.merge(cg) returns cg");
+            it("Component.above works as expected (Component.above ComponentGroup)", function () {
+                var cg = new Plottable.Component.Group([c1, c2, c3]);
+                var cg2 = c4.above(cg);
+                assert.equal(cg, cg2, "c4.above(cg) returns cg");
                 var components = cg.components();
                 assert.lengthOf(components, 4, "four components");
-                assert.equal(components[0], c1, "first component in front");
-                assert.equal(components[1], c2, "second component is second");
+                assert.equal(components[2], c3, "third component in third");
+                assert.equal(components[3], c4, "fourth component is last");
             });
-            it("Component.merge works as expected (ComponentGroup.merge Component)", function () {
-                var cg = new Plottable.Component.Group([c1, c2, c3]);
-                var cg2 = cg.below(c4);
-                assert.equal(cg, cg2, "cg.merge(c) returns cg");
+            it("Component.above works as expected (ComponentGroup.above Component)", function () {
+                var cg = new Plottable.Component.Group([c2, c3, c4]);
+                var cg2 = cg.above(c1);
+                assert.equal(cg, cg2, "cg.merge(c1) returns cg");
                 var components = cg.components();
                 assert.lengthOf(components, 4, "there are four components");
                 assert.equal(components[0], c1, "first is first");
                 assert.equal(components[3], c4, "fourth is fourth");
             });
-            it("Component.merge works as expected (ComponentGroup.merge ComponentGroup)", function () {
+            it("Component.above works as expected (ComponentGroup.above ComponentGroup)", function () {
                 var cg1 = new Plottable.Component.Group([c1, c2]);
                 var cg2 = new Plottable.Component.Group([c3, c4]);
-                var cg = cg1.below(cg2);
+                var cg = cg1.above(cg2);
                 assert.equal(cg, cg1, "merged == cg1");
                 assert.notEqual(cg, cg2, "merged != cg2");
                 var components = cg.components();
                 assert.lengthOf(components, 3, "there are three inner components");
-                assert.equal(components[0], c1, "components are inside");
-                assert.equal(components[1], c2, "components are inside");
-                assert.equal(components[2], cg2, "componentGroup2 inside componentGroup1");
+                assert.equal(components[0], cg2, "componentGroup2 inside componentGroup1");
+                assert.equal(components[1], c1, "components are inside");
+                assert.equal(components[2], c2, "components are inside");
             });
         });
         describe("below()", function () {


### PR DESCRIPTION
Replacing the `merge` API with an `above`/`below` API so users can make sense of where they are placing their components in regards to layering them on top of each other.

Fixes #1037