### PR TITLE
[SymbolDrawer] - Extends from ElementDrawer

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1608,10 +1608,9 @@ declare module Plottable {
 
 declare module Plottable {
     module _Drawer {
-        class Symbol extends AbstractDrawer {
-            protected _enterData(data: any[]): void;
+        class Symbol extends Element {
+            constructor(key: string);
             protected _drawStep(step: AppliedDrawStep): void;
-            _getSelector(): string;
             _getPixelPoint(datum: any, index: number): Point;
         }
     }

--- a/plottable.js
+++ b/plottable.js
@@ -3353,22 +3353,13 @@ var Plottable;
     (function (_Drawer) {
         var Symbol = (function (_super) {
             __extends(Symbol, _super);
-            function Symbol() {
-                _super.apply(this, arguments);
+            function Symbol(key) {
+                _super.call(this, key);
+                this._svgElement = "path";
+                this._className = "symbol";
             }
-            Symbol.prototype._enterData = function (data) {
-                _super.prototype._enterData.call(this, data);
-                var dataElements = this._getDrawSelection().data(data);
-                dataElements.enter().append("path");
-                dataElements.exit().remove();
-                dataElements.classed("symbol", true);
-            };
-            Symbol.prototype._getDrawSelection = function () {
-                return this._getRenderArea().selectAll("path");
-            };
             Symbol.prototype._drawStep = function (step) {
-                _super.prototype._drawStep.call(this, step);
-                var attrToProjector = Plottable._Util.Methods.copyMap(step.attrToProjector);
+                var attrToProjector = step.attrToProjector;
                 this._attrToProjector = Plottable._Util.Methods.copyMap(step.attrToProjector);
                 var xProjector = attrToProjector["x"];
                 var yProjector = attrToProjector["y"];
@@ -3380,20 +3371,13 @@ var Plottable;
                 var symbolProjector = attrToProjector["symbol"];
                 delete attrToProjector["symbol"];
                 attrToProjector["d"] = symbolProjector;
-                var drawSelection = this._getDrawSelection();
-                if (attrToProjector["fill"]) {
-                    drawSelection.attr("fill", attrToProjector["fill"]); // so colors don't animate
-                }
-                step.animator.animate(drawSelection, attrToProjector);
-            };
-            Symbol.prototype._getSelector = function () {
-                return "path";
+                _super.prototype._drawStep.call(this, step);
             };
             Symbol.prototype._getPixelPoint = function (datum, index) {
                 return { x: this._attrToProjector["x"](datum, index), y: this._attrToProjector["y"](datum, index) };
             };
             return Symbol;
-        })(_Drawer.AbstractDrawer);
+        })(_Drawer.Element);
         _Drawer.Symbol = Symbol;
     })(_Drawer = Plottable._Drawer || (Plottable._Drawer = {}));
 })(Plottable || (Plottable = {}));

--- a/src/drawers/symbolDrawer.ts
+++ b/src/drawers/symbolDrawer.ts
@@ -2,23 +2,16 @@
 
 module Plottable {
 export module _Drawer {
-  export class Symbol extends AbstractDrawer {
+  export class Symbol extends Element {
 
-    protected _enterData(data: any[]) {
-      super._enterData(data);
-      var dataElements = this._getDrawSelection().data(data);
-      dataElements.enter().append("path");
-      dataElements.exit().remove();
-      dataElements.classed("symbol", true);
-    }
-
-    private _getDrawSelection() {
-      return this._getRenderArea().selectAll("path");
+    constructor(key: string) {
+      super(key);
+      this._svgElement = "path";
+      this._className = "symbol";
     }
 
     protected _drawStep(step: AppliedDrawStep) {
-      super._drawStep(step);
-      var attrToProjector = <AttributeToAppliedProjector>_Util.Methods.copyMap(step.attrToProjector);
+      var attrToProjector = step.attrToProjector;
       this._attrToProjector = <AttributeToAppliedProjector>_Util.Methods.copyMap(step.attrToProjector);
 
       var xProjector = attrToProjector["x"];
@@ -38,16 +31,7 @@ export module _Drawer {
 
       attrToProjector["d"] = symbolProjector;
 
-      var drawSelection = this._getDrawSelection();
-      if (attrToProjector["fill"]) {
-        drawSelection.attr("fill", attrToProjector["fill"]); // so colors don't animate
-      }
-
-      step.animator.animate(drawSelection, attrToProjector);
-    }
-
-    public _getSelector() {
-      return "path";
+      super._drawStep(step);
     }
 
     public _getPixelPoint(datum: any, index: number): Point {

--- a/test/components/plots/scatterPlotTests.ts
+++ b/test/components/plots/scatterPlotTests.ts
@@ -111,6 +111,40 @@ describe("Plots", () => {
       svg.remove();
     });
 
+    it("correctly handles NaN and undefined x and y values", () => {
+      var svg = generateSVG(400, 400);
+      var data = [
+        { foo: 0.0, bar: 0.0 },
+        { foo: 0.2, bar: 0.2 },
+        { foo: 0.4, bar: 0.4 },
+        { foo: 0.6, bar: 0.6 },
+        { foo: 0.8, bar: 0.8 }
+      ];
+      var dataset = new Plottable.Dataset(data);
+      var xScale = new Plottable.Scale.Linear();
+      var yScale = new Plottable.Scale.Linear();
+      var plot = new Plottable.Plot.Scatter(xScale, yScale);
+      plot.addDataset(dataset)
+          .project("x", "foo", xScale)
+          .project("y", "bar", yScale);
+      plot.renderTo(svg);
+
+      var dataWithNaN = data.slice();
+      dataWithNaN[2] = { foo: 0.4, bar: NaN };
+      dataset.data(dataWithNaN);
+      assert.strictEqual(plot.getAllSelections().size(), 4, "does not retrieve NaN point");
+
+      var dataWithUndefined = data.slice();
+      dataWithUndefined[2] = { foo: 0.4, bar: undefined };
+      dataset.data(dataWithUndefined);
+      assert.strictEqual(plot.getAllSelections().size(), 4, "does not retrieve undefined point");
+      dataWithUndefined[2] = { foo: undefined, bar: 0.4 };
+      dataset.data(dataWithUndefined);
+      assert.strictEqual(plot.getAllSelections().size(), 4, "does not retrieve undefined point");
+
+      svg.remove();
+    });
+
     describe("Example ScatterPlot with quadratic series", () => {
       var svg: D3.Selection;
       var xScale: Plottable.Scale.Linear;

--- a/test/components/plots/scatterPlotTests.ts
+++ b/test/components/plots/scatterPlotTests.ts
@@ -132,15 +132,15 @@ describe("Plots", () => {
       var dataWithNaN = data.slice();
       dataWithNaN[2] = { foo: 0.4, bar: NaN };
       dataset.data(dataWithNaN);
-      assert.strictEqual(plot.getAllSelections().size(), 4, "does not retrieve NaN point");
+      assert.strictEqual(plot.getAllSelections().size(), 4, "does not draw NaN point");
 
       var dataWithUndefined = data.slice();
       dataWithUndefined[2] = { foo: 0.4, bar: undefined };
       dataset.data(dataWithUndefined);
-      assert.strictEqual(plot.getAllSelections().size(), 4, "does not retrieve undefined point");
+      assert.strictEqual(plot.getAllSelections().size(), 4, "does not draw undefined point");
       dataWithUndefined[2] = { foo: undefined, bar: 0.4 };
       dataset.data(dataWithUndefined);
-      assert.strictEqual(plot.getAllSelections().size(), 4, "does not retrieve undefined point");
+      assert.strictEqual(plot.getAllSelections().size(), 4, "does not draw undefined point");
 
       svg.remove();
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -3708,14 +3708,14 @@ describe("Plots", function () {
             var dataWithNaN = data.slice();
             dataWithNaN[2] = { foo: 0.4, bar: NaN };
             dataset.data(dataWithNaN);
-            assert.strictEqual(plot.getAllSelections().size(), 4, "does not retrieve NaN point");
+            assert.strictEqual(plot.getAllSelections().size(), 4, "does not draw NaN point");
             var dataWithUndefined = data.slice();
             dataWithUndefined[2] = { foo: 0.4, bar: undefined };
             dataset.data(dataWithUndefined);
-            assert.strictEqual(plot.getAllSelections().size(), 4, "does not retrieve undefined point");
+            assert.strictEqual(plot.getAllSelections().size(), 4, "does not draw undefined point");
             dataWithUndefined[2] = { foo: undefined, bar: 0.4 };
             dataset.data(dataWithUndefined);
-            assert.strictEqual(plot.getAllSelections().size(), 4, "does not retrieve undefined point");
+            assert.strictEqual(plot.getAllSelections().size(), 4, "does not draw undefined point");
             svg.remove();
         });
         describe("Example ScatterPlot with quadratic series", function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -3690,6 +3690,34 @@ describe("Plots", function () {
             assert.isNull(farFromAnyPointsResult.data, "returns no data if no circle were within range and test point does not touch any circles");
             svg.remove();
         });
+        it("correctly handles NaN and undefined x and y values", function () {
+            var svg = generateSVG(400, 400);
+            var data = [
+                { foo: 0.0, bar: 0.0 },
+                { foo: 0.2, bar: 0.2 },
+                { foo: 0.4, bar: 0.4 },
+                { foo: 0.6, bar: 0.6 },
+                { foo: 0.8, bar: 0.8 }
+            ];
+            var dataset = new Plottable.Dataset(data);
+            var xScale = new Plottable.Scale.Linear();
+            var yScale = new Plottable.Scale.Linear();
+            var plot = new Plottable.Plot.Scatter(xScale, yScale);
+            plot.addDataset(dataset).project("x", "foo", xScale).project("y", "bar", yScale);
+            plot.renderTo(svg);
+            var dataWithNaN = data.slice();
+            dataWithNaN[2] = { foo: 0.4, bar: NaN };
+            dataset.data(dataWithNaN);
+            assert.strictEqual(plot.getAllSelections().size(), 4, "does not retrieve NaN point");
+            var dataWithUndefined = data.slice();
+            dataWithUndefined[2] = { foo: 0.4, bar: undefined };
+            dataset.data(dataWithUndefined);
+            assert.strictEqual(plot.getAllSelections().size(), 4, "does not retrieve undefined point");
+            dataWithUndefined[2] = { foo: undefined, bar: 0.4 };
+            dataset.data(dataWithUndefined);
+            assert.strictEqual(plot.getAllSelections().size(), 4, "does not retrieve undefined point");
+            svg.remove();
+        });
         describe("Example ScatterPlot with quadratic series", function () {
             var svg;
             var xScale;


### PR DESCRIPTION
`Drawer.Element` has functionality that should have been picked up in `Drawer.Symbol` but due to the lack of extension, that was unfortunately not picked up.  Now the hierarchy is made.

Fixes #1771