### PR TITLE
[abstractComponentContainer] Can now merge groups that are already anchored

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1637,7 +1637,6 @@ declare module Plottable {
             protected _content: D3.Selection;
             protected _boundingBox: D3.Selection;
             clipPathEnabled: boolean;
-            _parent: AbstractComponentContainer;
             protected _fixedHeightFlag: boolean;
             protected _fixedWidthFlag: boolean;
             protected _isSetup: boolean;
@@ -1807,7 +1806,8 @@ declare module Plottable {
              * @returns The calling Component.
              */
             detach(): AbstractComponent;
-            _setParent(parent: AbstractComponentContainer): void;
+            _parent(): AbstractComponentContainer;
+            _parent(parentElement: AbstractComponentContainer): any;
             /**
              * Removes a Component from the DOM and disconnects it from everything it's
              * listening to (effectively destroying it).

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1807,6 +1807,7 @@ declare module Plottable {
              * @returns The calling Component.
              */
             detach(): AbstractComponent;
+            _setParent(parent: AbstractComponentContainer): void;
             /**
              * Removes a Component from the DOM and disconnects it from everything it's
              * listening to (effectively destroying it).

--- a/plottable.js
+++ b/plottable.js
@@ -6154,7 +6154,7 @@ var Plottable;
             Table.prototype.addComponent = function (row, col, component) {
                 var currentComponent = this._rows[row] && this._rows[row][col];
                 if (currentComponent) {
-                    component = component.above(currentComponent);
+                    component = currentComponent.below(component);
                 }
                 if (this._addComponent(component)) {
                     this._nRows = Math.max(row + 1, this._nRows);

--- a/plottable.js
+++ b/plottable.js
@@ -3574,6 +3574,7 @@ var Plottable;
              * @returns {Component} The calling component.
              */
             AbstractComponent.prototype.renderTo = function (element) {
+                this.detach();
                 if (element != null) {
                     var selection;
                     if (typeof (element) === "string") {

--- a/plottable.js
+++ b/plottable.js
@@ -3563,7 +3563,7 @@ var Plottable;
                         this._scheduleComputeLayout();
                     }
                     else {
-                        this._parent._invalidateLayout();
+                        this._parent()._invalidateLayout();
                     }
                 }
             };
@@ -3844,16 +3844,20 @@ var Plottable;
                 if (this._isAnchored) {
                     this._element.remove();
                 }
-                if (this._parent != null) {
-                    this._parent._removeComponent(this);
+                var parent = this._parent();
+                if (parent != null) {
+                    parent._removeComponent(this);
                 }
                 this._isAnchored = false;
-                this._parent = null;
+                this._parentElement = null;
                 return this;
             };
-            AbstractComponent.prototype._setParent = function (parent) {
+            AbstractComponent.prototype._parent = function (parentElement) {
+                if (parentElement === undefined) {
+                    return this._parentElement;
+                }
                 this.detach();
-                this._parent = parent;
+                this._parentElement = parentElement;
             };
             /**
              * Removes a Component from the DOM and disconnects it from everything it's
@@ -3897,12 +3901,12 @@ var Plottable;
              */
             AbstractComponent.prototype.originToSVG = function () {
                 var origin = this.origin();
-                var ancestor = this._parent;
+                var ancestor = this._parent();
                 while (ancestor != null) {
                     var ancestorOrigin = ancestor.origin();
                     origin.x += ancestorOrigin.x;
                     origin.y += ancestorOrigin.y;
-                    ancestor = ancestor._parent;
+                    ancestor = ancestor._parent();
                 }
                 return origin;
             };
@@ -4003,7 +4007,7 @@ var Plottable;
                 else {
                     this.components().push(c);
                 }
-                c._setParent(this);
+                c._parent(this);
                 if (this._isAnchored) {
                     c._anchor(this._content);
                 }

--- a/plottable.js
+++ b/plottable.js
@@ -6152,9 +6152,12 @@ var Plottable;
              * @returns {Table} The calling Table.
              */
             Table.prototype.addComponent = function (row, col, component) {
+                if (component == null) {
+                    throw Error("Cannot add null to a table cell");
+                }
                 var currentComponent = this._rows[row] && this._rows[row][col];
                 if (currentComponent) {
-                    component = currentComponent.below(component);
+                    component = component.above(currentComponent);
                 }
                 if (this._addComponent(component)) {
                     this._nRows = Math.max(row + 1, this._nRows);

--- a/plottable.js
+++ b/plottable.js
@@ -3789,9 +3789,6 @@ var Plottable;
             };
             AbstractComponent.prototype._merge = function (c, below) {
                 var cg;
-                if (this._isSetup || this._isAnchored) {
-                    throw new Error("Can't presently merge a component that's already been anchored");
-                }
                 if (Plottable.Component.Group.prototype.isPrototypeOf(c)) {
                     cg = c;
                     cg._addComponent(this, below);
@@ -3853,6 +3850,10 @@ var Plottable;
                 this._isAnchored = false;
                 this._parent = null;
                 return this;
+            };
+            AbstractComponent.prototype._setParent = function (parent) {
+                this.detach();
+                this._parent = parent;
             };
             /**
              * Removes a Component from the DOM and disconnects it from everything it's
@@ -4002,7 +4003,7 @@ var Plottable;
                 else {
                     this.components().push(c);
                 }
-                c._parent = this;
+                c._setParent(this);
                 if (this._isAnchored) {
                     c._anchor(this._content);
                 }
@@ -6118,7 +6119,9 @@ var Plottable;
                 this.classed("table", true);
                 rows.forEach(function (row, rowIndex) {
                     row.forEach(function (component, colIndex) {
-                        _this.addComponent(rowIndex, colIndex, component);
+                        if (component != null) {
+                            _this.addComponent(rowIndex, colIndex, component);
+                        }
                     });
                 });
             }
@@ -6147,7 +6150,6 @@ var Plottable;
             Table.prototype.addComponent = function (row, col, component) {
                 var currentComponent = this._rows[row] && this._rows[row][col];
                 if (currentComponent) {
-                    currentComponent.detach();
                     component = component.above(currentComponent);
                 }
                 if (this._addComponent(component)) {

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -194,6 +194,7 @@ export module Component {
      * @returns {Component} The calling component.
      */
     public renderTo(element: String | D3.Selection): AbstractComponent {
+      this.detach();
       if (element != null) {
         var selection: D3.Selection;
         if (typeof(element) === "string") {
@@ -210,6 +211,7 @@ export module Component {
         throw new Error("If a component has never been rendered before, then renderTo must be given a node to render to, \
           or a D3.Selection, or a selector string");
       }
+
       this._computeLayout();
       this._render();
       // flush so that consumers can immediately attach to stuff we create in the DOM

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -423,9 +423,6 @@ export module Component {
 
     public _merge(c: AbstractComponent, below: boolean): Component.Group {
       var cg: Component.Group;
-      if (this._isSetup || this._isAnchored) {
-        throw new Error("Can't presently merge a component that's already been anchored");
-      }
       if (Plottable.Component.Group.prototype.isPrototypeOf(c)) {
         cg = (<Plottable.Component.Group> c);
         cg._addComponent(this, below);
@@ -489,6 +486,11 @@ export module Component {
       this._isAnchored = false;
       this._parent = null;
       return this;
+    }
+
+    public _setParent(parent: AbstractComponent) {
+      this.detach();
+      this._parent = parent;
     }
 
     /**

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -488,7 +488,7 @@ export module Component {
       return this;
     }
 
-    public _setParent(parent: AbstractComponent) {
+    public _setParent(parent: AbstractComponentContainer) {
       this.detach();
       this._parent = parent;
     }

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -211,7 +211,6 @@ export module Component {
         throw new Error("If a component has never been rendered before, then renderTo must be given a node to render to, \
           or a D3.Selection, or a selector string");
       }
-
       this._computeLayout();
       this._render();
       // flush so that consumers can immediately attach to stuff we create in the DOM

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -12,7 +12,7 @@ export module Component {
     private _xOrigin: number; // Origin of the coordinate space for the component. Passed down from parent
     private _yOrigin: number;
 
-    public _parent: AbstractComponentContainer;
+    private _parentElement: AbstractComponentContainer;
     private _xAlignProportion = 0; // What % along the free space do we want to position (0 = left, .5 = center, 1 = right)
     private _yAlignProportion = 0;
     protected _fixedHeightFlag = false;
@@ -182,7 +182,7 @@ export module Component {
         if (this._isTopLevelComponent) {
           this._scheduleComputeLayout();
         } else {
-          this._parent._invalidateLayout();
+          this._parent()._invalidateLayout();
         }
       }
     }
@@ -480,17 +480,26 @@ export module Component {
       if (this._isAnchored) {
         this._element.remove();
       }
-      if (this._parent != null) {
-        this._parent._removeComponent(this);
+
+      var parent: AbstractComponentContainer = this._parent();
+
+      if (parent != null) {
+        parent._removeComponent(this);
       }
       this._isAnchored = false;
-      this._parent = null;
+      this._parentElement = null;
       return this;
     }
 
-    public _setParent(parent: AbstractComponentContainer) {
+    public _parent(): AbstractComponentContainer;
+    public _parent(parentElement: AbstractComponentContainer): any;
+    public _parent(parentElement?: AbstractComponentContainer): any {
+      if (parentElement === undefined) {
+        return this._parentElement;
+      }
+
       this.detach();
-      this._parent = parent;
+      this._parentElement = parentElement;
     }
 
     /**
@@ -539,12 +548,12 @@ export module Component {
      */
     public originToSVG(): Point {
       var origin = this.origin();
-      var ancestor = this._parent;
+      var ancestor = this._parent();
       while (ancestor != null) {
         var ancestorOrigin = ancestor.origin();
         origin.x += ancestorOrigin.x;
         origin.y += ancestorOrigin.y;
-        ancestor = ancestor._parent;
+        ancestor = ancestor._parent();
       }
       return origin;
     }

--- a/src/components/abstractComponentContainer.ts
+++ b/src/components/abstractComponentContainer.ts
@@ -36,7 +36,7 @@ export module Component {
       } else {
         this.components().push(c);
       }
-      c._setParent(this);
+      c._parent(this);
       if (this._isAnchored) {
         c._anchor(this._content);
       }

--- a/src/components/abstractComponentContainer.ts
+++ b/src/components/abstractComponentContainer.ts
@@ -36,7 +36,7 @@ export module Component {
       } else {
         this.components().push(c);
       }
-      c._parent = this;
+      c._setParent(this);
       if (this._isAnchored) {
         c._anchor(this._content);
       }

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -82,10 +82,14 @@ export module Component {
      */
     public addComponent(row: number, col: number, component: AbstractComponent): Table {
 
+      if (component == null) {
+        throw Error("Cannot add null to a table cell")
+      }
+
       var currentComponent = this._rows[row] && this._rows[row][col];
 
       if (currentComponent) {
-        component = currentComponent.below(component);
+        component = component.above(currentComponent);
       }
 
       if (this._addComponent(component)) {

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -81,6 +81,7 @@ export module Component {
      * @returns {Table} The calling Table.
      */
     public addComponent(row: number, col: number, component: AbstractComponent): Table {
+
       var currentComponent = this._rows[row] && this._rows[row][col];
 
       if (currentComponent) {

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -83,7 +83,7 @@ export module Component {
     public addComponent(row: number, col: number, component: AbstractComponent): Table {
 
       if (component == null) {
-        throw Error("Cannot add null to a table cell")
+        throw Error("Cannot add null to a table cell");
       }
 
       var currentComponent = this._rows[row] && this._rows[row][col];

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -51,7 +51,9 @@ export module Component {
       this.classed("table", true);
       rows.forEach((row, rowIndex) => {
         row.forEach((component, colIndex) => {
-          this.addComponent(rowIndex, colIndex, component);
+          if (component != null) {
+            this.addComponent(rowIndex, colIndex, component);
+          }
         });
       });
     }
@@ -79,11 +81,9 @@ export module Component {
      * @returns {Table} The calling Table.
      */
     public addComponent(row: number, col: number, component: AbstractComponent): Table {
-
       var currentComponent = this._rows[row] && this._rows[row][col];
 
       if (currentComponent) {
-        currentComponent.detach();
         component = component.above(currentComponent);
       }
 

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -85,7 +85,7 @@ export module Component {
       var currentComponent = this._rows[row] && this._rows[row][col];
 
       if (currentComponent) {
-        component = component.above(currentComponent);
+        component = currentComponent.below(component);
       }
 
       if (this._addComponent(component)) {

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -185,6 +185,31 @@ describe("ComponentGroups", () => {
       assert.strictEqual(cg.height(), SVG_HEIGHT, "occupies all offered height");
       svg.remove();
     });
+
+    it("can move components to other groups after anchoring", () => {
+      var svg = generateSVG();
+
+      var xScale = new Plottable.Scale.Category();
+      xScale.domain(["A", "B", "C"]);
+      var xAxis = new Plottable.Axis.Category(xScale, "bottom");
+      var yScale = new Plottable.Scale.Linear();
+      var yAxis = new Plottable.Axis.Numeric(yScale, "left");
+      var chart = new Plottable.Component.Table([
+          [yAxis, null],
+          [null,  xAxis]
+      ]);
+
+      var label = new Plottable.Component.Label("Movable");
+      chart.addComponent(0, 1, label);
+
+      chart.renderTo(svg);
+
+      assert.doesNotThrow(() => chart.addComponent(0, 0, label), Error,
+        "Should be able to move components between groups after anchoring");
+
+      svg.remove();
+    });
+
   });
 
     describe("Merging components works as expected", () => {

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -199,10 +199,10 @@ describe("ComponentGroups", () => {
       cg2.renderTo(svg);
 
       assert.strictEqual(cg2.components().length, 0,
-        "Second group should have no component before movement");
+        "second group should have no component before movement");
 
       assert.strictEqual(cg1.components().length, 1,
-        "First group should have 1 component before movement");
+        "first group should have 1 component before movement");
 
       assert.strictEqual(c._parent(), cg1,
         "component's parent before moving should be the group 1"
@@ -213,10 +213,10 @@ describe("ComponentGroups", () => {
       );
 
       assert.strictEqual(cg2.components().length, 1,
-        "Second group should have 1 component after movement");
+        "second group should have 1 component after movement");
 
       assert.strictEqual(cg1.components().length, 0,
-        "First group should have no components after movement");
+        "first group should have no components after movement");
 
       assert.strictEqual(c._parent(), cg2,
         "component's parent after movement should be the group 2"
@@ -225,6 +225,20 @@ describe("ComponentGroups", () => {
       svg.remove();
     });
 
+    it("can add null to a component without failing", () => {
+      var cg1 = new Plottable.Component.AbstractComponentContainer();
+      var c = new Plottable.Component.AbstractComponent;
+
+      cg1._addComponent(c);
+
+      assert.strictEqual(cg1.components().length, 1,
+        "there should first be 1 element in the group");
+
+      assert.doesNotThrow(() => cg1._addComponent(null));
+
+      assert.strictEqual(cg1.components().length, 1,
+        "adding null to a group should have no effect on the group");
+    });
   });
 
     describe("Merging components works as expected", () => {

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -189,19 +189,6 @@ describe("ComponentGroups", () => {
     it("can move components to other groups after anchoring", () => {
       var svg = generateSVG();
 
-      // var xScale = new Plottable.Scale.Category();
-      // xScale.domain(["A", "B", "C"]);
-      // var xAxis = new Plottable.Axis.Category(xScale, "bottom");
-      // var yScale = new Plottable.Scale.Linear();
-      // var yAxis = new Plottable.Axis.Numeric(yScale, "left");
-      // var chart = new Plottable.Component.Table([
-      //     [yAxis, null],
-      //     [null,  xAxis]
-      // ]);
-
-      // var label = new Plottable.Component.Label("Movable");
-      // chart.addComponent(1, 1, label);
-
       var cg1 = new Plottable.Component.AbstractComponentContainer();
       var cg2 = new Plottable.Component.AbstractComponentContainer();
       var c = new Plottable.Component.AbstractComponent();
@@ -211,23 +198,28 @@ describe("ComponentGroups", () => {
       cg1.renderTo(svg);
       cg2.renderTo(svg);
 
+      assert.strictEqual(cg2.components().length, 0,
+        "Second group should have no component before movement");
 
-      assert.strictEqual((<any> c)._parent(), cg1,
-        "label's parent before moving should be the table cell [1][1]"
+      assert.strictEqual(cg1.components().length, 1,
+        "First group should have 1 component before movement");
+
+      assert.strictEqual(c._parent(), cg1,
+        "component's parent before moving should be the group 1"
       );
 
       assert.doesNotThrow(() => cg2._addComponent(c), Error,
         "should be able to move components between groups after anchoring"
       );
 
-      assert.strictEqual((<any> cg2).components().length, 1,
-        "yAxis should be a group that contains 2 elements now (label and axis)");
+      assert.strictEqual(cg2.components().length, 1,
+        "Second group should have 1 component after movement");
 
-      assert.strictEqual((<any> cg1).components().length, 0,
-        "xAxis should be a group that contains 1 elements now (label and axis)");
+      assert.strictEqual(cg1.components().length, 0,
+        "First group should have no components after movement");
 
-      assert.strictEqual((<any> c)._parent(), cg2,
-        "label's parent after moving should be the table cell [0][0]"
+      assert.strictEqual(c._parent(), cg2,
+        "component's parent after movement should be the group 1"
       );
 
       svg.remove();

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -189,38 +189,44 @@ describe("ComponentGroups", () => {
     it("can move components to other groups after anchoring", () => {
       var svg = generateSVG();
 
-      var xScale = new Plottable.Scale.Category();
-      xScale.domain(["A", "B", "C"]);
-      var xAxis = new Plottable.Axis.Category(xScale, "bottom");
-      var yScale = new Plottable.Scale.Linear();
-      var yAxis = new Plottable.Axis.Numeric(yScale, "left");
-      var chart = new Plottable.Component.Table([
-          [yAxis, null],
-          [null,  xAxis]
-      ]);
+      // var xScale = new Plottable.Scale.Category();
+      // xScale.domain(["A", "B", "C"]);
+      // var xAxis = new Plottable.Axis.Category(xScale, "bottom");
+      // var yScale = new Plottable.Scale.Linear();
+      // var yAxis = new Plottable.Axis.Numeric(yScale, "left");
+      // var chart = new Plottable.Component.Table([
+      //     [yAxis, null],
+      //     [null,  xAxis]
+      // ]);
 
-      var label = new Plottable.Component.Label("Movable");
-      chart.addComponent(1, 1, label);
+      // var label = new Plottable.Component.Label("Movable");
+      // chart.addComponent(1, 1, label);
 
-      chart.renderTo(svg);
+      var cg1 = new Plottable.Component.AbstractComponentContainer();
+      var cg2 = new Plottable.Component.AbstractComponentContainer();
+      var c = new Plottable.Component.AbstractComponent();
 
-      assert.strictEqual((<any> label)._parent(), (<any> chart)._rows[1][1],
+      cg1._addComponent(c);
+
+      cg1.renderTo(svg);
+      cg2.renderTo(svg);
+
+
+      assert.strictEqual((<any> c)._parent(), cg1,
         "label's parent before moving should be the table cell [1][1]"
       );
 
-      assert.doesNotThrow(() => chart.addComponent(0, 0, label), Error,
+      assert.doesNotThrow(() => cg2._addComponent(c), Error,
         "should be able to move components between groups after anchoring"
       );
 
-      assert.strictEqual((<any> chart)._rows[0][0].components().length, 2,
+      assert.strictEqual((<any> cg2).components().length, 1,
         "yAxis should be a group that contains 2 elements now (label and axis)");
 
-      if (Plottable.Component.AbstractComponentContainer.prototype.isPrototypeOf((<any> chart)._rows[1][1])) {
-        assert.strictEqual((<any> chart)._rows[1][1].components().length, 1,
-          "xAxis should be a group that contains 1 elements now (label and axis)");
-      }
+      assert.strictEqual((<any> cg1).components().length, 0,
+        "xAxis should be a group that contains 1 elements now (label and axis)");
 
-      assert.strictEqual((<any> label)._parent(), (<any> chart)._rows[0][0],
+      assert.strictEqual((<any> c)._parent(), cg2,
         "label's parent after moving should be the table cell [0][0]"
       );
 

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -219,7 +219,7 @@ describe("ComponentGroups", () => {
         "First group should have no components after movement");
 
       assert.strictEqual(c._parent(), cg2,
-        "component's parent after movement should be the group 1"
+        "component's parent after movement should be the group 2"
       );
 
       svg.remove();

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -204,7 +204,7 @@ describe("ComponentGroups", () => {
 
       chart.renderTo(svg);
 
-      assert.strictEqual(label._parent, (<any> chart)._rows[1][1],
+      assert.strictEqual((<any> label)._parent, (<any> chart)._rows[1][1],
         "label's parent before moving should be the table cell [1][1]"
       );
 
@@ -220,7 +220,7 @@ describe("ComponentGroups", () => {
           "xAxis should be a group that contains 1 elements now (label and axis)");
       }
 
-      assert.strictEqual(label._parent, (<any> chart)._rows[0][0],
+      assert.strictEqual((<any> label)._parent, (<any> chart)._rows[0][0],
         "label's parent after moving should be the table cell [0][0]"
       );
 

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -200,12 +200,29 @@ describe("ComponentGroups", () => {
       ]);
 
       var label = new Plottable.Component.Label("Movable");
-      chart.addComponent(0, 1, label);
+      chart.addComponent(1, 1, label);
 
       chart.renderTo(svg);
 
+      assert.strictEqual(label._parent, (<any> chart)._rows[1][1],
+        "label's parent before moving should be the table cell [1][1]"
+      );
+
       assert.doesNotThrow(() => chart.addComponent(0, 0, label), Error,
-        "Should be able to move components between groups after anchoring");
+        "should be able to move components between groups after anchoring"
+      );
+
+      assert.strictEqual((<any> chart)._rows[0][0].components().length, 2,
+        "yAxis should be a group that contains 2 elements now (label and axis)");
+
+      if (Plottable.Component.AbstractComponentContainer.prototype.isPrototypeOf((<any> chart)._rows[1][1])) {
+        assert.strictEqual((<any> chart)._rows[1][1].components().length, 1,
+          "xAxis should be a group that contains 1 elements now (label and axis)");
+      }
+
+      assert.strictEqual(label._parent, (<any> chart)._rows[0][0],
+        "label's parent after moving should be the table cell [0][0]"
+      );
 
       svg.remove();
     });

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -204,7 +204,7 @@ describe("ComponentGroups", () => {
 
       chart.renderTo(svg);
 
-      assert.strictEqual((<any> label)._parent, (<any> chart)._rows[1][1],
+      assert.strictEqual((<any> label)._parent(), (<any> chart)._rows[1][1],
         "label's parent before moving should be the table cell [1][1]"
       );
 
@@ -220,7 +220,7 @@ describe("ComponentGroups", () => {
           "xAxis should be a group that contains 1 elements now (label and axis)");
       }
 
-      assert.strictEqual((<any> label)._parent, (<any> chart)._rows[0][0],
+      assert.strictEqual((<any> label)._parent(), (<any> chart)._rows[0][0],
         "label's parent after moving should be the table cell [0][0]"
       );
 

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -403,6 +403,33 @@ describe("Component behavior", () => {
     svg.remove();
   });
 
+  it("rendering to a new svg detaches the component", () => {
+    var SVG_HEIGHT_1 = 300;
+    var SVG_HEIGHT_2 = 50;
+    var svg1 = generateSVG(300, SVG_HEIGHT_1);
+    var svg2 = generateSVG(300, SVG_HEIGHT_2);
+
+    var xScale = new Plottable.Scale.Linear();
+    var yScale = new Plottable.Scale.Linear();
+    var plot = new Plottable.Plot.Line(xScale, yScale);
+    var group = new Plottable.Component.Group;
+    group.renderTo(svg1);
+
+    group._addComponent(plot);
+
+    assert.deepEqual(plot._parent(), group, "the plot should be inside the group");
+    assert.strictEqual(plot.height(), SVG_HEIGHT_1, "the plot should occupy the entire space of the first svg");
+
+    plot.renderTo(svg2);
+
+    assert.equal(plot._parent(), null, "the plot should be outside the group");
+    assert.strictEqual(plot.height(), SVG_HEIGHT_2, "the plot should occupy the entire space of the second svg");
+
+    svg1.remove();
+    svg2.remove();
+    svg.remove();
+  });
+
   describe("origin methods", () => {
     var cWidth = 100;
     var cHeight = 100;

--- a/test/core/tableTests.ts
+++ b/test/core/tableTests.ts
@@ -68,7 +68,7 @@ describe("Tables", () => {
     assert.isNull(rows[1][0], "component at (1, 0) is null");
   });
 
-  it("Add a component where one already exists creates a new group", () => {
+  it("add a component where one already exists creates a new group", () => {
     var c1 = new Plottable.Component.AbstractComponent();
     var c2 = new Plottable.Component.AbstractComponent();
     var c3 = new Plottable.Component.AbstractComponent();
@@ -86,7 +86,7 @@ describe("Tables", () => {
     assert.equal(components[1], c3, "Second element in the group at (0, 2) should be c3");
   });
 
-  it("Add a component where a group already exists adds the component to the group", () => {
+  it("add a component where a group already exists adds the component to the group", () => {
     var c1 = new Plottable.Component.AbstractComponent();
     var c2 = new Plottable.Component.AbstractComponent();
     var grp = new Plottable.Component.Group([c1, c2]);
@@ -104,6 +104,26 @@ describe("Tables", () => {
     assert.equal(components[0], c1, "First element in the group at (0, 2) should still be c1");
     assert.equal(components[1], c2, "Second element in the group at (0, 2) should still be c2");
     assert.equal(components[2], c3, "The Component was added to the existing Group");
+  });
+
+  it("add null to a table cell where there was a group should have no effect", () => {
+    var c1 = new Plottable.Component.AbstractComponent();
+    var c2 = new Plottable.Component.AbstractComponent();
+    var grp = new Plottable.Component.Group([c1, c2]);
+
+    var t = new Plottable.Component.Table([[grp]]);
+
+    assert.strictEqual(t.components().length, 1, "Table should only have 1 component");
+
+    var groupInTable: Plottable.Component.Group = t.components()[0];
+    assert.strictEqual(groupInTable.components().length, 2, "the group should contain the initial 2 elements");
+
+    assert.doesNotThrow(() => t.addComponent(0, 0, null), "adding null to a table should not throw an Error");
+
+    assert.strictEqual(t.components().length, 1, "Table should still have 1 component");
+
+    var newGroupInTable: Plottable.Component.Group = t.components()[0];
+    assert.strictEqual(newGroupInTable.components().length, 2, "the group should still contain the initial 2 elements");
   });
 
   it("addComponent works even if a component is added with a high column and low row index", () => {

--- a/test/core/tableTests.ts
+++ b/test/core/tableTests.ts
@@ -106,24 +106,11 @@ describe("Tables", () => {
     assert.equal(components[2], c3, "The Component was added to the existing Group");
   });
 
-  it("add null to a table cell where there was a group should have no effect", () => {
+  it("add null to a table cell where there was a group should throw an error", () => {
     var c1 = new Plottable.Component.AbstractComponent();
-    var c2 = new Plottable.Component.AbstractComponent();
-    var grp = new Plottable.Component.Group([c1, c2]);
+    var t = new Plottable.Component.Table([[c1]]);
 
-    var t = new Plottable.Component.Table([[grp]]);
-
-    assert.strictEqual(t.components().length, 1, "Table should only have 1 component");
-
-    var groupInTable: Plottable.Component.Group = <Plottable.Component.Group> t.components()[0];
-    assert.strictEqual(groupInTable.components().length, 2, "the group should contain the initial 2 elements");
-
-    assert.doesNotThrow(() => t.addComponent(0, 0, null), "adding null to a table should not throw an Error");
-
-    assert.strictEqual(t.components().length, 1, "Table should still have 1 component");
-
-    var newGroupInTable: Plottable.Component.Group = <Plottable.Component.Group> t.components()[0];
-    assert.strictEqual(newGroupInTable.components().length, 2, "the group should still contain the initial 2 elements");
+    assert.throw(() => t.addComponent(0, 0, null), "Cannot add null to a table cell");
   });
 
   it("addComponent works even if a component is added with a high column and low row index", () => {

--- a/test/core/tableTests.ts
+++ b/test/core/tableTests.ts
@@ -115,14 +115,14 @@ describe("Tables", () => {
 
     assert.strictEqual(t.components().length, 1, "Table should only have 1 component");
 
-    var groupInTable: Plottable.Component.Group = t.components()[0];
+    var groupInTable: Plottable.Component.Group = <Plottable.Component.Group> t.components()[0];
     assert.strictEqual(groupInTable.components().length, 2, "the group should contain the initial 2 elements");
 
     assert.doesNotThrow(() => t.addComponent(0, 0, null), "adding null to a table should not throw an Error");
 
     assert.strictEqual(t.components().length, 1, "Table should still have 1 component");
 
-    var newGroupInTable: Plottable.Component.Group = t.components()[0];
+    var newGroupInTable: Plottable.Component.Group = <Plottable.Component.Group> t.components()[0];
     assert.strictEqual(newGroupInTable.components().length, 2, "the group should still contain the initial 2 elements");
   });
 

--- a/test/core/tableTests.ts
+++ b/test/core/tableTests.ts
@@ -106,7 +106,7 @@ describe("Tables", () => {
     assert.equal(components[2], c3, "The Component was added to the existing Group");
   });
 
-  it("add null to a table cell where there was a group should throw an error", () => {
+  it("adding null to a table cell should throw an error", () => {
     var c1 = new Plottable.Component.AbstractComponent();
     var t = new Plottable.Component.Table([[c1]]);
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -6761,18 +6761,10 @@ describe("Tables", function () {
         assert.equal(components[1], c2, "Second element in the group at (0, 2) should still be c2");
         assert.equal(components[2], c3, "The Component was added to the existing Group");
     });
-    it("add null to a table cell where there was a group should have no effect", function () {
+    it("add null to a table cell where there was a group should throw an error", function () {
         var c1 = new Plottable.Component.AbstractComponent();
-        var c2 = new Plottable.Component.AbstractComponent();
-        var grp = new Plottable.Component.Group([c1, c2]);
-        var t = new Plottable.Component.Table([[grp]]);
-        assert.strictEqual(t.components().length, 1, "Table should only have 1 component");
-        var groupInTable = t.components()[0];
-        assert.strictEqual(groupInTable.components().length, 2, "the group should contain the initial 2 elements");
-        assert.doesNotThrow(function () { return t.addComponent(0, 0, null); }, "adding null to a table should not throw an Error");
-        assert.strictEqual(t.components().length, 1, "Table should still have 1 component");
-        var newGroupInTable = t.components()[0];
-        assert.strictEqual(newGroupInTable.components().length, 2, "the group should still contain the initial 2 elements");
+        var t = new Plottable.Component.Table([[c1]]);
+        assert.throw(function () { return t.addComponent(0, 0, null); }, "Cannot add null to a table cell");
     });
     it("addComponent works even if a component is added with a high column and low row index", function () {
         // Solves #180, a weird bug

--- a/test/tests.js
+++ b/test/tests.js
@@ -6761,7 +6761,7 @@ describe("Tables", function () {
         assert.equal(components[1], c2, "Second element in the group at (0, 2) should still be c2");
         assert.equal(components[2], c3, "The Component was added to the existing Group");
     });
-    it("add null to a table cell where there was a group should throw an error", function () {
+    it("adding null to a table cell should throw an error", function () {
         var c1 = new Plottable.Component.AbstractComponent();
         var t = new Plottable.Component.Table([[c1]]);
         assert.throw(function () { return t.addComponent(0, 0, null); }, "Cannot add null to a table cell");

--- a/test/tests.js
+++ b/test/tests.js
@@ -6517,6 +6517,26 @@ describe("Component behavior", function () {
         assert.isTrue(renderFlag, "render occurs if width and height are positive");
         svg.remove();
     });
+    it("rendering to a new svg detaches the component", function () {
+        var SVG_HEIGHT_1 = 300;
+        var SVG_HEIGHT_2 = 50;
+        var svg1 = generateSVG(300, SVG_HEIGHT_1);
+        var svg2 = generateSVG(300, SVG_HEIGHT_2);
+        var xScale = new Plottable.Scale.Linear();
+        var yScale = new Plottable.Scale.Linear();
+        var plot = new Plottable.Plot.Line(xScale, yScale);
+        var group = new Plottable.Component.Group;
+        group.renderTo(svg1);
+        group._addComponent(plot);
+        assert.deepEqual(plot._parent(), group, "the plot should be inside the group");
+        assert.strictEqual(plot.height(), SVG_HEIGHT_1, "the plot should occupy the entire space of the first svg");
+        plot.renderTo(svg2);
+        assert.equal(plot._parent(), null, "the plot should be outside the group");
+        assert.strictEqual(plot.height(), SVG_HEIGHT_2, "the plot should occupy the entire space of the second svg");
+        svg1.remove();
+        svg2.remove();
+        svg.remove();
+    });
     describe("origin methods", function () {
         var cWidth = 100;
         var cHeight = 100;

--- a/test/tests.js
+++ b/test/tests.js
@@ -6079,7 +6079,7 @@ describe("ComponentGroups", function () {
             assert.doesNotThrow(function () { return cg2._addComponent(c); }, Error, "should be able to move components between groups after anchoring");
             assert.strictEqual(cg2.components().length, 1, "Second group should have 1 component after movement");
             assert.strictEqual(cg1.components().length, 0, "First group should have no components after movement");
-            assert.strictEqual(c._parent(), cg2, "component's parent after movement should be the group 1");
+            assert.strictEqual(c._parent(), cg2, "component's parent after movement should be the group 2");
             svg.remove();
         });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -6067,28 +6067,19 @@ describe("ComponentGroups", function () {
         });
         it("can move components to other groups after anchoring", function () {
             var svg = generateSVG();
-            // var xScale = new Plottable.Scale.Category();
-            // xScale.domain(["A", "B", "C"]);
-            // var xAxis = new Plottable.Axis.Category(xScale, "bottom");
-            // var yScale = new Plottable.Scale.Linear();
-            // var yAxis = new Plottable.Axis.Numeric(yScale, "left");
-            // var chart = new Plottable.Component.Table([
-            //     [yAxis, null],
-            //     [null,  xAxis]
-            // ]);
-            // var label = new Plottable.Component.Label("Movable");
-            // chart.addComponent(1, 1, label);
             var cg1 = new Plottable.Component.AbstractComponentContainer();
             var cg2 = new Plottable.Component.AbstractComponentContainer();
             var c = new Plottable.Component.AbstractComponent();
             cg1._addComponent(c);
             cg1.renderTo(svg);
             cg2.renderTo(svg);
-            assert.strictEqual(c._parent(), cg1, "label's parent before moving should be the table cell [1][1]");
+            assert.strictEqual(cg2.components().length, 0, "Second group should have no component before movement");
+            assert.strictEqual(cg1.components().length, 1, "First group should have 1 component before movement");
+            assert.strictEqual(c._parent(), cg1, "component's parent before moving should be the group 1");
             assert.doesNotThrow(function () { return cg2._addComponent(c); }, Error, "should be able to move components between groups after anchoring");
-            assert.strictEqual(cg2.components().length, 1, "yAxis should be a group that contains 2 elements now (label and axis)");
-            assert.strictEqual(cg1.components().length, 0, "xAxis should be a group that contains 1 elements now (label and axis)");
-            assert.strictEqual(c._parent(), cg2, "label's parent after moving should be the table cell [0][0]");
+            assert.strictEqual(cg2.components().length, 1, "Second group should have 1 component after movement");
+            assert.strictEqual(cg1.components().length, 0, "First group should have no components after movement");
+            assert.strictEqual(c._parent(), cg2, "component's parent after movement should be the group 1");
             svg.remove();
         });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -6077,9 +6077,15 @@ describe("ComponentGroups", function () {
                 [null, xAxis]
             ]);
             var label = new Plottable.Component.Label("Movable");
-            chart.addComponent(0, 1, label);
+            chart.addComponent(1, 1, label);
             chart.renderTo(svg);
-            assert.doesNotThrow(function () { return chart.addComponent(0, 0, label); }, Error, "Should be able to move components between groups after anchoring");
+            assert.strictEqual(label._parent, chart._rows[1][1], "label's parent before moving should be the table cell [1][1]");
+            assert.doesNotThrow(function () { return chart.addComponent(0, 0, label); }, Error, "should be able to move components between groups after anchoring");
+            assert.strictEqual(chart._rows[0][0].components().length, 2, "yAxis should be a group that contains 2 elements now (label and axis)");
+            if (Plottable.Component.AbstractComponentContainer.prototype.isPrototypeOf(chart._rows[1][1])) {
+                assert.strictEqual(chart._rows[1][1].components().length, 1, "xAxis should be a group that contains 1 elements now (label and axis)");
+            }
+            assert.strictEqual(label._parent, chart._rows[0][0], "label's parent after moving should be the table cell [0][0]");
             svg.remove();
         });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -6079,13 +6079,13 @@ describe("ComponentGroups", function () {
             var label = new Plottable.Component.Label("Movable");
             chart.addComponent(1, 1, label);
             chart.renderTo(svg);
-            assert.strictEqual(label._parent, chart._rows[1][1], "label's parent before moving should be the table cell [1][1]");
+            assert.strictEqual(label._parent(), chart._rows[1][1], "label's parent before moving should be the table cell [1][1]");
             assert.doesNotThrow(function () { return chart.addComponent(0, 0, label); }, Error, "should be able to move components between groups after anchoring");
             assert.strictEqual(chart._rows[0][0].components().length, 2, "yAxis should be a group that contains 2 elements now (label and axis)");
             if (Plottable.Component.AbstractComponentContainer.prototype.isPrototypeOf(chart._rows[1][1])) {
                 assert.strictEqual(chart._rows[1][1].components().length, 1, "xAxis should be a group that contains 1 elements now (label and axis)");
             }
-            assert.strictEqual(label._parent, chart._rows[0][0], "label's parent after moving should be the table cell [0][0]");
+            assert.strictEqual(label._parent(), chart._rows[0][0], "label's parent after moving should be the table cell [0][0]");
             svg.remove();
         });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -6067,25 +6067,28 @@ describe("ComponentGroups", function () {
         });
         it("can move components to other groups after anchoring", function () {
             var svg = generateSVG();
-            var xScale = new Plottable.Scale.Category();
-            xScale.domain(["A", "B", "C"]);
-            var xAxis = new Plottable.Axis.Category(xScale, "bottom");
-            var yScale = new Plottable.Scale.Linear();
-            var yAxis = new Plottable.Axis.Numeric(yScale, "left");
-            var chart = new Plottable.Component.Table([
-                [yAxis, null],
-                [null, xAxis]
-            ]);
-            var label = new Plottable.Component.Label("Movable");
-            chart.addComponent(1, 1, label);
-            chart.renderTo(svg);
-            assert.strictEqual(label._parent(), chart._rows[1][1], "label's parent before moving should be the table cell [1][1]");
-            assert.doesNotThrow(function () { return chart.addComponent(0, 0, label); }, Error, "should be able to move components between groups after anchoring");
-            assert.strictEqual(chart._rows[0][0].components().length, 2, "yAxis should be a group that contains 2 elements now (label and axis)");
-            if (Plottable.Component.AbstractComponentContainer.prototype.isPrototypeOf(chart._rows[1][1])) {
-                assert.strictEqual(chart._rows[1][1].components().length, 1, "xAxis should be a group that contains 1 elements now (label and axis)");
-            }
-            assert.strictEqual(label._parent(), chart._rows[0][0], "label's parent after moving should be the table cell [0][0]");
+            // var xScale = new Plottable.Scale.Category();
+            // xScale.domain(["A", "B", "C"]);
+            // var xAxis = new Plottable.Axis.Category(xScale, "bottom");
+            // var yScale = new Plottable.Scale.Linear();
+            // var yAxis = new Plottable.Axis.Numeric(yScale, "left");
+            // var chart = new Plottable.Component.Table([
+            //     [yAxis, null],
+            //     [null,  xAxis]
+            // ]);
+            // var label = new Plottable.Component.Label("Movable");
+            // chart.addComponent(1, 1, label);
+            var cg1 = new Plottable.Component.AbstractComponentContainer();
+            var cg2 = new Plottable.Component.AbstractComponentContainer();
+            var c = new Plottable.Component.AbstractComponent();
+            cg1._addComponent(c);
+            cg1.renderTo(svg);
+            cg2.renderTo(svg);
+            assert.strictEqual(c._parent(), cg1, "label's parent before moving should be the table cell [1][1]");
+            assert.doesNotThrow(function () { return cg2._addComponent(c); }, Error, "should be able to move components between groups after anchoring");
+            assert.strictEqual(cg2.components().length, 1, "yAxis should be a group that contains 2 elements now (label and axis)");
+            assert.strictEqual(cg1.components().length, 0, "xAxis should be a group that contains 1 elements now (label and axis)");
+            assert.strictEqual(c._parent(), cg2, "label's parent after moving should be the table cell [0][0]");
             svg.remove();
         });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -6065,6 +6065,23 @@ describe("ComponentGroups", function () {
             assert.strictEqual(cg.height(), SVG_HEIGHT, "occupies all offered height");
             svg.remove();
         });
+        it("can move components to other groups after anchoring", function () {
+            var svg = generateSVG();
+            var xScale = new Plottable.Scale.Category();
+            xScale.domain(["A", "B", "C"]);
+            var xAxis = new Plottable.Axis.Category(xScale, "bottom");
+            var yScale = new Plottable.Scale.Linear();
+            var yAxis = new Plottable.Axis.Numeric(yScale, "left");
+            var chart = new Plottable.Component.Table([
+                [yAxis, null],
+                [null, xAxis]
+            ]);
+            var label = new Plottable.Component.Label("Movable");
+            chart.addComponent(0, 1, label);
+            chart.renderTo(svg);
+            assert.doesNotThrow(function () { return chart.addComponent(0, 0, label); }, Error, "Should be able to move components between groups after anchoring");
+            svg.remove();
+        });
     });
     describe("Merging components works as expected", function () {
         var c1 = new Plottable.Component.AbstractComponent();

--- a/test/tests.js
+++ b/test/tests.js
@@ -6073,14 +6073,22 @@ describe("ComponentGroups", function () {
             cg1._addComponent(c);
             cg1.renderTo(svg);
             cg2.renderTo(svg);
-            assert.strictEqual(cg2.components().length, 0, "Second group should have no component before movement");
-            assert.strictEqual(cg1.components().length, 1, "First group should have 1 component before movement");
+            assert.strictEqual(cg2.components().length, 0, "second group should have no component before movement");
+            assert.strictEqual(cg1.components().length, 1, "first group should have 1 component before movement");
             assert.strictEqual(c._parent(), cg1, "component's parent before moving should be the group 1");
             assert.doesNotThrow(function () { return cg2._addComponent(c); }, Error, "should be able to move components between groups after anchoring");
-            assert.strictEqual(cg2.components().length, 1, "Second group should have 1 component after movement");
-            assert.strictEqual(cg1.components().length, 0, "First group should have no components after movement");
+            assert.strictEqual(cg2.components().length, 1, "second group should have 1 component after movement");
+            assert.strictEqual(cg1.components().length, 0, "first group should have no components after movement");
             assert.strictEqual(c._parent(), cg2, "component's parent after movement should be the group 2");
             svg.remove();
+        });
+        it("can add null to a component without failing", function () {
+            var cg1 = new Plottable.Component.AbstractComponentContainer();
+            var c = new Plottable.Component.AbstractComponent;
+            cg1._addComponent(c);
+            assert.strictEqual(cg1.components().length, 1, "there should first be 1 element in the group");
+            assert.doesNotThrow(function () { return cg1._addComponent(null); });
+            assert.strictEqual(cg1.components().length, 1, "adding null to a group should have no effect on the group");
         });
     });
     describe("Merging components works as expected", function () {
@@ -6724,7 +6732,7 @@ describe("Tables", function () {
         assert.isNull(rows[0][1], "component at (0, 1) is null");
         assert.isNull(rows[1][0], "component at (1, 0) is null");
     });
-    it("Add a component where one already exists creates a new group", function () {
+    it("add a component where one already exists creates a new group", function () {
         var c1 = new Plottable.Component.AbstractComponent();
         var c2 = new Plottable.Component.AbstractComponent();
         var c3 = new Plottable.Component.AbstractComponent();
@@ -6738,7 +6746,7 @@ describe("Tables", function () {
         assert.equal(components[0], c1, "First element in the group at (0, 2) should be c1");
         assert.equal(components[1], c3, "Second element in the group at (0, 2) should be c3");
     });
-    it("Add a component where a group already exists adds the component to the group", function () {
+    it("add a component where a group already exists adds the component to the group", function () {
         var c1 = new Plottable.Component.AbstractComponent();
         var c2 = new Plottable.Component.AbstractComponent();
         var grp = new Plottable.Component.Group([c1, c2]);
@@ -6752,6 +6760,19 @@ describe("Tables", function () {
         assert.equal(components[0], c1, "First element in the group at (0, 2) should still be c1");
         assert.equal(components[1], c2, "Second element in the group at (0, 2) should still be c2");
         assert.equal(components[2], c3, "The Component was added to the existing Group");
+    });
+    it("add null to a table cell where there was a group should have no effect", function () {
+        var c1 = new Plottable.Component.AbstractComponent();
+        var c2 = new Plottable.Component.AbstractComponent();
+        var grp = new Plottable.Component.Group([c1, c2]);
+        var t = new Plottable.Component.Table([[grp]]);
+        assert.strictEqual(t.components().length, 1, "Table should only have 1 component");
+        var groupInTable = t.components()[0];
+        assert.strictEqual(groupInTable.components().length, 2, "the group should contain the initial 2 elements");
+        assert.doesNotThrow(function () { return t.addComponent(0, 0, null); }, "adding null to a table should not throw an Error");
+        assert.strictEqual(t.components().length, 1, "Table should still have 1 component");
+        var newGroupInTable = t.components()[0];
+        assert.strictEqual(newGroupInTable.components().length, 2, "the group should still contain the initial 2 elements");
     });
     it("addComponent works even if a component is added with a high column and low row index", function () {
         // Solves #180, a weird bug


### PR DESCRIPTION
Changelog:
- No longer setting the parent field, but rather have a method for doing that, which also detaches the component from its old parent (if there's the case)
- No longer throwing an error if the component was already setup or anchored, as we can now do it
- Throwing an error if we are trying to add `null` to a table cell

Closes #1823 

Before: http://jsfiddle.net/0r93afbf/
After: http://jsfiddle.net/0r93afbf/5/

Fiddle explanation: Click on the button. If it works correctly, the label "AWESOME" should be taken from the x-Axis and put inside the graph. The default position is center (vertically and horizontally)