### PR TITLE
[ClickInteraction] - Refactor to new Interaction API

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3776,6 +3776,12 @@ declare module Plottable {
              */
             callback(cb: (p: Point) => any): Click;
         }
+    }
+}
+
+
+declare module Plottable {
+    module Interaction {
         class DoubleClick extends AbstractInteraction {
             _anchor(component: Component.AbstractComponent, hitBox: D3.Selection): void;
             _requiresHitbox(): boolean;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3767,14 +3767,19 @@ declare module Plottable {
     module Interaction {
         class Click extends AbstractInteraction {
             _anchor(component: Component.AbstractComponent, hitBox: D3.Selection): void;
-            _requiresHitbox(): boolean;
-            protected _listenTo(): string;
             /**
-             * Sets a callback to be called when a click is received.
+             * Gets the callback called when the Component is clicked.
              *
-             * @param {(p: Point) => any} cb Callback that takes the pixel position of the click event.
+             * @return {(p: Point) => any} The current callback.
              */
-            callback(cb: (p: Point) => any): Click;
+            onClick(): (p: Point) => any;
+            /**
+             * Sets the callback called when the Component is clicked.
+             *
+             * @param {(p: Point) => any} callback The callback to set.
+             * @return {Interaction.Pointer} The calling Interaction.Click.
+             */
+            onClick(callback: (p: Point) => any): Interaction.Click;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3776,8 +3776,16 @@ declare module Plottable {
              */
             callback(cb: (p: Point) => any): Click;
         }
-        class DoubleClick extends Click {
+        class DoubleClick extends AbstractInteraction {
+            _anchor(component: Component.AbstractComponent, hitBox: D3.Selection): void;
+            _requiresHitbox(): boolean;
             protected _listenTo(): string;
+            /**
+             * Sets a callback to be called when a click is received.
+             *
+             * @param {(p: Point) => any} cb Callback that takes the pixel position of the click event.
+             */
+            callback(cb: (p: Point) => any): DoubleClick;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -9385,10 +9385,10 @@ var Plottable;
                 }
             };
             Click.prototype._handleMouseUp = function (p) {
-                this._clickedDown = false;
-                if (this._isInsideComponent(p)) {
+                if (this._clickedDown && this._isInsideComponent(p)) {
                     this.onClick()(p);
                 }
+                this._clickedDown = false;
             };
             Click.prototype.onClick = function (callback) {
                 if (callback === undefined) {

--- a/plottable.js
+++ b/plottable.js
@@ -9396,6 +9396,20 @@ var Plottable;
             return Click;
         })(Interaction.AbstractInteraction);
         Interaction.Click = Click;
+    })(Interaction = Plottable.Interaction || (Plottable.Interaction = {}));
+})(Plottable || (Plottable = {}));
+
+///<reference path="../reference.ts" />
+var __extends = this.__extends || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    __.prototype = b.prototype;
+    d.prototype = new __();
+};
+var Plottable;
+(function (Plottable) {
+    var Interaction;
+    (function (Interaction) {
         var DoubleClick = (function (_super) {
             __extends(DoubleClick, _super);
             function DoubleClick() {

--- a/plottable.js
+++ b/plottable.js
@@ -9401,11 +9401,33 @@ var Plottable;
             function DoubleClick() {
                 _super.apply(this, arguments);
             }
+            DoubleClick.prototype._anchor = function (component, hitBox) {
+                var _this = this;
+                _super.prototype._anchor.call(this, component, hitBox);
+                hitBox.on(this._listenTo(), function () {
+                    var xy = d3.mouse(hitBox.node());
+                    var x = xy[0];
+                    var y = xy[1];
+                    _this._callback({ x: x, y: y });
+                });
+            };
+            DoubleClick.prototype._requiresHitbox = function () {
+                return true;
+            };
             DoubleClick.prototype._listenTo = function () {
                 return "dblclick";
             };
+            /**
+             * Sets a callback to be called when a click is received.
+             *
+             * @param {(p: Point) => any} cb Callback that takes the pixel position of the click event.
+             */
+            DoubleClick.prototype.callback = function (cb) {
+                this._callback = cb;
+                return this;
+            };
             return DoubleClick;
-        })(Click);
+        })(Interaction.AbstractInteraction);
         Interaction.DoubleClick = DoubleClick;
     })(Interaction = Plottable.Interaction || (Plottable.Interaction = {}));
 })(Plottable || (Plottable = {}));

--- a/plottable.js
+++ b/plottable.js
@@ -9371,26 +9371,21 @@ var Plottable;
             Click.prototype._anchor = function (component, hitBox) {
                 var _this = this;
                 _super.prototype._anchor.call(this, component, hitBox);
-                hitBox.on(this._listenTo(), function () {
-                    var xy = d3.mouse(hitBox.node());
-                    var x = xy[0];
-                    var y = xy[1];
-                    _this._callback({ x: x, y: y });
-                });
+                this._mouseDispatcher = Plottable.Dispatcher.Mouse.getDispatcher(component.content().node());
+                this._mouseDispatcher.onMouseDown("Interaction.Click" + this.getID(), function (p) { return _this._handleMouseDown(p); });
+                this._mouseDispatcher.onMouseUp("Interaction.Click" + this.getID(), function (p) { return _this._handleMouseUp(p); });
             };
-            Click.prototype._requiresHitbox = function () {
-                return true;
+            Click.prototype._handleMouseDown = function (p) {
+                // TODO: implement this
             };
-            Click.prototype._listenTo = function () {
-                return "click";
+            Click.prototype._handleMouseUp = function (p) {
+                // TODO: implement this
             };
-            /**
-             * Sets a callback to be called when a click is received.
-             *
-             * @param {(p: Point) => any} cb Callback that takes the pixel position of the click event.
-             */
-            Click.prototype.callback = function (cb) {
-                this._callback = cb;
+            Click.prototype.onClick = function (callback) {
+                if (callback === undefined) {
+                    return this._clickCallback;
+                }
+                this._clickCallback = callback;
                 return this;
             };
             return Click;

--- a/plottable.js
+++ b/plottable.js
@@ -9380,13 +9380,15 @@ var Plottable;
                 this._touchDispatcher.onTouchEnd("Interaction.Click" + this.getID(), function (p) { return _this._handleClickUp(p); });
             };
             Click.prototype._handleClickDown = function (p) {
-                if (this._isInsideComponent(p)) {
+                var translatedPoint = this._translateToComponentSpace(p);
+                if (this._isInsideComponent(translatedPoint)) {
                     this._clickedDown = true;
                 }
             };
             Click.prototype._handleClickUp = function (p) {
-                if (this._clickedDown && this._isInsideComponent(p) && (this._clickCallback != null)) {
-                    this._clickCallback(p);
+                var translatedPoint = this._translateToComponentSpace(p);
+                if (this._clickedDown && this._isInsideComponent(translatedPoint) && (this._clickCallback != null)) {
+                    this._clickCallback(translatedPoint);
                 }
                 this._clickedDown = false;
             };

--- a/plottable.js
+++ b/plottable.js
@@ -9374,6 +9374,9 @@ var Plottable;
                 this._mouseDispatcher = Plottable.Dispatcher.Mouse.getDispatcher(component.content().node());
                 this._mouseDispatcher.onMouseDown("Interaction.Click" + this.getID(), function (p) { return _this._handleMouseDown(p); });
                 this._mouseDispatcher.onMouseUp("Interaction.Click" + this.getID(), function (p) { return _this._handleMouseUp(p); });
+                this._touchDispatcher = Plottable.Dispatcher.Touch.getDispatcher(component.content().node());
+                this._touchDispatcher.onTouchStart("Interaction.Click" + this.getID(), function (p) { return _this._handleMouseDown(p); });
+                this._touchDispatcher.onTouchEnd("Interaction.Click" + this.getID(), function (p) { return _this._handleMouseUp(p); });
             };
             Click.prototype._handleMouseDown = function (p) {
                 // TODO: implement this

--- a/plottable.js
+++ b/plottable.js
@@ -9385,8 +9385,8 @@ var Plottable;
                 }
             };
             Click.prototype._handleClickUp = function (p) {
-                if (this._clickedDown && this._isInsideComponent(p) && (this.onClick() != null)) {
-                    this.onClick()(p);
+                if (this._clickedDown && this._isInsideComponent(p) && (this._clickCallback != null)) {
+                    this._clickCallback(p);
                 }
                 this._clickedDown = false;
             };

--- a/plottable.js
+++ b/plottable.js
@@ -9385,7 +9385,7 @@ var Plottable;
                 }
             };
             Click.prototype._handleMouseUp = function (p) {
-                if (this._clickedDown && this._isInsideComponent(p)) {
+                if (this._clickedDown && this._isInsideComponent(p) && (this.onClick() != null)) {
                     this.onClick()(p);
                 }
                 this._clickedDown = false;

--- a/plottable.js
+++ b/plottable.js
@@ -9373,18 +9373,18 @@ var Plottable;
                 var _this = this;
                 _super.prototype._anchor.call(this, component, hitBox);
                 this._mouseDispatcher = Plottable.Dispatcher.Mouse.getDispatcher(component.content().node());
-                this._mouseDispatcher.onMouseDown("Interaction.Click" + this.getID(), function (p) { return _this._handleMouseDown(p); });
-                this._mouseDispatcher.onMouseUp("Interaction.Click" + this.getID(), function (p) { return _this._handleMouseUp(p); });
+                this._mouseDispatcher.onMouseDown("Interaction.Click" + this.getID(), function (p) { return _this._handleClickDown(p); });
+                this._mouseDispatcher.onMouseUp("Interaction.Click" + this.getID(), function (p) { return _this._handleClickUp(p); });
                 this._touchDispatcher = Plottable.Dispatcher.Touch.getDispatcher(component.content().node());
-                this._touchDispatcher.onTouchStart("Interaction.Click" + this.getID(), function (p) { return _this._handleMouseDown(p); });
-                this._touchDispatcher.onTouchEnd("Interaction.Click" + this.getID(), function (p) { return _this._handleMouseUp(p); });
+                this._touchDispatcher.onTouchStart("Interaction.Click" + this.getID(), function (p) { return _this._handleClickDown(p); });
+                this._touchDispatcher.onTouchEnd("Interaction.Click" + this.getID(), function (p) { return _this._handleClickUp(p); });
             };
-            Click.prototype._handleMouseDown = function (p) {
+            Click.prototype._handleClickDown = function (p) {
                 if (this._isInsideComponent(p)) {
                     this._clickedDown = true;
                 }
             };
-            Click.prototype._handleMouseUp = function (p) {
+            Click.prototype._handleClickUp = function (p) {
                 if (this._clickedDown && this._isInsideComponent(p) && (this.onClick() != null)) {
                     this.onClick()(p);
                 }

--- a/plottable.js
+++ b/plottable.js
@@ -9367,6 +9367,7 @@ var Plottable;
             __extends(Click, _super);
             function Click() {
                 _super.apply(this, arguments);
+                this._clickedDown = false;
             }
             Click.prototype._anchor = function (component, hitBox) {
                 var _this = this;
@@ -9379,10 +9380,15 @@ var Plottable;
                 this._touchDispatcher.onTouchEnd("Interaction.Click" + this.getID(), function (p) { return _this._handleMouseUp(p); });
             };
             Click.prototype._handleMouseDown = function (p) {
-                // TODO: implement this
+                if (this._isInsideComponent(p)) {
+                    this._clickedDown = true;
+                }
             };
             Click.prototype._handleMouseUp = function (p) {
-                // TODO: implement this
+                this._clickedDown = false;
+                if (this._isInsideComponent(p)) {
+                    this.onClick()(p);
+                }
             };
             Click.prototype.onClick = function (callback) {
                 if (callback === undefined) {

--- a/src/interactions/clickInteraction.ts
+++ b/src/interactions/clickInteraction.ts
@@ -5,6 +5,7 @@ export module Interaction {
   export class Click extends AbstractInteraction {
 
     private _mouseDispatcher: Plottable.Dispatcher.Mouse;
+    private _touchDispatcher: Plottable.Dispatcher.Touch;
     private _clickCallback: (p: Point) => any;
 
     public _anchor(component: Component.AbstractComponent, hitBox: D3.Selection) {
@@ -13,6 +14,10 @@ export module Interaction {
       this._mouseDispatcher = Dispatcher.Mouse.getDispatcher(<SVGElement> component.content().node());
       this._mouseDispatcher.onMouseDown("Interaction.Click" + this.getID(), (p: Point) => this._handleMouseDown(p));
       this._mouseDispatcher.onMouseUp("Interaction.Click" + this.getID(), (p: Point) => this._handleMouseUp(p));
+
+      this._touchDispatcher = Dispatcher.Touch.getDispatcher(<SVGElement> component.content().node());
+      this._touchDispatcher.onTouchStart("Interaction.Click" + this.getID(), (p: Point) => this._handleMouseDown(p));
+      this._touchDispatcher.onTouchEnd("Interaction.Click" + this.getID(), (p: Point) => this._handleMouseUp(p));
     }
 
     private _handleMouseDown(p: Point) {

--- a/src/interactions/clickInteraction.ts
+++ b/src/interactions/clickInteraction.ts
@@ -28,8 +28,8 @@ export module Interaction {
     }
 
     private _handleClickUp(p: Point) {
-      if (this._clickedDown && this._isInsideComponent(p) && (this.onClick() != null)) {
-        this.onClick()(p);
+      if (this._clickedDown && this._isInsideComponent(p) && (this._clickCallback != null)) {
+        this._clickCallback(p);
       }
       this._clickedDown = false;
     }

--- a/src/interactions/clickInteraction.ts
+++ b/src/interactions/clickInteraction.ts
@@ -3,33 +3,44 @@
 module Plottable {
 export module Interaction {
   export class Click extends AbstractInteraction {
-    private _callback: (p: Point) => any;
+
+    private _mouseDispatcher: Plottable.Dispatcher.Mouse;
+    private _clickCallback: (p: Point) => any;
 
     public _anchor(component: Component.AbstractComponent, hitBox: D3.Selection) {
       super._anchor(component, hitBox);
-      hitBox.on(this._listenTo(), () => {
-        var xy = d3.mouse(hitBox.node());
-        var x = xy[0];
-        var y = xy[1];
-        this._callback({x: x, y: y});
-      });
+
+      this._mouseDispatcher = Dispatcher.Mouse.getDispatcher(<SVGElement> component.content().node());
+      this._mouseDispatcher.onMouseDown("Interaction.Click" + this.getID(), (p: Point) => this._handleMouseDown(p));
+      this._mouseDispatcher.onMouseUp("Interaction.Click" + this.getID(), (p: Point) => this._handleMouseUp(p));
     }
 
-    public _requiresHitbox() {
-      return true;
+    private _handleMouseDown(p: Point) {
+      // TODO: implement this
     }
 
-    protected _listenTo(): string {
-      return "click";
+    private _handleMouseUp(p: Point) {
+      // TODO: implement this
     }
 
     /**
-     * Sets a callback to be called when a click is received.
+     * Gets the callback called when the Component is clicked.
      *
-     * @param {(p: Point) => any} cb Callback that takes the pixel position of the click event.
+     * @return {(p: Point) => any} The current callback.
      */
-    public callback(cb: (p: Point) => any): Click {
-      this._callback = cb;
+    public onClick(): (p: Point) => any;
+    /**
+     * Sets the callback called when the Component is clicked.
+     *
+     * @param {(p: Point) => any} callback The callback to set.
+     * @return {Interaction.Pointer} The calling Interaction.Click.
+     */
+    public onClick(callback: (p: Point) => any): Interaction.Click;
+    public onClick(callback?: (p: Point) => any): any {
+      if (callback === undefined) {
+        return this._clickCallback;
+      }
+      this._clickCallback = callback;
       return this;
     }
 

--- a/src/interactions/clickInteraction.ts
+++ b/src/interactions/clickInteraction.ts
@@ -34,9 +34,36 @@ export module Interaction {
     }
   }
 
-  export class DoubleClick extends Click {
+  export class DoubleClick extends AbstractInteraction {
+
+    private _callback: (p: Point) => any;
+
+    public _anchor(component: Component.AbstractComponent, hitBox: D3.Selection) {
+      super._anchor(component, hitBox);
+      hitBox.on(this._listenTo(), () => {
+        var xy = d3.mouse(hitBox.node());
+        var x = xy[0];
+        var y = xy[1];
+        this._callback({x: x, y: y});
+      });
+    }
+
+    public _requiresHitbox() {
+      return true;
+    }
+
     protected _listenTo(): string {
       return "dblclick";
+    }
+
+    /**
+     * Sets a callback to be called when a click is received.
+     *
+     * @param {(p: Point) => any} cb Callback that takes the pixel position of the click event.
+     */
+    public callback(cb: (p: Point) => any): DoubleClick {
+      this._callback = cb;
+      return this;
     }
   }
 }

--- a/src/interactions/clickInteraction.ts
+++ b/src/interactions/clickInteraction.ts
@@ -13,21 +13,21 @@ export module Interaction {
       super._anchor(component, hitBox);
 
       this._mouseDispatcher = Dispatcher.Mouse.getDispatcher(<SVGElement> component.content().node());
-      this._mouseDispatcher.onMouseDown("Interaction.Click" + this.getID(), (p: Point) => this._handleMouseDown(p));
-      this._mouseDispatcher.onMouseUp("Interaction.Click" + this.getID(), (p: Point) => this._handleMouseUp(p));
+      this._mouseDispatcher.onMouseDown("Interaction.Click" + this.getID(), (p: Point) => this._handleClickDown(p));
+      this._mouseDispatcher.onMouseUp("Interaction.Click" + this.getID(), (p: Point) => this._handleClickUp(p));
 
       this._touchDispatcher = Dispatcher.Touch.getDispatcher(<SVGElement> component.content().node());
-      this._touchDispatcher.onTouchStart("Interaction.Click" + this.getID(), (p: Point) => this._handleMouseDown(p));
-      this._touchDispatcher.onTouchEnd("Interaction.Click" + this.getID(), (p: Point) => this._handleMouseUp(p));
+      this._touchDispatcher.onTouchStart("Interaction.Click" + this.getID(), (p: Point) => this._handleClickDown(p));
+      this._touchDispatcher.onTouchEnd("Interaction.Click" + this.getID(), (p: Point) => this._handleClickUp(p));
     }
 
-    private _handleMouseDown(p: Point) {
+    private _handleClickDown(p: Point) {
       if (this._isInsideComponent(p)) {
         this._clickedDown = true;
       }
     }
 
-    private _handleMouseUp(p: Point) {
+    private _handleClickUp(p: Point) {
       if (this._clickedDown && this._isInsideComponent(p) && (this.onClick() != null)) {
         this.onClick()(p);
       }

--- a/src/interactions/clickInteraction.ts
+++ b/src/interactions/clickInteraction.ts
@@ -7,6 +7,7 @@ export module Interaction {
     private _mouseDispatcher: Plottable.Dispatcher.Mouse;
     private _touchDispatcher: Plottable.Dispatcher.Touch;
     private _clickCallback: (p: Point) => any;
+    private _clickedDown = false;
 
     public _anchor(component: Component.AbstractComponent, hitBox: D3.Selection) {
       super._anchor(component, hitBox);
@@ -21,11 +22,16 @@ export module Interaction {
     }
 
     private _handleMouseDown(p: Point) {
-      // TODO: implement this
+      if (this._isInsideComponent(p)) {
+        this._clickedDown = true;
+      }
     }
 
     private _handleMouseUp(p: Point) {
-      // TODO: implement this
+      this._clickedDown = false;
+      if (this._isInsideComponent(p)) {
+        this.onClick()(p);
+      }
     }
 
     /**

--- a/src/interactions/clickInteraction.ts
+++ b/src/interactions/clickInteraction.ts
@@ -28,10 +28,10 @@ export module Interaction {
     }
 
     private _handleMouseUp(p: Point) {
-      this._clickedDown = false;
-      if (this._isInsideComponent(p)) {
+      if (this._clickedDown && this._isInsideComponent(p)) {
         this.onClick()(p);
       }
+      this._clickedDown = false;
     }
 
     /**

--- a/src/interactions/clickInteraction.ts
+++ b/src/interactions/clickInteraction.ts
@@ -28,7 +28,7 @@ export module Interaction {
     }
 
     private _handleMouseUp(p: Point) {
-      if (this._clickedDown && this._isInsideComponent(p)) {
+      if (this._clickedDown && this._isInsideComponent(p) && (this.onClick() != null)) {
         this.onClick()(p);
       }
       this._clickedDown = false;

--- a/src/interactions/clickInteraction.ts
+++ b/src/interactions/clickInteraction.ts
@@ -22,14 +22,16 @@ export module Interaction {
     }
 
     private _handleClickDown(p: Point) {
-      if (this._isInsideComponent(p)) {
+      var translatedPoint = this._translateToComponentSpace(p);
+      if (this._isInsideComponent(translatedPoint)) {
         this._clickedDown = true;
       }
     }
 
     private _handleClickUp(p: Point) {
-      if (this._clickedDown && this._isInsideComponent(p) && (this._clickCallback != null)) {
-        this._clickCallback(p);
+      var translatedPoint = this._translateToComponentSpace(p);
+      if (this._clickedDown && this._isInsideComponent(translatedPoint) && (this._clickCallback != null)) {
+        this._clickCallback(translatedPoint);
       }
       this._clickedDown = false;
     }

--- a/src/interactions/doubleClickInteraction.ts
+++ b/src/interactions/doubleClickInteraction.ts
@@ -2,7 +2,8 @@
 
 module Plottable {
 export module Interaction {
-  export class Click extends AbstractInteraction {
+  export class DoubleClick extends AbstractInteraction {
+
     private _callback: (p: Point) => any;
 
     public _anchor(component: Component.AbstractComponent, hitBox: D3.Selection) {
@@ -20,7 +21,7 @@ export module Interaction {
     }
 
     protected _listenTo(): string {
-      return "click";
+      return "dblclick";
     }
 
     /**
@@ -28,11 +29,10 @@ export module Interaction {
      *
      * @param {(p: Point) => any} cb Callback that takes the pixel position of the click event.
      */
-    public callback(cb: (p: Point) => any): Click {
+    public callback(cb: (p: Point) => any): DoubleClick {
       this._callback = cb;
       return this;
     }
-
   }
 }
 }

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -86,6 +86,7 @@
 
 /// <reference path="interactions/abstractInteraction.ts" />
 /// <reference path="interactions/clickInteraction.ts" />
+/// <reference path="interactions/doubleClickInteraction.ts" />
 /// <reference path="interactions/keyInteraction.ts" />
 /// <reference path="interactions/pointerInteraction.ts" />
 /// <reference path="interactions/panZoomInteraction.ts" />

--- a/test/interactions/clickInteractionTests.ts
+++ b/test/interactions/clickInteractionTests.ts
@@ -1,0 +1,60 @@
+///<reference path="../testReference.ts" />
+
+var assert = chai.assert;
+
+describe("Interactions", () => {
+  describe("Click", () => {
+    var SVG_WIDTH = 400;
+    var SVG_HEIGHT = 400;
+
+    it("onClick", () => {
+      var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      var c = new Plottable.Component.AbstractComponent();
+      c.renderTo(svg);
+
+      var clickInteraction = new Plottable.Interaction.Click();
+      c.registerInteraction(clickInteraction);
+
+      var callbackCalled = false;
+      var lastPoint: Plottable.Point;
+      var callback = function(p: Plottable.Point) {
+        callbackCalled = true;
+        lastPoint = p;
+      };
+      clickInteraction.onClick(callback);
+      assert.strictEqual(clickInteraction.onClick(), callback, "callback can be retrieved");
+
+      triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
+      triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
+      assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
+      assert.deepEqual(lastPoint, { x: SVG_WIDTH/2, y: SVG_HEIGHT/2 }, "was passed correct point (mouse)");
+
+//      callbackCalled = false;
+//      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH/4, SVG_HEIGHT/4);
+//      assert.isFalse(callbackCalled, "callback not called again if already in Component (mouse)");
+//
+//      triggerFakeMouseEvent("mousemove", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
+//      assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
+
+      callbackCalled = false;
+      lastPoint = null;
+      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
+      triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
+      assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
+      assert.deepEqual(lastPoint, { x: SVG_WIDTH/2, y: SVG_HEIGHT/2 }, "was passed correct point (touch)");
+
+//      callbackCalled = false;
+//      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH/4, SVG_HEIGHT/4);
+//      assert.isFalse(callbackCalled, "callback not called again if already in Component (touch)");
+//
+//      triggerFakeTouchEvent("touchstart", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
+//      assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
+//
+//      clickInteraction.onPointerEnter(null);
+//      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
+//      assert.isFalse(callbackCalled, "callback removed by passing null");
+
+      svg.remove();
+    });
+  });
+});

--- a/test/interactions/clickInteractionTests.ts
+++ b/test/interactions/clickInteractionTests.ts
@@ -24,14 +24,15 @@ describe("Interactions", () => {
       clickInteraction.onClick(callback);
       assert.strictEqual(clickInteraction.onClick(), callback, "callback can be retrieved");
 
-      triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
-      triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
+      triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+      triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
       assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
-      assert.deepEqual(lastPoint, { x: SVG_WIDTH/2, y: SVG_HEIGHT/2 }, "was passed correct point (mouse)");
+      assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (mouse)");
 
-//      callbackCalled = false;
-//      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH/4, SVG_HEIGHT/4);
-//      assert.isFalse(callbackCalled, "callback not called again if already in Component (mouse)");
+      callbackCalled = false;
+      triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+      triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
+      assert.isFalse(callbackCalled, "callback not called if released outside component (mouse)");
 //
 //      triggerFakeMouseEvent("mousemove", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
 //      assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
@@ -42,6 +43,11 @@ describe("Interactions", () => {
       triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
       assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
       assert.deepEqual(lastPoint, { x: SVG_WIDTH/2, y: SVG_HEIGHT/2 }, "was passed correct point (touch)");
+
+      callbackCalled = false;
+      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+      triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
+      assert.isFalse(callbackCalled, "callback not called if released outside component (touch)");
 
 //      callbackCalled = false;
 //      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH/4, SVG_HEIGHT/4);

--- a/test/interactions/clickInteractionTests.ts
+++ b/test/interactions/clickInteractionTests.ts
@@ -33,6 +33,10 @@ describe("Interactions", () => {
       triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
       triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
       assert.isFalse(callbackCalled, "callback not called if released outside component (mouse)");
+
+      triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
+      triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+      assert.isFalse(callbackCalled, "callback not called if started outside component (mouse)");
 //
 //      triggerFakeMouseEvent("mousemove", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
 //      assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
@@ -48,6 +52,11 @@ describe("Interactions", () => {
       triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
       triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
       assert.isFalse(callbackCalled, "callback not called if released outside component (touch)");
+
+      callbackCalled = false;
+      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
+      triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+      assert.isFalse(callbackCalled, "callback not called if started outside component (touch)");
 
 //      callbackCalled = false;
 //      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH/4, SVG_HEIGHT/4);

--- a/test/interactions/clickInteractionTests.ts
+++ b/test/interactions/clickInteractionTests.ts
@@ -30,6 +30,13 @@ describe("Interactions", () => {
       assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (mouse)");
 
       callbackCalled = false;
+      lastPoint = null;
+      triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+      triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH / 4, SVG_HEIGHT / 4);
+      assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
+      assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed mouseup point (mouse)");
+
+      callbackCalled = false;
       triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
       triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
       assert.isFalse(callbackCalled, "callback not called if released outside component (mouse)");
@@ -37,9 +44,11 @@ describe("Interactions", () => {
       triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
       triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
       assert.isFalse(callbackCalled, "callback not called if started outside component (mouse)");
-//
-//      triggerFakeMouseEvent("mousemove", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
-//      assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
+
+      triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
+      triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+      assert.isTrue(callbackCalled, "callback called even if moved outside component (mouse)");
 
       callbackCalled = false;
       lastPoint = null;
@@ -47,6 +56,13 @@ describe("Interactions", () => {
       triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
       assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
       assert.deepEqual(lastPoint, { x: SVG_WIDTH/2, y: SVG_HEIGHT/2 }, "was passed correct point (touch)");
+
+      callbackCalled = false;
+      lastPoint = null;
+      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+      triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH / 4, SVG_HEIGHT / 4);
+      assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
+      assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed mouseup point (touch)");
 
       callbackCalled = false;
       triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
@@ -58,16 +74,10 @@ describe("Interactions", () => {
       triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
       assert.isFalse(callbackCalled, "callback not called if started outside component (touch)");
 
-//      callbackCalled = false;
-//      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH/4, SVG_HEIGHT/4);
-//      assert.isFalse(callbackCalled, "callback not called again if already in Component (touch)");
-//
-//      triggerFakeTouchEvent("touchstart", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
-//      assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
-//
-//      clickInteraction.onPointerEnter(null);
-//      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
-//      assert.isFalse(callbackCalled, "callback removed by passing null");
+      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+      triggerFakeTouchEvent("touchmove", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
+      triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+      assert.isTrue(callbackCalled, "callback called even if moved outside component (touch)");
 
       svg.remove();
     });

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -62,6 +62,7 @@
 ///<reference path="interactions/pointerInteractionTests.ts" />
 ///<reference path="interactions/dragBoxTests.ts" />
 ///<reference path="interactions/hoverInteractionTests.ts" />
+///<reference path="interactions/clickInteractionTests.ts" />
 
 ///<reference path="dispatchers/dispatcherTests.ts" />
 ///<reference path="dispatchers/mouseDispatcherTests.ts" />

--- a/test/tests.js
+++ b/test/tests.js
@@ -8073,6 +8073,9 @@ describe("Interactions", function () {
             triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
             triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
             assert.isFalse(callbackCalled, "callback not called if released outside component (mouse)");
+            triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
+            triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            assert.isFalse(callbackCalled, "callback not called if started outside component (mouse)");
             //
             //      triggerFakeMouseEvent("mousemove", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
             //      assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
@@ -8086,6 +8089,10 @@ describe("Interactions", function () {
             triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
             triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
             assert.isFalse(callbackCalled, "callback not called if released outside component (touch)");
+            callbackCalled = false;
+            triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
+            triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            assert.isFalse(callbackCalled, "callback not called if started outside component (touch)");
             //      callbackCalled = false;
             //      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH/4, SVG_HEIGHT/4);
             //      assert.isFalse(callbackCalled, "callback not called again if already in Component (touch)");

--- a/test/tests.js
+++ b/test/tests.js
@@ -8069,9 +8069,10 @@ describe("Interactions", function () {
             triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
             assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
             assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (mouse)");
-            //      callbackCalled = false;
-            //      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH/4, SVG_HEIGHT/4);
-            //      assert.isFalse(callbackCalled, "callback not called again if already in Component (mouse)");
+            callbackCalled = false;
+            triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
+            assert.isFalse(callbackCalled, "callback not called if released outside component (mouse)");
             //
             //      triggerFakeMouseEvent("mousemove", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
             //      assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
@@ -8081,6 +8082,10 @@ describe("Interactions", function () {
             triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
             assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
             assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (touch)");
+            callbackCalled = false;
+            triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
+            assert.isFalse(callbackCalled, "callback not called if released outside component (touch)");
             //      callbackCalled = false;
             //      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH/4, SVG_HEIGHT/4);
             //      assert.isFalse(callbackCalled, "callback not called again if already in Component (touch)");

--- a/test/tests.js
+++ b/test/tests.js
@@ -8070,21 +8070,34 @@ describe("Interactions", function () {
             assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
             assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (mouse)");
             callbackCalled = false;
+            lastPoint = null;
+            triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH / 4, SVG_HEIGHT / 4);
+            assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
+            assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed mouseup point (mouse)");
+            callbackCalled = false;
             triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
             triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
             assert.isFalse(callbackCalled, "callback not called if released outside component (mouse)");
             triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
             triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
             assert.isFalse(callbackCalled, "callback not called if started outside component (mouse)");
-            //
-            //      triggerFakeMouseEvent("mousemove", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
-            //      assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
+            triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
+            triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            assert.isTrue(callbackCalled, "callback called even if moved outside component (mouse)");
             callbackCalled = false;
             lastPoint = null;
             triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
             triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
             assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
             assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (touch)");
+            callbackCalled = false;
+            lastPoint = null;
+            triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH / 4, SVG_HEIGHT / 4);
+            assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
+            assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed mouseup point (touch)");
             callbackCalled = false;
             triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
             triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
@@ -8093,16 +8106,10 @@ describe("Interactions", function () {
             triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
             triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
             assert.isFalse(callbackCalled, "callback not called if started outside component (touch)");
-            //      callbackCalled = false;
-            //      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH/4, SVG_HEIGHT/4);
-            //      assert.isFalse(callbackCalled, "callback not called again if already in Component (touch)");
-            //
-            //      triggerFakeTouchEvent("touchstart", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
-            //      assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
-            //
-            //      clickInteraction.onPointerEnter(null);
-            //      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
-            //      assert.isFalse(callbackCalled, "callback removed by passing null");
+            triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            triggerFakeTouchEvent("touchmove", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
+            triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            assert.isTrue(callbackCalled, "callback called even if moved outside component (touch)");
             svg.remove();
         });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -8047,6 +8047,57 @@ describe("Interactions", function () {
 
 ///<reference path="../testReference.ts" />
 var assert = chai.assert;
+describe("Interactions", function () {
+    describe("Click", function () {
+        var SVG_WIDTH = 400;
+        var SVG_HEIGHT = 400;
+        it("onClick", function () {
+            var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+            var c = new Plottable.Component.AbstractComponent();
+            c.renderTo(svg);
+            var clickInteraction = new Plottable.Interaction.Click();
+            c.registerInteraction(clickInteraction);
+            var callbackCalled = false;
+            var lastPoint;
+            var callback = function (p) {
+                callbackCalled = true;
+                lastPoint = p;
+            };
+            clickInteraction.onClick(callback);
+            assert.strictEqual(clickInteraction.onClick(), callback, "callback can be retrieved");
+            triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
+            assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (mouse)");
+            //      callbackCalled = false;
+            //      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH/4, SVG_HEIGHT/4);
+            //      assert.isFalse(callbackCalled, "callback not called again if already in Component (mouse)");
+            //
+            //      triggerFakeMouseEvent("mousemove", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
+            //      assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
+            callbackCalled = false;
+            lastPoint = null;
+            triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            triggerFakeTouchEvent("touchend", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+            assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
+            assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (touch)");
+            //      callbackCalled = false;
+            //      triggerFakeTouchEvent("touchstart", c.content(), SVG_WIDTH/4, SVG_HEIGHT/4);
+            //      assert.isFalse(callbackCalled, "callback not called again if already in Component (touch)");
+            //
+            //      triggerFakeTouchEvent("touchstart", c.content(), 2*SVG_WIDTH, 2*SVG_HEIGHT);
+            //      assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
+            //
+            //      clickInteraction.onPointerEnter(null);
+            //      triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH/2, SVG_HEIGHT/2);
+            //      assert.isFalse(callbackCalled, "callback removed by passing null");
+            svg.remove();
+        });
+    });
+});
+
+///<reference path="../testReference.ts" />
+var assert = chai.assert;
 describe("Dispatchers", function () {
     describe("AbstractDispatcher", function () {
         it("_connect() and _disconnect()", function () {


### PR DESCRIPTION
`Interaction.Click` responds to clicks within a component using a callback set through `onClick`

API-Breaks:
The `callback` setter on `Interaction.Click` has been reworked and renamed into an `onClick` getter/setter API.

Fixes #1684 