### PR TITLE
Change order of arguments to addComponent()

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2534,28 +2534,25 @@ declare module Plottable {
              */
             constructor(rows?: AbstractComponent[][]);
             /**
-             * Adds a Component in the specified cell.
+             * Adds a Component at the specified row and column position.
              *
-             * If the cell is already occupied, there are 3 cases
-             *  - Component + Component => Group containing both components
-             *  - Component + Group => Component is added to the group
-             *  - Group + Component => Component is added to the group
+             * For example,
+             *     new Table([[a, b]]);
+             * is equivalent to
+             *     var table = new Table();
+             *     table.addComponent(a, 0, 0);
+             *     table.addComponent(b, 0, 1);
              *
-             * For example, instead of calling `new Table([[a, b], [null, c]])`, you
-             * could call
-             * ```typescript
-             * var table = new Table();
-             * table.addComponent(0, 0, a);
-             * table.addComponent(0, 1, b);
-             * table.addComponent(1, 1, c);
-             * ```
+             * If the cell is already occupied, the Component being added is combined
+             * with the existing Component:
+             *   componentToAdd.above(componentAlreadyThere)
              *
+             * @param {Component} component The Component to be added.
              * @param {number} row The row in which to add the Component.
              * @param {number} col The column in which to add the Component.
-             * @param {Component} component The Component to be added.
              * @returns {Table} The calling Table.
              */
-            addComponent(row: number, col: number, component: AbstractComponent): Table;
+            addComponent(componentToAdd: AbstractComponent, row: number, col: number): Table;
             _removeComponent(component: AbstractComponent): void;
             _requestedSpace(offeredWidth: number, offeredHeight: number): _SpaceRequest;
             _computeLayout(offeredXOrigin?: number, offeredYOrigin?: number, availableWidth?: number, availableHeight?: number): void;

--- a/plottable.js
+++ b/plottable.js
@@ -6068,43 +6068,40 @@ var Plottable;
                 this.classed("table", true);
                 rows.forEach(function (row, rowIndex) {
                     row.forEach(function (component, colIndex) {
-                        _this.addComponent(rowIndex, colIndex, component);
+                        _this.addComponent(component, rowIndex, colIndex);
                     });
                 });
             }
             /**
-             * Adds a Component in the specified cell.
+             * Adds a Component at the specified row and column position.
              *
-             * If the cell is already occupied, there are 3 cases
-             *  - Component + Component => Group containing both components
-             *  - Component + Group => Component is added to the group
-             *  - Group + Component => Component is added to the group
+             * For example,
+             *     new Table([[a, b]]);
+             * is equivalent to
+             *     var table = new Table();
+             *     table.addComponent(a, 0, 0);
+             *     table.addComponent(b, 0, 1);
              *
-             * For example, instead of calling `new Table([[a, b], [null, c]])`, you
-             * could call
-             * ```typescript
-             * var table = new Table();
-             * table.addComponent(0, 0, a);
-             * table.addComponent(0, 1, b);
-             * table.addComponent(1, 1, c);
-             * ```
+             * If the cell is already occupied, the Component being added is combined
+             * with the existing Component:
+             *   componentToAdd.above(componentAlreadyThere)
              *
+             * @param {Component} component The Component to be added.
              * @param {number} row The row in which to add the Component.
              * @param {number} col The column in which to add the Component.
-             * @param {Component} component The Component to be added.
              * @returns {Table} The calling Table.
              */
-            Table.prototype.addComponent = function (row, col, component) {
+            Table.prototype.addComponent = function (componentToAdd, row, col) {
                 var currentComponent = this._rows[row] && this._rows[row][col];
                 if (currentComponent) {
                     currentComponent.detach();
-                    component = component.above(currentComponent);
+                    componentToAdd = componentToAdd.above(currentComponent);
                 }
-                if (this._addComponent(component)) {
+                if (this._addComponent(componentToAdd)) {
                     this._nRows = Math.max(row + 1, this._nRows);
                     this._nCols = Math.max(col + 1, this._nCols);
                     this._padTableToSize(this._nRows, this._nCols);
-                    this._rows[row][col] = component;
+                    this._rows[row][col] = componentToAdd;
                 }
                 return this;
             };

--- a/quicktests/js/basic_moveToFront.js
+++ b/quicktests/js/basic_moveToFront.js
@@ -51,20 +51,20 @@ function run(div, data, Plottable) {
   var title1 = new Plottable.Component.TitleLabel( "front: areaPlot", "horizontal");
   var legend1 = new Plottable.Component.Legend(colorScale1);
   legend1.maxEntriesPerRow(1);
-  
-  var titleTable = new Plottable.Component.Table().addComponent(0,0, title1)
-                                        .addComponent(0,1, legend1);
+
+  var titleTable = new Plottable.Component.Table().addComponent(title1, 0, 0)
+                                        .addComponent(legend1, 0, 1);
 
   var plotGroup = scatterPlot.merge(linePlot).merge(areaPlot);
 
   var basicTable = new Plottable.Component.Table()
-              .addComponent(2, 0, yAxis)
-              .addComponent(2, 1, plotGroup)
-              .addComponent(3, 1, xAxis);
+              .addComponent(yAxis, 2, 0)
+              .addComponent(plotGroup, 2, 1)
+              .addComponent(xAxis, 3, 1);
 
   var bigTable = new Plottable.Component.Table()
-             .addComponent(0, 0, titleTable)
-             .addComponent(1,0, basicTable);
+             .addComponent(titleTable, 0, 0)
+             .addComponent(basicTable, 1, 0);
 
   bigTable.renderTo(svg);
 

--- a/quicktests/js/category_project.js
+++ b/quicktests/js/category_project.js
@@ -37,10 +37,10 @@ function run(div, data, Plottable) {
   var label = new Plottable.Component.Label("Width is 3*d.x + 3", "horizontal");
 
   var xAxisTable = new Plottable.Component.Table([[xAxis],[label]]);
-  var basicTable = new Plottable.Component.Table().addComponent(0,2, title1)
-                                          .addComponent(1, 1, yAxis)
-                                          .addComponent(1, 2, renderAreaD1)
-                                          .addComponent(2, 2, xAxisTable);
+  var basicTable = new Plottable.Component.Table().addComponent(title1, 0, 2)
+                                          .addComponent(yAxis, 1, 1)
+                                          .addComponent(renderAreaD1, 1, 2)
+                                          .addComponent(xAxisTable, 2, 2);
 
   basicTable.renderTo(svg);
 }

--- a/quicktests/js/changeData_onClick.js
+++ b/quicktests/js/changeData_onClick.js
@@ -37,9 +37,9 @@ function run(div, data, Plottable) {
     var renderGroup = barPlot.merge(scatterPlot);
 
     var basicTable = new Plottable.Component.Table()
-                .addComponent(2, 0, yAxis)
-                .addComponent(2, 1, renderGroup)
-                .addComponent(3, 1, xAxis);
+                .addComponent(yAxis, 2, 0)
+                .addComponent(renderGroup, 2, 1)
+                .addComponent(xAxis, 3, 1);
 
     basicTable.renderTo(svg);
 

--- a/quicktests/js/layout_tables.js
+++ b/quicktests/js/layout_tables.js
@@ -42,32 +42,32 @@ function run(div, data, Plottable) {
     //test merge:
     //empty component + empty component
 
-    var basicTable0 = new Plottable.Component.Table().addComponent(0,0, yAxis0);
+    var basicTable0 = new Plottable.Component.Table().addComponent(yAxis0, 0, 0);
 
     //empty component + XYRenderer
-    var basicTable1 = new Plottable.Component.Table().addComponent(0,1, renderAreaD0);
+    var basicTable1 = new Plottable.Component.Table().addComponent(renderAreaD0, 0, 1);
 
 
     //XYRenderer + empty component
-    var basicTable2 = new Plottable.Component.Table().addComponent(0,0, yAxis2)
-                                          .addComponent(0,1, renderAreaD1)
-                                          .addComponent(1,1,xAxis2);
+    var basicTable2 = new Plottable.Component.Table().addComponent(yAxis2, 0, 0)
+                                          .addComponent(renderAreaD1, 0, 1)
+                                          .addComponent(xAxis2, 1, 1);
     //XYRenderer + XYRenderer
     var renderGroup3 = renderAreaD3.merge(renderAreaD2);
-    var basicTable3 = new Plottable.Component.Table().addComponent(0,1, renderGroup3)
-                                          .addComponent(1,1,xAxis3);
+    var basicTable3 = new Plottable.Component.Table().addComponent(renderGroup3, 0, 1)
+                                          .addComponent(xAxis3, 1, 1);
 
     var bigtable = new Plottable.Component.Table();
 
     var line1 = new Plottable.Component.Label("Tables in Tables", "horizontal");
     var line2 = new Plottable.Component.Label("for Dan", "horizontal");
 
-    bigtable = new Plottable.Component.Table().addComponent(0,0, basicTable0)
-                                          .addComponent(0,2, basicTable1)
-                                          .addComponent(3,0, basicTable2)
-                                          .addComponent(3,2,basicTable3)
-                                          .addComponent(1, 1, line1)
-                                          .addComponent(2, 1, line2);
+    bigtable = new Plottable.Component.Table().addComponent(basicTable0, 0, 0)
+                                          .addComponent(basicTable1, 0, 2)
+                                          .addComponent(basicTable2, 3, 0)
+                                          .addComponent(basicTable3, 3, 2)
+                                          .addComponent(line1, 1, 1)
+                                          .addComponent(line2, 2, 1);
     bigtable.renderTo(svg);
 
 

--- a/quicktests/js/legend_basic.js
+++ b/quicktests/js/legend_basic.js
@@ -42,13 +42,13 @@ function run(div, data, Plottable) {
 
   var title1 = new Plottable.Component.TitleLabel( "Four Data Series", "horizontal");
   var legend1 = new Plottable.Component.Legend(colorScale1).maxEntriesPerRow(1);
-  var titleTable = new Plottable.Component.Table().addComponent(0,0, title1)
-  .addComponent(0,1, legend1);
+  var titleTable = new Plottable.Component.Table().addComponent(title1, 0, 0)
+  .addComponent(legend1, 0, 1);
 
-  var basicTable = new Plottable.Component.Table().addComponent(0,2, titleTable)
-              .addComponent(1, 1, yAxis)
-              .addComponent(1, 2, renderAreas)
-              .addComponent(2, 2, xAxis);
+  var basicTable = new Plottable.Component.Table().addComponent(titleTable, 0, 2)
+              .addComponent(yAxis, 1, 1)
+              .addComponent(renderAreas, 1, 2)
+              .addComponent(xAxis, 2, 2);
 
   basicTable.renderTo(svg);
 }

--- a/quicktests/js/multi_area.js
+++ b/quicktests/js/multi_area.js
@@ -47,14 +47,14 @@ function run(div, data, Plottable) {
   var title1 = new Plottable.Component.TitleLabel( "Two Data Series", "horizontal");
   var legend1 = new Plottable.Component.Legend(colorScale);
   legend1.maxEntriesPerRow(1);
-  
-  var titleTable = new Plottable.Component.Table().addComponent(0,0, title1)
-                                        .addComponent(0,1, legend1);
 
-  var basicTable = new Plottable.Component.Table().addComponent(0,2, titleTable)
-              .addComponent(1, 1, yAxis)
-              .addComponent(1, 2, plot)
-              .addComponent(2, 2, xAxis);
+  var titleTable = new Plottable.Component.Table().addComponent(title1, 0, 0)
+                                        .addComponent(legend1, 0, 1);
+
+  var basicTable = new Plottable.Component.Table().addComponent(titleTable, 0, 2)
+              .addComponent(yAxis, 1, 1)
+              .addComponent(plot, 1, 2)
+              .addComponent(xAxis, 2, 2);
 
   basicTable.renderTo(svg);
 

--- a/quicktests/js/multi_line.js
+++ b/quicktests/js/multi_line.js
@@ -47,13 +47,13 @@ function run(div, data, Plottable) {
   var legend1 = new Plottable.Component.Legend(colorScale);
   legend1.maxEntriesPerRow(1);
 
-  var titleTable = new Plottable.Component.Table().addComponent(0,0, title1)
-                                        .addComponent(0,1, legend1);
+  var titleTable = new Plottable.Component.Table().addComponent(title1, 0, 0)
+                                        .addComponent(legend1, 0, 1);
 
-  var basicTable = new Plottable.Component.Table().addComponent(0,2, titleTable)
-              .addComponent(1, 1, yAxis)
-              .addComponent(1, 2, linePlot)
-              .addComponent(2, 2, xAxis);
+  var basicTable = new Plottable.Component.Table().addComponent(titleTable, 0, 2)
+              .addComponent(yAxis, 1, 1)
+              .addComponent(linePlot, 1, 2)
+              .addComponent(xAxis, 2, 2);
 
   basicTable.renderTo(svg);
 

--- a/quicktests/js/multi_scatter_with_modified_log.js
+++ b/quicktests/js/multi_scatter_with_modified_log.js
@@ -47,13 +47,13 @@ function run(div, data, Plottable) {
   var legend1 = new Plottable.Component.Legend(colorScale);
   legend1.maxEntriesPerRow(1);
 
-  var titleTable = new Plottable.Component.Table().addComponent(0,0, title1)
-                                        .addComponent(0,1, legend1);
+  var titleTable = new Plottable.Component.Table().addComponent(title1, 0, 0)
+                                        .addComponent(legend1, 0, 1);
 
-  var basicTable = new Plottable.Component.Table().addComponent(0,2, titleTable)
-              .addComponent(1, 1, yAxis)
-              .addComponent(1, 2, scatterPlot)
-              .addComponent(2, 2, xAxis);
+  var basicTable = new Plottable.Component.Table().addComponent(titleTable, 0, 2)
+              .addComponent(yAxis, 1, 1)
+              .addComponent(scatterPlot, 1, 2)
+              .addComponent(xAxis, 2, 2);
 
   basicTable.renderTo(svg);
 }

--- a/quicktests/js/project_scatter.js
+++ b/quicktests/js/project_scatter.js
@@ -50,10 +50,10 @@ function run(div, data, Plottable) {
     var title1 = new Plottable.Component.TitleLabel( "Opacity, r, color", "horizontal");
 
 
-    var basicTable = new Plottable.Component.Table().addComponent(0,2, title1)
-                .addComponent(1, 1, yAxis)
-                .addComponent(1, 2, renderAreaD1)
-                .addComponent(2, 2, xAxis);
+    var basicTable = new Plottable.Component.Table().addComponent(title1, 0, 2)
+                .addComponent(yAxis, 1, 1)
+                .addComponent(renderAreaD1, 1, 2)
+                .addComponent(xAxis, 2, 2);
 
     basicTable.renderTo(svg);
 

--- a/quicktests/overlaying/tests/animations/project_scatter.js
+++ b/quicktests/overlaying/tests/animations/project_scatter.js
@@ -44,10 +44,10 @@ function run(svg, data, Plottable) {
     //title + legend
     var title1 = new Plottable.Component.TitleLabel( "Opacity, r, color", "horizontal");
 
-    var basicTable = new Plottable.Component.Table().addComponent(0,2, title1)
-                .addComponent(1, 1, yAxis)
-                .addComponent(1, 2, renderAreaD1)
-                .addComponent(2, 2, xAxis);
+    var basicTable = new Plottable.Component.Table().addComponent(title1, 0, 2)
+                .addComponent(yAxis, 1, 1)
+                .addComponent(renderAreaD1, 1, 2)
+                .addComponent(xAxis, 2, 2);
 
     basicTable.renderTo(svg);
 

--- a/quicktests/overlaying/tests/basic/category_project.js
+++ b/quicktests/overlaying/tests/basic/category_project.js
@@ -36,10 +36,10 @@ function run(svg, data, Plottable) {
   var label = new Plottable.Component.Label("Width is 3*d.x + 3", "horizontal");
 
   var xAxisTable = new Plottable.Component.Table([[xAxis],[label]]);
-  var basicTable = new Plottable.Component.Table().addComponent(0,2, title1)
-                                          .addComponent(1, 1, yAxis)
-                                          .addComponent(1, 2, renderAreaD1)
-                                          .addComponent(2, 2, xAxisTable);
+  var basicTable = new Plottable.Component.Table().addComponent(title1, 0, 2)
+                                          .addComponent(yAxis, 1, 1)
+                                          .addComponent(renderAreaD1, 1, 2)
+                                          .addComponent(xAxisTable, 2, 2);
 
   basicTable.renderTo(svg);
 }

--- a/quicktests/overlaying/tests/basic/layout_tables.js
+++ b/quicktests/overlaying/tests/basic/layout_tables.js
@@ -40,32 +40,32 @@ function run(svg, data, Plottable) {
     //test merge:
     //empty component + empty component
 
-    var basicTable0 = new Plottable.Component.Table().addComponent(0,0, yAxis0);
+    var basicTable0 = new Plottable.Component.Table().addComponent(yAxis0, 0, 0);
 
     //empty component + XYRenderer
-    var basicTable1 = new Plottable.Component.Table().addComponent(0,1, renderAreaD0);
+    var basicTable1 = new Plottable.Component.Table().addComponent(renderAreaD0, 0, 1);
 
 
     //XYRenderer + empty component
-    var basicTable2 = new Plottable.Component.Table().addComponent(0,0, yAxis2)
-                                          .addComponent(0,1, renderAreaD1)
-                                          .addComponent(1,1,xAxis2);
+    var basicTable2 = new Plottable.Component.Table().addComponent(yAxis2, 0, 0)
+                                          .addComponent(renderAreaD1, 0, 1)
+                                          .addComponent(xAxis2, 1, 1);
     //XYRenderer + XYRenderer
     var renderGroup3 = renderAreaD3.below(renderAreaD2);
-    var basicTable3 = new Plottable.Component.Table().addComponent(0,1, renderGroup3)
-                                          .addComponent(1,1,xAxis3);
+    var basicTable3 = new Plottable.Component.Table().addComponent(renderGroup3, 0, 1)
+                                          .addComponent(xAxis3, 1, 1);
 
     var bigtable = new Plottable.Component.Table();
 
     var line1 = new Plottable.Component.Label("Tables in Tables", "horizontal");
     var line2 = new Plottable.Component.Label("for Dan", "horizontal");
 
-    bigtable = new Plottable.Component.Table().addComponent(0,0, basicTable0)
-                                          .addComponent(0,2, basicTable1)
-                                          .addComponent(3,0, basicTable2)
-                                          .addComponent(3,2,basicTable3)
-                                          .addComponent(1, 1, line1)
-                                          .addComponent(2, 1, line2);
+    bigtable = new Plottable.Component.Table().addComponent(basicTable0, 0, 0)
+                                          .addComponent(basicTable1, 0, 2)
+                                          .addComponent(basicTable2, 3, 0)
+                                          .addComponent(basicTable3, 3, 2)
+                                          .addComponent(line1, 1, 1)
+                                          .addComponent(line2, 2, 1);
     bigtable.renderTo(svg);
 
 

--- a/quicktests/overlaying/tests/basic/legend_basic.js
+++ b/quicktests/overlaying/tests/basic/legend_basic.js
@@ -40,13 +40,13 @@ function run(svg, data, Plottable) {
 
   var title1 = new Plottable.Component.TitleLabel( "Four Data Series", "horizontal");
   var legend1 = new Plottable.Component.Legend(colorScale1).maxEntriesPerRow(1);
-  var titleTable = new Plottable.Component.Table().addComponent(0,0, title1)
-  .addComponent(0,1, legend1);
+  var titleTable = new Plottable.Component.Table().addComponent(title1, 0, 0)
+  .addComponent(legend1, 0, 1);
 
-  var basicTable = new Plottable.Component.Table().addComponent(0,2, titleTable)
-              .addComponent(1, 1, yAxis)
-              .addComponent(1, 2, renderAreas)
-              .addComponent(2, 2, xAxis);
+  var basicTable = new Plottable.Component.Table().addComponent(titleTable, 0, 2)
+              .addComponent(yAxis, 1, 1)
+              .addComponent(renderAreas, 1, 2)
+              .addComponent(xAxis, 2, 2);
 
   basicTable.renderTo(svg);
 }

--- a/quicktests/overlaying/tests/basic/multi_area.js
+++ b/quicktests/overlaying/tests/basic/multi_area.js
@@ -44,14 +44,14 @@ function run(svg, data, Plottable) {
   var title1 = new Plottable.Component.TitleLabel( "Two Data Series", "horizontal");
   var legend1 = new Plottable.Component.Legend(colorScale);
   legend1.maxEntriesPerRow(1);
-  
-  var titleTable = new Plottable.Component.Table().addComponent(0,0, title1)
-                                        .addComponent(0,1, legend1);
 
-  var basicTable = new Plottable.Component.Table().addComponent(0,2, titleTable)
-              .addComponent(1, 1, yAxis)
-              .addComponent(1, 2, plot)
-              .addComponent(2, 2, xAxis);
+  var titleTable = new Plottable.Component.Table().addComponent(title1, 0, 0)
+                                        .addComponent(legend1, 0, 1);
+
+  var basicTable = new Plottable.Component.Table().addComponent(titleTable, 0, 2)
+              .addComponent(yAxis, 1, 1)
+              .addComponent(plot, 1, 2)
+              .addComponent(xAxis, 2, 2);
 
   basicTable.renderTo(svg);
 

--- a/quicktests/overlaying/tests/basic/multi_line.js
+++ b/quicktests/overlaying/tests/basic/multi_line.js
@@ -44,13 +44,13 @@ function run(svg, data, Plottable) {
   var legend1 = new Plottable.Component.Legend(colorScale);
   legend1.maxEntriesPerRow(1);
 
-  var titleTable = new Plottable.Component.Table().addComponent(0,0, title1)
-                                        .addComponent(0,1, legend1);
+  var titleTable = new Plottable.Component.Table().addComponent(title1, 0, 0)
+                                        .addComponent(legend1, 0, 1);
 
-  var basicTable = new Plottable.Component.Table().addComponent(0,2, titleTable)
-              .addComponent(1, 1, yAxis)
-              .addComponent(1, 2, linePlot)
-              .addComponent(2, 2, xAxis);
+  var basicTable = new Plottable.Component.Table().addComponent(titleTable, 0, 2)
+              .addComponent(yAxis, 1, 1)
+              .addComponent(linePlot, 1, 2)
+              .addComponent(xAxis, 2, 2);
 
   basicTable.renderTo(svg);
 

--- a/quicktests/overlaying/tests/basic/multi_scatter_with_modified_log.js
+++ b/quicktests/overlaying/tests/basic/multi_scatter_with_modified_log.js
@@ -43,13 +43,13 @@ function run(svg, data, Plottable) {
   var legend1 = new Plottable.Component.Legend(colorScale);
   legend1.maxEntriesPerRow(1);
 
-  var titleTable = new Plottable.Component.Table().addComponent(0,0, title1)
-                                        .addComponent(0,1, legend1);
+  var titleTable = new Plottable.Component.Table().addComponent(title1, 0, 0)
+                                        .addComponent(legend1, 0, 1);
 
-  var basicTable = new Plottable.Component.Table().addComponent(0,2, titleTable)
-              .addComponent(1, 1, yAxis)
-              .addComponent(1, 2, scatterPlot)
-              .addComponent(2, 2, xAxis);
+  var basicTable = new Plottable.Component.Table().addComponent(titleTable, 0, 2)
+              .addComponent(yAxis, 1, 1)
+              .addComponent(scatterPlot, 1, 2)
+              .addComponent(xAxis, 2, 2);
 
   basicTable.renderTo(svg);
 }

--- a/quicktests/overlaying/tests/functional/changeData_onClick.js
+++ b/quicktests/overlaying/tests/functional/changeData_onClick.js
@@ -35,9 +35,9 @@ function run(svg, data, Plottable) {
     var renderGroup = barPlot.below(scatterPlot);
 
     var basicTable = new Plottable.Component.Table()
-                .addComponent(2, 0, yAxis)
-                .addComponent(2, 1, renderGroup)
-                .addComponent(3, 1, xAxis);
+                .addComponent(yAxis, 2, 0)
+                .addComponent(renderGroup, 2, 1)
+                .addComponent(xAxis, 3, 1);
 
     basicTable.renderTo(svg);
 

--- a/quicktests/overlaying/tests/interactions/basic_moveToFront.js
+++ b/quicktests/overlaying/tests/interactions/basic_moveToFront.js
@@ -49,19 +49,19 @@ function run(svg, data, Plottable) {
   var legend1 = new Plottable.Component.Legend(colorScale1);
   legend1.maxEntriesPerRow(1);
 
-  var titleTable = new Plottable.Component.Table().addComponent(0,0, title1)
-                                        .addComponent(0,1, legend1);
+  var titleTable = new Plottable.Component.Table().addComponent(title1, 0, 0)
+                                        .addComponent(legend1, 0, 1);
 
   var plotGroup = scatterPlot.below(linePlot).below(areaPlot);
 
   var basicTable = new Plottable.Component.Table()
-              .addComponent(2, 0, yAxis)
-              .addComponent(2, 1, plotGroup)
-              .addComponent(3, 1, xAxis);
+              .addComponent(yAxis, 2, 0)
+              .addComponent(plotGroup, 2, 1)
+              .addComponent(xAxis, 3, 1);
 
   var bigTable = new Plottable.Component.Table()
-             .addComponent(0, 0, titleTable)
-             .addComponent(1,0, basicTable);
+             .addComponent(titleTable, 0, 0)
+             .addComponent(basicTable, 1, 0);
 
   bigTable.renderTo(svg);
 

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -51,48 +51,43 @@ export module Component {
       this.classed("table", true);
       rows.forEach((row, rowIndex) => {
         row.forEach((component, colIndex) => {
-          this.addComponent(rowIndex, colIndex, component);
+          this.addComponent(component, rowIndex, colIndex);
         });
       });
     }
 
     /**
-     * Adds a Component in the specified cell. 
-     * 
-     * If the cell is already occupied, there are 3 cases
-     *  - Component + Component => Group containing both components
-     *  - Component + Group => Component is added to the group
-     *  - Group + Component => Component is added to the group
+     * Adds a Component at the specified row and column position.
      *
-     * For example, instead of calling `new Table([[a, b], [null, c]])`, you
-     * could call
-     * ```typescript
-     * var table = new Table();
-     * table.addComponent(0, 0, a);
-     * table.addComponent(0, 1, b);
-     * table.addComponent(1, 1, c);
-     * ```
+     * For example,
+     *     new Table([[a, b]]);
+     * is equivalent to
+     *     var table = new Table();
+     *     table.addComponent(a, 0, 0);
+     *     table.addComponent(b, 0, 1);
      *
+     * If the cell is already occupied, the Component being added is combined
+     * with the existing Component:
+     *   componentToAdd.above(componentAlreadyThere)
+     *
+     * @param {Component} component The Component to be added.
      * @param {number} row The row in which to add the Component.
      * @param {number} col The column in which to add the Component.
-     * @param {Component} component The Component to be added.
      * @returns {Table} The calling Table.
      */
-    public addComponent(row: number, col: number, component: AbstractComponent): Table {
-
+    public addComponent(componentToAdd: AbstractComponent, row: number, col: number): Table {
       var currentComponent = this._rows[row] && this._rows[row][col];
 
       if (currentComponent) {
         currentComponent.detach();
-        component = component.above(currentComponent);
+        componentToAdd = componentToAdd.above(currentComponent);
       }
 
-      if (this._addComponent(component)) {
+      if (this._addComponent(componentToAdd)) {
         this._nRows = Math.max(row + 1, this._nRows);
         this._nCols = Math.max(col + 1, this._nCols);
         this._padTableToSize(this._nRows, this._nCols);
-
-        this._rows[row][col] = component;
+        this._rows[row][col] = componentToAdd;
       }
       return this;
     }

--- a/test/components/gridlinesTests.ts
+++ b/test/components/gridlinesTests.ts
@@ -14,10 +14,10 @@ describe("Gridlines", () => {
     var yAxis = new Plottable.Axis.Numeric(yScale, "left");
 
     var gridlines = new Plottable.Component.Gridlines(xScale, yScale);
-    var basicTable = new Plottable.Component.Table().addComponent(0, 0, yAxis)
-                                          .addComponent(0, 1, gridlines)
-                                          .addComponent(1, 1, xAxis);
-
+    var basicTable = new Plottable.Component.Table([
+      [yAxis, gridlines],
+      [null,  xAxis    ]
+    ]);
     basicTable._anchor(svg);
     basicTable._computeLayout();
     xScale.range([0, xAxis.width() ]); // manually set range since we don't have a renderer

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -89,7 +89,8 @@ describe("Labels", () => {
     var svg = generateSVG(400, 400);
     var label = new Plottable.Component.TitleLabel("X");
     var t = new Plottable.Component.Table([
-      [label, new Plottable.Component.AbstractComponent()]
+      [label],
+      [new Plottable.Component.AbstractComponent()]
     ]);
     t.renderTo(svg);
     var textTranslate = d3.transform((<any> label)._content.select("g").attr("transform")).translate;

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -88,8 +88,9 @@ describe("Labels", () => {
   it("centered text in a table is positioned properly", () => {
     var svg = generateSVG(400, 400);
     var label = new Plottable.Component.TitleLabel("X");
-    var t = new Plottable.Component.Table().addComponent(0, 0, label)
-                                 .addComponent(1, 0, new Plottable.Component.AbstractComponent());
+    var t = new Plottable.Component.Table([
+      [label, new Plottable.Component.AbstractComponent()]
+    ]);
     t.renderTo(svg);
     var textTranslate = d3.transform((<any> label)._content.select("g").attr("transform")).translate;
     var eleTranslate  = d3.transform((<any> label)._element.attr("transform")).translate;

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -352,10 +352,10 @@ describe("Component behavior", () => {
     var horizontalComponent = new Plottable.Component.AbstractComponent();
     var verticalComponent = new Plottable.Component.AbstractComponent();
     var placeHolder = new Plottable.Component.AbstractComponent();
-    var t = new Plottable.Component.Table().addComponent(0, 0, verticalComponent)
-                                 .addComponent(0, 1, new Plottable.Component.AbstractComponent())
-                                 .addComponent(1, 0, placeHolder)
-                                 .addComponent(1, 1, horizontalComponent);
+    var t = new Plottable.Component.Table().addComponent(verticalComponent, 0, 0)
+                                 .addComponent(new Plottable.Component.AbstractComponent(), 0, 1)
+                                 .addComponent(placeHolder, 1, 0)
+                                 .addComponent(horizontalComponent, 1, 1);
     t.renderTo(svg);
     horizontalComponent.xAlign("center");
     verticalComponent.yAlign("bottom");

--- a/test/core/tableTests.ts
+++ b/test/core/tableTests.ts
@@ -11,7 +11,7 @@ function generateBasicTable(nRows: number, nCols: number) {
   for(var i = 0; i<nRows; i++) {
     for(var j = 0; j<nCols; j++) {
       var r = new Plottable.Component.AbstractComponent();
-      table.addComponent(i, j, r);
+      table.addComponent(r, i, j);
       components.push(r);
     }
   }
@@ -48,7 +48,7 @@ describe("Tables", () => {
     var table = new Plottable.Component.Table([row1, row2]);
     assert.equal((<any> table)._rows[0][1], c0, "the component is in the right spot");
     var c1 = new Plottable.Component.AbstractComponent();
-    table.addComponent(2, 2, c1);
+    table.addComponent(c1, 2, 2);
     assert.equal((<any> table)._rows[2][2], c1, "the inserted component went to the right spot");
   });
 
@@ -56,8 +56,8 @@ describe("Tables", () => {
     var table = new Plottable.Component.Table();
     var c1 = new Plottable.Component.AbstractComponent();
     var c2 = new Plottable.Component.AbstractComponent();
-    table.addComponent(0, 0, c1);
-    table.addComponent(1, 1, c2);
+    table.addComponent(c1, 0, 0);
+    table.addComponent(c2, 1, 1);
     var rows = (<any> table)._rows;
     assert.lengthOf(rows, 2, "there are two rows");
     assert.lengthOf(rows[0], 2, "two cols in first row");
@@ -74,9 +74,9 @@ describe("Tables", () => {
     var c3 = new Plottable.Component.AbstractComponent();
     var t = new Plottable.Component.Table();
 
-    t.addComponent(0, 2, c1);
-    t.addComponent(0, 0, c2);
-    t.addComponent(0, 2, c3);
+    t.addComponent(c1, 0, 2);
+    t.addComponent(c2, 0, 0);
+    t.addComponent(c3, 0, 2);
 
     assert.isTrue(Plottable.Component.Group.prototype.isPrototypeOf((<any> t)._rows[0][2]), "A group was created");
 
@@ -95,8 +95,8 @@ describe("Tables", () => {
 
     var t = new Plottable.Component.Table();
 
-    t.addComponent(0, 2, grp);
-    t.addComponent(0, 2, c3);
+    t.addComponent(grp, 0, 2);
+    t.addComponent(c3, 0, 2);
     assert.isTrue(Plottable.Component.Group.prototype.isPrototypeOf((<any> t)._rows[0][2]), "The cell still contains a group");
 
     var components: Plottable.Component.AbstractComponent[] = (<any> t)._rows[0][2].components();
@@ -110,8 +110,8 @@ describe("Tables", () => {
     // Solves #180, a weird bug
     var t = new Plottable.Component.Table();
     var svg = generateSVG();
-    t.addComponent(1, 0, new Plottable.Component.AbstractComponent());
-    t.addComponent(0, 2, new Plottable.Component.AbstractComponent());
+    t.addComponent(new Plottable.Component.AbstractComponent(), 1, 0);
+    t.addComponent(new Plottable.Component.AbstractComponent(), 0, 2);
     t.renderTo(svg); //would throw an error without the fix (tested);
     svg.remove();
   });

--- a/test/tests.js
+++ b/test/tests.js
@@ -1306,7 +1306,10 @@ describe("Gridlines", function () {
         yScale.domain([0, 10]);
         var yAxis = new Plottable.Axis.Numeric(yScale, "left");
         var gridlines = new Plottable.Component.Gridlines(xScale, yScale);
-        var basicTable = new Plottable.Component.Table().addComponent(0, 0, yAxis).addComponent(0, 1, gridlines).addComponent(1, 1, xAxis);
+        var basicTable = new Plottable.Component.Table([
+            [yAxis, gridlines],
+            [null, xAxis]
+        ]);
         basicTable._anchor(svg);
         basicTable._computeLayout();
         xScale.range([0, xAxis.width()]); // manually set range since we don't have a renderer
@@ -1416,7 +1419,9 @@ describe("Labels", function () {
     it("centered text in a table is positioned properly", function () {
         var svg = generateSVG(400, 400);
         var label = new Plottable.Component.TitleLabel("X");
-        var t = new Plottable.Component.Table().addComponent(0, 0, label).addComponent(1, 0, new Plottable.Component.AbstractComponent());
+        var t = new Plottable.Component.Table([
+            [label, new Plottable.Component.AbstractComponent()]
+        ]);
         t.renderTo(svg);
         var textTranslate = d3.transform(label._content.select("g").attr("transform")).translate;
         var eleTranslate = d3.transform(label._element.attr("transform")).translate;
@@ -5692,7 +5697,7 @@ describe("Component behavior", function () {
         var horizontalComponent = new Plottable.Component.AbstractComponent();
         var verticalComponent = new Plottable.Component.AbstractComponent();
         var placeHolder = new Plottable.Component.AbstractComponent();
-        var t = new Plottable.Component.Table().addComponent(0, 0, verticalComponent).addComponent(0, 1, new Plottable.Component.AbstractComponent()).addComponent(1, 0, placeHolder).addComponent(1, 1, horizontalComponent);
+        var t = new Plottable.Component.Table().addComponent(verticalComponent, 0, 0).addComponent(new Plottable.Component.AbstractComponent(), 0, 1).addComponent(placeHolder, 1, 0).addComponent(horizontalComponent, 1, 1);
         t.renderTo(svg);
         horizontalComponent.xAlign("center");
         verticalComponent.yAlign("bottom");
@@ -5896,7 +5901,7 @@ function generateBasicTable(nRows, nCols) {
     for (var i = 0; i < nRows; i++) {
         for (var j = 0; j < nCols; j++) {
             var r = new Plottable.Component.AbstractComponent();
-            table.addComponent(i, j, r);
+            table.addComponent(r, i, j);
             components.push(r);
         }
     }
@@ -5929,15 +5934,15 @@ describe("Tables", function () {
         var table = new Plottable.Component.Table([row1, row2]);
         assert.equal(table._rows[0][1], c0, "the component is in the right spot");
         var c1 = new Plottable.Component.AbstractComponent();
-        table.addComponent(2, 2, c1);
+        table.addComponent(c1, 2, 2);
         assert.equal(table._rows[2][2], c1, "the inserted component went to the right spot");
     });
     it("tables can be constructed by adding components in matrix style", function () {
         var table = new Plottable.Component.Table();
         var c1 = new Plottable.Component.AbstractComponent();
         var c2 = new Plottable.Component.AbstractComponent();
-        table.addComponent(0, 0, c1);
-        table.addComponent(1, 1, c2);
+        table.addComponent(c1, 0, 0);
+        table.addComponent(c2, 1, 1);
         var rows = table._rows;
         assert.lengthOf(rows, 2, "there are two rows");
         assert.lengthOf(rows[0], 2, "two cols in first row");
@@ -5952,9 +5957,9 @@ describe("Tables", function () {
         var c2 = new Plottable.Component.AbstractComponent();
         var c3 = new Plottable.Component.AbstractComponent();
         var t = new Plottable.Component.Table();
-        t.addComponent(0, 2, c1);
-        t.addComponent(0, 0, c2);
-        t.addComponent(0, 2, c3);
+        t.addComponent(c1, 0, 2);
+        t.addComponent(c2, 0, 0);
+        t.addComponent(c3, 0, 2);
         assert.isTrue(Plottable.Component.Group.prototype.isPrototypeOf(t._rows[0][2]), "A group was created");
         var components = t._rows[0][2].components();
         assert.lengthOf(components, 2, "The group created should have 2 components");
@@ -5967,8 +5972,8 @@ describe("Tables", function () {
         var grp = new Plottable.Component.Group([c1, c2]);
         var c3 = new Plottable.Component.AbstractComponent();
         var t = new Plottable.Component.Table();
-        t.addComponent(0, 2, grp);
-        t.addComponent(0, 2, c3);
+        t.addComponent(grp, 0, 2);
+        t.addComponent(c3, 0, 2);
         assert.isTrue(Plottable.Component.Group.prototype.isPrototypeOf(t._rows[0][2]), "The cell still contains a group");
         var components = t._rows[0][2].components();
         assert.lengthOf(components, 3, "The group created should have 3 components");
@@ -5980,8 +5985,8 @@ describe("Tables", function () {
         // Solves #180, a weird bug
         var t = new Plottable.Component.Table();
         var svg = generateSVG();
-        t.addComponent(1, 0, new Plottable.Component.AbstractComponent());
-        t.addComponent(0, 2, new Plottable.Component.AbstractComponent());
+        t.addComponent(new Plottable.Component.AbstractComponent(), 1, 0);
+        t.addComponent(new Plottable.Component.AbstractComponent(), 0, 2);
         t.renderTo(svg); //would throw an error without the fix (tested);
         svg.remove();
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -1420,7 +1420,8 @@ describe("Labels", function () {
         var svg = generateSVG(400, 400);
         var label = new Plottable.Component.TitleLabel("X");
         var t = new Plottable.Component.Table([
-            [label, new Plottable.Component.AbstractComponent()]
+            [label],
+            [new Plottable.Component.AbstractComponent()]
         ]);
         t.renderTo(svg);
         var textTranslate = d3.transform(label._content.select("g").attr("transform")).translate;


### PR DESCRIPTION
On `Table`, `addComponent` has been changed so that the `Component` to add is the first argument:
```Typescript
public addComponent(componentToAdd: AbstractComponent, row: number, col: number): Table;
```

This signature is much more readable, as `addComponent(comp, r, c)` can be read as "add `Component` *comp* to row *r* and column *c*". The original argument ordering was less memorable and was thus more likely to read to mistakes. In particular, it is reasonable to expect that a method `addThing()` takes a `Thing` as the first argument.