### PR TITLE
[Table] - addComponent to already occupied cell appends component

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2528,7 +2528,12 @@ declare module Plottable {
              */
             constructor(rows?: AbstractComponent[][]);
             /**
-             * Adds a Component in the specified cell. The cell must be unoccupied.
+             * Adds a Component in the specified cell.
+             *
+             * If the cell is already occupied, there are 3 cases
+             *  - Component + Component => Group containing both components
+             *  - Component + Group => Component is added to the group
+             *  - Group + Component => Component is added to the group
              *
              * For example, instead of calling `new Table([[a, b], [null, c]])`, you
              * could call

--- a/plottable.js
+++ b/plottable.js
@@ -6073,7 +6073,12 @@ var Plottable;
                 });
             }
             /**
-             * Adds a Component in the specified cell. The cell must be unoccupied.
+             * Adds a Component in the specified cell.
+             *
+             * If the cell is already occupied, there are 3 cases
+             *  - Component + Component => Group containing both components
+             *  - Component + Group => Component is added to the group
+             *  - Group + Component => Component is added to the group
              *
              * For example, instead of calling `new Table([[a, b], [null, c]])`, you
              * could call
@@ -6090,14 +6095,15 @@ var Plottable;
              * @returns {Table} The calling Table.
              */
             Table.prototype.addComponent = function (row, col, component) {
+                var currentComponent = this._rows[row] && this._rows[row][col];
+                if (currentComponent) {
+                    currentComponent.detach();
+                    component = component.above(currentComponent);
+                }
                 if (this._addComponent(component)) {
                     this._nRows = Math.max(row + 1, this._nRows);
                     this._nCols = Math.max(col + 1, this._nCols);
                     this._padTableToSize(this._nRows, this._nCols);
-                    var currentComponent = this._rows[row][col];
-                    if (currentComponent) {
-                        throw new Error("Table.addComponent cannot be called on a cell where a component already exists (for the moment)");
-                    }
                     this._rows[row][col] = component;
                 }
                 return this;

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -57,7 +57,12 @@ export module Component {
     }
 
     /**
-     * Adds a Component in the specified cell. The cell must be unoccupied.
+     * Adds a Component in the specified cell. 
+     * 
+     * If the cell is already occupied, there are 3 cases
+     *  - Component + Component => Group containing both components
+     *  - Component + Group => Component is added to the group
+     *  - Group + Component => Component is added to the group
      *
      * For example, instead of calling `new Table([[a, b], [null, c]])`, you
      * could call
@@ -74,15 +79,18 @@ export module Component {
      * @returns {Table} The calling Table.
      */
     public addComponent(row: number, col: number, component: AbstractComponent): Table {
+
+      var currentComponent = this._rows[row] && this._rows[row][col];
+
+      if (currentComponent) {
+        currentComponent.detach();
+        component = component.above(currentComponent);
+      }
+
       if (this._addComponent(component)) {
         this._nRows = Math.max(row + 1, this._nRows);
         this._nCols = Math.max(col + 1, this._nCols);
         this._padTableToSize(this._nRows, this._nCols);
-
-        var currentComponent = this._rows[row][col];
-        if (currentComponent) {
-          throw new Error("Table.addComponent cannot be called on a cell where a component already exists (for the moment)");
-        }
 
         this._rows[row][col] = component;
       }

--- a/test/core/tableTests.ts
+++ b/test/core/tableTests.ts
@@ -78,7 +78,7 @@ describe("Tables", () => {
     t.addComponent(0, 0, c2);
     t.addComponent(0, 2, c3);
 
-    assert.isTrue(Plottable.Component.Group.prototype.isPrototypeOf((<any> t)._rows[0][2]));
+    assert.isTrue(Plottable.Component.Group.prototype.isPrototypeOf((<any> t)._rows[0][2]), "A group was created");
 
     var components: Plottable.Component.AbstractComponent[] = (<any> t)._rows[0][2].components();
     assert.lengthOf(components, 2, "The group created should have 2 components");
@@ -89,20 +89,21 @@ describe("Tables", () => {
   it("Add a component where a group already exists adds the component to the group", () => {
     var c1 = new Plottable.Component.AbstractComponent();
     var c2 = new Plottable.Component.AbstractComponent();
+    var grp = new Plottable.Component.Group([c1, c2]);
+
     var c3 = new Plottable.Component.AbstractComponent();
+
     var t = new Plottable.Component.Table();
 
-    t.addComponent(0, 2, c1);
-    t.addComponent(0, 2, c2);
+    t.addComponent(0, 2, grp);
     t.addComponent(0, 2, c3);
-
-    assert.isTrue(Plottable.Component.Group.prototype.isPrototypeOf((<any> t)._rows[0][2]));
+    assert.isTrue(Plottable.Component.Group.prototype.isPrototypeOf((<any> t)._rows[0][2]), "The cell still contains a group");
 
     var components: Plottable.Component.AbstractComponent[] = (<any> t)._rows[0][2].components();
-    assert.lengthOf(components, 3, "The group created should have 2 components");
-    assert.equal(components[0], c1, "First element in the group at (0, 2) should be c1");
-    assert.equal(components[1], c2, "Second element in the group at (0, 2) should be c2");
-    assert.equal(components[2], c3, "Third element in the group at (0, 2) should be c3");
+    assert.lengthOf(components, 3, "The group created should have 3 components");
+    assert.equal(components[0], c1, "First element in the group at (0, 2) should still be c1");
+    assert.equal(components[1], c2, "Second element in the group at (0, 2) should still be c2");
+    assert.equal(components[2], c3, "The Component was added to the existing Group");
   });
 
   it("addComponent works even if a component is added with a high column and low row index", () => {

--- a/test/core/tableTests.ts
+++ b/test/core/tableTests.ts
@@ -78,7 +78,9 @@ describe("Tables", () => {
     t.addComponent(0, 0, c2);
     t.addComponent(0, 2, c3);
 
-    var components: Plottable.Component.AbstractComponent[] = t._rows[0][2].components();
+    assert.isTrue(Plottable.Component.Group.prototype.isPrototypeOf((<any> t)._rows[0][2]));
+
+    var components: Plottable.Component.AbstractComponent[] = (<any> t)._rows[0][2].components();
     assert.lengthOf(components, 2, "The group created should have 2 components");
     assert.equal(components[0], c1, "First element in the group at (0, 2) should be c1");
     assert.equal(components[1], c3, "Second element in the group at (0, 2) should be c3");
@@ -94,7 +96,9 @@ describe("Tables", () => {
     t.addComponent(0, 2, c2);
     t.addComponent(0, 2, c3);
 
-    var components: Plottable.Component.AbstractComponent[] = t._rows[0][2].components();
+    assert.isTrue(Plottable.Component.Group.prototype.isPrototypeOf((<any> t)._rows[0][2]));
+
+    var components: Plottable.Component.AbstractComponent[] = (<any> t)._rows[0][2].components();
     assert.lengthOf(components, 3, "The group created should have 2 components");
     assert.equal(components[0], c1, "First element in the group at (0, 2) should be c1");
     assert.equal(components[1], c2, "Second element in the group at (0, 2) should be c2");

--- a/test/core/tableTests.ts
+++ b/test/core/tableTests.ts
@@ -68,14 +68,37 @@ describe("Tables", () => {
     assert.isNull(rows[1][0], "component at (1, 0) is null");
   });
 
-  it("can't add a component where one already exists", () => {
+  it("Add a component where one already exists creates a new group", () => {
     var c1 = new Plottable.Component.AbstractComponent();
     var c2 = new Plottable.Component.AbstractComponent();
     var c3 = new Plottable.Component.AbstractComponent();
     var t = new Plottable.Component.Table();
+
     t.addComponent(0, 2, c1);
     t.addComponent(0, 0, c2);
-    assert.throws(() => t.addComponent(0, 2, c3), Error, "component already exists");
+    t.addComponent(0, 2, c3);
+
+    var components: Plottable.Component.AbstractComponent[] = t._rows[0][2].components();
+    assert.lengthOf(components, 2, "The group created should have 2 components");
+    assert.equal(components[0], c1, "First element in the group at (0, 2) should be c1");
+    assert.equal(components[1], c3, "Second element in the group at (0, 2) should be c3");
+  });
+
+  it("Add a component where a group already exists adds the component to the group", () => {
+    var c1 = new Plottable.Component.AbstractComponent();
+    var c2 = new Plottable.Component.AbstractComponent();
+    var c3 = new Plottable.Component.AbstractComponent();
+    var t = new Plottable.Component.Table();
+
+    t.addComponent(0, 2, c1);
+    t.addComponent(0, 2, c2);
+    t.addComponent(0, 2, c3);
+
+    var components: Plottable.Component.AbstractComponent[] = t._rows[0][2].components();
+    assert.lengthOf(components, 3, "The group created should have 2 components");
+    assert.equal(components[0], c1, "First element in the group at (0, 2) should be c1");
+    assert.equal(components[1], c2, "Second element in the group at (0, 2) should be c2");
+    assert.equal(components[2], c3, "Third element in the group at (0, 2) should be c3");
   });
 
   it("addComponent works even if a component is added with a high column and low row index", () => {

--- a/test/tests.js
+++ b/test/tests.js
@@ -5946,14 +5946,32 @@ describe("Tables", function () {
         assert.isNull(rows[0][1], "component at (0, 1) is null");
         assert.isNull(rows[1][0], "component at (1, 0) is null");
     });
-    it("can't add a component where one already exists", function () {
+    it("Add a component where one already exists creates a new group", function () {
         var c1 = new Plottable.Component.AbstractComponent();
         var c2 = new Plottable.Component.AbstractComponent();
         var c3 = new Plottable.Component.AbstractComponent();
         var t = new Plottable.Component.Table();
         t.addComponent(0, 2, c1);
         t.addComponent(0, 0, c2);
-        assert.throws(function () { return t.addComponent(0, 2, c3); }, Error, "component already exists");
+        t.addComponent(0, 2, c3);
+        var components = t._rows[0][2].components();
+        assert.lengthOf(components, 2, "The group created should have 2 components");
+        assert.equal(components[0], c1, "First element in the group at (0, 2) should be c1");
+        assert.equal(components[1], c3, "Second element in the group at (0, 2) should be c3");
+    });
+    it("Add a component where a group already exists adds the component to the group", function () {
+        var c1 = new Plottable.Component.AbstractComponent();
+        var c2 = new Plottable.Component.AbstractComponent();
+        var c3 = new Plottable.Component.AbstractComponent();
+        var t = new Plottable.Component.Table();
+        t.addComponent(0, 2, c1);
+        t.addComponent(0, 2, c2);
+        t.addComponent(0, 2, c3);
+        var components = t._rows[0][2].components();
+        assert.lengthOf(components, 3, "The group created should have 2 components");
+        assert.equal(components[0], c1, "First element in the group at (0, 2) should be c1");
+        assert.equal(components[1], c2, "Second element in the group at (0, 2) should be c2");
+        assert.equal(components[2], c3, "Third element in the group at (0, 2) should be c3");
     });
     it("addComponent works even if a component is added with a high column and low row index", function () {
         // Solves #180, a weird bug

--- a/test/tests.js
+++ b/test/tests.js
@@ -5954,6 +5954,7 @@ describe("Tables", function () {
         t.addComponent(0, 2, c1);
         t.addComponent(0, 0, c2);
         t.addComponent(0, 2, c3);
+        assert.isTrue(Plottable.Component.Group.prototype.isPrototypeOf(t._rows[0][2]));
         var components = t._rows[0][2].components();
         assert.lengthOf(components, 2, "The group created should have 2 components");
         assert.equal(components[0], c1, "First element in the group at (0, 2) should be c1");
@@ -5967,6 +5968,7 @@ describe("Tables", function () {
         t.addComponent(0, 2, c1);
         t.addComponent(0, 2, c2);
         t.addComponent(0, 2, c3);
+        assert.isTrue(Plottable.Component.Group.prototype.isPrototypeOf(t._rows[0][2]));
         var components = t._rows[0][2].components();
         assert.lengthOf(components, 3, "The group created should have 2 components");
         assert.equal(components[0], c1, "First element in the group at (0, 2) should be c1");

--- a/test/tests.js
+++ b/test/tests.js
@@ -5954,7 +5954,7 @@ describe("Tables", function () {
         t.addComponent(0, 2, c1);
         t.addComponent(0, 0, c2);
         t.addComponent(0, 2, c3);
-        assert.isTrue(Plottable.Component.Group.prototype.isPrototypeOf(t._rows[0][2]));
+        assert.isTrue(Plottable.Component.Group.prototype.isPrototypeOf(t._rows[0][2]), "A group was created");
         var components = t._rows[0][2].components();
         assert.lengthOf(components, 2, "The group created should have 2 components");
         assert.equal(components[0], c1, "First element in the group at (0, 2) should be c1");
@@ -5963,17 +5963,17 @@ describe("Tables", function () {
     it("Add a component where a group already exists adds the component to the group", function () {
         var c1 = new Plottable.Component.AbstractComponent();
         var c2 = new Plottable.Component.AbstractComponent();
+        var grp = new Plottable.Component.Group([c1, c2]);
         var c3 = new Plottable.Component.AbstractComponent();
         var t = new Plottable.Component.Table();
-        t.addComponent(0, 2, c1);
-        t.addComponent(0, 2, c2);
+        t.addComponent(0, 2, grp);
         t.addComponent(0, 2, c3);
-        assert.isTrue(Plottable.Component.Group.prototype.isPrototypeOf(t._rows[0][2]));
+        assert.isTrue(Plottable.Component.Group.prototype.isPrototypeOf(t._rows[0][2]), "The cell still contains a group");
         var components = t._rows[0][2].components();
-        assert.lengthOf(components, 3, "The group created should have 2 components");
-        assert.equal(components[0], c1, "First element in the group at (0, 2) should be c1");
-        assert.equal(components[1], c2, "Second element in the group at (0, 2) should be c2");
-        assert.equal(components[2], c3, "Third element in the group at (0, 2) should be c3");
+        assert.lengthOf(components, 3, "The group created should have 3 components");
+        assert.equal(components[0], c1, "First element in the group at (0, 2) should still be c1");
+        assert.equal(components[1], c2, "Second element in the group at (0, 2) should still be c2");
+        assert.equal(components[2], c3, "The Component was added to the existing Group");
     });
     it("addComponent works even if a component is added with a high column and low row index", function () {
         // Solves #180, a weird bug


### PR DESCRIPTION
Closes #1714 
As per title. addComponent used to throw an error if the cell was already containing a component. Now it just appends the component to a group (and creates the group if necessary). Unit test included.