### PR TITLE
[BarPlot] - getAllPlotData pixelPoints corrected for negative-valued bars and barAlignment

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3109,6 +3109,7 @@ declare module Plottable {
             _hoverOverComponent(p: Point): void;
             _hoverOutComponent(p: Point): void;
             _doHover(p: Point): Interaction.HoverData;
+            protected _getAllPlotData(datasetKeys: string[]): PlotData;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -7832,6 +7832,7 @@ var Plottable;
                 var valueScale = this._isVertical ? this._yScale : this._xScale;
                 var scaledBaseline = (this._isVertical ? this._yScale : this._xScale).scale(this.baseline());
                 var isVertical = this._isVertical;
+                var barAlignmentFactor = this._barAlignmentFactor;
                 plotData.selection.each(function (datum, index) {
                     var bar = d3.select(this);
                     if (isVertical && +bar.attr("y") + +bar.attr("height") > scaledBaseline) {
@@ -7839,6 +7840,12 @@ var Plottable;
                     }
                     else if (!isVertical && +bar.attr("x") < scaledBaseline) {
                         plotData.pixelPoints[index].x -= +bar.attr("width");
+                    }
+                    if (isVertical) {
+                        plotData.pixelPoints[index].x = +bar.attr("x") + +bar.attr("width") * barAlignmentFactor;
+                    }
+                    else {
+                        plotData.pixelPoints[index].y = +bar.attr("y") + +bar.attr("height") * barAlignmentFactor;
                     }
                 });
                 return plotData;

--- a/plottable.js
+++ b/plottable.js
@@ -7835,10 +7835,11 @@ var Plottable;
                 var barAlignmentFactor = this._barAlignmentFactor;
                 plotData.selection.each(function (datum, index) {
                     var bar = d3.select(this);
-                    if (isVertical && +bar.attr("y") >= scaledBaseline) {
+                    // Using floored pixel values to account for pixel accuracy inconsistencies across browsers
+                    if (isVertical && Math.floor(+bar.attr("y")) >= Math.floor(scaledBaseline)) {
                         plotData.pixelPoints[index].y += +bar.attr("height");
                     }
-                    else if (!isVertical && +bar.attr("x") < scaledBaseline) {
+                    else if (!isVertical && Math.floor(+bar.attr("x")) < Math.floor(scaledBaseline)) {
                         plotData.pixelPoints[index].x -= +bar.attr("width");
                     }
                     if (isVertical) {

--- a/plottable.js
+++ b/plottable.js
@@ -7826,6 +7826,23 @@ var Plottable;
                     selection: barsSelection
                 };
             };
+            //===== /Hover logic =====
+            Bar.prototype._getAllPlotData = function (datasetKeys) {
+                var plotData = _super.prototype._getAllPlotData.call(this, datasetKeys);
+                var valueScale = this._isVertical ? this._yScale : this._xScale;
+                var scaledBaseline = (this._isVertical ? this._yScale : this._xScale).scale(this.baseline());
+                var isVertical = this._isVertical;
+                plotData.selection.each(function (datum, index) {
+                    var bar = d3.select(this);
+                    if (isVertical && +bar.attr("y") + +bar.attr("height") > scaledBaseline) {
+                        plotData.pixelPoints[index].y += +bar.attr("height");
+                    }
+                    else if (!isVertical && +bar.attr("x") < scaledBaseline) {
+                        plotData.pixelPoints[index].x -= +bar.attr("width");
+                    }
+                });
+                return plotData;
+            };
             Bar._BarAlignmentToFactor = { "left": 0, "center": 0.5, "right": 1 };
             Bar._DEFAULT_WIDTH = 10;
             Bar._BAR_WIDTH_RATIO = 0.95;

--- a/plottable.js
+++ b/plottable.js
@@ -7835,7 +7835,7 @@ var Plottable;
                 var barAlignmentFactor = this._barAlignmentFactor;
                 plotData.selection.each(function (datum, index) {
                     var bar = d3.select(this);
-                    if (isVertical && +bar.attr("y") + +bar.attr("height") > scaledBaseline) {
+                    if (isVertical && +bar.attr("y") >= scaledBaseline) {
                         plotData.pixelPoints[index].y += +bar.attr("height");
                     }
                     else if (!isVertical && +bar.attr("x") < scaledBaseline) {

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -501,7 +501,7 @@ export module Plot {
       plotData.selection.each(function (datum, index) {
         var bar = d3.select(this);
 
-        if (isVertical && +bar.attr("y") + +bar.attr("height") > scaledBaseline) {
+        if (isVertical && +bar.attr("y") >= scaledBaseline) {
           plotData.pixelPoints[index].y += +bar.attr("height");
         } else if (!isVertical && +bar.attr("x") < scaledBaseline) {
           plotData.pixelPoints[index].x -= +bar.attr("width");

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -489,6 +489,26 @@ export module Plot {
       };
     }
     //===== /Hover logic =====
+
+    protected _getAllPlotData(datasetKeys: string[]): PlotData {
+      var plotData = super._getAllPlotData(datasetKeys);
+
+      var valueScale = this._isVertical ? this._yScale : this._xScale;
+      var scaledBaseline = (<Scale.AbstractScale<any, any>> (this._isVertical ? this._yScale : this._xScale)).scale(this.baseline());
+      var isVertical = this._isVertical;
+
+      plotData.selection.each(function (datum, index) {
+        var bar = d3.select(this);
+
+        if (isVertical && +bar.attr("y") + +bar.attr("height") > scaledBaseline) {
+          plotData.pixelPoints[index].y += +bar.attr("height");
+        } else if (!isVertical && +bar.attr("x") < scaledBaseline) {
+          plotData.pixelPoints[index].x -= +bar.attr("width");
+        }
+      });
+
+      return plotData;
+    }
   }
 }
 }

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -501,9 +501,10 @@ export module Plot {
       plotData.selection.each(function (datum, index) {
         var bar = d3.select(this);
 
-        if (isVertical && +bar.attr("y") >= scaledBaseline) {
+        // Using floored pixel values to account for pixel accuracy inconsistencies across browsers
+        if (isVertical && Math.floor(+bar.attr("y")) >= Math.floor(scaledBaseline)) {
           plotData.pixelPoints[index].y += +bar.attr("height");
-        } else if (!isVertical && +bar.attr("x") < scaledBaseline) {
+        } else if (!isVertical && Math.floor(+bar.attr("x")) < Math.floor(scaledBaseline)) {
           plotData.pixelPoints[index].x -= +bar.attr("width");
         }
 

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -496,6 +496,7 @@ export module Plot {
       var valueScale = this._isVertical ? this._yScale : this._xScale;
       var scaledBaseline = (<Scale.AbstractScale<any, any>> (this._isVertical ? this._yScale : this._xScale)).scale(this.baseline());
       var isVertical = this._isVertical;
+      var barAlignmentFactor = this._barAlignmentFactor;
 
       plotData.selection.each(function (datum, index) {
         var bar = d3.select(this);
@@ -504,6 +505,12 @@ export module Plot {
           plotData.pixelPoints[index].y += +bar.attr("height");
         } else if (!isVertical && +bar.attr("x") < scaledBaseline) {
           plotData.pixelPoints[index].x -= +bar.attr("width");
+        }
+
+        if (isVertical) {
+          plotData.pixelPoints[index].x = +bar.attr("x") + +bar.attr("width") * barAlignmentFactor;
+        } else {
+          plotData.pixelPoints[index].y = +bar.attr("y") + +bar.attr("height") * barAlignmentFactor;
         }
       });
 

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -128,6 +128,28 @@ describe("Plots", () => {
         });
         svg.remove();
       });
+
+      it("getAllPlotData() pixel points corrected for barAlignment left", () => {
+        barPlot.barAlignment("left");
+        var plotData = barPlot.getAllPlotData();
+        plotData.data.forEach((datum, i) => {
+          var barSelection = d3.select(plotData.selection[0][i]);
+          var pixelPointX = plotData.pixelPoints[i].x;
+          assert.strictEqual(pixelPointX, +barSelection.attr("x"), "barAlignment left x correct");
+        });
+        svg.remove();
+      });
+
+      it("getAllPlotData() pixel points corrected for barAlignment right", () => {
+        barPlot.barAlignment("right");
+        var plotData = barPlot.getAllPlotData();
+        plotData.data.forEach((datum, i) => {
+          var barSelection = d3.select(plotData.selection[0][i]);
+          var pixelPointX = plotData.pixelPoints[i].x;
+          assert.strictEqual(pixelPointX, +barSelection.attr("x") + +barSelection.attr("width"), "barAlignment right x correct");
+        });
+        svg.remove();
+      });
     });
 
     describe("Vertical Bar Plot modified log scale", () => {

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -115,41 +115,53 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("getAllPlotData() pixel points corrected for negative-valued bars", () => {
-        var plotData = barPlot.getAllPlotData();
-        plotData.data.forEach((datum, i) => {
-          var barSelection = d3.select(plotData.selection[0][i]);
-          var pixelPointY = plotData.pixelPoints[i].y;
-          if (datum.y < 0) {
-            assert.strictEqual(pixelPointY, +barSelection.attr("y") + +barSelection.attr("height"), "negative on bottom");
-          } else {
-            assert.strictEqual(pixelPointY, +barSelection.attr("y"), "positive on top");
-          }
+      describe("getAllPlotData()", () => {
+
+        describe("pixelPoints", () => {
+
+          it("getAllPlotData() pixel points corrected for negative-valued bars",() => {
+            var plotData = barPlot.getAllPlotData();
+            plotData.data.forEach((datum, i) => {
+              var barSelection = d3.select(plotData.selection[0][i]);
+              var pixelPointY = plotData.pixelPoints[i].y;
+              if (datum.y < 0) {
+                assert.strictEqual(pixelPointY, +barSelection.attr("y") + +barSelection.attr("height"), "negative on bottom");
+              } else {
+                assert.strictEqual(pixelPointY, +barSelection.attr("y"), "positive on top");
+              }
+            });
+            svg.remove();
+          });
+
+          describe("barAlignment", () => {
+            it("getAllPlotData() pixel points corrected for barAlignment left",() => {
+              barPlot.barAlignment("left");
+              var plotData = barPlot.getAllPlotData();
+              plotData.data.forEach((datum, i) => {
+                var barSelection = d3.select(plotData.selection[0][i]);
+                var pixelPointX = plotData.pixelPoints[i].x;
+                assert.strictEqual(pixelPointX, +barSelection.attr("x"), "barAlignment left x correct");
+              });
+              svg.remove();
+            });
+
+            it("getAllPlotData() pixel points corrected for barAlignment right",() => {
+              barPlot.barAlignment("right");
+              var plotData = barPlot.getAllPlotData();
+              plotData.data.forEach((datum, i) => {
+                var barSelection = d3.select(plotData.selection[0][i]);
+                var pixelPointX = plotData.pixelPoints[i].x;
+                assert.strictEqual(pixelPointX, +barSelection.attr("x") + +barSelection.attr("width"), "barAlignment right x correct");
+              });
+              svg.remove();
+            });
+          });
+
         });
-        svg.remove();
+
       });
 
-      it("getAllPlotData() pixel points corrected for barAlignment left", () => {
-        barPlot.barAlignment("left");
-        var plotData = barPlot.getAllPlotData();
-        plotData.data.forEach((datum, i) => {
-          var barSelection = d3.select(plotData.selection[0][i]);
-          var pixelPointX = plotData.pixelPoints[i].x;
-          assert.strictEqual(pixelPointX, +barSelection.attr("x"), "barAlignment left x correct");
-        });
-        svg.remove();
-      });
 
-      it("getAllPlotData() pixel points corrected for barAlignment right", () => {
-        barPlot.barAlignment("right");
-        var plotData = barPlot.getAllPlotData();
-        plotData.data.forEach((datum, i) => {
-          var barSelection = d3.select(plotData.selection[0][i]);
-          var pixelPointX = plotData.pixelPoints[i].x;
-          assert.strictEqual(pixelPointX, +barSelection.attr("x") + +barSelection.attr("width"), "barAlignment right x correct");
-        });
-        svg.remove();
-      });
     });
 
     describe("Vertical Bar Plot modified log scale", () => {
@@ -392,41 +404,52 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("getAllPlotData() pixel points corrected for negative-valued bars", () => {
-        var plotData = barPlot.getAllPlotData();
-        plotData.data.forEach((datum, i) => {
-          var barSelection = d3.select(plotData.selection[0][i]);
-          var pixelPointX = plotData.pixelPoints[i].x;
-          if (datum.x < 0) {
-            assert.strictEqual(pixelPointX, +barSelection.attr("x"), "negative on left");
-          } else {
-            assert.strictEqual(pixelPointX, +barSelection.attr("x") + +barSelection.attr("width"), "positive on right");
-          }
+      describe("getAllPlotData()", () => {
+
+        describe("pixelPoints", () => {
+
+          it("getAllPlotData() pixel points corrected for negative-valued bars",() => {
+            var plotData = barPlot.getAllPlotData();
+            plotData.data.forEach((datum, i) => {
+              var barSelection = d3.select(plotData.selection[0][i]);
+              var pixelPointX = plotData.pixelPoints[i].x;
+              if (datum.x < 0) {
+                assert.strictEqual(pixelPointX, +barSelection.attr("x"), "negative on left");
+              } else {
+                assert.strictEqual(pixelPointX, +barSelection.attr("x") + +barSelection.attr("width"), "positive on right");
+              }
+            });
+            svg.remove();
+          });
+
+          describe("accounting for barAlignment", () => {
+            it("getAllPlotData() pixel points corrected for barAlignment left",() => {
+              barPlot.barAlignment("left");
+              var plotData = barPlot.getAllPlotData();
+              plotData.data.forEach((datum, i) => {
+                var barSelection = d3.select(plotData.selection[0][i]);
+                var pixelPointY = plotData.pixelPoints[i].y;
+                assert.strictEqual(pixelPointY, +barSelection.attr("y"), "barAlignment left y correct");
+              });
+              svg.remove();
+            });
+
+            it("getAllPlotData() pixel points corrected for barAlignment right",() => {
+              barPlot.barAlignment("right");
+              var plotData = barPlot.getAllPlotData();
+              plotData.data.forEach((datum, i) => {
+                var barSelection = d3.select(plotData.selection[0][i]);
+                var pixelPointY = plotData.pixelPoints[i].y;
+                assert.strictEqual(pixelPointY, +barSelection.attr("y") + +barSelection.attr("height"), "barAlignment right y correct");
+              });
+              svg.remove();
+            });
+          });
+
         });
-        svg.remove();
+
       });
 
-      it("getAllPlotData() pixel points corrected for barAlignment left", () => {
-        barPlot.barAlignment("left");
-        var plotData = barPlot.getAllPlotData();
-        plotData.data.forEach((datum, i) => {
-          var barSelection = d3.select(plotData.selection[0][i]);
-          var pixelPointY = plotData.pixelPoints[i].y;
-          assert.strictEqual(pixelPointY, +barSelection.attr("y"), "barAlignment left y correct");
-        });
-        svg.remove();
-      });
-
-      it("getAllPlotData() pixel points corrected for barAlignment right", () => {
-        barPlot.barAlignment("right");
-        var plotData = barPlot.getAllPlotData();
-        plotData.data.forEach((datum, i) => {
-          var barSelection = d3.select(plotData.selection[0][i]);
-          var pixelPointY = plotData.pixelPoints[i].y;
-          assert.strictEqual(pixelPointY, +barSelection.attr("y") + +barSelection.attr("height"), "barAlignment right y correct");
-        });
-        svg.remove();
-      });
     });
 
     describe("Vertical Bar Plot With Bar Labels", () => {

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -405,6 +405,28 @@ describe("Plots", () => {
         });
         svg.remove();
       });
+
+      it("getAllPlotData() pixel points corrected for barAlignment left", () => {
+        barPlot.barAlignment("left");
+        var plotData = barPlot.getAllPlotData();
+        plotData.data.forEach((datum, i) => {
+          var barSelection = d3.select(plotData.selection[0][i]);
+          var pixelPointY = plotData.pixelPoints[i].y;
+          assert.strictEqual(pixelPointY, +barSelection.attr("y"), "barAlignment left y correct");
+        });
+        svg.remove();
+      });
+
+      it("getAllPlotData() pixel points corrected for barAlignment right", () => {
+        barPlot.barAlignment("right");
+        var plotData = barPlot.getAllPlotData();
+        plotData.data.forEach((datum, i) => {
+          var barSelection = d3.select(plotData.selection[0][i]);
+          var pixelPointY = plotData.pixelPoints[i].y;
+          assert.strictEqual(pixelPointY, +barSelection.attr("y") + +barSelection.attr("height"), "barAlignment right y correct");
+        });
+        svg.remove();
+      });
     });
 
     describe("Vertical Bar Plot With Bar Labels", () => {

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -114,6 +114,20 @@ describe("Plots", () => {
         assert.lengthOf(bars[0], 0, "no bars have been rendered");
         svg.remove();
       });
+
+      it("getAllPlotData() pixel points corrected for negative-valued bars", () => {
+        var plotData = barPlot.getAllPlotData();
+        plotData.data.forEach((datum, i) => {
+          var barSelection = d3.select(plotData.selection[0][i]);
+          var pixelPointY = plotData.pixelPoints[i].y;
+          if (datum.y < 0) {
+            assert.strictEqual(pixelPointY, +barSelection.attr("y") + +barSelection.attr("height"), "negative on bottom");
+          } else {
+            assert.strictEqual(pixelPointY, +barSelection.attr("y"), "positive on top");
+          }
+        });
+        svg.remove();
+      });
     });
 
     describe("Vertical Bar Plot modified log scale", () => {
@@ -353,6 +367,20 @@ describe("Plots", () => {
         assert.closeTo(numAttr(bar1, "width"), 150, 0.01, "bar1 width");
         assert.closeTo(numAttr(bar0, "y"), yScale.scale(bar0y) - numAttr(bar0, "height") / 2, 0.01, "bar0 ypos");
         assert.closeTo(numAttr(bar1, "y"), yScale.scale(bar1y) - numAttr(bar1, "height") / 2, 0.01, "bar1 ypos");
+        svg.remove();
+      });
+
+      it("getAllPlotData() pixel points corrected for negative-valued bars", () => {
+        var plotData = barPlot.getAllPlotData();
+        plotData.data.forEach((datum, i) => {
+          var barSelection = d3.select(plotData.selection[0][i]);
+          var pixelPointX = plotData.pixelPoints[i].x;
+          if (datum.x < 0) {
+            assert.strictEqual(pixelPointX, +barSelection.attr("x"), "negative on left");
+          } else {
+            assert.strictEqual(pixelPointX, +barSelection.attr("x") + +barSelection.attr("width"), "positive on right");
+          }
+        });
         svg.remove();
       });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -3113,39 +3113,45 @@ describe("Plots", function () {
                 assert.lengthOf(bars[0], 0, "no bars have been rendered");
                 svg.remove();
             });
-            it("getAllPlotData() pixel points corrected for negative-valued bars", function () {
-                var plotData = barPlot.getAllPlotData();
-                plotData.data.forEach(function (datum, i) {
-                    var barSelection = d3.select(plotData.selection[0][i]);
-                    var pixelPointY = plotData.pixelPoints[i].y;
-                    if (datum.y < 0) {
-                        assert.strictEqual(pixelPointY, +barSelection.attr("y") + +barSelection.attr("height"), "negative on bottom");
-                    }
-                    else {
-                        assert.strictEqual(pixelPointY, +barSelection.attr("y"), "positive on top");
-                    }
+            describe("getAllPlotData()", function () {
+                describe("pixelPoints", function () {
+                    it("getAllPlotData() pixel points corrected for negative-valued bars", function () {
+                        var plotData = barPlot.getAllPlotData();
+                        plotData.data.forEach(function (datum, i) {
+                            var barSelection = d3.select(plotData.selection[0][i]);
+                            var pixelPointY = plotData.pixelPoints[i].y;
+                            if (datum.y < 0) {
+                                assert.strictEqual(pixelPointY, +barSelection.attr("y") + +barSelection.attr("height"), "negative on bottom");
+                            }
+                            else {
+                                assert.strictEqual(pixelPointY, +barSelection.attr("y"), "positive on top");
+                            }
+                        });
+                        svg.remove();
+                    });
+                    describe("barAlignment", function () {
+                        it("getAllPlotData() pixel points corrected for barAlignment left", function () {
+                            barPlot.barAlignment("left");
+                            var plotData = barPlot.getAllPlotData();
+                            plotData.data.forEach(function (datum, i) {
+                                var barSelection = d3.select(plotData.selection[0][i]);
+                                var pixelPointX = plotData.pixelPoints[i].x;
+                                assert.strictEqual(pixelPointX, +barSelection.attr("x"), "barAlignment left x correct");
+                            });
+                            svg.remove();
+                        });
+                        it("getAllPlotData() pixel points corrected for barAlignment right", function () {
+                            barPlot.barAlignment("right");
+                            var plotData = barPlot.getAllPlotData();
+                            plotData.data.forEach(function (datum, i) {
+                                var barSelection = d3.select(plotData.selection[0][i]);
+                                var pixelPointX = plotData.pixelPoints[i].x;
+                                assert.strictEqual(pixelPointX, +barSelection.attr("x") + +barSelection.attr("width"), "barAlignment right x correct");
+                            });
+                            svg.remove();
+                        });
+                    });
                 });
-                svg.remove();
-            });
-            it("getAllPlotData() pixel points corrected for barAlignment left", function () {
-                barPlot.barAlignment("left");
-                var plotData = barPlot.getAllPlotData();
-                plotData.data.forEach(function (datum, i) {
-                    var barSelection = d3.select(plotData.selection[0][i]);
-                    var pixelPointX = plotData.pixelPoints[i].x;
-                    assert.strictEqual(pixelPointX, +barSelection.attr("x"), "barAlignment left x correct");
-                });
-                svg.remove();
-            });
-            it("getAllPlotData() pixel points corrected for barAlignment right", function () {
-                barPlot.barAlignment("right");
-                var plotData = barPlot.getAllPlotData();
-                plotData.data.forEach(function (datum, i) {
-                    var barSelection = d3.select(plotData.selection[0][i]);
-                    var pixelPointX = plotData.pixelPoints[i].x;
-                    assert.strictEqual(pixelPointX, +barSelection.attr("x") + +barSelection.attr("width"), "barAlignment right x correct");
-                });
-                svg.remove();
             });
         });
         describe("Vertical Bar Plot modified log scale", function () {
@@ -3354,39 +3360,45 @@ describe("Plots", function () {
                 assert.closeTo(numAttr(bar1, "y"), yScale.scale(bar1y) - numAttr(bar1, "height") / 2, 0.01, "bar1 ypos");
                 svg.remove();
             });
-            it("getAllPlotData() pixel points corrected for negative-valued bars", function () {
-                var plotData = barPlot.getAllPlotData();
-                plotData.data.forEach(function (datum, i) {
-                    var barSelection = d3.select(plotData.selection[0][i]);
-                    var pixelPointX = plotData.pixelPoints[i].x;
-                    if (datum.x < 0) {
-                        assert.strictEqual(pixelPointX, +barSelection.attr("x"), "negative on left");
-                    }
-                    else {
-                        assert.strictEqual(pixelPointX, +barSelection.attr("x") + +barSelection.attr("width"), "positive on right");
-                    }
+            describe("getAllPlotData()", function () {
+                describe("pixelPoints", function () {
+                    it("getAllPlotData() pixel points corrected for negative-valued bars", function () {
+                        var plotData = barPlot.getAllPlotData();
+                        plotData.data.forEach(function (datum, i) {
+                            var barSelection = d3.select(plotData.selection[0][i]);
+                            var pixelPointX = plotData.pixelPoints[i].x;
+                            if (datum.x < 0) {
+                                assert.strictEqual(pixelPointX, +barSelection.attr("x"), "negative on left");
+                            }
+                            else {
+                                assert.strictEqual(pixelPointX, +barSelection.attr("x") + +barSelection.attr("width"), "positive on right");
+                            }
+                        });
+                        svg.remove();
+                    });
+                    describe("accounting for barAlignment", function () {
+                        it("getAllPlotData() pixel points corrected for barAlignment left", function () {
+                            barPlot.barAlignment("left");
+                            var plotData = barPlot.getAllPlotData();
+                            plotData.data.forEach(function (datum, i) {
+                                var barSelection = d3.select(plotData.selection[0][i]);
+                                var pixelPointY = plotData.pixelPoints[i].y;
+                                assert.strictEqual(pixelPointY, +barSelection.attr("y"), "barAlignment left y correct");
+                            });
+                            svg.remove();
+                        });
+                        it("getAllPlotData() pixel points corrected for barAlignment right", function () {
+                            barPlot.barAlignment("right");
+                            var plotData = barPlot.getAllPlotData();
+                            plotData.data.forEach(function (datum, i) {
+                                var barSelection = d3.select(plotData.selection[0][i]);
+                                var pixelPointY = plotData.pixelPoints[i].y;
+                                assert.strictEqual(pixelPointY, +barSelection.attr("y") + +barSelection.attr("height"), "barAlignment right y correct");
+                            });
+                            svg.remove();
+                        });
+                    });
                 });
-                svg.remove();
-            });
-            it("getAllPlotData() pixel points corrected for barAlignment left", function () {
-                barPlot.barAlignment("left");
-                var plotData = barPlot.getAllPlotData();
-                plotData.data.forEach(function (datum, i) {
-                    var barSelection = d3.select(plotData.selection[0][i]);
-                    var pixelPointY = plotData.pixelPoints[i].y;
-                    assert.strictEqual(pixelPointY, +barSelection.attr("y"), "barAlignment left y correct");
-                });
-                svg.remove();
-            });
-            it("getAllPlotData() pixel points corrected for barAlignment right", function () {
-                barPlot.barAlignment("right");
-                var plotData = barPlot.getAllPlotData();
-                plotData.data.forEach(function (datum, i) {
-                    var barSelection = d3.select(plotData.selection[0][i]);
-                    var pixelPointY = plotData.pixelPoints[i].y;
-                    assert.strictEqual(pixelPointY, +barSelection.attr("y") + +barSelection.attr("height"), "barAlignment right y correct");
-                });
-                svg.remove();
             });
         });
         describe("Vertical Bar Plot With Bar Labels", function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -3127,6 +3127,26 @@ describe("Plots", function () {
                 });
                 svg.remove();
             });
+            it("getAllPlotData() pixel points corrected for barAlignment left", function () {
+                barPlot.barAlignment("left");
+                var plotData = barPlot.getAllPlotData();
+                plotData.data.forEach(function (datum, i) {
+                    var barSelection = d3.select(plotData.selection[0][i]);
+                    var pixelPointX = plotData.pixelPoints[i].x;
+                    assert.strictEqual(pixelPointX, +barSelection.attr("x"), "barAlignment left x correct");
+                });
+                svg.remove();
+            });
+            it("getAllPlotData() pixel points corrected for barAlignment right", function () {
+                barPlot.barAlignment("right");
+                var plotData = barPlot.getAllPlotData();
+                plotData.data.forEach(function (datum, i) {
+                    var barSelection = d3.select(plotData.selection[0][i]);
+                    var pixelPointX = plotData.pixelPoints[i].x;
+                    assert.strictEqual(pixelPointX, +barSelection.attr("x") + +barSelection.attr("width"), "barAlignment right x correct");
+                });
+                svg.remove();
+            });
         });
         describe("Vertical Bar Plot modified log scale", function () {
             var svg;

--- a/test/tests.js
+++ b/test/tests.js
@@ -3113,6 +3113,20 @@ describe("Plots", function () {
                 assert.lengthOf(bars[0], 0, "no bars have been rendered");
                 svg.remove();
             });
+            it("getAllPlotData() pixel points corrected for negative-valued bars", function () {
+                var plotData = barPlot.getAllPlotData();
+                plotData.data.forEach(function (datum, i) {
+                    var barSelection = d3.select(plotData.selection[0][i]);
+                    var pixelPointY = plotData.pixelPoints[i].y;
+                    if (datum.y < 0) {
+                        assert.strictEqual(pixelPointY, +barSelection.attr("y") + +barSelection.attr("height"), "negative on bottom");
+                    }
+                    else {
+                        assert.strictEqual(pixelPointY, +barSelection.attr("y"), "positive on top");
+                    }
+                });
+                svg.remove();
+            });
         });
         describe("Vertical Bar Plot modified log scale", function () {
             var svg;
@@ -3318,6 +3332,20 @@ describe("Plots", function () {
                 assert.closeTo(numAttr(bar1, "width"), 150, 0.01, "bar1 width");
                 assert.closeTo(numAttr(bar0, "y"), yScale.scale(bar0y) - numAttr(bar0, "height") / 2, 0.01, "bar0 ypos");
                 assert.closeTo(numAttr(bar1, "y"), yScale.scale(bar1y) - numAttr(bar1, "height") / 2, 0.01, "bar1 ypos");
+                svg.remove();
+            });
+            it("getAllPlotData() pixel points corrected for negative-valued bars", function () {
+                var plotData = barPlot.getAllPlotData();
+                plotData.data.forEach(function (datum, i) {
+                    var barSelection = d3.select(plotData.selection[0][i]);
+                    var pixelPointX = plotData.pixelPoints[i].x;
+                    if (datum.x < 0) {
+                        assert.strictEqual(pixelPointX, +barSelection.attr("x"), "negative on left");
+                    }
+                    else {
+                        assert.strictEqual(pixelPointX, +barSelection.attr("x") + +barSelection.attr("width"), "positive on right");
+                    }
+                });
                 svg.remove();
             });
         });

--- a/test/tests.js
+++ b/test/tests.js
@@ -3368,6 +3368,26 @@ describe("Plots", function () {
                 });
                 svg.remove();
             });
+            it("getAllPlotData() pixel points corrected for barAlignment left", function () {
+                barPlot.barAlignment("left");
+                var plotData = barPlot.getAllPlotData();
+                plotData.data.forEach(function (datum, i) {
+                    var barSelection = d3.select(plotData.selection[0][i]);
+                    var pixelPointY = plotData.pixelPoints[i].y;
+                    assert.strictEqual(pixelPointY, +barSelection.attr("y"), "barAlignment left y correct");
+                });
+                svg.remove();
+            });
+            it("getAllPlotData() pixel points corrected for barAlignment right", function () {
+                barPlot.barAlignment("right");
+                var plotData = barPlot.getAllPlotData();
+                plotData.data.forEach(function (datum, i) {
+                    var barSelection = d3.select(plotData.selection[0][i]);
+                    var pixelPointY = plotData.pixelPoints[i].y;
+                    assert.strictEqual(pixelPointY, +barSelection.attr("y") + +barSelection.attr("height"), "barAlignment right y correct");
+                });
+                svg.remove();
+            });
         });
         describe("Vertical Bar Plot With Bar Labels", function () {
             var plot;


### PR DESCRIPTION
Bar plots would normally place their pixelPoints for `getAllPlotData` at the top of the bar under the assumption that the bar was positive valued.  This is incorrect if the bar is negative-valued or has a different barAlignment

Bars should now place their pixelPoints at the bottom of the bar if they are negative-valued (left of the bar for horizontal bar plots)

Accompanying JSFiddle - http://jsfiddle.net/8w5v19ry/1/