### PR TITLE
[timeAxis] Height computed from maximum number of tiers

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -4509,9 +4509,9 @@ var Plottable;
             };
             Time.prototype.axisConfigurations = function (configurations) {
                 if (configurations == null) {
-                    return this._currentTimeAxisConfigurations;
+                    return this._possibleTimeAxisConfigurations;
                 }
-                this._currentTimeAxisConfigurations = configurations;
+                this._possibleTimeAxisConfigurations = configurations;
                 this._maximumTiers = Plottable._Util.Methods.max(configurations.map(function (config) { return config.length; }), 0);
                 this._invalidateLayout();
                 return this;
@@ -4521,13 +4521,13 @@ var Plottable;
              */
             Time.prototype._getMostPreciseConfigurationIndex = function () {
                 var _this = this;
-                var mostPreciseIndex = this._currentTimeAxisConfigurations.length;
-                this._currentTimeAxisConfigurations.forEach(function (interval, index) {
+                var mostPreciseIndex = this._possibleTimeAxisConfigurations.length;
+                this._possibleTimeAxisConfigurations.forEach(function (interval, index) {
                     if (index < mostPreciseIndex && interval.every(function (tier) { return _this._checkTimeAxisTierConfigurationWidth(tier); })) {
                         mostPreciseIndex = index;
                     }
                 });
-                if (mostPreciseIndex === this._currentTimeAxisConfigurations.length) {
+                if (mostPreciseIndex === this._possibleTimeAxisConfigurations.length) {
                     Plottable._Util.Methods.warn("zoomed out too far: could not find suitable interval to display labels");
                     --mostPreciseIndex;
                 }
@@ -4592,7 +4592,7 @@ var Plottable;
             };
             Time.prototype._getTickValues = function () {
                 var _this = this;
-                return this._currentTimeAxisConfigurations[this._mostPreciseConfigIndex].reduce(function (ticks, config) { return ticks.concat(_this._getTickIntervalValues(config)); }, []);
+                return this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex].reduce(function (ticks, config) { return ticks.concat(_this._getTickIntervalValues(config)); }, []);
             };
             Time.prototype._cleanTier = function (index) {
                 this._tierLabelContainers[index].selectAll("." + Axis.AbstractAxis.TICK_LABEL_CLASS).remove();
@@ -4681,12 +4681,12 @@ var Plottable;
                 if (this._mostPreciseConfigIndex < 1) {
                     return [];
                 }
-                return this._getTickIntervalValues(this._currentTimeAxisConfigurations[this._mostPreciseConfigIndex - 1][0]);
+                return this._getTickIntervalValues(this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex - 1][0]);
             };
             Time.prototype._doRender = function () {
                 var _this = this;
                 this._mostPreciseConfigIndex = this._getMostPreciseConfigurationIndex();
-                var tierConfigs = this._currentTimeAxisConfigurations[this._mostPreciseConfigIndex];
+                var tierConfigs = this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex];
                 for (var i = 0; i < Time._NUM_TIERS; ++i) {
                     this._cleanTier(i);
                 }

--- a/plottable.js
+++ b/plottable.js
@@ -4489,118 +4489,6 @@ var Plottable;
              */
             function Time(scale, orientation) {
                 _super.call(this, scale, orientation);
-                /*
-                 * Default possible axis configurations.
-                 */
-                this._DEFAULT_TIME_AXIS_CONFIGURATIONS = [
-                    [
-                        { interval: d3.time.second, step: 1, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                        { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ],
-                    [
-                        { interval: d3.time.second, step: 5, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                        { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ],
-                    [
-                        { interval: d3.time.second, step: 10, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                        { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ],
-                    [
-                        { interval: d3.time.second, step: 15, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                        { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ],
-                    [
-                        { interval: d3.time.second, step: 30, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                        { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ],
-                    [
-                        { interval: d3.time.minute, step: 1, formatter: Plottable.Formatters.time("%I:%M %p") },
-                        { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ],
-                    [
-                        { interval: d3.time.minute, step: 5, formatter: Plottable.Formatters.time("%I:%M %p") },
-                        { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ],
-                    [
-                        { interval: d3.time.minute, step: 10, formatter: Plottable.Formatters.time("%I:%M %p") },
-                        { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ],
-                    [
-                        { interval: d3.time.minute, step: 15, formatter: Plottable.Formatters.time("%I:%M %p") },
-                        { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ],
-                    [
-                        { interval: d3.time.minute, step: 30, formatter: Plottable.Formatters.time("%I:%M %p") },
-                        { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ],
-                    [
-                        { interval: d3.time.hour, step: 1, formatter: Plottable.Formatters.time("%I %p") },
-                        { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ],
-                    [
-                        { interval: d3.time.hour, step: 3, formatter: Plottable.Formatters.time("%I %p") },
-                        { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ],
-                    [
-                        { interval: d3.time.hour, step: 6, formatter: Plottable.Formatters.time("%I %p") },
-                        { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ],
-                    [
-                        { interval: d3.time.hour, step: 12, formatter: Plottable.Formatters.time("%I %p") },
-                        { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
-                    ],
-                    [
-                        { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%a %e") },
-                        { interval: d3.time.month, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
-                    ],
-                    [
-                        { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%e") },
-                        { interval: d3.time.month, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
-                    ],
-                    [
-                        { interval: d3.time.month, step: 1, formatter: Plottable.Formatters.time("%B") },
-                        { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
-                    ],
-                    [
-                        { interval: d3.time.month, step: 1, formatter: Plottable.Formatters.time("%b") },
-                        { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
-                    ],
-                    [
-                        { interval: d3.time.month, step: 3, formatter: Plottable.Formatters.time("%b") },
-                        { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
-                    ],
-                    [
-                        { interval: d3.time.month, step: 6, formatter: Plottable.Formatters.time("%b") },
-                        { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
-                    ],
-                    [
-                        { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
-                    ],
-                    [
-                        { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%y") }
-                    ],
-                    [
-                        { interval: d3.time.year, step: 5, formatter: Plottable.Formatters.time("%Y") }
-                    ],
-                    [
-                        { interval: d3.time.year, step: 25, formatter: Plottable.Formatters.time("%Y") }
-                    ],
-                    [
-                        { interval: d3.time.year, step: 50, formatter: Plottable.Formatters.time("%Y") }
-                    ],
-                    [
-                        { interval: d3.time.year, step: 100, formatter: Plottable.Formatters.time("%Y") }
-                    ],
-                    [
-                        { interval: d3.time.year, step: 200, formatter: Plottable.Formatters.time("%Y") }
-                    ],
-                    [
-                        { interval: d3.time.year, step: 500, formatter: Plottable.Formatters.time("%Y") }
-                    ],
-                    [
-                        { interval: d3.time.year, step: 1000, formatter: Plottable.Formatters.time("%Y") }
-                    ]
-                ];
                 this.classed("time-axis", true);
                 this.tickLabelPadding(5);
                 this.tierLabelPositions(["between", "between"]);
@@ -4854,6 +4742,118 @@ var Plottable;
                     }
                 });
             };
+            /*
+             * Default possible axis configurations.
+             */
+            Time._DEFAULT_TIME_AXIS_CONFIGURATIONS = [
+                [
+                    { interval: d3.time.second, step: 1, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                ],
+                [
+                    { interval: d3.time.second, step: 5, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                ],
+                [
+                    { interval: d3.time.second, step: 10, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                ],
+                [
+                    { interval: d3.time.second, step: 15, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                ],
+                [
+                    { interval: d3.time.second, step: 30, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                ],
+                [
+                    { interval: d3.time.minute, step: 1, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                ],
+                [
+                    { interval: d3.time.minute, step: 5, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                ],
+                [
+                    { interval: d3.time.minute, step: 10, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                ],
+                [
+                    { interval: d3.time.minute, step: 15, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                ],
+                [
+                    { interval: d3.time.minute, step: 30, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                ],
+                [
+                    { interval: d3.time.hour, step: 1, formatter: Plottable.Formatters.time("%I %p") },
+                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                ],
+                [
+                    { interval: d3.time.hour, step: 3, formatter: Plottable.Formatters.time("%I %p") },
+                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                ],
+                [
+                    { interval: d3.time.hour, step: 6, formatter: Plottable.Formatters.time("%I %p") },
+                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                ],
+                [
+                    { interval: d3.time.hour, step: 12, formatter: Plottable.Formatters.time("%I %p") },
+                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                ],
+                [
+                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%a %e") },
+                    { interval: d3.time.month, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
+                ],
+                [
+                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%e") },
+                    { interval: d3.time.month, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
+                ],
+                [
+                    { interval: d3.time.month, step: 1, formatter: Plottable.Formatters.time("%B") },
+                    { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                ],
+                [
+                    { interval: d3.time.month, step: 1, formatter: Plottable.Formatters.time("%b") },
+                    { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                ],
+                [
+                    { interval: d3.time.month, step: 3, formatter: Plottable.Formatters.time("%b") },
+                    { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                ],
+                [
+                    { interval: d3.time.month, step: 6, formatter: Plottable.Formatters.time("%b") },
+                    { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                ],
+                [
+                    { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                ],
+                [
+                    { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%y") }
+                ],
+                [
+                    { interval: d3.time.year, step: 5, formatter: Plottable.Formatters.time("%Y") }
+                ],
+                [
+                    { interval: d3.time.year, step: 25, formatter: Plottable.Formatters.time("%Y") }
+                ],
+                [
+                    { interval: d3.time.year, step: 50, formatter: Plottable.Formatters.time("%Y") }
+                ],
+                [
+                    { interval: d3.time.year, step: 100, formatter: Plottable.Formatters.time("%Y") }
+                ],
+                [
+                    { interval: d3.time.year, step: 200, formatter: Plottable.Formatters.time("%Y") }
+                ],
+                [
+                    { interval: d3.time.year, step: 500, formatter: Plottable.Formatters.time("%Y") }
+                ],
+                [
+                    { interval: d3.time.year, step: 1000, formatter: Plottable.Formatters.time("%Y") }
+                ]
+            ];
             Time._LONG_DATE = new Date(9999, 8, 29, 12, 59, 9999);
             /**
              * Number of possible tiers.

--- a/plottable.js
+++ b/plottable.js
@@ -4540,14 +4540,11 @@ var Plottable;
                 return _super.prototype.orient.call(this, orientation); // maintains getter-setter functionality
             };
             Time.prototype._computeHeight = function () {
-                var _this = this;
                 var textHeight = this._measurer.measure().height;
-                this._tierHeights = this._tierLabelPositions.map(function (pos, index) {
-                    if (index >= _this._maximumTiers) {
-                        return 0;
-                    }
-                    return textHeight + _this.tickLabelPadding() + ((pos === "between") ? 0 : _this._maxLabelTickLength());
-                });
+                this._tierHeights = [];
+                for (var i = 0; i < this._maximumTiers; i++) {
+                    this._tierHeights.push(textHeight + this.tickLabelPadding() + ((this._tierLabelPositions[i]) === "between" ? 0 : this._maxLabelTickLength()));
+                }
                 this._computedHeight = d3.sum(this._tierHeights);
                 return this._computedHeight;
             };

--- a/plottable.js
+++ b/plottable.js
@@ -4492,7 +4492,7 @@ var Plottable;
                 this.classed("time-axis", true);
                 this.tickLabelPadding(5);
                 this.tierLabelPositions(["between", "between"]);
-                this.axisConfigurations(this._DEFAULT_TIME_AXIS_CONFIGURATIONS);
+                this.axisConfigurations(Time._DEFAULT_TIME_AXIS_CONFIGURATIONS);
             }
             Time.prototype.tierLabelPositions = function (newPositions) {
                 if (newPositions == null) {

--- a/plottable.js
+++ b/plottable.js
@@ -4512,7 +4512,6 @@ var Plottable;
                     return this._possibleTimeAxisConfigurations;
                 }
                 this._possibleTimeAxisConfigurations = configurations;
-                this._maximumTiers = Plottable._Util.Methods.max(configurations.map(function (config) { return config.length; }), 0);
                 this._invalidateLayout();
                 return this;
             };
@@ -4541,8 +4540,9 @@ var Plottable;
             };
             Time.prototype._computeHeight = function () {
                 var textHeight = this._measurer.measure().height;
+                var maximumTiers = Plottable._Util.Methods.max(this._possibleTimeAxisConfigurations.map(function (config) { return config.length; }), 0);
                 this._tierHeights = [];
-                for (var i = 0; i < this._maximumTiers; i++) {
+                for (var i = 0; i < maximumTiers; i++) {
                     this._tierHeights.push(textHeight + this.tickLabelPadding() + ((this._tierLabelPositions[i]) === "between" ? 0 : this._maxLabelTickLength()));
                 }
                 this._computedHeight = d3.sum(this._tierHeights);

--- a/plottable.js
+++ b/plottable.js
@@ -4652,7 +4652,12 @@ var Plottable;
             Time.prototype._computeHeight = function () {
                 var _this = this;
                 var textHeight = this._measurer.measure().height;
-                this._tierHeights = this._tierLabelPositions.map(function (pos) { return textHeight + _this.tickLabelPadding() + ((pos === "between") ? 0 : _this._maxLabelTickLength()); });
+                this._tierHeights = this._tierLabelPositions.map(function (pos, index) {
+                    if (index >= _this._possibleTimeAxisConfigurations[0].length) {
+                        return 0;
+                    }
+                    return textHeight + _this.tickLabelPadding() + ((pos === "between") ? 0 : _this._maxLabelTickLength());
+                });
                 this._computedHeight = d3.sum(this._tierHeights);
                 return this._computedHeight;
             };

--- a/plottable.js
+++ b/plottable.js
@@ -4492,7 +4492,7 @@ var Plottable;
                 /*
                  * Default possible axis configurations.
                  */
-                this._possibleTimeAxisConfigurations = [
+                this._DEFAULT_TIME_AXIS_CONFIGURATIONS = [
                     [
                         { interval: d3.time.second, step: 1, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
                         { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
@@ -4601,10 +4601,10 @@ var Plottable;
                         { interval: d3.time.year, step: 1000, formatter: Plottable.Formatters.time("%Y") }
                     ]
                 ];
-                this._maximumTires = 2;
                 this.classed("time-axis", true);
                 this.tickLabelPadding(5);
                 this.tierLabelPositions(["between", "between"]);
+                this.axisConfigurations(this._DEFAULT_TIME_AXIS_CONFIGURATIONS);
             }
             Time.prototype.tierLabelPositions = function (newPositions) {
                 if (newPositions == null) {
@@ -4621,12 +4621,10 @@ var Plottable;
             };
             Time.prototype.axisConfigurations = function (configurations) {
                 if (configurations == null) {
-                    return this._possibleTimeAxisConfigurations;
+                    return this._currentTimeAxisConfigurations;
                 }
-                this._possibleTimeAxisConfigurations = configurations;
-                this._maximumTires = Math.max.apply(null, configurations.map(function (e) {
-                    return e.length;
-                }));
+                this._currentTimeAxisConfigurations = configurations;
+                this._maximumTires = Math.max.apply(null, configurations.map(function (config) { return config.length; }));
                 this._invalidateLayout();
                 return this;
             };
@@ -4635,13 +4633,13 @@ var Plottable;
              */
             Time.prototype._getMostPreciseConfigurationIndex = function () {
                 var _this = this;
-                var mostPreciseIndex = this._possibleTimeAxisConfigurations.length;
-                this._possibleTimeAxisConfigurations.forEach(function (interval, index) {
+                var mostPreciseIndex = this._currentTimeAxisConfigurations.length;
+                this._currentTimeAxisConfigurations.forEach(function (interval, index) {
                     if (index < mostPreciseIndex && interval.every(function (tier) { return _this._checkTimeAxisTierConfigurationWidth(tier); })) {
                         mostPreciseIndex = index;
                     }
                 });
-                if (mostPreciseIndex === this._possibleTimeAxisConfigurations.length) {
+                if (mostPreciseIndex === this._currentTimeAxisConfigurations.length) {
                     Plottable._Util.Methods.warn("zoomed out too far: could not find suitable interval to display labels");
                     --mostPreciseIndex;
                 }
@@ -4706,7 +4704,7 @@ var Plottable;
             };
             Time.prototype._getTickValues = function () {
                 var _this = this;
-                return this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex].reduce(function (ticks, config) { return ticks.concat(_this._getTickIntervalValues(config)); }, []);
+                return this._currentTimeAxisConfigurations[this._mostPreciseConfigIndex].reduce(function (ticks, config) { return ticks.concat(_this._getTickIntervalValues(config)); }, []);
             };
             Time.prototype._cleanTier = function (index) {
                 this._tierLabelContainers[index].selectAll("." + Axis.AbstractAxis.TICK_LABEL_CLASS).remove();
@@ -4795,12 +4793,12 @@ var Plottable;
                 if (this._mostPreciseConfigIndex < 1) {
                     return [];
                 }
-                return this._getTickIntervalValues(this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex - 1][0]);
+                return this._getTickIntervalValues(this._currentTimeAxisConfigurations[this._mostPreciseConfigIndex - 1][0]);
             };
             Time.prototype._doRender = function () {
                 var _this = this;
                 this._mostPreciseConfigIndex = this._getMostPreciseConfigurationIndex();
-                var tierConfigs = this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex];
+                var tierConfigs = this._currentTimeAxisConfigurations[this._mostPreciseConfigIndex];
                 for (var i = 0; i < Time._NUM_TIERS; ++i) {
                     this._cleanTier(i);
                 }

--- a/plottable.js
+++ b/plottable.js
@@ -4601,6 +4601,7 @@ var Plottable;
                         { interval: d3.time.year, step: 1000, formatter: Plottable.Formatters.time("%Y") }
                     ]
                 ];
+                this._maximumTires = 2;
                 this.classed("time-axis", true);
                 this.tickLabelPadding(5);
                 this.tierLabelPositions(["between", "between"]);
@@ -4623,6 +4624,9 @@ var Plottable;
                     return this._possibleTimeAxisConfigurations;
                 }
                 this._possibleTimeAxisConfigurations = configurations;
+                this._maximumTires = Math.max.apply(null, configurations.map(function (e) {
+                    return e.length;
+                }));
                 this._invalidateLayout();
                 return this;
             };
@@ -4653,7 +4657,7 @@ var Plottable;
                 var _this = this;
                 var textHeight = this._measurer.measure().height;
                 this._tierHeights = this._tierLabelPositions.map(function (pos, index) {
-                    if (index >= _this._possibleTimeAxisConfigurations[0].length) {
+                    if (index >= _this._maximumTires) {
                         return 0;
                     }
                     return textHeight + _this.tickLabelPadding() + ((pos === "between") ? 0 : _this._maxLabelTickLength());

--- a/plottable.js
+++ b/plottable.js
@@ -4512,7 +4512,7 @@ var Plottable;
                     return this._currentTimeAxisConfigurations;
                 }
                 this._currentTimeAxisConfigurations = configurations;
-                this._maximumTires = Math.max.apply(null, configurations.map(function (config) { return config.length; }));
+                this._maximumTiers = Plottable._Util.Methods.max(configurations.map(function (config) { return config.length; }), 0);
                 this._invalidateLayout();
                 return this;
             };
@@ -4543,7 +4543,7 @@ var Plottable;
                 var _this = this;
                 var textHeight = this._measurer.measure().height;
                 this._tierHeights = this._tierLabelPositions.map(function (pos, index) {
-                    if (index >= _this._maximumTires) {
+                    if (index >= _this._maximumTiers) {
                         return 0;
                     }
                     return textHeight + _this.tickLabelPadding() + ((pos === "between") ? 0 : _this._maxLabelTickLength());

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -142,7 +142,7 @@ export module Axis {
     private _tierBaselines: D3.Selection[];
     private _tierHeights: number[];
     private _currentTimeAxisConfigurations: TimeAxisConfiguration[];
-    private _maximumTires: number;
+    private _maximumTiers: number;
     private _measurer: SVGTypewriter.Measurers.Measurer;
 
     private _mostPreciseConfigIndex: number;
@@ -208,7 +208,7 @@ export module Axis {
         return this._currentTimeAxisConfigurations;
       }
       this._currentTimeAxisConfigurations = configurations;
-      this._maximumTires = Math.max.apply(null, configurations.map((config: TimeAxisConfiguration) => config.length));
+      this._maximumTiers = _Util.Methods.max(configurations.map((config: TimeAxisConfiguration) => config.length), 0);
       this._invalidateLayout();
       return this;
     }
@@ -245,7 +245,7 @@ export module Axis {
     public _computeHeight() {
       var textHeight = this._measurer.measure().height;
       this._tierHeights = this._tierLabelPositions.map((pos: string, index: number) => {
-        if (index >= this._maximumTires) {
+        if (index >= this._maximumTiers) {
           return 0;
         }
         return textHeight + this.tickLabelPadding() + ((pos === "between") ? 0 : this._maxLabelTickLength());

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -27,7 +27,7 @@ export module Axis {
     /*
      * Default possible axis configurations.
      */
-    private _DEFAULT_TIME_AXIS_CONFIGURATIONS: TimeAxisConfiguration[] = [
+    private static _DEFAULT_TIME_AXIS_CONFIGURATIONS: TimeAxisConfiguration[] = [
       [
         {interval: d3.time.second, step: 1, formatter: Formatters.time("%I:%M:%S %p")},
         {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -244,12 +244,13 @@ export module Axis {
 
     public _computeHeight() {
       var textHeight = this._measurer.measure().height;
-      this._tierHeights = this._tierLabelPositions.map((pos: string, index: number) => {
-        if (index >= this._maximumTiers) {
-          return 0;
-        }
-        return textHeight + this.tickLabelPadding() + ((pos === "between") ? 0 : this._maxLabelTickLength());
-      });
+
+      this._tierHeights = [];
+      for (var i = 0; i < this._maximumTiers; i++) {
+        this._tierHeights.push(textHeight + this.tickLabelPadding() +
+                              ((this._tierLabelPositions[i]) === "between" ? 0 : this._maxLabelTickLength()));
+      }
+
       this._computedHeight = d3.sum(this._tierHeights);
       return this._computedHeight;
     }

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -141,6 +141,7 @@ export module Axis {
     private _tierMarkContainers: D3.Selection[];
     private _tierBaselines: D3.Selection[];
     private _tierHeights: number[];
+    private _maximumTires: number = 2;
     private _measurer: SVGTypewriter.Measurers.Measurer;
 
     private _mostPreciseConfigIndex: number;
@@ -205,6 +206,7 @@ export module Axis {
         return this._possibleTimeAxisConfigurations;
       }
       this._possibleTimeAxisConfigurations = configurations;
+      this._maximumTires = Math.max.apply(null, configurations.map(function(e) {return e.length}));
       this._invalidateLayout();
       return this;
     }
@@ -241,7 +243,7 @@ export module Axis {
     public _computeHeight() {
       var textHeight = this._measurer.measure().height;
       this._tierHeights = this._tierLabelPositions.map((pos: string, index: number) => {
-        if (index >= this._possibleTimeAxisConfigurations[0].length) {
+        if (index >= this._maximumTires) {
           return 0;
         }
         return textHeight + this.tickLabelPadding() + ((pos === "between") ? 0 : this._maxLabelTickLength());

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -141,7 +141,7 @@ export module Axis {
     private _tierMarkContainers: D3.Selection[];
     private _tierBaselines: D3.Selection[];
     private _tierHeights: number[];
-    private _currentTimeAxisConfigurations: TimeAxisConfiguration[];
+    private _possibleTimeAxisConfigurations: TimeAxisConfiguration[];
     private _maximumTiers: number;
     private _measurer: SVGTypewriter.Measurers.Measurer;
 
@@ -205,9 +205,9 @@ export module Axis {
     public axisConfigurations(configurations: TimeAxisConfiguration[]): Time;
     public axisConfigurations(configurations?: any): any {
       if(configurations == null){
-        return this._currentTimeAxisConfigurations;
+        return this._possibleTimeAxisConfigurations;
       }
-      this._currentTimeAxisConfigurations = configurations;
+      this._possibleTimeAxisConfigurations = configurations;
       this._maximumTiers = _Util.Methods.max(configurations.map((config: TimeAxisConfiguration) => config.length), 0);
       this._invalidateLayout();
       return this;
@@ -217,15 +217,15 @@ export module Axis {
      * Gets the index of the most precise TimeAxisConfiguration that will fit in the current width.
      */
     private _getMostPreciseConfigurationIndex(): number {
-      var mostPreciseIndex = this._currentTimeAxisConfigurations.length;
-      this._currentTimeAxisConfigurations.forEach((interval: TimeAxisConfiguration, index: number) => {
+      var mostPreciseIndex = this._possibleTimeAxisConfigurations.length;
+      this._possibleTimeAxisConfigurations.forEach((interval: TimeAxisConfiguration, index: number) => {
         if (index < mostPreciseIndex && interval.every((tier: TimeAxisTierConfiguration) =>
           this._checkTimeAxisTierConfigurationWidth(tier))) {
           mostPreciseIndex = index;
         }
       });
 
-      if (mostPreciseIndex === this._currentTimeAxisConfigurations.length) {
+      if (mostPreciseIndex === this._possibleTimeAxisConfigurations.length) {
         _Util.Methods.warn("zoomed out too far: could not find suitable interval to display labels");
         --mostPreciseIndex;
       }
@@ -300,7 +300,7 @@ export module Axis {
     }
 
     protected _getTickValues(): any[] {
-      return this._currentTimeAxisConfigurations[this._mostPreciseConfigIndex].reduce(
+      return this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex].reduce(
           (ticks: any[], config: TimeAxisTierConfiguration) => ticks.concat(this._getTickIntervalValues(config)),
           []
         );
@@ -402,12 +402,12 @@ export module Axis {
         return [];
       }
 
-      return this._getTickIntervalValues(this._currentTimeAxisConfigurations[this._mostPreciseConfigIndex - 1][0]);
+      return this._getTickIntervalValues(this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex - 1][0]);
     }
 
     public _doRender() {
       this._mostPreciseConfigIndex = this._getMostPreciseConfigurationIndex();
-      var tierConfigs = this._currentTimeAxisConfigurations[this._mostPreciseConfigIndex];
+      var tierConfigs = this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex];
       for (var i = 0; i < Time._NUM_TIERS; ++i) {
         this._cleanTier(i);
       }

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -142,7 +142,6 @@ export module Axis {
     private _tierBaselines: D3.Selection[];
     private _tierHeights: number[];
     private _possibleTimeAxisConfigurations: TimeAxisConfiguration[];
-    private _maximumTiers: number;
     private _measurer: SVGTypewriter.Measurers.Measurer;
 
     private _mostPreciseConfigIndex: number;
@@ -208,7 +207,6 @@ export module Axis {
         return this._possibleTimeAxisConfigurations;
       }
       this._possibleTimeAxisConfigurations = configurations;
-      this._maximumTiers = _Util.Methods.max(configurations.map((config: TimeAxisConfiguration) => config.length), 0);
       this._invalidateLayout();
       return this;
     }
@@ -244,9 +242,10 @@ export module Axis {
 
     public _computeHeight() {
       var textHeight = this._measurer.measure().height;
+      var maximumTiers = _Util.Methods.max(this._possibleTimeAxisConfigurations.map((config: TimeAxisConfiguration) => config.length), 0);
 
       this._tierHeights = [];
-      for (var i = 0; i < this._maximumTiers; i++) {
+      for (var i = 0; i < maximumTiers; i++) {
         this._tierHeights.push(textHeight + this.tickLabelPadding() +
                               ((this._tierLabelPositions[i]) === "between" ? 0 : this._maxLabelTickLength()));
       }

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -170,7 +170,7 @@ export module Axis {
       this.classed("time-axis", true);
       this.tickLabelPadding(5);
       this.tierLabelPositions(["between", "between"]);
-      this.axisConfigurations(this._DEFAULT_TIME_AXIS_CONFIGURATIONS);
+      this.axisConfigurations(Time._DEFAULT_TIME_AXIS_CONFIGURATIONS);
     }
 
     public tierLabelPositions(): string[];

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -240,8 +240,12 @@ export module Axis {
 
     public _computeHeight() {
       var textHeight = this._measurer.measure().height;
-      this._tierHeights = this._tierLabelPositions.map((pos: string) =>
-        textHeight + this.tickLabelPadding() + ((pos === "between") ? 0 : this._maxLabelTickLength()));
+      this._tierHeights = this._tierLabelPositions.map((pos: string, index: number) => {
+        if (index >= this._possibleTimeAxisConfigurations[0].length) {
+          return 0;
+        }
+        return textHeight + this.tickLabelPadding() + ((pos === "between") ? 0 : this._maxLabelTickLength());
+      });
       this._computedHeight = d3.sum(this._tierHeights);
       return this._computedHeight;
     }

--- a/test/components/timeAxisTests.ts
+++ b/test/components/timeAxisTests.ts
@@ -152,11 +152,9 @@ describe("TimeAxis", () => {
   });
 
   it("if the time only uses one tier, there should be no space left for the second tier", () => {
-    var svg = generateSVG(400, 100);
-
+    var svg = generateSVG();
     var xScale = new Plottable.Scale.Time();
     xScale.domain([new Date("2013-03-23 12:00"), new Date("2013-04-03 0:00")]);
-
     var xAxis = new Plottable.Axis.Time(xScale, "bottom");
     xAxis.gutter(0);
 
@@ -168,34 +166,20 @@ describe("TimeAxis", () => {
 
     xAxis.renderTo(svg);
 
+    var oneTierSize: number = xAxis.height();
 
-    var svg2 = generateSVG(400, 100);
-
-    var xScale2 = new Plottable.Scale.Time();
-    xScale2.domain([new Date("2013-03-23 12:00"), new Date("2013-04-03 0:00")]);
-
-    var xAxis2 = new Plottable.Axis.Time(xScale2, "bottom");
-    xAxis2.gutter(0);
-
-    xAxis2.axisConfigurations([
+    xAxis.axisConfigurations([
         [
            {interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e")},
            {interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e")}
         ],
     ]);
 
-    xAxis2.renderTo(svg2);
+    var twoTierSize: number = xAxis.height();
 
-
-    var bbox = Plottable._Util.DOM.getBBox(svg);
-
-    var bbox2 = Plottable._Util.DOM.getBBox(svg2);
-
-    assert.equal(bbox.height * 2, bbox2.height, "The box should have size 20");
+    assert.strictEqual(twoTierSize, oneTierSize * 2, "two-tier axis is twice as tall as one-tier axis");
 
     svg.remove();
-    svg2.remove();
-
   });
 
 });

--- a/test/components/timeAxisTests.ts
+++ b/test/components/timeAxisTests.ts
@@ -150,4 +150,52 @@ describe("TimeAxis", () => {
     });
     svg.remove();
   });
+
+  it("if the time only uses one tier, there should be no space left for the second tier", () => {
+    var svg = generateSVG(400, 100);
+
+    var xScale = new Plottable.Scale.Time();
+    xScale.domain([new Date("2013-03-23 12:00"), new Date("2013-04-03 0:00")]);
+
+    var xAxis = new Plottable.Axis.Time(xScale, "bottom");
+    xAxis.gutter(0);
+
+    xAxis.axisConfigurations([
+        [
+           {interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e")}
+        ],
+    ]);
+
+    xAxis.renderTo(svg);
+
+
+    var svg2 = generateSVG(400, 100);
+
+    var xScale2 = new Plottable.Scale.Time();
+    xScale2.domain([new Date("2013-03-23 12:00"), new Date("2013-04-03 0:00")]);
+
+    var xAxis2 = new Plottable.Axis.Time(xScale2, "bottom");
+    xAxis2.gutter(0);
+
+    xAxis2.axisConfigurations([
+        [
+           {interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e")},
+           {interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e")}
+        ],
+    ]);
+
+    xAxis2.renderTo(svg2);
+
+
+    var bbox = Plottable._Util.DOM.getBBox(svg);
+
+    var bbox2 = Plottable._Util.DOM.getBBox(svg2);
+
+    assert.equal(bbox.height * 2, bbox2.height, "The box should have size 20");
+
+    svg.remove();
+    svg2.remove();
+
+  });
+
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -783,7 +783,7 @@ describe("TimeAxis", function () {
         svg.remove();
     });
     it("if the time only uses one tier, there should be no space left for the second tier", function () {
-        var svg = generateSVG(400, 100);
+        var svg = generateSVG();
         var xScale = new Plottable.Scale.Time();
         xScale.domain([new Date("2013-03-23 12:00"), new Date("2013-04-03 0:00")]);
         var xAxis = new Plottable.Axis.Time(xScale, "bottom");
@@ -794,23 +794,16 @@ describe("TimeAxis", function () {
             ],
         ]);
         xAxis.renderTo(svg);
-        var svg2 = generateSVG(400, 100);
-        var xScale2 = new Plottable.Scale.Time();
-        xScale2.domain([new Date("2013-03-23 12:00"), new Date("2013-04-03 0:00")]);
-        var xAxis2 = new Plottable.Axis.Time(xScale2, "bottom");
-        xAxis2.gutter(0);
-        xAxis2.axisConfigurations([
+        var oneTierSize = xAxis.height();
+        xAxis.axisConfigurations([
             [
                 { interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e") },
                 { interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e") }
             ],
         ]);
-        xAxis2.renderTo(svg2);
-        var bbox = Plottable._Util.DOM.getBBox(svg);
-        var bbox2 = Plottable._Util.DOM.getBBox(svg2);
-        assert.equal(bbox.height * 2, bbox2.height, "The box should have size 20");
+        var twoTierSize = xAxis.height();
+        assert.strictEqual(twoTierSize, oneTierSize * 2, "two-tier axis is twice as tall as one-tier axis");
         svg.remove();
-        svg2.remove();
     });
 });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -782,6 +782,36 @@ describe("TimeAxis", function () {
         });
         svg.remove();
     });
+    it("if the time only uses one tier, there should be no space left for the second tier", function () {
+        var svg = generateSVG(400, 100);
+        var xScale = new Plottable.Scale.Time();
+        xScale.domain([new Date("2013-03-23 12:00"), new Date("2013-04-03 0:00")]);
+        var xAxis = new Plottable.Axis.Time(xScale, "bottom");
+        xAxis.gutter(0);
+        xAxis.axisConfigurations([
+            [
+                { interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e") }
+            ],
+        ]);
+        xAxis.renderTo(svg);
+        var svg2 = generateSVG(400, 100);
+        var xScale2 = new Plottable.Scale.Time();
+        xScale2.domain([new Date("2013-03-23 12:00"), new Date("2013-04-03 0:00")]);
+        var xAxis2 = new Plottable.Axis.Time(xScale2, "bottom");
+        xAxis2.gutter(0);
+        xAxis2.axisConfigurations([
+            [
+                { interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e") },
+                { interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e") }
+            ],
+        ]);
+        xAxis2.renderTo(svg2);
+        var bbox = Plottable._Util.DOM.getBBox(svg);
+        var bbox2 = Plottable._Util.DOM.getBBox(svg2);
+        assert.equal(bbox.height * 2, bbox2.height, "The box should have size 20");
+        svg.remove();
+        svg2.remove();
+    });
 });
 
 ///<reference path="../testReference.ts" />


### PR DESCRIPTION
Before (see URL) we were always setting the number of tiers to the maximum value (2). That meant that if we were only ever using 1 tier, there would be whitespace reserved for the second tier, which will never be used.

We now look through configurations and derive the maximum number of tiers.

Catch: If there is a chance to ever display 2 tiers, we will leave space for 2 tiers even when only 1 tier is displayed, because we don't want the graph to jump on resize of the axis

Also included small refactoring:
- added a private static default configurations _DEFAULT_TIME_AXIS_CONFIGURATIONS
All should help readability 

Before: http://jsfiddle.net/9kk194m6/2/
After: http://jsfiddle.net/6yvtwzvm/