### PR TITLE
Make Component.Group expand only if necessary

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1664,26 +1664,28 @@ declare module Plottable {
              */
             redraw(): AbstractComponent;
             /**
-             * Sets the x alignment of the Component. This will be used if the
-             * Component is given more space than it needs.
+             * Gets the x alignment of the Component.
              *
-             * For example, you may want to make a Legend postition itself it the top
-             * right, so you would call `legend.xAlign("right")` and
-             * `legend.yAlign("top")`.
+             * @returns {string} The current x alignment.
+             */
+            xAlign(): string;
+            /**
+             * Sets the x alignment of the Component.
              *
              * @param {string} alignment The x alignment of the Component (one of ["left", "center", "right"]).
              * @returns {Component} The calling Component.
              */
             xAlign(alignment: string): AbstractComponent;
             /**
-             * Sets the y alignment of the Component. This will be used if the
-             * Component is given more space than it needs.
+             * Gets the y alignment of the Component.
              *
-             * For example, you may want to make a Legend postition itself it the top
-             * right, so you would call `legend.xAlign("right")` and
-             * `legend.yAlign("top")`.
+             * @returns {string} The current y alignment.
+             */
+            yAlign(): string;
+            /**
+             * Sets the y alignment of the Component.
              *
-             * @param {string} alignment The x alignment of the Component (one of ["top", "center", "bottom"]).
+             * @param {string} alignment The y alignment of the Component (one of ["top", "center", "bottom"]).
              * @returns {Component} The calling Component.
              */
             yAlign(alignment: string): AbstractComponent;
@@ -2254,22 +2256,6 @@ declare module Plottable {
              * @param {string} orientation The orientation of the Label (horizontal/left/right) (default = "horizontal").
              */
             constructor(displayText?: string, orientation?: string);
-            /**
-             * Sets the horizontal side the label will go to given the label is given more space that it needs
-             *
-             * @param {string} alignment The new setting, one of `["left", "center",
-             * "right"]`. Defaults to `"center"`.
-             * @returns {Label} The calling Label.
-             */
-            xAlign(alignment: string): Label;
-            /**
-             * Sets the vertical side the label will go to given the label is given more space that it needs
-             *
-             * @param {string} alignment The new setting, one of `["top", "center",
-             * "bottom"]`. Defaults to `"center"`.
-             * @returns {Label} The calling Label.
-             */
-            yAlign(alignment: string): Label;
             _requestedSpace(offeredWidth: number, offeredHeight: number): _SpaceRequest;
             protected _setup(): void;
             /**

--- a/plottable.js
+++ b/plottable.js
@@ -4048,10 +4048,16 @@ var Plottable;
                 return this;
             };
             Group.prototype._isFixedWidth = function () {
-                return false;
+                var components = this.components();
+                var allFixedWidth = components.every(function (c) { return c._isFixedWidth(); });
+                var allSameXAlignment = components.every(function (c) { return c.xAlign() === components[0].xAlign(); });
+                return allFixedWidth && allSameXAlignment;
             };
             Group.prototype._isFixedHeight = function () {
-                return false;
+                var components = this.components();
+                var allFixedHeight = components.every(function (c) { return c._isFixedHeight(); });
+                var allSameYAlignment = components.every(function (c) { return c.yAlign() === components[0].yAlign(); });
+                return allFixedHeight && allSameYAlignment;
             };
             return Group;
         })(Component.AbstractComponentContainer);

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -13,8 +13,18 @@ export module Component {
     private _yOrigin: number;
 
     public _parent: AbstractComponentContainer;
-    private _xAlignProportion = 0; // What % along the free space do we want to position (0 = left, .5 = center, 1 = right)
-    private _yAlignProportion = 0;
+    private _xAlignment: string = "left";
+    private static _xAlignToProportion: { [alignment: string]: number } = {
+      "left": 0,
+      "center": 0.5,
+      "right": 1
+    };
+    private _yAlignment: string = "top";
+    private static _yAlignToProportion: { [alignment: string]: number } = {
+      "top": 0,
+      "center": 0.5,
+      "bottom": 1
+    };
     protected _fixedHeightFlag = false;
     protected _fixedWidthFlag = false;
     protected _isSetup = false;
@@ -138,8 +148,10 @@ export module Component {
       this._width  = this._isFixedWidth()  ? Math.min(availableWidth , requestedSpace.width)  : availableWidth ;
       this._height = this._isFixedHeight() ? Math.min(availableHeight, requestedSpace.height) : availableHeight;
 
-      this._xOrigin = offeredXOrigin + this._xOffset + (availableWidth - this.width()) * this._xAlignProportion;
-      this._yOrigin = offeredYOrigin + this._yOffset + (availableHeight - this.height()) * this._yAlignProportion;;
+      var xAlignProportion = AbstractComponent._xAlignToProportion[this._xAlignment];
+      this._xOrigin = offeredXOrigin + this._xOffset + (availableWidth - this.width()) * xAlignProportion;
+      var yAlignProportion = AbstractComponent._yAlignToProportion[this._yAlignment];
+      this._yOrigin = offeredYOrigin + this._yOffset + (availableHeight - this.height()) * yAlignProportion;;
 
       this._element.attr("transform", "translate(" + this._xOrigin + "," + this._yOrigin + ")");
       this._boxes.forEach((b: D3.Selection) => b.attr("width", this.width()).attr("height", this.height()));
@@ -225,53 +237,55 @@ export module Component {
     }
 
     /**
-     * Sets the x alignment of the Component. This will be used if the
-     * Component is given more space than it needs.
+     * Gets the x alignment of the Component.
      *
-     * For example, you may want to make a Legend postition itself it the top
-     * right, so you would call `legend.xAlign("right")` and
-     * `legend.yAlign("top")`.
+     * @returns {string} The current x alignment.
+     */
+    public xAlign(): string;
+    /**
+     * Sets the x alignment of the Component.
      *
      * @param {string} alignment The x alignment of the Component (one of ["left", "center", "right"]).
      * @returns {Component} The calling Component.
      */
-    public xAlign(alignment: string): AbstractComponent {
-      alignment = alignment.toLowerCase();
-      if (alignment === "left") {
-        this._xAlignProportion = 0;
-      } else if (alignment === "center") {
-        this._xAlignProportion = 0.5;
-      } else if (alignment === "right") {
-        this._xAlignProportion = 1;
-      } else {
-        throw new Error("Unsupported alignment");
+    public xAlign(alignment: string): AbstractComponent;
+    public xAlign(alignment?: string): any {
+      if (alignment == null) {
+        return this._xAlignment;
       }
+
+      alignment = alignment.toLowerCase();
+      if (AbstractComponent._xAlignToProportion[alignment] == null) {
+        throw new Error("Unsupported alignment: " + alignment);
+      }
+      this._xAlignment = alignment;
       this._invalidateLayout();
       return this;
     }
 
     /**
-     * Sets the y alignment of the Component. This will be used if the
-     * Component is given more space than it needs.
+     * Gets the y alignment of the Component.
      *
-     * For example, you may want to make a Legend postition itself it the top
-     * right, so you would call `legend.xAlign("right")` and
-     * `legend.yAlign("top")`.
+     * @returns {string} The current y alignment.
+     */
+    public yAlign(): string;
+    /**
+     * Sets the y alignment of the Component.
      *
-     * @param {string} alignment The x alignment of the Component (one of ["top", "center", "bottom"]).
+     * @param {string} alignment The y alignment of the Component (one of ["top", "center", "bottom"]).
      * @returns {Component} The calling Component.
      */
-    public yAlign(alignment: string): AbstractComponent {
-      alignment = alignment.toLowerCase();
-      if (alignment === "top") {
-        this._yAlignProportion = 0;
-      } else if (alignment === "center") {
-        this._yAlignProportion = 0.5;
-      } else if (alignment === "bottom") {
-        this._yAlignProportion = 1;
-      } else {
-        throw new Error("Unsupported alignment");
+    public yAlign(alignment: string): AbstractComponent;
+    public yAlign(alignment?: string): any {
+      if (alignment == null) {
+        return this._yAlignment;
       }
+
+      alignment = alignment.toLowerCase();
+      if (AbstractComponent._yAlignToProportion[alignment] == null) {
+        throw new Error("Unsupported alignment: " + alignment);
+      }
+      this._yAlignment = alignment;
       this._invalidateLayout();
       return this;
     }

--- a/src/components/componentGroup.ts
+++ b/src/components/componentGroup.ts
@@ -50,11 +50,17 @@ export module Component {
     }
 
     public _isFixedWidth(): boolean {
-      return false;
+      var components = this.components();
+      var allFixedWidth = components.every((c) => c._isFixedWidth());
+      var allSameXAlignment = components.every((c) => c.xAlign() === components[0].xAlign());
+      return allFixedWidth && allSameXAlignment;
     }
 
     public _isFixedHeight(): boolean {
-      return false;
+      var components = this.components();
+      var allFixedHeight = components.every((c) => c._isFixedHeight());
+      var allSameYAlignment = components.every((c) => c.yAlign() === components[0].yAlign());
+      return allFixedHeight && allSameYAlignment;
     }
   }
 }

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -9,8 +9,6 @@ export module Component {
     private _measurer: SVGTypewriter.Measurers.Measurer;
     private _wrapper: SVGTypewriter.Wrappers.Wrapper;
     private _writer: SVGTypewriter.Writers.Writer;
-    private _xAlignment: string;
-    private _yAlignment: string;
     private _padding: number;
 
     /**
@@ -32,34 +30,6 @@ export module Component {
       this._fixedHeightFlag = true;
       this._fixedWidthFlag = true;
       this._padding = 0;
-    }
-
-    /**
-     * Sets the horizontal side the label will go to given the label is given more space that it needs
-     *
-     * @param {string} alignment The new setting, one of `["left", "center",
-     * "right"]`. Defaults to `"center"`.
-     * @returns {Label} The calling Label.
-     */
-    public xAlign(alignment: string): Label {
-      var alignmentLC = alignment.toLowerCase();
-      super.xAlign(alignmentLC);
-      this._xAlignment = alignmentLC;
-      return this;
-    }
-
-    /**
-     * Sets the vertical side the label will go to given the label is given more space that it needs
-     *
-     * @param {string} alignment The new setting, one of `["top", "center",
-     * "bottom"]`. Defaults to `"center"`.
-     * @returns {Label} The calling Label.
-     */
-    public yAlign(alignment: string): Label {
-      var alignmentLC = alignment.toLowerCase();
-      super.yAlign(alignmentLC);
-      this._yAlignment = alignmentLC;
-      return this;
     }
 
     public _requestedSpace(offeredWidth: number, offeredHeight: number): _SpaceRequest {
@@ -176,8 +146,8 @@ export module Component {
       var textRotation: {[s: string]: number} = {horizontal: 0, right: 90, left: -90};
       var writeOptions = {
                         selection: this._textContainer,
-                        xAlign: this._xAlignment,
-                        yAlign: this._yAlignment,
+                        xAlign: this.xAlign(),
+                        yAlign: this.yAlign(),
                         textRotation: textRotation[this.orient()]
                     };
       this._writer.write(this._text, writeWidth, writeHeight, writeOptions);

--- a/test/components/baseAxisTests.ts
+++ b/test/components/baseAxisTests.ts
@@ -200,12 +200,12 @@ describe("BaseAxis", () => {
   it("default alignment based on orientation", () => {
     var scale = new Plottable.Scale.Linear();
     var baseAxis = new Plottable.Axis.AbstractAxis(scale, "bottom");
-    assert.equal((<any> baseAxis)._yAlignProportion, 0, "yAlignProportion defaults to 0 for bottom axis");
+    assert.equal(baseAxis.yAlign(), "top", "y alignment defaults to \"top\" for bottom axis");
     baseAxis = new Plottable.Axis.AbstractAxis(scale, "top");
-    assert.equal((<any> baseAxis)._yAlignProportion, 1, "yAlignProportion defaults to 1 for top axis");
+    assert.equal(baseAxis.yAlign(), "bottom", "y alignment defaults to \"bottom\" for top axis");
     baseAxis = new Plottable.Axis.AbstractAxis(scale, "left");
-    assert.equal((<any> baseAxis)._xAlignProportion, 1, "xAlignProportion defaults to 1 for left axis");
+    assert.equal(baseAxis.xAlign(), "right", "x alignment defaults to \"right\" for left axis");
     baseAxis = new Plottable.Axis.AbstractAxis(scale, "right");
-    assert.equal((<any> baseAxis)._xAlignProportion, 0, "xAlignProportion defaults to 0 for right axis");
+    assert.equal(baseAxis.xAlign(), "left", "x alignment defaults to \"left\" for right axis");
   });
 });

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -191,8 +191,8 @@ describe("Component behavior", () => {
     assert.equal(layout.height, 0, "requested height defaults to 0");
     assert.equal(layout.wantsWidth , false, "_requestedSpace().wantsWidth  defaults to false");
     assert.equal(layout.wantsHeight, false, "_requestedSpace().wantsHeight defaults to false");
-    assert.equal((<any> c)._xAlignProportion, 0, "_xAlignProportion defaults to 0");
-    assert.equal((<any> c)._yAlignProportion, 0, "_yAlignProportion defaults to 0");
+    assert.equal(c.xAlign(), "left", "x alignment defaults to \"left\"");
+    assert.equal(c.yAlign(), "top", "y alignment defaults to \"top\"");
     assert.equal((<any> c)._xOffset, 0, "xOffset defaults to 0");
     assert.equal((<any> c)._yOffset, 0, "yOffset defaults to 0");
     svg.remove();

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -327,20 +327,6 @@ describe("Component behavior", () => {
     svg.remove();
   });
 
-  it("_invalidateLayout works as expected", () => {
-    var cg = new Plottable.Component.Group();
-    var c = makeFixedSizeComponent(10, 10);
-    cg._addComponent(c);
-    cg.renderTo(svg);
-    assert.equal(cg.height(), 300, "height() is the entire available height");
-    assert.equal(cg.width(), 400, "width() is the entire available width");
-    fixComponentSize(c, 50, 50);
-    c._invalidateLayout();
-    assert.equal(cg.height(), 300, "height() after resizing is the entire available height");
-    assert.equal(cg.width(), 400, "width() after resizing is the entire available width");
-    svg.remove();
-  });
-
   it("components can be detached even if not anchored", () => {
     var c = new Plottable.Component.AbstractComponent();
     c.detach(); // no error thrown

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -1,0 +1,25 @@
+///<reference path="testReference.ts" />
+
+module Mocks {
+  export class FixedSizeComponent extends Plottable.Component.AbstractComponent {
+    public fixedWidth: number;
+    public fixedHeight: number;
+
+    constructor(width = 0, height = 0) {
+      super();
+      this.fixedWidth = width;
+      this.fixedHeight = height;
+      this._fixedWidthFlag = true;
+      this._fixedHeightFlag = true;
+    }
+
+    public _requestedSpace(availableWidth : number, availableHeight: number): Plottable._SpaceRequest {
+      return {
+        width:  this.fixedWidth,
+        height: this.fixedHeight,
+        wantsWidth : availableWidth < this.fixedWidth,
+        wantsHeight: availableHeight < this.fixedHeight
+      };
+    }
+  }
+}

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -3,9 +3,10 @@
 ///<reference path="../typings/d3/d3.d.ts" />
 ///<reference path="../typings/jquery/jquery.d.ts" />
 ///<reference path="../typings/jquery.simulate/jquery.simulate.d.ts" />
-///<reference path="testUtils.ts" />
 ///<reference path="../build/plottable.d.ts" />
 ///<reference path="../bower_components/svg-typewriter/svgtypewriter.d.ts" />
+///<reference path="testUtils.ts" />
+///<reference path="mocks.ts" />
 
 ///<reference path="globalInitialization.ts" />
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -641,13 +641,13 @@ describe("BaseAxis", function () {
     it("default alignment based on orientation", function () {
         var scale = new Plottable.Scale.Linear();
         var baseAxis = new Plottable.Axis.AbstractAxis(scale, "bottom");
-        assert.equal(baseAxis._yAlignProportion, 0, "yAlignProportion defaults to 0 for bottom axis");
+        assert.equal(baseAxis.yAlign(), "top", "y alignment defaults to \"top\" for bottom axis");
         baseAxis = new Plottable.Axis.AbstractAxis(scale, "top");
-        assert.equal(baseAxis._yAlignProportion, 1, "yAlignProportion defaults to 1 for top axis");
+        assert.equal(baseAxis.yAlign(), "bottom", "y alignment defaults to \"bottom\" for top axis");
         baseAxis = new Plottable.Axis.AbstractAxis(scale, "left");
-        assert.equal(baseAxis._xAlignProportion, 1, "xAlignProportion defaults to 1 for left axis");
+        assert.equal(baseAxis.xAlign(), "right", "x alignment defaults to \"right\" for left axis");
         baseAxis = new Plottable.Axis.AbstractAxis(scale, "right");
-        assert.equal(baseAxis._xAlignProportion, 0, "xAlignProportion defaults to 0 for right axis");
+        assert.equal(baseAxis.xAlign(), "left", "x alignment defaults to \"left\" for right axis");
     });
 });
 
@@ -5551,8 +5551,8 @@ describe("Component behavior", function () {
         assert.equal(layout.height, 0, "requested height defaults to 0");
         assert.equal(layout.wantsWidth, false, "_requestedSpace().wantsWidth  defaults to false");
         assert.equal(layout.wantsHeight, false, "_requestedSpace().wantsHeight defaults to false");
-        assert.equal(c._xAlignProportion, 0, "_xAlignProportion defaults to 0");
-        assert.equal(c._yAlignProportion, 0, "_yAlignProportion defaults to 0");
+        assert.equal(c.xAlign(), "left", "x alignment defaults to \"left\"");
+        assert.equal(c.yAlign(), "top", "y alignment defaults to \"top\"");
         assert.equal(c._xOffset, 0, "xOffset defaults to 0");
         assert.equal(c._yOffset, 0, "yOffset defaults to 0");
         svg.remove();

--- a/test/tests.js
+++ b/test/tests.js
@@ -216,6 +216,39 @@ function assertAreaPathCloseTo(actualPath, expectedPath, precision, msg) {
 }
 
 ///<reference path="testReference.ts" />
+var __extends = this.__extends || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    __.prototype = b.prototype;
+    d.prototype = new __();
+};
+var Mocks;
+(function (Mocks) {
+    var FixedSizeComponent = (function (_super) {
+        __extends(FixedSizeComponent, _super);
+        function FixedSizeComponent(width, height) {
+            if (width === void 0) { width = 0; }
+            if (height === void 0) { height = 0; }
+            _super.call(this);
+            this.fixedWidth = width;
+            this.fixedHeight = height;
+            this._fixedWidthFlag = true;
+            this._fixedHeightFlag = true;
+        }
+        FixedSizeComponent.prototype._requestedSpace = function (availableWidth, availableHeight) {
+            return {
+                width: this.fixedWidth,
+                height: this.fixedHeight,
+                wantsWidth: availableWidth < this.fixedWidth,
+                wantsHeight: availableHeight < this.fixedHeight
+            };
+        };
+        return FixedSizeComponent;
+    })(Plottable.Component.AbstractComponent);
+    Mocks.FixedSizeComponent = FixedSizeComponent;
+})(Mocks || (Mocks = {}));
+
+///<reference path="testReference.ts" />
 before(function () {
     // Set the render policy to immediate to make sure ETE tests can check DOM change immediately
     Plottable.Core.RenderController.setRenderPolicy("immediate");
@@ -5170,20 +5203,6 @@ describe("ComponentGroups", function () {
         assertWidthHeight(t3, 400, 400, "rect3 sized correctly");
         svg.remove();
     });
-    it("components in componentGroups occupies all available space", function () {
-        var svg = generateSVG(400, 400);
-        var xAxis = new Plottable.Axis.Numeric(new Plottable.Scale.Linear(), "bottom");
-        var leftLabel = new Plottable.Component.Label("LEFT").xAlign("left");
-        var rightLabel = new Plottable.Component.Label("RIGHT").xAlign("right");
-        var labelGroup = new Plottable.Component.Group([leftLabel, rightLabel]);
-        var table = new Plottable.Component.Table([
-            [labelGroup],
-            [xAxis]
-        ]);
-        table.renderTo(svg);
-        assertBBoxNonIntersection(leftLabel._element.select(".bounding-box"), rightLabel._element.select(".bounding-box"));
-        svg.remove();
-    });
     it("components can be added before and after anchoring", function () {
         var c1 = makeFixedSizeComponent(10, 10);
         var c2 = makeFixedSizeComponent(20, 20);
@@ -5204,20 +5223,6 @@ describe("ComponentGroups", function () {
         var t3 = svg.select(".test-box3");
         assertWidthHeight(t3, 400, 400, "rect3 sized correctly");
         svg.remove();
-    });
-    it("component fixity is computed appropriately", function () {
-        var cg = new Plottable.Component.Group();
-        var c1 = new Plottable.Component.AbstractComponent();
-        var c2 = new Plottable.Component.AbstractComponent();
-        cg.below(c1).below(c2);
-        assert.isFalse(cg._isFixedHeight(), "height not fixed when both components unfixed");
-        assert.isFalse(cg._isFixedWidth(), "width not fixed when both components unfixed");
-        fixComponentSize(c1, 10, 10);
-        assert.isFalse(cg._isFixedHeight(), "height not fixed when one component unfixed");
-        assert.isFalse(cg._isFixedWidth(), "width not fixed when one component unfixed");
-        fixComponentSize(c2, null, 10);
-        assert.isFalse(cg._isFixedHeight(), "height unfixed when both components fixed");
-        assert.isFalse(cg._isFixedWidth(), "width unfixed when one component unfixed");
     });
     it("componentGroup subcomponents have xOffset, yOffset of 0", function () {
         var cg = new Plottable.Component.Group();
@@ -5280,30 +5285,70 @@ describe("ComponentGroups", function () {
         assert.isFalse(c3._isAnchored, "c3 was detached");
         assert.lengthOf(cg.components(), 0, "cg has no components");
     });
-    describe("ComponentGroup._requestedSpace works as expected", function () {
-        it("_works for an empty ComponentGroup", function () {
-            var cg = new Plottable.Component.Group();
-            var request = cg._requestedSpace(10, 10);
-            verifySpaceRequest(request, 0, 0, false, false, "");
+    describe("Sizing based on contents", function () {
+        var SVG_WIDTH = 400;
+        var SVG_HEIGHT = 400;
+        it("no Components", function () {
+            var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+            var cg = new Plottable.Component.Group([]);
+            cg.renderTo(svg);
+            assert.strictEqual(cg.width(), 0, "empty Group has zero width");
+            assert.strictEqual(cg.height(), 0, "empty Group has zero height");
+            svg.remove();
         });
-        it("works for a ComponentGroup with only proportional-size components", function () {
-            var cg = new Plottable.Component.Group();
-            var c1 = new Plottable.Component.AbstractComponent();
-            var c2 = new Plottable.Component.AbstractComponent();
-            cg.below(c1).below(c2);
-            var request = cg._requestedSpace(10, 10);
-            verifySpaceRequest(request, 0, 0, false, false, "");
+        it("expanding Components", function () {
+            var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+            var cg = new Plottable.Component.Group([
+                new Plottable.Component.AbstractComponent(),
+                new Plottable.Component.AbstractComponent()
+            ]);
+            cg.renderTo(svg);
+            assert.strictEqual(cg.width(), SVG_WIDTH, "expands to fill available width");
+            assert.strictEqual(cg.height(), SVG_HEIGHT, "expands to fill available height");
+            svg.remove();
         });
-        it("works when there are fixed-size components", function () {
-            var cg = new Plottable.Component.Group();
-            var c1 = new Plottable.Component.AbstractComponent();
-            var c2 = new Plottable.Component.AbstractComponent();
-            var c3 = new Plottable.Component.AbstractComponent();
-            cg.below(c1).below(c2).below(c3);
-            fixComponentSize(c1, null, 10);
-            fixComponentSize(c2, null, 50);
-            var request = cg._requestedSpace(10, 10);
-            verifySpaceRequest(request, 0, 50, false, true, "");
+        it("one expanding and one fixed-size Component", function () {
+            var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+            var cg = new Plottable.Component.Group([
+                new Plottable.Component.AbstractComponent(),
+                new Mocks.FixedSizeComponent(SVG_WIDTH / 2, SVG_HEIGHT / 2)
+            ]);
+            cg.renderTo(svg);
+            assert.strictEqual(cg.width(), SVG_WIDTH, "expands to fill available width");
+            assert.strictEqual(cg.height(), SVG_HEIGHT, "expands to fill available height");
+            svg.remove();
+        });
+        it("fixed-size Components, same x and same y alignments", function () {
+            var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+            var tall = new Mocks.FixedSizeComponent(SVG_WIDTH / 4, SVG_HEIGHT / 2);
+            var wide = new Mocks.FixedSizeComponent(SVG_WIDTH / 2, SVG_HEIGHT / 4);
+            var cg = new Plottable.Component.Group([tall, wide]);
+            cg.renderTo(svg);
+            var largestWidth = cg.components().map(function (c) { return c.width(); }).sort(function (a, b) { return b - a; })[0];
+            assert.strictEqual(cg.width(), largestWidth, "takes on the width of widest fixed-size component");
+            var largestHeight = cg.components().map(function (c) { return c.height(); }).sort(function (a, b) { return b - a; })[0];
+            assert.strictEqual(cg.height(), largestHeight, "takes on the height of tallest fixed-size component");
+            svg.remove();
+        });
+        it("fixed-size Components, different x alignments", function () {
+            var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+            var left = new Mocks.FixedSizeComponent(SVG_WIDTH / 4, SVG_HEIGHT / 4).xAlign("left");
+            var right = new Mocks.FixedSizeComponent(SVG_WIDTH / 4, SVG_HEIGHT / 4).xAlign("right");
+            var cg = new Plottable.Component.Group([left, right]);
+            cg.renderTo(svg);
+            assert.strictEqual(cg.width(), SVG_WIDTH, "expands to fill available width");
+            assert.strictEqual(cg.height(), left.height(), "takes on the height of fixed-size components");
+            svg.remove();
+        });
+        it("fixed-size Components, different y alignments", function () {
+            var svg = generateSVG(SVG_WIDTH, SVG_HEIGHT);
+            var top = new Mocks.FixedSizeComponent(SVG_WIDTH / 4, SVG_HEIGHT / 4).yAlign("top");
+            var bottom = new Mocks.FixedSizeComponent(SVG_WIDTH / 4, SVG_HEIGHT / 4).yAlign("bottom");
+            var cg = new Plottable.Component.Group([top, bottom]);
+            cg.renderTo(svg);
+            assert.strictEqual(cg.width(), top.width(), "takes on the width of fixed-size components");
+            assert.strictEqual(cg.height(), SVG_HEIGHT, "expands to fill available height");
+            svg.remove();
         });
     });
     describe("Merging components works as expected", function () {
@@ -5667,19 +5712,6 @@ describe("Component behavior", function () {
         c1.renderTo(svg);
         c1.remove();
         assert.throws(function () { return c1.renderTo(svg); }, "reuse");
-        svg.remove();
-    });
-    it("_invalidateLayout works as expected", function () {
-        var cg = new Plottable.Component.Group();
-        var c = makeFixedSizeComponent(10, 10);
-        cg._addComponent(c);
-        cg.renderTo(svg);
-        assert.equal(cg.height(), 300, "height() is the entire available height");
-        assert.equal(cg.width(), 400, "width() is the entire available width");
-        fixComponentSize(c, 50, 50);
-        c._invalidateLayout();
-        assert.equal(cg.height(), 300, "height() after resizing is the entire available height");
-        assert.equal(cg.width(), 400, "width() after resizing is the entire available width");
         svg.remove();
     });
     it("components can be detached even if not anchored", function () {


### PR DESCRIPTION
Now, if a Group contains only fixed-width Components, its width will
expand to fill the available space only if those Components do not
share the same x alignment. Same for height, based on y alignment.

Added "Mocks" module which contains classes for use in testing.

Wrote better tests for checking Group behavior based on contents.
Moved a misplaced test.

Close #1791.