### PR TITLE
First pass Line.getClosestPlotData() impl.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2801,10 +2801,10 @@ declare module Plottable {
             getAllPlotData(datasetKeys?: string | string[]): PlotData;
             protected _getAllPlotData(datasetKeys: string[]): PlotData;
             /**
-             * Retrieves the closest PlotData across all datasets, where distance is defined to be
-             * the Euclidiean norm.
+             * Retrieves PlotData with the lowest distance, where distance is defined
+             * to be the Euclidiean norm.
              *
-             * @param {Point} queryPoint The point to which dataset points should be compared
+             * @param {Point} queryPoint The point to which plot data should be compared
              *
              * @returns {PlotData} The PlotData closest to queryPoint
              */
@@ -3126,6 +3126,16 @@ declare module Plottable {
                 };
             };
             protected _getAllPlotData(datasetKeys: string[]): PlotData;
+            /**
+             * Retrieves the closest PlotData to queryPoint.
+             *
+             * Lines implement an x-dominant notion of distance; points closest in x are
+             * tie-broken by y distance.
+             *
+             * @param {Point} queryPoint The point to which plot data should be compared
+             *
+             * @returns {PlotData} The PlotData closest to queryPoint
+             */
             getClosestPlotData(queryPoint: Point): PlotData;
             _hoverOverComponent(p: Point): void;
             _hoverOutComponent(p: Point): void;

--- a/plottable.js
+++ b/plottable.js
@@ -7969,7 +7969,9 @@ var Plottable;
                 var _this = this;
                 var minXDist = Infinity;
                 var minYDist = Infinity;
-                var closest;
+                var closestData = [];
+                var closestPixelPoints = [];
+                var closestElements = [];
                 this.datasetOrder().forEach(function (key) {
                     var plotData = _this.getAllPlotData(key);
                     plotData.pixelPoints.forEach(function (pxPt, index) {
@@ -7979,34 +7981,23 @@ var Plottable;
                         var xDist = Math.abs(queryPoint.x - pxPt.x);
                         var yDist = Math.abs(queryPoint.y - pxPt.y);
                         if (xDist < minXDist || xDist === minXDist && yDist < minYDist) {
-                            closest = [];
+                            closestData = [];
+                            closestPixelPoints = [];
+                            closestElements = [];
                             minXDist = xDist;
                             minYDist = yDist;
                         }
                         if (xDist === minXDist && yDist === minYDist) {
-                            closest.push({
-                                datum: plotData.data[index],
-                                pixelPoint: pxPt,
-                                node: plotData.selection[0][0]
-                            });
+                            closestData.push(plotData.data[index]);
+                            closestPixelPoints.push(pxPt);
+                            closestElements.push(plotData.selection[0][0]);
                         }
                     });
                 });
-                if (minXDist === Infinity) {
-                    return { data: [], pixelPoints: [], selection: d3.select() };
-                }
-                var data = [];
-                var pixelPoints = [];
-                var nodes = [];
-                closest.forEach(function (c) {
-                    data.push(c.datum);
-                    pixelPoints.push(c.pixelPoint);
-                    nodes.push(c.node);
-                });
                 return {
-                    data: data,
-                    pixelPoints: pixelPoints,
-                    selection: d3.selectAll(nodes)
+                    data: closestData,
+                    pixelPoints: closestPixelPoints,
+                    selection: d3.selectAll(closestElements)
                 };
             };
             //===== Hover logic =====

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -168,11 +168,9 @@ export module Plot {
       var minXDist = Infinity;
       var minYDist = Infinity;
 
-      var closest: {
-        datum: any;
-        pixelPoint: Point;
-        node: Node
-      }[];
+      var closestData: any[] = [];
+      var closestPixelPoints: Point[] = [];
+      var closestElements: Element[] = [];
 
       this.datasetOrder().forEach((key: string) => {
         var plotData = this.getAllPlotData(key);
@@ -185,39 +183,26 @@ export module Plot {
           var yDist = Math.abs(queryPoint.y - pxPt.y);
 
           if (xDist < minXDist || xDist === minXDist && yDist < minYDist) {
-            closest = [];
+            closestData = [];
+            closestPixelPoints = [];
+            closestElements = [];
+
             minXDist = xDist;
             minYDist = yDist;
           }
 
           if (xDist === minXDist && yDist === minYDist) {
-            closest.push({
-              datum: plotData.data[index],
-              pixelPoint: pxPt,
-              node: plotData.selection[0][0]
-            });
+            closestData.push(plotData.data[index]);
+            closestPixelPoints.push(pxPt);
+            closestElements.push(plotData.selection[0][0]);
           }
         });
       });
 
-      if (minXDist === Infinity) {
-        return { data: [], pixelPoints: [], selection: d3.select() };
-      }
-
-      var data: any[] = [];
-      var pixelPoints: Point[] = [];
-      var nodes: Node[] = [];
-
-      closest.forEach((c: any) => {
-        data.push(c.datum);
-        pixelPoints.push(c.pixelPoint);
-        nodes.push(c.node);
-      });
-
       return {
-        data: data,
-        pixelPoints: pixelPoints,
-        selection: d3.selectAll(nodes)
+        data: closestData,
+        pixelPoints: closestPixelPoints,
+        selection: d3.selectAll(closestElements)
       };
     }
 

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -154,33 +154,70 @@ export module Plot {
       return { data: data, pixelPoints: pixelPoints, selection: d3.selectAll(allElements) };
     }
 
+    /**
+     * Retrieves the closest PlotData to queryPoint.
+     *
+     * Lines implement an x-dominant notion of distance; points closest in x are
+     * tie-broken by y distance.
+     *
+     * @param {Point} queryPoint The point to which plot data should be compared
+     *
+     * @returns {PlotData} The PlotData closest to queryPoint
+     */
     public getClosestPlotData(queryPoint: Point): PlotData {
-      var closestDistanceSquared = Infinity;
-      var closestDatum: any;
-      var closestSelection: D3.Selection;
-      var closestPoint: Point;
+      var minXDist = Infinity;
+      var minYDist = Infinity;
 
-      this.datasetOrder().forEach((datasetKey: string) => {
-        var plotData = this.getAllPlotData(datasetKey);
-        plotData.pixelPoints.forEach((pixelPoint: Point, index: number) => {
-          var pixelPointDist = _Util.Methods.distanceSquared(queryPoint, pixelPoint);
-          if (pixelPointDist < closestDistanceSquared) {
-            closestDistanceSquared = pixelPointDist;
-            closestDatum = plotData.data[index];
-            closestPoint = pixelPoint;
-            closestSelection = plotData.selection;
+      var closest: {
+        datum: any;
+        pixelPoint: Point;
+        node: Node
+      }[];
+
+      this.datasetOrder().forEach((key: string) => {
+        var plotData = this.getAllPlotData(key);
+        plotData.pixelPoints.forEach((pxPt: Point, index: number) => {
+          if (pxPt.x < 0 || pxPt.y < 0 || pxPt.x > this.width() || pxPt.y > this.height()) {
+            return;
+          }
+
+          var xDist = Math.abs(queryPoint.x - pxPt.x);
+          var yDist = Math.abs(queryPoint.y - pxPt.y);
+
+          if (xDist < minXDist || xDist === minXDist && yDist < minYDist) {
+            closest = [];
+            minXDist = xDist;
+            minYDist = yDist;
+          }
+
+          if (xDist === minXDist && yDist === minYDist) {
+            closest.push({
+              datum: plotData.data[index],
+              pixelPoint: pxPt,
+              node: plotData.selection[0][0]
+            });
           }
         });
       });
 
-      if (closestDatum == null) {
+      if (minXDist === Infinity) {
         return { data: [], pixelPoints: [], selection: d3.select() };
       }
 
+      var data: any[] = [];
+      var pixelPoints: Point[] = [];
+      var nodes: Node[] = [];
+
+      closest.forEach((c: any) => {
+        data.push(c.datum);
+        pixelPoints.push(c.pixelPoint);
+        nodes.push(c.node);
+      });
+
       return {
-        data: [closestDatum],
-        pixelPoints: [closestPoint],
-        selection: closestSelection
+        data: data,
+        pixelPoints: pixelPoints,
+        selection: d3.selectAll(nodes)
       };
     }
 

--- a/test/components/plots/linePlotTests.ts
+++ b/test/components/plots/linePlotTests.ts
@@ -242,6 +242,11 @@ describe("Plots", () => {
     });
 
     describe("getClosestPlotData()", () => {
+      var lines: D3.Selection;
+      var d0: any, d1: any;
+      var d0Px: Plottable.Point, d1Px: Plottable.Point;
+      var dataset3: any[];
+
       function assertPlotDataEqual(expected: Plottable.Plot.PlotData, actual: Plottable.Plot.PlotData, msg: string) {
         assert.deepEqual(expected.data, actual.data, msg);
         assert.closeTo(expected.pixelPoints[0].x, actual.pixelPoints[0].x, 0.01, msg);
@@ -249,26 +254,29 @@ describe("Plots", () => {
         assert.deepEqual(expected.selection, actual.selection, msg);
       }
 
-      it("retrieves correct data", () => {
-        var dataset3 = [
+      beforeEach(() => {
+        dataset3 = [
           { foo: 0, bar: 0.75 },
           { foo: 1, bar: 0.25 }
         ];
+
         linePlot.addDataset("d3", dataset3);
 
-        var lines = d3.selectAll(".line-plot .line");
-        var d0 = dataset3[0];
-        var d0Px = {
+        lines = d3.selectAll(".line-plot .line");
+        d0 = dataset3[0];
+        d0Px = {
           x: xScale.scale(xAccessor(d0)),
           y: yScale.scale(yAccessor(d0))
         };
 
-        var d1 = dataset3[1];
-        var d1Px = {
+        d1 = dataset3[1];
+        d1Px = {
           x: xScale.scale(xAccessor(d1)),
           y: yScale.scale(yAccessor(d1))
         };
+      });
 
+      it("returns correct closest plot data", () => {
         var expected = {
           data: [d0],
           pixelPoints: [d0Px],
@@ -293,30 +301,37 @@ describe("Plots", () => {
         closest = linePlot.getClosestPlotData({x: d1Px.x - 1, y: d1Px.y});
         assertPlotDataEqual(expected, closest, "if left of a point, it is closest");
 
-        xScale.domain([0.25,1]);
-        expected.pixelPoints = [{
-          x: xScale.scale(xAccessor(d1)),
-          y: yScale.scale(yAccessor(d1))
-        }];
+        svg.remove();
+      });
 
-        closest = linePlot.getClosestPlotData({x: xScale.scale(0.25), y: d1Px.y});
-        assertPlotDataEqual(expected, closest, "only in-view points are considered");
+      it("considers only in-view points", () => {
+        xScale.domain([0.25, 1]);
 
-        linePlot = new Plottable.Plot.Line(xScale, yScale);
-        expected = {
-          data: [],
-          pixelPoints: [],
-          selection: d3.selection()
+        var expected = {
+          data: [d1],
+          pixelPoints: [{
+            x: xScale.scale(xAccessor(d1)),
+            y: yScale.scale(yAccessor(d1))
+          }],
+          selection: d3.selectAll([lines[0][2]])
         };
 
-        closest = linePlot.getClosestPlotData({x: d0Px.x, y: d0Px.y});
-        assert.lengthOf(closest.data, 0, "empty plots return empty data");
-        assert.lengthOf(closest.pixelPoints, 0, "empty plots return empty pixelPoints");
-        assert.isTrue(closest.selection.empty(), "empty plots return empty selection");
+        var closest = linePlot.getClosestPlotData({ x: xScale.scale(0.25), y: d1Px.y });
+        assertPlotDataEqual(expected, closest, "only in-view points are considered");
 
         svg.remove();
       });
 
+      it("handles empty plots gracefully", () => {
+        linePlot = new Plottable.Plot.Line(xScale, yScale);
+
+        var closest = linePlot.getClosestPlotData({ x: d0Px.x, y: d0Px.y });
+        assert.lengthOf(closest.data, 0);
+        assert.lengthOf(closest.pixelPoints, 0);
+        assert.isTrue(closest.selection.empty());
+
+        svg.remove();
+      });
     });
 
     it("retains original classes when class is projected", () => {

--- a/test/components/plots/linePlotTests.ts
+++ b/test/components/plots/linePlotTests.ts
@@ -309,7 +309,7 @@ describe("Plots", () => {
           selection: d3.selection()
         };
 
-        var closest = linePlot.getClosestPlotData({x: d0Px.x, y: d0Px.y});
+        closest = linePlot.getClosestPlotData({x: d0Px.x, y: d0Px.y});
         assert.lengthOf(closest.data, 0, "empty plots return empty data");
         assert.lengthOf(closest.pixelPoints, 0, "empty plots return empty pixelPoints");
         assert.isTrue(closest.selection.empty(), "empty plots return empty selection");

--- a/test/components/plots/linePlotTests.ts
+++ b/test/components/plots/linePlotTests.ts
@@ -242,17 +242,65 @@ describe("Plots", () => {
     });
 
     describe("getClosestPlotData()", () => {
+      function assertPlotDataEqual(expected: Plottable.Plot.PlotData, actual: Plottable.Plot.PlotData, msg: string) {
+        assert.deepEqual(expected.data, actual.data, msg);
+        assert.closeTo(expected.pixelPoints[0].x, actual.pixelPoints[0].x, 0.01, msg);
+        assert.closeTo(expected.pixelPoints[0].y, actual.pixelPoints[0].y, 0.01, msg);
+        assert.deepEqual(expected.selection, actual.selection, msg);
+      }
 
       it("retrieves correct data", () => {
         var dataset3 = [
-          { foo: 0, bar: 1 },
-          { foo: 1, bar: 0.95 }
+          { foo: 0, bar: 0.75 },
+          { foo: 1, bar: 0.25 }
         ];
         linePlot.addDataset("d3", dataset3);
 
-        var lineData = linePlot.getClosestPlotData({x: 490, y: 300});
-        assert.strictEqual(lineData.selection.size(), 1, "only 1 line retreieved");
-        assert.strictEqual(lineData.data[0], dataset3[1], "correct datum retrieved");
+        var lines = d3.selectAll(".line-plot .line");
+        var d0 = dataset3[0];
+        var d0Px = {
+          x: xScale.scale(xAccessor(d0)),
+          y: yScale.scale(yAccessor(d0))
+        };
+
+        var d1 = dataset3[1];
+        var d1Px = {
+          x: xScale.scale(xAccessor(d1)),
+          y: yScale.scale(yAccessor(d1))
+        };
+
+        var expected = {
+          data: [d0],
+          pixelPoints: [d0Px],
+          selection: d3.selectAll([lines[0][2]])
+        };
+
+        var closest = linePlot.getClosestPlotData({x: d0Px.x, y: d0Px.y - 1});
+        assertPlotDataEqual(expected, closest, "if above a point, it is closest");
+
+        closest = linePlot.getClosestPlotData({x: d0Px.x, y: d0Px.y + 1});
+        assertPlotDataEqual(expected, closest, "if below a point, it is closest");
+
+        closest = linePlot.getClosestPlotData({x: d0Px.x + 1, y: d0Px.y + 1});
+        assertPlotDataEqual(expected, closest, "if right of a point, it is closest");
+
+        expected = {
+          data: [d1],
+          pixelPoints: [d1Px],
+          selection: d3.selectAll([lines[0][2]])
+        };
+
+        closest = linePlot.getClosestPlotData({x: d1Px.x - 1, y: d1Px.y});
+        assertPlotDataEqual(expected, closest, "if left of a point, it is closest");
+
+        xScale.domain([0.25,1]);
+        expected.pixelPoints = [{
+          x: xScale.scale(xAccessor(d1)),
+          y: yScale.scale(yAccessor(d1))
+        }];
+
+        closest = linePlot.getClosestPlotData({x: xScale.scale(0.25), y: d1Px.y});
+        assertPlotDataEqual(expected, closest, "only in-view points are considered");
 
         svg.remove();
       });

--- a/test/components/plots/linePlotTests.ts
+++ b/test/components/plots/linePlotTests.ts
@@ -302,6 +302,18 @@ describe("Plots", () => {
         closest = linePlot.getClosestPlotData({x: xScale.scale(0.25), y: d1Px.y});
         assertPlotDataEqual(expected, closest, "only in-view points are considered");
 
+        linePlot = new Plottable.Plot.Line(xScale, yScale);
+        expected = {
+          data: [],
+          pixelPoints: [],
+          selection: d3.selection()
+        };
+
+        var closest = linePlot.getClosestPlotData({x: d0Px.x, y: d0Px.y});
+        assert.lengthOf(closest.data, 0, "empty plots return empty data");
+        assert.lengthOf(closest.pixelPoints, 0, "empty plots return empty pixelPoints");
+        assert.isTrue(closest.selection.empty(), "empty plots return empty selection");
+
         svg.remove();
       });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -2845,29 +2845,35 @@ describe("Plots", function () {
             });
         });
         describe("getClosestPlotData()", function () {
+            var lines;
+            var d0, d1;
+            var d0Px, d1Px;
+            var dataset3;
             function assertPlotDataEqual(expected, actual, msg) {
                 assert.deepEqual(expected.data, actual.data, msg);
                 assert.closeTo(expected.pixelPoints[0].x, actual.pixelPoints[0].x, 0.01, msg);
                 assert.closeTo(expected.pixelPoints[0].y, actual.pixelPoints[0].y, 0.01, msg);
                 assert.deepEqual(expected.selection, actual.selection, msg);
             }
-            it("retrieves correct data", function () {
-                var dataset3 = [
+            beforeEach(function () {
+                dataset3 = [
                     { foo: 0, bar: 0.75 },
                     { foo: 1, bar: 0.25 }
                 ];
                 linePlot.addDataset("d3", dataset3);
-                var lines = d3.selectAll(".line-plot .line");
-                var d0 = dataset3[0];
-                var d0Px = {
+                lines = d3.selectAll(".line-plot .line");
+                d0 = dataset3[0];
+                d0Px = {
                     x: xScale.scale(xAccessor(d0)),
                     y: yScale.scale(yAccessor(d0))
                 };
-                var d1 = dataset3[1];
-                var d1Px = {
+                d1 = dataset3[1];
+                d1Px = {
                     x: xScale.scale(xAccessor(d1)),
                     y: yScale.scale(yAccessor(d1))
                 };
+            });
+            it("returns correct closest plot data", function () {
                 var expected = {
                     data: [d0],
                     pixelPoints: [d0Px],
@@ -2886,23 +2892,28 @@ describe("Plots", function () {
                 };
                 closest = linePlot.getClosestPlotData({ x: d1Px.x - 1, y: d1Px.y });
                 assertPlotDataEqual(expected, closest, "if left of a point, it is closest");
+                svg.remove();
+            });
+            it("considers only in-view points", function () {
                 xScale.domain([0.25, 1]);
-                expected.pixelPoints = [{
-                    x: xScale.scale(xAccessor(d1)),
-                    y: yScale.scale(yAccessor(d1))
-                }];
-                closest = linePlot.getClosestPlotData({ x: xScale.scale(0.25), y: d1Px.y });
-                assertPlotDataEqual(expected, closest, "only in-view points are considered");
-                linePlot = new Plottable.Plot.Line(xScale, yScale);
-                expected = {
-                    data: [],
-                    pixelPoints: [],
-                    selection: d3.selection()
+                var expected = {
+                    data: [d1],
+                    pixelPoints: [{
+                        x: xScale.scale(xAccessor(d1)),
+                        y: yScale.scale(yAccessor(d1))
+                    }],
+                    selection: d3.selectAll([lines[0][2]])
                 };
-                closest = linePlot.getClosestPlotData({ x: d0Px.x, y: d0Px.y });
-                assert.lengthOf(closest.data, 0, "empty plots return empty data");
-                assert.lengthOf(closest.pixelPoints, 0, "empty plots return empty pixelPoints");
-                assert.isTrue(closest.selection.empty(), "empty plots return empty selection");
+                var closest = linePlot.getClosestPlotData({ x: xScale.scale(0.25), y: d1Px.y });
+                assertPlotDataEqual(expected, closest, "only in-view points are considered");
+                svg.remove();
+            });
+            it("handles empty plots gracefully", function () {
+                linePlot = new Plottable.Plot.Line(xScale, yScale);
+                var closest = linePlot.getClosestPlotData({ x: d0Px.x, y: d0Px.y });
+                assert.lengthOf(closest.data, 0);
+                assert.lengthOf(closest.pixelPoints, 0);
+                assert.isTrue(closest.selection.empty());
                 svg.remove();
             });
         });

--- a/test/tests.js
+++ b/test/tests.js
@@ -2899,7 +2899,7 @@ describe("Plots", function () {
                     pixelPoints: [],
                     selection: d3.selection()
                 };
-                var closest = linePlot.getClosestPlotData({ x: d0Px.x, y: d0Px.y });
+                closest = linePlot.getClosestPlotData({ x: d0Px.x, y: d0Px.y });
                 assert.lengthOf(closest.data, 0, "empty plots return empty data");
                 assert.lengthOf(closest.pixelPoints, 0, "empty plots return empty pixelPoints");
                 assert.isTrue(closest.selection.empty(), "empty plots return empty selection");

--- a/test/tests.js
+++ b/test/tests.js
@@ -2893,6 +2893,16 @@ describe("Plots", function () {
                 }];
                 closest = linePlot.getClosestPlotData({ x: xScale.scale(0.25), y: d1Px.y });
                 assertPlotDataEqual(expected, closest, "only in-view points are considered");
+                linePlot = new Plottable.Plot.Line(xScale, yScale);
+                expected = {
+                    data: [],
+                    pixelPoints: [],
+                    selection: d3.selection()
+                };
+                var closest = linePlot.getClosestPlotData({ x: d0Px.x, y: d0Px.y });
+                assert.lengthOf(closest.data, 0, "empty plots return empty data");
+                assert.lengthOf(closest.pixelPoints, 0, "empty plots return empty pixelPoints");
+                assert.isTrue(closest.selection.empty(), "empty plots return empty selection");
                 svg.remove();
             });
         });


### PR DESCRIPTION
Brandon, a couple of questions: 

1. I've repeated code in linePlotTests.ts that could be shared once this merges with the Bar closest plot data work. See assertPlotDataEqual(). What are your thoughts on sharing this code? And where would you prefer to put it if we were to share?

2. There's also a block of code at the end of getClosestPlotData() that could be shared between the bar and line case. We can talk about that as well.