### PR TITLE
Enable clipPath on DragBoxLayer.

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -10032,6 +10032,12 @@ var Plottable;
                     this._detectionRadius = 3;
                     this._resizable = false;
                     this._hasCorners = true;
+                    /*
+                     * Enable clipPath to hide _detectionEdge s and _detectionCorner s
+                     * that overlap with the edge of the DragBoxLayer. This prevents the
+                     * user's cursor from changing outside the DragBoxLayer, where they
+                     * wouldn't be able to grab the edges or corners for resizing.
+                     */
                     this.clipPathEnabled = true;
                     this.classed("drag-box-layer", true);
                     this._dragInteraction = new Plottable.Interaction.Drag();

--- a/plottable.js
+++ b/plottable.js
@@ -10032,6 +10032,7 @@ var Plottable;
                     this._detectionRadius = 3;
                     this._resizable = false;
                     this._hasCorners = true;
+                    this.clipPathEnabled = true;
                     this.classed("drag-box-layer", true);
                     this._dragInteraction = new Plottable.Interaction.Drag();
                     this._setUpCallbacks();

--- a/src/components/interactive/dragBoxLayer.ts
+++ b/src/components/interactive/dragBoxLayer.ts
@@ -31,6 +31,12 @@ export module Component {
 
       constructor() {
         super();
+        /*
+         * Enable clipPath to hide _detectionEdge s and _detectionCorner s
+         * that overlap with the edge of the DragBoxLayer. This prevents the
+         * user's cursor from changing outside the DragBoxLayer, where they
+         * wouldn't be able to grab the edges or corners for resizing.
+         */
         this.clipPathEnabled = true;
         this.classed("drag-box-layer", true);
 

--- a/src/components/interactive/dragBoxLayer.ts
+++ b/src/components/interactive/dragBoxLayer.ts
@@ -31,6 +31,7 @@ export module Component {
 
       constructor() {
         super();
+        this.clipPathEnabled = true;
         this.classed("drag-box-layer", true);
 
         this._dragInteraction = new Interaction.Drag();

--- a/test/components/interactive/dragBoxLayerTests.ts
+++ b/test/components/interactive/dragBoxLayerTests.ts
@@ -50,6 +50,15 @@ describe("Interactive Components", () => {
       svg.remove();
     });
 
+    it("clipPath enabled", () => {
+      /*
+       * clipPath has to be enabled so the resize handle doesn't show on hovering
+       * over the edge of the drag box
+       */
+      var dbl = new Plottable.Component.Interactive.DragBoxLayer();
+      assert.isTrue(dbl.clipPathEnabled);
+    });
+
     it("detectionRadius()", () => {
       var dbl = new Plottable.Component.Interactive.DragBoxLayer();
 

--- a/test/components/interactive/dragBoxLayerTests.ts
+++ b/test/components/interactive/dragBoxLayerTests.ts
@@ -51,12 +51,8 @@ describe("Interactive Components", () => {
     });
 
     it("clipPath enabled", () => {
-      /*
-       * clipPath has to be enabled so the resize handle doesn't show on hovering
-       * over the edge of the drag box
-       */
       var dbl = new Plottable.Component.Interactive.DragBoxLayer();
-      assert.isTrue(dbl.clipPathEnabled);
+      assert.isTrue(dbl.clipPathEnabled, "uses clipPath (to hide detection edges)");
     });
 
     it("detectionRadius()", () => {

--- a/test/tests.js
+++ b/test/tests.js
@@ -8559,6 +8559,14 @@ describe("Interactive Components", function () {
             assert.isFalse(dbl.boxVisible(), "box is hidden on click");
             svg.remove();
         });
+        it("clipPath enabled", function () {
+            /*
+             * clipPath has to be enabled so the resize handle doesn't show on hovering
+             * over the edge of the drag box
+             */
+            var dbl = new Plottable.Component.Interactive.DragBoxLayer();
+            assert.isTrue(dbl.clipPathEnabled);
+        });
         it("detectionRadius()", function () {
             var dbl = new Plottable.Component.Interactive.DragBoxLayer();
             assert.doesNotThrow(function () { return dbl.detectionRadius(3); }, Error, "can set detection radius before anchoring");

--- a/test/tests.js
+++ b/test/tests.js
@@ -8560,12 +8560,8 @@ describe("Interactive Components", function () {
             svg.remove();
         });
         it("clipPath enabled", function () {
-            /*
-             * clipPath has to be enabled so the resize handle doesn't show on hovering
-             * over the edge of the drag box
-             */
             var dbl = new Plottable.Component.Interactive.DragBoxLayer();
-            assert.isTrue(dbl.clipPathEnabled);
+            assert.isTrue(dbl.clipPathEnabled, "uses clipPath (to hide detection edges)");
         });
         it("detectionRadius()", function () {
             var dbl = new Plottable.Component.Interactive.DragBoxLayer();


### PR DESCRIPTION
Previously, a `DragBoxLayer` whose box was dragged all the way to the edge would show a "resizing" cursor, even though the user's cursor might be outside the `DragBoxLayer` and hence unable to click on it. This is because the hover-sensitive area is larger than the box itself.

Resolved by using a clipPath to hide the parts of the drag-box that are outside the `DragBoxLayer`.