### PR TITLE
Component.Group now occupies all offered space

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1618,8 +1618,6 @@ declare module Plottable {
             protected _fixedWidthFlag: boolean;
             protected _isSetup: boolean;
             protected _isAnchored: boolean;
-            protected _width: number;
-            protected _height: number;
             /**
              * Attaches the Component as a child of a given a DOM element. Usually only directly invoked on root-level Components.
              *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1618,6 +1618,8 @@ declare module Plottable {
             protected _fixedWidthFlag: boolean;
             protected _isSetup: boolean;
             protected _isAnchored: boolean;
+            protected _width: number;
+            protected _height: number;
             /**
              * Attaches the Component as a child of a given a DOM element. Usually only directly invoked on root-level Components.
              *
@@ -1642,6 +1644,7 @@ declare module Plottable {
              * @param {number} availableHeight available height for the Component to render in
              */
             _computeLayout(offeredXOrigin?: number, offeredYOrigin?: number, availableWidth?: number, availableHeight?: number): void;
+            protected _setSize(availableWidth: number, availableHeight: number): void;
             _render(): void;
             _doRender(): void;
             _useLastCalculatedLayout(): boolean;
@@ -1897,6 +1900,7 @@ declare module Plottable {
             _requestedSpace(offeredWidth: number, offeredHeight: number): _SpaceRequest;
             _merge(c: AbstractComponent, below: boolean): Group;
             _computeLayout(offeredXOrigin?: number, offeredYOrigin?: number, availableWidth?: number, availableHeight?: number): Group;
+            protected _setSize(availableWidth: number, availableHeight: number): void;
             _isFixedWidth(): boolean;
             _isFixedHeight(): boolean;
         }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1644,7 +1644,10 @@ declare module Plottable {
              * @param {number} availableHeight available height for the Component to render in
              */
             _computeLayout(offeredXOrigin?: number, offeredYOrigin?: number, availableWidth?: number, availableHeight?: number): void;
-            protected _setSize(availableWidth: number, availableHeight: number): void;
+            protected _getSize(availableWidth: number, availableHeight: number): {
+                width: number;
+                height: number;
+            };
             _render(): void;
             _doRender(): void;
             _useLastCalculatedLayout(): boolean;
@@ -1900,7 +1903,10 @@ declare module Plottable {
             _requestedSpace(offeredWidth: number, offeredHeight: number): _SpaceRequest;
             _merge(c: AbstractComponent, below: boolean): Group;
             _computeLayout(offeredXOrigin?: number, offeredYOrigin?: number, availableWidth?: number, availableHeight?: number): Group;
-            protected _setSize(availableWidth: number, availableHeight: number): void;
+            protected _getSize(availableWidth: number, availableHeight: number): {
+                width: number;
+                height: number;
+            };
             _isFixedWidth(): boolean;
             _isFixedHeight(): boolean;
         }

--- a/plottable.js
+++ b/plottable.js
@@ -3459,6 +3459,7 @@ var Plottable;
              * @param {number} availableHeight available height for the Component to render in
              */
             AbstractComponent.prototype._computeLayout = function (offeredXOrigin, offeredYOrigin, availableWidth, availableHeight) {
+                var _this = this;
                 if (offeredXOrigin == null || offeredYOrigin == null || availableWidth == null || availableHeight == null) {
                     if (this._element == null) {
                         throw new Error("anchor must be called before computeLayout");
@@ -3489,13 +3490,12 @@ var Plottable;
                 this._yOrigin = offeredYOrigin + this._yOffset + (availableHeight - this.height()) * this._yAlignProportion;
                 ;
                 this._element.attr("transform", "translate(" + this._xOrigin + "," + this._yOrigin + ")");
+                this._boxes.forEach(function (b) { return b.attr("width", _this.width()).attr("height", _this.height()); });
             };
             AbstractComponent.prototype._setSize = function (availableWidth, availableHeight) {
-                var _this = this;
                 var requestedSpace = this._requestedSpace(availableWidth, availableHeight);
                 this._width = this._isFixedWidth() ? Math.min(availableWidth, requestedSpace.width) : availableWidth;
                 this._height = this._isFixedHeight() ? Math.min(availableHeight, requestedSpace.height) : availableHeight;
-                this._boxes.forEach(function (b) { return b.attr("width", _this.width()).attr("height", _this.height()); });
             };
             AbstractComponent.prototype._render = function () {
                 if (this._isAnchored && this._isSetup && this.width() >= 0 && this.height() >= 0) {

--- a/plottable.js
+++ b/plottable.js
@@ -3485,17 +3485,20 @@ var Plottable;
                         throw new Error("null arguments cannot be passed to _computeLayout() on a non-root node");
                     }
                 }
-                this._setSize(availableWidth, availableHeight);
+                var size = this._getSize(availableWidth, availableHeight);
+                this._width = size.width;
+                this._height = size.height;
                 this._xOrigin = offeredXOrigin + this._xOffset + (availableWidth - this.width()) * this._xAlignProportion;
                 this._yOrigin = offeredYOrigin + this._yOffset + (availableHeight - this.height()) * this._yAlignProportion;
-                ;
                 this._element.attr("transform", "translate(" + this._xOrigin + "," + this._yOrigin + ")");
                 this._boxes.forEach(function (b) { return b.attr("width", _this.width()).attr("height", _this.height()); });
             };
-            AbstractComponent.prototype._setSize = function (availableWidth, availableHeight) {
+            AbstractComponent.prototype._getSize = function (availableWidth, availableHeight) {
                 var requestedSpace = this._requestedSpace(availableWidth, availableHeight);
-                this._width = this._isFixedWidth() ? Math.min(availableWidth, requestedSpace.width) : availableWidth;
-                this._height = this._isFixedHeight() ? Math.min(availableHeight, requestedSpace.height) : availableHeight;
+                return {
+                    width: this._isFixedWidth() ? Math.min(availableWidth, requestedSpace.width) : availableWidth,
+                    height: this._isFixedHeight() ? Math.min(availableHeight, requestedSpace.height) : availableHeight
+                };
             };
             AbstractComponent.prototype._render = function () {
                 if (this._isAnchored && this._isSetup && this.width() >= 0 && this.height() >= 0) {
@@ -4070,9 +4073,11 @@ var Plottable;
                 });
                 return this;
             };
-            Group.prototype._setSize = function (availableWidth, availableHeight) {
-                this._width = availableWidth;
-                this._height = availableHeight;
+            Group.prototype._getSize = function (availableWidth, availableHeight) {
+                return {
+                    width: availableWidth,
+                    height: availableHeight
+                };
             };
             Group.prototype._isFixedWidth = function () {
                 return this.components().every(function (c) { return c._isFixedWidth(); });

--- a/plottable.js
+++ b/plottable.js
@@ -3459,7 +3459,6 @@ var Plottable;
              * @param {number} availableHeight available height for the Component to render in
              */
             AbstractComponent.prototype._computeLayout = function (offeredXOrigin, offeredYOrigin, availableWidth, availableHeight) {
-                var _this = this;
                 if (offeredXOrigin == null || offeredYOrigin == null || availableWidth == null || availableHeight == null) {
                     if (this._element == null) {
                         throw new Error("anchor must be called before computeLayout");
@@ -3485,13 +3484,17 @@ var Plottable;
                         throw new Error("null arguments cannot be passed to _computeLayout() on a non-root node");
                     }
                 }
-                var requestedSpace = this._requestedSpace(availableWidth, availableHeight);
-                this._width = this._isFixedWidth() ? Math.min(availableWidth, requestedSpace.width) : availableWidth;
-                this._height = this._isFixedHeight() ? Math.min(availableHeight, requestedSpace.height) : availableHeight;
+                this._setSize(availableWidth, availableHeight);
                 this._xOrigin = offeredXOrigin + this._xOffset + (availableWidth - this.width()) * this._xAlignProportion;
                 this._yOrigin = offeredYOrigin + this._yOffset + (availableHeight - this.height()) * this._yAlignProportion;
                 ;
                 this._element.attr("transform", "translate(" + this._xOrigin + "," + this._yOrigin + ")");
+            };
+            AbstractComponent.prototype._setSize = function (availableWidth, availableHeight) {
+                var _this = this;
+                var requestedSpace = this._requestedSpace(availableWidth, availableHeight);
+                this._width = this._isFixedWidth() ? Math.min(availableWidth, requestedSpace.width) : availableWidth;
+                this._height = this._isFixedHeight() ? Math.min(availableHeight, requestedSpace.height) : availableHeight;
                 this._boxes.forEach(function (b) { return b.attr("width", _this.width()).attr("height", _this.height()); });
             };
             AbstractComponent.prototype._render = function () {
@@ -4067,11 +4070,15 @@ var Plottable;
                 });
                 return this;
             };
+            Group.prototype._setSize = function (availableWidth, availableHeight) {
+                this._width = availableWidth;
+                this._height = availableHeight;
+            };
             Group.prototype._isFixedWidth = function () {
-                return false;
+                return this.components().every(function (c) { return c._isFixedWidth(); });
             };
             Group.prototype._isFixedHeight = function () {
-                return false;
+                return this.components().every(function (c) { return c._isFixedHeight(); });
             };
             return Group;
         })(Component.AbstractComponentContainer);

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -138,13 +138,13 @@ export module Component {
       this._xOrigin = offeredXOrigin + this._xOffset + (availableWidth - this.width()) * this._xAlignProportion;
       this._yOrigin = offeredYOrigin + this._yOffset + (availableHeight - this.height()) * this._yAlignProportion;;
       this._element.attr("transform", "translate(" + this._xOrigin + "," + this._yOrigin + ")");
+      this._boxes.forEach((b: D3.Selection) => b.attr("width", this.width()).attr("height", this.height()));
     }
 
     protected _setSize(availableWidth: number, availableHeight: number) {
       var requestedSpace = this._requestedSpace(availableWidth, availableHeight);
       this._width  = this._isFixedWidth()  ? Math.min(availableWidth , requestedSpace.width)  : availableWidth ;
       this._height = this._isFixedHeight() ? Math.min(availableHeight, requestedSpace.height) : availableHeight;
-      this._boxes.forEach((b: D3.Selection) => b.attr("width", this.width()).attr("height", this.height()));
     }
 
     public _render() {

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -26,8 +26,8 @@ export module Component {
     private _boxContainer: D3.Selection;
     private _rootSVG: D3.Selection;
     private _isTopLevelComponent = false;
-    private _width: number; // Width and height of the component. Used to size the hitbox, bounding box, etc
-    private _height: number;
+    protected _width: number; // Width and height of the component. Used to size the hitbox, bounding box, etc
+    protected _height: number;
     private _xOffset = 0; // Offset from Origin, used for alignment and floating positioning
     private _yOffset = 0;
     private _cssClasses: string[] = ["component"];
@@ -134,14 +134,16 @@ export module Component {
           throw new Error("null arguments cannot be passed to _computeLayout() on a non-root node");
         }
       }
+      this._setSize(availableWidth, availableHeight);
+      this._xOrigin = offeredXOrigin + this._xOffset + (availableWidth - this.width()) * this._xAlignProportion;
+      this._yOrigin = offeredYOrigin + this._yOffset + (availableHeight - this.height()) * this._yAlignProportion;;
+      this._element.attr("transform", "translate(" + this._xOrigin + "," + this._yOrigin + ")");
+    }
+
+    protected _setSize(availableWidth: number, availableHeight: number) {
       var requestedSpace = this._requestedSpace(availableWidth, availableHeight);
       this._width  = this._isFixedWidth()  ? Math.min(availableWidth , requestedSpace.width)  : availableWidth ;
       this._height = this._isFixedHeight() ? Math.min(availableHeight, requestedSpace.height) : availableHeight;
-
-      this._xOrigin = offeredXOrigin + this._xOffset + (availableWidth - this.width()) * this._xAlignProportion;
-      this._yOrigin = offeredYOrigin + this._yOffset + (availableHeight - this.height()) * this._yAlignProportion;;
-
-      this._element.attr("transform", "translate(" + this._xOrigin + "," + this._yOrigin + ")");
       this._boxes.forEach((b: D3.Selection) => b.attr("width", this.width()).attr("height", this.height()));
     }
 

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -26,8 +26,8 @@ export module Component {
     private _boxContainer: D3.Selection;
     private _rootSVG: D3.Selection;
     private _isTopLevelComponent = false;
-    protected _width: number; // Width and height of the component. Used to size the hitbox, bounding box, etc
-    protected _height: number;
+    private _width: number; // Width and height of the component. Used to size the hitbox, bounding box, etc
+    private _height: number;
     private _xOffset = 0; // Offset from Origin, used for alignment and floating positioning
     private _yOffset = 0;
     private _cssClasses: string[] = ["component"];

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -134,17 +134,21 @@ export module Component {
           throw new Error("null arguments cannot be passed to _computeLayout() on a non-root node");
         }
       }
-      this._setSize(availableWidth, availableHeight);
+      var size = this._getSize(availableWidth, availableHeight);
+      this._width = size.width;
+      this._height = size.height;
       this._xOrigin = offeredXOrigin + this._xOffset + (availableWidth - this.width()) * this._xAlignProportion;
-      this._yOrigin = offeredYOrigin + this._yOffset + (availableHeight - this.height()) * this._yAlignProportion;;
+      this._yOrigin = offeredYOrigin + this._yOffset + (availableHeight - this.height()) * this._yAlignProportion;
       this._element.attr("transform", "translate(" + this._xOrigin + "," + this._yOrigin + ")");
       this._boxes.forEach((b: D3.Selection) => b.attr("width", this.width()).attr("height", this.height()));
     }
 
-    protected _setSize(availableWidth: number, availableHeight: number) {
+    protected _getSize(availableWidth: number, availableHeight: number) {
       var requestedSpace = this._requestedSpace(availableWidth, availableHeight);
-      this._width  = this._isFixedWidth()  ? Math.min(availableWidth , requestedSpace.width)  : availableWidth ;
-      this._height = this._isFixedHeight() ? Math.min(availableHeight, requestedSpace.height) : availableHeight;
+      return {
+        width: this._isFixedWidth()  ? Math.min(availableWidth , requestedSpace.width)  : availableWidth,
+        height: this._isFixedHeight() ? Math.min(availableHeight, requestedSpace.height) : availableHeight
+      };
     }
 
     public _render() {

--- a/src/components/componentGroup.ts
+++ b/src/components/componentGroup.ts
@@ -49,9 +49,11 @@ export module Component {
       return this;
     }
 
-    protected _setSize(availableWidth: number, availableHeight: number) {
-      this._width = availableWidth;
-      this._height = availableHeight;
+    protected _getSize(availableWidth: number, availableHeight: number) {
+      return {
+        width: availableWidth,
+        height: availableHeight
+      };
     }
 
     public _isFixedWidth(): boolean {

--- a/src/components/componentGroup.ts
+++ b/src/components/componentGroup.ts
@@ -49,12 +49,17 @@ export module Component {
       return this;
     }
 
+    protected _setSize(availableWidth: number, availableHeight: number) {
+      this._width = availableWidth;
+      this._height = availableHeight;
+    }
+
     public _isFixedWidth(): boolean {
-      return false;
+      return this.components().every((c) => c._isFixedWidth());
     }
 
     public _isFixedHeight(): boolean {
-      return false;
+      return this.components().every((c) => c._isFixedHeight());
     }
   }
 }

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -25,26 +25,6 @@ describe("ComponentGroups", () => {
     svg.remove();
   });
 
-  it("components in componentGroups occupies all available space", () => {
-    var svg = generateSVG(400, 400);
-    var xAxis = new Plottable.Axis.Numeric(new Plottable.Scale.Linear(), "bottom");
-
-    var leftLabel = new Plottable.Component.Label("LEFT").xAlign("left");
-    var rightLabel = new Plottable.Component.Label("RIGHT").xAlign("right");
-
-    var labelGroup = new Plottable.Component.Group([leftLabel, rightLabel]);
-
-    var table = new Plottable.Component.Table([
-        [labelGroup],
-        [xAxis]
-    ]);
-
-    table.renderTo(svg);
-
-    assertBBoxNonIntersection((<any>leftLabel)._element.select(".bounding-box"), (<any>rightLabel)._element.select(".bounding-box"));
-    svg.remove();
-  });
-
   it("components can be added before and after anchoring", () => {
     var c1 = makeFixedSizeComponent(10, 10);
     var c2 = makeFixedSizeComponent(20, 20);
@@ -66,24 +46,6 @@ describe("ComponentGroups", () => {
     var t3 = svg.select(".test-box3");
     assertWidthHeight(t3, 400, 400, "rect3 sized correctly");
     svg.remove();
-  });
-
-  it("component fixity is computed appropriately", () => {
-    var cg = new Plottable.Component.Group();
-    var c1 = new Plottable.Component.AbstractComponent();
-    var c2 = new Plottable.Component.AbstractComponent();
-
-    cg.below(c1).below(c2);
-    assert.isFalse(cg._isFixedHeight(), "height not fixed when both components unfixed");
-    assert.isFalse(cg._isFixedWidth(), "width not fixed when both components unfixed");
-
-    fixComponentSize(c1, 10, 10);
-    assert.isFalse(cg._isFixedHeight(), "height not fixed when one component unfixed");
-    assert.isFalse(cg._isFixedWidth(), "width not fixed when one component unfixed");
-
-    fixComponentSize(c2, null, 10);
-    assert.isFalse(cg._isFixedHeight(), "height unfixed when both components fixed");
-    assert.isFalse(cg._isFixedWidth(), "width unfixed when one component unfixed");
   });
 
   it("componentGroup subcomponents have xOffset, yOffset of 0", () => {
@@ -164,32 +126,54 @@ describe("ComponentGroups", () => {
     assert.lengthOf(cg.components(), 0, "cg has no components");
   });
 
-  describe("ComponentGroup._requestedSpace works as expected", () => {
-    it("_works for an empty ComponentGroup", () => {
-        var cg = new Plottable.Component.Group();
-        var request = cg._requestedSpace(10, 10);
-        verifySpaceRequest(request, 0, 0, false, false, "");
+  describe("requests space based on contents, but occupies total offered space", () => {
+    var SVG_WIDTH = 400;
+    var SVG_HEIGHT = 400;
+
+    it("with no Components", () => {
+      var svg = generateSVG();
+      var cg = new Plottable.Component.Group([]);
+
+      var request = cg._requestedSpace(SVG_WIDTH, SVG_HEIGHT);
+      verifySpaceRequest(request, 0, 0, false, false, "empty Group doesn't request any space");
+
+      cg.renderTo(svg);
+      assert.strictEqual(cg.width(), SVG_WIDTH, "occupies all offered width");
+      assert.strictEqual(cg.height(), SVG_HEIGHT, "occupies all offered height");
+      svg.remove();
     });
 
-    it("works for a ComponentGroup with only proportional-size components", () => {
-      var cg = new Plottable.Component.Group();
-      var c1 = new Plottable.Component.AbstractComponent();
-      var c2 = new Plottable.Component.AbstractComponent();
-      cg.below(c1).below(c2);
-      var request = cg._requestedSpace(10, 10);
-      verifySpaceRequest(request, 0, 0, false, false, "");
+    it("with proportional Components", () => {
+      var svg = generateSVG();
+      var cg = new Plottable.Component.Group([
+        new Plottable.Component.AbstractComponent(),
+        new Plottable.Component.AbstractComponent()
+      ]);
+
+      var request = cg._requestedSpace(SVG_WIDTH, SVG_HEIGHT);
+      verifySpaceRequest(request, 0, 0, false, false, "empty Group doesn't request any space");
+
+      cg.renderTo(svg);
+      assert.strictEqual(cg.width(), SVG_WIDTH, "occupies all offered width");
+      assert.strictEqual(cg.height(), SVG_HEIGHT, "occupies all offered height");
+      svg.remove();
     });
 
-    it("works when there are fixed-size components", () => {
-      var cg = new Plottable.Component.Group();
-      var c1 = new Plottable.Component.AbstractComponent();
-      var c2 = new Plottable.Component.AbstractComponent();
-      var c3 = new Plottable.Component.AbstractComponent();
-      cg.below(c1).below(c2).below(c3);
-      fixComponentSize(c1, null, 10);
-      fixComponentSize(c2, null, 50);
-      var request = cg._requestedSpace(10, 10);
-      verifySpaceRequest(request, 0, 50, false, true, "");
+    it("with fixed-size Components", () => {
+      var svg = generateSVG();
+      var tall = new Mocks.FixedSizeComponent(SVG_WIDTH/4, SVG_WIDTH/2);
+      var wide = new Mocks.FixedSizeComponent(SVG_WIDTH/2, SVG_WIDTH/4);
+
+      var cg = new Plottable.Component.Group([tall, wide]);
+
+      var request = cg._requestedSpace(SVG_WIDTH, SVG_HEIGHT);
+      assert.strictEqual(request.width, SVG_WIDTH/2, "requested enough space for widest Component");
+      assert.strictEqual(request.height, SVG_HEIGHT/2, "requested enough space for tallest Component");
+
+      cg.renderTo(svg);
+      assert.strictEqual(cg.width(), SVG_WIDTH, "occupies all offered width");
+      assert.strictEqual(cg.height(), SVG_HEIGHT, "occupies all offered height");
+      svg.remove();
     });
   });
 

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -143,15 +143,17 @@ describe("ComponentGroups", () => {
       svg.remove();
     });
 
-    it("with proportional Components", () => {
+    it("with a non-fixed-size Component", () => {
       var svg = generateSVG();
-      var cg = new Plottable.Component.Group([
-        new Plottable.Component.AbstractComponent(),
-        new Plottable.Component.AbstractComponent()
-      ]);
+      var c1 = new Plottable.Component.AbstractComponent();
+      var c2 = new Plottable.Component.AbstractComponent();
+      var cg = new Plottable.Component.Group([c1, c2]);
 
-      var request = cg._requestedSpace(SVG_WIDTH, SVG_HEIGHT);
-      verifySpaceRequest(request, 0, 0, false, false, "empty Group doesn't request any space");
+      var groupRequest = cg._requestedSpace(SVG_WIDTH, SVG_HEIGHT);
+      var c1Request = c1._requestedSpace(SVG_WIDTH, SVG_HEIGHT);
+      assert.deepEqual(groupRequest, c1Request, "request reflects request of sub-component");
+      assert.isFalse(cg._isFixedWidth(), "width is not fixed if subcomponents are not fixed width");
+      assert.isFalse(cg._isFixedHeight(), "height is not fixed if subcomponents are not fixed height");
 
       cg.renderTo(svg);
       assert.strictEqual(cg.width(), SVG_WIDTH, "occupies all offered width");
@@ -167,8 +169,16 @@ describe("ComponentGroups", () => {
       var cg = new Plottable.Component.Group([tall, wide]);
 
       var request = cg._requestedSpace(SVG_WIDTH, SVG_HEIGHT);
-      assert.strictEqual(request.width, SVG_WIDTH/2, "requested enough space for widest Component");
+      assert.strictEqual(request.width, SVG_WIDTH/2,"requested enough space for widest Component");
+      assert.isFalse(request.wantsWidth, "does not request more width if enough was supplied for widest Component");
       assert.strictEqual(request.height, SVG_HEIGHT/2, "requested enough space for tallest Component");
+      assert.isFalse(request.wantsHeight, "does not request more height if enough was supplied for tallest Component");
+
+      var constrainedRequest = cg._requestedSpace(SVG_WIDTH/10, SVG_HEIGHT/10);
+      assert.strictEqual(constrainedRequest.width, SVG_WIDTH/2, "requested enough space for widest Component");
+      assert.isTrue(constrainedRequest.wantsWidth, "requests more width if not enough was supplied for widest Component");
+      assert.strictEqual(constrainedRequest.height, SVG_HEIGHT/2, "requested enough space for tallest Component");
+      assert.isTrue(constrainedRequest.wantsHeight, "requests more height if not enough was supplied for tallest Component");
 
       cg.renderTo(svg);
       assert.strictEqual(cg.width(), SVG_WIDTH, "occupies all offered width");

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -1,0 +1,25 @@
+///<reference path="testReference.ts" />
+
+module Mocks {
+  export class FixedSizeComponent extends Plottable.Component.AbstractComponent {
+    public fixedWidth: number;
+    public fixedHeight: number;
+
+    constructor(width = 0, height = 0) {
+      super();
+      this.fixedWidth = width;
+      this.fixedHeight = height;
+      this._fixedWidthFlag = true;
+      this._fixedHeightFlag = true;
+    }
+
+    public _requestedSpace(availableWidth : number, availableHeight: number): Plottable._SpaceRequest {
+      return {
+        width:  this.fixedWidth,
+        height: this.fixedHeight,
+        wantsWidth : availableWidth < this.fixedWidth,
+        wantsHeight: availableHeight < this.fixedHeight
+      };
+    }
+  }
+}

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -3,9 +3,10 @@
 ///<reference path="../typings/d3/d3.d.ts" />
 ///<reference path="../typings/jquery/jquery.d.ts" />
 ///<reference path="../typings/jquery.simulate/jquery.simulate.d.ts" />
-///<reference path="testUtils.ts" />
 ///<reference path="../build/plottable.d.ts" />
 ///<reference path="../bower_components/svg-typewriter/svgtypewriter.d.ts" />
+///<reference path="testUtils.ts" />
+///<reference path="mocks.ts" />
 
 ///<reference path="globalInitialization.ts" />
 

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -51,11 +51,11 @@ function fakeDragSequence(anyedInteraction: any, startX: number, startY: number,
   d3.mouse = originalD3Mouse;
 }
 
-function verifySpaceRequest(sr: Plottable._SpaceRequest, w: number, h: number, ww: boolean, wh: boolean, id: string) {
-  assert.equal(sr.width,  w, "width requested is as expected #"  + id);
-  assert.equal(sr.height, h, "height requested is as expected #" + id);
-  assert.equal(sr.wantsWidth , ww, "needs more width is as expected #"  + id);
-  assert.equal(sr.wantsHeight, wh, "needs more height is as expected #" + id);
+function verifySpaceRequest(sr: Plottable._SpaceRequest, w: number, h: number, ww: boolean, wh: boolean, message: string) {
+  assert.equal(sr.width,  w, message + " (space request: width)");
+  assert.equal(sr.height, h, message + " (space request: height)");
+  assert.equal(sr.wantsWidth , ww, message + " (space request: wantsWidth)");
+  assert.equal(sr.wantsHeight, wh, message + " (space request: wantsHeight)");
 }
 
 function fixComponentSize(c: Plottable.Component.AbstractComponent, fixedWidth?: number, fixedHeight?: number) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -5298,14 +5298,16 @@ describe("ComponentGroups", function () {
             assert.strictEqual(cg.height(), SVG_HEIGHT, "occupies all offered height");
             svg.remove();
         });
-        it("with proportional Components", function () {
+        it("with a non-fixed-size Component", function () {
             var svg = generateSVG();
-            var cg = new Plottable.Component.Group([
-                new Plottable.Component.AbstractComponent(),
-                new Plottable.Component.AbstractComponent()
-            ]);
-            var request = cg._requestedSpace(SVG_WIDTH, SVG_HEIGHT);
-            verifySpaceRequest(request, 0, 0, false, false, "empty Group doesn't request any space");
+            var c1 = new Plottable.Component.AbstractComponent();
+            var c2 = new Plottable.Component.AbstractComponent();
+            var cg = new Plottable.Component.Group([c1, c2]);
+            var groupRequest = cg._requestedSpace(SVG_WIDTH, SVG_HEIGHT);
+            var c1Request = c1._requestedSpace(SVG_WIDTH, SVG_HEIGHT);
+            assert.deepEqual(groupRequest, c1Request, "request reflects request of sub-component");
+            assert.isFalse(cg._isFixedWidth(), "width is not fixed if subcomponents are not fixed width");
+            assert.isFalse(cg._isFixedHeight(), "height is not fixed if subcomponents are not fixed height");
             cg.renderTo(svg);
             assert.strictEqual(cg.width(), SVG_WIDTH, "occupies all offered width");
             assert.strictEqual(cg.height(), SVG_HEIGHT, "occupies all offered height");
@@ -5318,7 +5320,14 @@ describe("ComponentGroups", function () {
             var cg = new Plottable.Component.Group([tall, wide]);
             var request = cg._requestedSpace(SVG_WIDTH, SVG_HEIGHT);
             assert.strictEqual(request.width, SVG_WIDTH / 2, "requested enough space for widest Component");
+            assert.isFalse(request.wantsWidth, "does not request more width if enough was supplied for widest Component");
             assert.strictEqual(request.height, SVG_HEIGHT / 2, "requested enough space for tallest Component");
+            assert.isFalse(request.wantsHeight, "does not request more height if enough was supplied for tallest Component");
+            var constrainedRequest = cg._requestedSpace(SVG_WIDTH / 10, SVG_HEIGHT / 10);
+            assert.strictEqual(constrainedRequest.width, SVG_WIDTH / 2, "requested enough space for widest Component");
+            assert.isTrue(constrainedRequest.wantsWidth, "requests more width if not enough was supplied for widest Component");
+            assert.strictEqual(constrainedRequest.height, SVG_HEIGHT / 2, "requested enough space for tallest Component");
+            assert.isTrue(constrainedRequest.wantsHeight, "requests more height if not enough was supplied for tallest Component");
             cg.renderTo(svg);
             assert.strictEqual(cg.width(), SVG_WIDTH, "occupies all offered width");
             assert.strictEqual(cg.height(), SVG_HEIGHT, "occupies all offered height");


### PR DESCRIPTION
This change causes `Component.Group` to behave as though it's not there by occupying the entirety of any space in the final offer, although it will still request no more space than is necessary to fit its `Components`.

Close #1791.
Also should not break #1255.