### PR TITLE
[Interaction.DoubleClick] - Removing Click hierarchy

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3776,6 +3776,12 @@ declare module Plottable {
              */
             callback(cb: (p: Point) => any): Click;
         }
+    }
+}
+
+
+declare module Plottable {
+    module Interaction {
         class DoubleClick extends AbstractInteraction {
             _anchor(component: Component.AbstractComponent, hitBox: D3.Selection): void;
             _requiresHitbox(): boolean;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3776,8 +3776,16 @@ declare module Plottable {
              */
             callback(cb: (p: Point) => any): Click;
         }
-        class DoubleClick extends Click {
+        class DoubleClick extends AbstractInteraction {
+            _anchor(component: Component.AbstractComponent, hitBox: D3.Selection): void;
+            _requiresHitbox(): boolean;
             protected _listenTo(): string;
+            /**
+             * Sets a callback to be called when a click is received.
+             *
+             * @param {(p: Point) => any} cb Callback that takes the pixel position of the click event.
+             */
+            callback(cb: (p: Point) => any): DoubleClick;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -9396,6 +9396,20 @@ var Plottable;
             return Click;
         })(Interaction.AbstractInteraction);
         Interaction.Click = Click;
+    })(Interaction = Plottable.Interaction || (Plottable.Interaction = {}));
+})(Plottable || (Plottable = {}));
+
+///<reference path="../reference.ts" />
+var __extends = this.__extends || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    __.prototype = b.prototype;
+    d.prototype = new __();
+};
+var Plottable;
+(function (Plottable) {
+    var Interaction;
+    (function (Interaction) {
         var DoubleClick = (function (_super) {
             __extends(DoubleClick, _super);
             function DoubleClick() {

--- a/plottable.js
+++ b/plottable.js
@@ -9401,11 +9401,33 @@ var Plottable;
             function DoubleClick() {
                 _super.apply(this, arguments);
             }
+            DoubleClick.prototype._anchor = function (component, hitBox) {
+                var _this = this;
+                _super.prototype._anchor.call(this, component, hitBox);
+                hitBox.on(this._listenTo(), function () {
+                    var xy = d3.mouse(hitBox.node());
+                    var x = xy[0];
+                    var y = xy[1];
+                    _this._callback({ x: x, y: y });
+                });
+            };
+            DoubleClick.prototype._requiresHitbox = function () {
+                return true;
+            };
             DoubleClick.prototype._listenTo = function () {
                 return "dblclick";
             };
+            /**
+             * Sets a callback to be called when a click is received.
+             *
+             * @param {(p: Point) => any} cb Callback that takes the pixel position of the click event.
+             */
+            DoubleClick.prototype.callback = function (cb) {
+                this._callback = cb;
+                return this;
+            };
             return DoubleClick;
-        })(Click);
+        })(Interaction.AbstractInteraction);
         Interaction.DoubleClick = DoubleClick;
     })(Interaction = Plottable.Interaction || (Plottable.Interaction = {}));
 })(Plottable || (Plottable = {}));

--- a/src/interactions/clickInteraction.ts
+++ b/src/interactions/clickInteraction.ts
@@ -34,9 +34,36 @@ export module Interaction {
     }
   }
 
-  export class DoubleClick extends Click {
+  export class DoubleClick extends AbstractInteraction {
+
+    private _callback: (p: Point) => any;
+
+    public _anchor(component: Component.AbstractComponent, hitBox: D3.Selection) {
+      super._anchor(component, hitBox);
+      hitBox.on(this._listenTo(), () => {
+        var xy = d3.mouse(hitBox.node());
+        var x = xy[0];
+        var y = xy[1];
+        this._callback({x: x, y: y});
+      });
+    }
+
+    public _requiresHitbox() {
+      return true;
+    }
+
     protected _listenTo(): string {
       return "dblclick";
+    }
+
+    /**
+     * Sets a callback to be called when a click is received.
+     *
+     * @param {(p: Point) => any} cb Callback that takes the pixel position of the click event.
+     */
+    public callback(cb: (p: Point) => any): DoubleClick {
+      this._callback = cb;
+      return this;
     }
   }
 }

--- a/src/interactions/doubleClickInteraction.ts
+++ b/src/interactions/doubleClickInteraction.ts
@@ -2,7 +2,8 @@
 
 module Plottable {
 export module Interaction {
-  export class Click extends AbstractInteraction {
+  export class DoubleClick extends AbstractInteraction {
+
     private _callback: (p: Point) => any;
 
     public _anchor(component: Component.AbstractComponent, hitBox: D3.Selection) {
@@ -20,7 +21,7 @@ export module Interaction {
     }
 
     protected _listenTo(): string {
-      return "click";
+      return "dblclick";
     }
 
     /**
@@ -28,11 +29,10 @@ export module Interaction {
      *
      * @param {(p: Point) => any} cb Callback that takes the pixel position of the click event.
      */
-    public callback(cb: (p: Point) => any): Click {
+    public callback(cb: (p: Point) => any): DoubleClick {
       this._callback = cb;
       return this;
     }
-
   }
 }
 }

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -86,6 +86,7 @@
 
 /// <reference path="interactions/abstractInteraction.ts" />
 /// <reference path="interactions/clickInteraction.ts" />
+/// <reference path="interactions/doubleClickInteraction.ts" />
 /// <reference path="interactions/keyInteraction.ts" />
 /// <reference path="interactions/pointerInteraction.ts" />
 /// <reference path="interactions/panZoomInteraction.ts" />


### PR DESCRIPTION
As `Interaction.Click` is going to be rearchitected, we should shelve off `Interaction.DoubleClick` to use the old architecture to retain functionality.