### PR TITLE
Allow disabling of constraint functionality.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3911,6 +3911,10 @@ declare module Plottable {
              * Returns whether or not this Interaction constrains Points passed to its
              * callbacks to lie inside its Component.
              *
+             * If true, when the user drags outside of the Component, the closest Point
+             * inside the Component will be passed to the callback instead of the actual
+             * cursor position.
+             *
              * @return {boolean} Whether or not the Interaction.Drag constrains.
              */
             constrain(): boolean;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3908,17 +3908,21 @@ declare module Plottable {
         class Drag extends AbstractInteraction {
             _anchor(component: Component.AbstractComponent, hitBox: D3.Selection): void;
             /**
-             * Returns whether or not this Interaction constrains drag end-points
-             * to inside its Component (default true).
+             * Returns whether or not this Interaction constrains Points passed to its
+             * callbacks to lie inside its Component.
              *
              * @return {boolean} Whether or not the Interaction.Drag constrains.
              */
             constrain(): boolean;
             /**
-             * Sets whether or not this Interaction constrains drag end-points
-             * to inside its Component.
+             * Sets whether or not this Interaction constrains Points passed to its
+             * callbacks to lie inside its Component.
              *
-             * @param {boolean} doConstrain Whether or not to constrain the end-point.
+             * If true, when the user drags outside of the Component, the closest Point
+             * inside the Component will be passed to the callback instead of the actual
+             * cursor position.
+             *
+             * @param {boolean} doConstrain Whether or not to constrain Points.
              * @return {Interaction.Drag} The calling Interaction.Drag.
              */
             constrain(doConstrain: boolean): Drag;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -11,6 +11,15 @@ declare module Plottable {
              * @return {boolean} Whether x is in [a, b]
              */
             function inRange(x: number, a: number, b: number): boolean;
+            /**
+             * Clamps x to the range [min, max].
+             *
+             * @param {number} x The value to be clamped.
+             * @param {number} min The minimum value.
+             * @param {number} max The maximum value.
+             * @return {number} A clamped value in the range [min, max].
+             */
+            function clamp(x: number, min: number, max: number): number;
             /** Print a warning message to the console, if it is available.
              *
              * @param {string} The warnings to print
@@ -755,12 +764,6 @@ declare module Plottable {
         wantsWidth: boolean;
         wantsHeight: boolean;
     };
-    type _PixelArea = {
-        xMin: number;
-        xMax: number;
-        yMin: number;
-        yMax: number;
-    };
     /**
      * The range of your current data. For example, [1, 2, 6, -5] has the Extent
      * `{min: -5, max: 6}`.
@@ -778,6 +781,13 @@ declare module Plottable {
     type Point = {
         x: number;
         y: number;
+    };
+    /**
+     * The corners of a box.
+     */
+    type Bounds = {
+        topLeft: Point;
+        bottomRight: Point;
     };
 }
 
@@ -3898,6 +3908,21 @@ declare module Plottable {
         class Drag extends AbstractInteraction {
             _anchor(component: Component.AbstractComponent, hitBox: D3.Selection): void;
             /**
+             * Returns whether or not this Interaction constrains drag end-points
+             * to inside its Component (default true).
+             *
+             * @return {boolean} Whether or not the Interaction.Drag constrains.
+             */
+            constrain(): boolean;
+            /**
+             * Sets whether or not this Interaction constrains drag end-points
+             * to inside its Component.
+             *
+             * @param {boolean} doConstrain Whether or not to constrain the end-point.
+             * @return {Interaction.Drag} The calling Interaction.Drag.
+             */
+            constrain(doConstrain: boolean): Drag;
+            /**
              * Gets the callback that is called when dragging starts.
              *
              * @returns {(start: Point) => any} The callback called when dragging starts.
@@ -3972,6 +3997,7 @@ declare module Plottable {
         }
         class Hover extends Interaction.AbstractInteraction {
             _componentToListenTo: Hoverable;
+            constructor();
             _anchor(component: Hoverable, hitBox: D3.Selection): void;
             /**
              * Attaches an callback to be called when the user mouses over an element.

--- a/plottable.js
+++ b/plottable.js
@@ -9691,6 +9691,7 @@ var Plottable;
             function Drag() {
                 _super.apply(this, arguments);
                 this._dragging = false;
+                this._constrain = true;
             }
             Drag.prototype._anchor = function (component, hitBox) {
                 var _this = this;
@@ -9706,6 +9707,9 @@ var Plottable;
             };
             Drag.prototype._translateAndConstrain = function (p) {
                 var translatedP = this._translateToComponentSpace(p);
+                if (!this._constrain) {
+                    return translatedP;
+                }
                 return {
                     x: Plottable._Util.Methods.clamp(translatedP.x, 0, this._componentToListenTo.width()),
                     y: Plottable._Util.Methods.clamp(translatedP.y, 0, this._componentToListenTo.height())
@@ -9738,6 +9742,13 @@ var Plottable;
                         this._dragEndCallback(this._dragOrigin, constrainedP);
                     }
                 }
+            };
+            Drag.prototype.constrain = function (doConstrain) {
+                if (doConstrain == null) {
+                    return this._constrain;
+                }
+                this._constrain = doConstrain;
+                return this;
             };
             Drag.prototype.onDragStart = function (cb) {
                 if (cb === undefined) {

--- a/src/interactions/dragInteraction.ts
+++ b/src/interactions/dragInteraction.ts
@@ -75,17 +75,21 @@ export module Interaction {
     }
 
     /**
-     * Returns whether or not this Interaction constrains drag end-points
-     * to inside its Component (default true).
+     * Returns whether or not this Interaction constrains Points passed to its
+     * callbacks to lie inside its Component.
      *
      * @return {boolean} Whether or not the Interaction.Drag constrains.
      */
     public constrain(): boolean;
     /**
-     * Sets whether or not this Interaction constrains drag end-points
-     * to inside its Component.
+     * Sets whether or not this Interaction constrains Points passed to its
+     * callbacks to lie inside its Component.
      *
-     * @param {boolean} doConstrain Whether or not to constrain the end-point.
+     * If true, when the user drags outside of the Component, the closest Point
+     * inside the Component will be passed to the callback instead of the actual
+     * cursor position.
+     *
+     * @param {boolean} doConstrain Whether or not to constrain Points.
      * @return {Interaction.Drag} The calling Interaction.Drag.
      */
     public constrain(doConstrain: boolean): Drag;

--- a/src/interactions/dragInteraction.ts
+++ b/src/interactions/dragInteraction.ts
@@ -78,6 +78,10 @@ export module Interaction {
      * Returns whether or not this Interaction constrains Points passed to its
      * callbacks to lie inside its Component.
      *
+     * If true, when the user drags outside of the Component, the closest Point
+     * inside the Component will be passed to the callback instead of the actual
+     * cursor position.
+     *
      * @return {boolean} Whether or not the Interaction.Drag constrains.
      */
     public constrain(): boolean;

--- a/src/interactions/dragInteraction.ts
+++ b/src/interactions/dragInteraction.ts
@@ -4,6 +4,7 @@ module Plottable {
 export module Interaction {
   export class Drag extends AbstractInteraction {
     private _dragging = false;
+    private _constrain = true;
     private _mouseDispatcher: Plottable.Dispatcher.Mouse;
     private _touchDispatcher: Dispatcher.Touch;
     private _dragOrigin: Point;
@@ -32,6 +33,10 @@ export module Interaction {
 
     private _translateAndConstrain(p: Point) {
       var translatedP = this._translateToComponentSpace(p);
+      if (!this._constrain) {
+        return translatedP;
+      }
+
       return {
         x: _Util.Methods.clamp(translatedP.x, 0, this._componentToListenTo.width()),
         y: _Util.Methods.clamp(translatedP.y, 0, this._componentToListenTo.height())
@@ -67,6 +72,29 @@ export module Interaction {
           this._dragEndCallback(this._dragOrigin, constrainedP);
         }
       }
+    }
+
+    /**
+     * Returns whether or not this Interaction constrains drag end-points
+     * to inside its Component (default true).
+     *
+     * @return {boolean} Whether or not the Interaction.Drag constrains.
+     */
+    public constrain(): boolean;
+    /**
+     * Sets whether or not this Interaction constrains drag end-points
+     * to inside its Component.
+     *
+     * @param {boolean} doConstrain Whether or not to constrain the end-point.
+     * @return {Interaction.Drag} The calling Interaction.Drag.
+     */
+    public constrain(doConstrain: boolean): Drag;
+    public constrain(doConstrain?: boolean): any {
+      if (doConstrain == null) {
+        return this._constrain;
+      }
+      this._constrain = doConstrain;
+      return this;
     }
 
     /**

--- a/test/interactions/dragInteractionTests.ts
+++ b/test/interactions/dragInteractionTests.ts
@@ -33,7 +33,7 @@ describe("Interactions", () => {
       y: 0
     };
 
-    it("onDragStart", () => {
+    it("onDragStart()", () => {
       var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var c = new Plottable.Component.AbstractComponent();
       c.renderTo(svg);
@@ -75,7 +75,7 @@ describe("Interactions", () => {
       svg.remove();
     });
 
-    it("onDrag", () => {
+    it("onDrag()", () => {
       var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var c = new Plottable.Component.AbstractComponent();
       c.renderTo(svg);
@@ -107,24 +107,13 @@ describe("Interactions", () => {
       assert.deepEqual(receivedStart, startPoint, "was passed the correct starting point");
       assert.deepEqual(receivedEnd, endPoint, "was passed the correct current point");
 
-      triggerFakeMouseEvent("mousemove", target, outsidePointPos.x, outsidePointPos.y);
-      assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (mousemove)");
-      triggerFakeMouseEvent("mousemove", target, outsidePointNeg.x, outsidePointNeg.y);
-      assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (mousemove)");
-
-      receivedEnd = null;
-      triggerFakeTouchEvent("touchmove", target, outsidePointPos.x, outsidePointPos.y);
-      assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (touchmove)");
-      triggerFakeTouchEvent("touchmove", target, outsidePointNeg.x, outsidePointNeg.y);
-      assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (touchmove)");
-
       assert.strictEqual(drag.onDrag(), moveCallback, "retrieves the callback if called with no arguments");
       drag.onDrag(null);
       assert.isNull(drag.onDrag(), "removes the callback if called with null");
       svg.remove();
     });
 
-    it("onDragEnd", () => {
+    it("onDragEnd()", () => {
       var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var c = new Plottable.Component.AbstractComponent();
       c.renderTo(svg);
@@ -156,6 +145,49 @@ describe("Interactions", () => {
       assert.deepEqual(receivedStart, startPoint, "was passed the correct starting point");
       assert.deepEqual(receivedEnd, endPoint, "was passed the correct current point");
 
+      assert.strictEqual(drag.onDragEnd(), endCallback, "retrieves the callback if called with no arguments");
+      drag.onDragEnd(null);
+      assert.isNull(drag.onDragEnd(), "removes the callback if called with null");
+      svg.remove();
+    });
+
+    it("constrain()", () => {
+      var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      var c = new Plottable.Component.AbstractComponent();
+      c.renderTo(svg);
+
+      var drag = new Plottable.Interaction.Drag();
+      assert.isTrue(drag.constrain(), "constrains by default");
+
+      var receivedStart: Plottable.Point;
+      var receivedEnd: Plottable.Point;
+      var moveCallback = (start: Plottable.Point, end: Plottable.Point) => {
+        receivedStart = start;
+        receivedEnd = end;
+      };
+      drag.onDrag(moveCallback);
+      var endCallback = (start: Plottable.Point, end: Plottable.Point) => {
+        receivedStart = start;
+        receivedEnd = end;
+      };
+      drag.onDragEnd(endCallback);
+
+      c.registerInteraction(drag);
+      var target = c.content();
+
+      triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+      triggerFakeMouseEvent("mousemove", target, outsidePointPos.x, outsidePointPos.y);
+      assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (mousemove)");
+      triggerFakeMouseEvent("mousemove", target, outsidePointNeg.x, outsidePointNeg.y);
+      assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (mousemove)");
+
+      receivedEnd = null;
+      triggerFakeTouchEvent("touchmove", target, outsidePointPos.x, outsidePointPos.y);
+      assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (touchmove)");
+      triggerFakeTouchEvent("touchmove", target, outsidePointNeg.x, outsidePointNeg.y);
+      assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (touchmove)");
+
+      receivedEnd = null;
       triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
       triggerFakeMouseEvent("mouseup", target, outsidePointPos.x, outsidePointPos.y);
       assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (mouseup)");
@@ -171,9 +203,43 @@ describe("Interactions", () => {
       triggerFakeTouchEvent("touchend", target, outsidePointNeg.x, outsidePointNeg.y);
       assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (touchend)");
 
-      assert.strictEqual(drag.onDragEnd(), endCallback, "retrieves the callback if called with no arguments");
-      drag.onDragEnd(null);
-      assert.isNull(drag.onDragEnd(), "removes the callback if called with null");
+      drag.constrain(false);
+
+      triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+      triggerFakeMouseEvent("mousemove", target, outsidePointPos.x, outsidePointPos.y);
+      assert.deepEqual(receivedEnd, outsidePointPos,
+                       "dragging outside the Component is no longer constrained (positive) (mousemove)");
+      triggerFakeMouseEvent("mousemove", target, outsidePointNeg.x, outsidePointNeg.y);
+      assert.deepEqual(receivedEnd, outsidePointNeg,
+                       "dragging outside the Component is no longer constrained (negative) (mousemove)");
+
+      receivedEnd = null;
+      triggerFakeTouchEvent("touchmove", target, outsidePointPos.x, outsidePointPos.y);
+      assert.deepEqual(receivedEnd, outsidePointPos,
+                       "dragging outside the Component is no longer constrained (positive) (touchmove)");
+      triggerFakeTouchEvent("touchmove", target, outsidePointNeg.x, outsidePointNeg.y);
+      assert.deepEqual(receivedEnd, outsidePointNeg,
+                       "dragging outside the Component is no longer constrained (negative) (touchmove)");
+
+      receivedEnd = null;
+      triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+      triggerFakeMouseEvent("mouseup", target, outsidePointPos.x, outsidePointPos.y);
+      assert.deepEqual(receivedEnd, outsidePointPos,
+                       "dragging outside the Component is no longer constrained (positive) (mouseup)");
+      triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+      triggerFakeMouseEvent("mouseup", target, outsidePointNeg.x, outsidePointNeg.y);
+      assert.deepEqual(receivedEnd, outsidePointNeg,
+                       "dragging outside the Component is no longer constrained (negative) (mouseup)");
+
+      receivedEnd = null;
+      triggerFakeTouchEvent("touchstart", target, startPoint.x, startPoint.y);
+      triggerFakeTouchEvent("touchend", target, outsidePointPos.x, outsidePointPos.y);
+      assert.deepEqual(receivedEnd, outsidePointPos,
+                       "dragging outside the Component is no longer constrained (positive) (touchend)");
+      triggerFakeTouchEvent("touchstart", target, startPoint.x, startPoint.y);
+      triggerFakeTouchEvent("touchend", target, outsidePointNeg.x, outsidePointNeg.y);
+      assert.deepEqual(receivedEnd, outsidePointNeg,
+                       "dragging outside the Component is no longer constrained (negative) (touchend)");
       svg.remove();
     });
   });

--- a/test/tests.js
+++ b/test/tests.js
@@ -7782,7 +7782,7 @@ describe("Interactions", function () {
             x: 0,
             y: 0
         };
-        it("onDragStart", function () {
+        it("onDragStart()", function () {
             var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var c = new Plottable.Component.AbstractComponent();
             c.renderTo(svg);
@@ -7817,7 +7817,7 @@ describe("Interactions", function () {
             assert.isNull(drag.onDragStart(), "removes the callback if called with null");
             svg.remove();
         });
-        it("onDrag", function () {
+        it("onDrag()", function () {
             var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var c = new Plottable.Component.AbstractComponent();
             c.renderTo(svg);
@@ -7845,21 +7845,12 @@ describe("Interactions", function () {
             assert.isTrue(moveCallbackCalled, "callback was called on dragging (touchmove)");
             assert.deepEqual(receivedStart, startPoint, "was passed the correct starting point");
             assert.deepEqual(receivedEnd, endPoint, "was passed the correct current point");
-            triggerFakeMouseEvent("mousemove", target, outsidePointPos.x, outsidePointPos.y);
-            assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (mousemove)");
-            triggerFakeMouseEvent("mousemove", target, outsidePointNeg.x, outsidePointNeg.y);
-            assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (mousemove)");
-            receivedEnd = null;
-            triggerFakeTouchEvent("touchmove", target, outsidePointPos.x, outsidePointPos.y);
-            assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (touchmove)");
-            triggerFakeTouchEvent("touchmove", target, outsidePointNeg.x, outsidePointNeg.y);
-            assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (touchmove)");
             assert.strictEqual(drag.onDrag(), moveCallback, "retrieves the callback if called with no arguments");
             drag.onDrag(null);
             assert.isNull(drag.onDrag(), "removes the callback if called with null");
             svg.remove();
         });
-        it("onDragEnd", function () {
+        it("onDragEnd()", function () {
             var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var c = new Plottable.Component.AbstractComponent();
             c.renderTo(svg);
@@ -7887,6 +7878,42 @@ describe("Interactions", function () {
             assert.isTrue(endCallbackCalled, "callback was called on drag ending (touchend)");
             assert.deepEqual(receivedStart, startPoint, "was passed the correct starting point");
             assert.deepEqual(receivedEnd, endPoint, "was passed the correct current point");
+            assert.strictEqual(drag.onDragEnd(), endCallback, "retrieves the callback if called with no arguments");
+            drag.onDragEnd(null);
+            assert.isNull(drag.onDragEnd(), "removes the callback if called with null");
+            svg.remove();
+        });
+        it("constrain()", function () {
+            var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+            var c = new Plottable.Component.AbstractComponent();
+            c.renderTo(svg);
+            var drag = new Plottable.Interaction.Drag();
+            assert.isTrue(drag.constrain(), "constrains by default");
+            var receivedStart;
+            var receivedEnd;
+            var moveCallback = function (start, end) {
+                receivedStart = start;
+                receivedEnd = end;
+            };
+            drag.onDrag(moveCallback);
+            var endCallback = function (start, end) {
+                receivedStart = start;
+                receivedEnd = end;
+            };
+            drag.onDragEnd(endCallback);
+            c.registerInteraction(drag);
+            var target = c.content();
+            triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+            triggerFakeMouseEvent("mousemove", target, outsidePointPos.x, outsidePointPos.y);
+            assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (mousemove)");
+            triggerFakeMouseEvent("mousemove", target, outsidePointNeg.x, outsidePointNeg.y);
+            assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (mousemove)");
+            receivedEnd = null;
+            triggerFakeTouchEvent("touchmove", target, outsidePointPos.x, outsidePointPos.y);
+            assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (touchmove)");
+            triggerFakeTouchEvent("touchmove", target, outsidePointNeg.x, outsidePointNeg.y);
+            assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (touchmove)");
+            receivedEnd = null;
             triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
             triggerFakeMouseEvent("mouseup", target, outsidePointPos.x, outsidePointPos.y);
             assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (mouseup)");
@@ -7900,9 +7927,31 @@ describe("Interactions", function () {
             triggerFakeTouchEvent("touchstart", target, startPoint.x, startPoint.y);
             triggerFakeTouchEvent("touchend", target, outsidePointNeg.x, outsidePointNeg.y);
             assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (touchend)");
-            assert.strictEqual(drag.onDragEnd(), endCallback, "retrieves the callback if called with no arguments");
-            drag.onDragEnd(null);
-            assert.isNull(drag.onDragEnd(), "removes the callback if called with null");
+            drag.constrain(false);
+            triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+            triggerFakeMouseEvent("mousemove", target, outsidePointPos.x, outsidePointPos.y);
+            assert.deepEqual(receivedEnd, outsidePointPos, "dragging outside the Component is no longer constrained (positive) (mousemove)");
+            triggerFakeMouseEvent("mousemove", target, outsidePointNeg.x, outsidePointNeg.y);
+            assert.deepEqual(receivedEnd, outsidePointNeg, "dragging outside the Component is no longer constrained (negative) (mousemove)");
+            receivedEnd = null;
+            triggerFakeTouchEvent("touchmove", target, outsidePointPos.x, outsidePointPos.y);
+            assert.deepEqual(receivedEnd, outsidePointPos, "dragging outside the Component is no longer constrained (positive) (touchmove)");
+            triggerFakeTouchEvent("touchmove", target, outsidePointNeg.x, outsidePointNeg.y);
+            assert.deepEqual(receivedEnd, outsidePointNeg, "dragging outside the Component is no longer constrained (negative) (touchmove)");
+            receivedEnd = null;
+            triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+            triggerFakeMouseEvent("mouseup", target, outsidePointPos.x, outsidePointPos.y);
+            assert.deepEqual(receivedEnd, outsidePointPos, "dragging outside the Component is no longer constrained (positive) (mouseup)");
+            triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+            triggerFakeMouseEvent("mouseup", target, outsidePointNeg.x, outsidePointNeg.y);
+            assert.deepEqual(receivedEnd, outsidePointNeg, "dragging outside the Component is no longer constrained (negative) (mouseup)");
+            receivedEnd = null;
+            triggerFakeTouchEvent("touchstart", target, startPoint.x, startPoint.y);
+            triggerFakeTouchEvent("touchend", target, outsidePointPos.x, outsidePointPos.y);
+            assert.deepEqual(receivedEnd, outsidePointPos, "dragging outside the Component is no longer constrained (positive) (touchend)");
+            triggerFakeTouchEvent("touchstart", target, startPoint.x, startPoint.y);
+            triggerFakeTouchEvent("touchend", target, outsidePointNeg.x, outsidePointNeg.y);
+            assert.deepEqual(receivedEnd, outsidePointNeg, "dragging outside the Component is no longer constrained (negative) (touchend)");
             svg.remove();
         });
     });


### PR DESCRIPTION
Important for panning to feel intuitive.

Moved all `assert` statements corresponding to constraint to a new test.