### PR TITLE
2 tests were failing if the # symbol was presented in the URL

### DIFF
--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -206,6 +206,7 @@ describe("Component behavior", () => {
     c._computeLayout(0, 0, 100, 100);
     c._render();
     var expectedPrefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
+    expectedPrefix = expectedPrefix.replace(/#.*/g, "");
     var expectedClipPathURL = "url(" + expectedPrefix + "#clipPath" + expectedClipPathID+ ")";
     // IE 9 has clipPath like 'url("#clipPath")', must accomodate
     var normalizeClipPath = (s: string) => s.replace(/"/g, "");

--- a/test/tests.js
+++ b/test/tests.js
@@ -5565,6 +5565,7 @@ describe("Component behavior", function () {
         c._computeLayout(0, 0, 100, 100);
         c._render();
         var expectedPrefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
+        expectedPrefix = expectedPrefix.replace(/#.*/g, "");
         var expectedClipPathURL = "url(" + expectedPrefix + "#clipPath" + expectedClipPathID + ")";
         // IE 9 has clipPath like 'url("#clipPath")', must accomodate
         var normalizeClipPath = function (s) { return s.replace(/"/g, ""); };


### PR DESCRIPTION
To reproduce 
http://localhost:9999/test/tests.html#

Fix: regex strip down of suffix. 