### PR TITLE
[colorScale] Quickfix for infinite recursion bug on CSS colors

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -2451,7 +2451,6 @@ var Plottable;
                     i++;
                 }
                 colorTester.remove();
-                console.log("AAA", plottableDefaultColors);
                 return plottableDefaultColors;
             };
             // Modifying the original scale method so that colors that are looped are lightened according

--- a/plottable.js
+++ b/plottable.js
@@ -2443,7 +2443,7 @@ var Plottable;
             };
             Color._getPlottableColors = function () {
                 var plottableDefaultColors = [];
-                var colorTester = d3.select("body").append("div");
+                var colorTester = d3.select("body").append("plottable");
                 var i = 0;
                 var colorHex;
                 while ((colorHex = Plottable._Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null) {
@@ -2451,6 +2451,7 @@ var Plottable;
                     i++;
                 }
                 colorTester.remove();
+                console.log("AAA", plottableDefaultColors);
                 return plottableDefaultColors;
             };
             // Modifying the original scale method so that colors that are looped are lightened according

--- a/plottable.js
+++ b/plottable.js
@@ -2443,7 +2443,7 @@ var Plottable;
             };
             Color._getPlottableColors = function () {
                 var plottableDefaultColors = [];
-                var colorTester = d3.select("body").append("plottable");
+                var colorTester = d3.select("body").append("plottable_color_testing");
                 var i = 0;
                 var colorHex;
                 while ((colorHex = Plottable._Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null) {

--- a/plottable.js
+++ b/plottable.js
@@ -2446,7 +2446,7 @@ var Plottable;
                 var colorTester = d3.select("body").append("plottable-color-tester");
                 var i = 0;
                 var colorHex;
-                while ((colorHex = Plottable._Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null) {
+                while ((colorHex = Plottable._Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null && i < this.MAXIMUM_COLORS) {
                     plottableDefaultColors.push(colorHex);
                     i++;
                 }
@@ -2464,6 +2464,7 @@ var Plottable;
             };
             Color.HEX_SCALE_FACTOR = 20;
             Color.LOOP_LIGHTEN_FACTOR = 1.6;
+            Color.MAXIMUM_COLORS = 256;
             return Color;
         })(Scale.AbstractScale);
         Scale.Color = Color;

--- a/plottable.js
+++ b/plottable.js
@@ -2448,10 +2448,10 @@ var Plottable;
                 var i = 0;
                 var colorHex;
                 while ((colorHex = Plottable._Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null) {
-                    plottableDefaultColors.push(colorHex);
                     if (colorHex === defaultColorHex && colorHex === plottableDefaultColors[plottableDefaultColors.length - 1]) {
                         break;
                     }
+                    plottableDefaultColors.push(colorHex);
                     i++;
                 }
                 colorTester.remove();

--- a/plottable.js
+++ b/plottable.js
@@ -2447,7 +2447,7 @@ var Plottable;
                 var defaultColorHex = Plottable._Util.Methods.colorTest(colorTester, "");
                 var i = 0;
                 var colorHex;
-                while ((colorHex = Plottable._Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null) {
+                while ((colorHex = Plottable._Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null && i < this.MAXIMUM_COLORS_FROM_CSS) {
                     if (colorHex === defaultColorHex && colorHex === plottableDefaultColors[plottableDefaultColors.length - 1]) {
                         break;
                     }
@@ -2468,6 +2468,8 @@ var Plottable;
             };
             Color.HEX_SCALE_FACTOR = 20;
             Color.LOOP_LIGHTEN_FACTOR = 1.6;
+            //The maximum number of colors we are getting from CSS stylesheets
+            Color.MAXIMUM_COLORS_FROM_CSS = 256;
             return Color;
         })(Scale.AbstractScale);
         Scale.Color = Color;

--- a/plottable.js
+++ b/plottable.js
@@ -2444,10 +2444,14 @@ var Plottable;
             Color._getPlottableColors = function () {
                 var plottableDefaultColors = [];
                 var colorTester = d3.select("body").append("plottable-color-tester");
+                var defaultColorHex = Plottable._Util.Methods.colorTest(colorTester, "");
                 var i = 0;
                 var colorHex;
-                while ((colorHex = Plottable._Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null && i < this.MAXIMUM_COLORS) {
+                while ((colorHex = Plottable._Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null) {
                     plottableDefaultColors.push(colorHex);
+                    if (colorHex === defaultColorHex && colorHex === plottableDefaultColors[plottableDefaultColors.length - 1]) {
+                        break;
+                    }
                     i++;
                 }
                 colorTester.remove();
@@ -2464,7 +2468,6 @@ var Plottable;
             };
             Color.HEX_SCALE_FACTOR = 20;
             Color.LOOP_LIGHTEN_FACTOR = 1.6;
-            Color.MAXIMUM_COLORS = 256;
             return Color;
         })(Scale.AbstractScale);
         Scale.Color = Color;

--- a/plottable.js
+++ b/plottable.js
@@ -2443,7 +2443,7 @@ var Plottable;
             };
             Color._getPlottableColors = function () {
                 var plottableDefaultColors = [];
-                var colorTester = d3.select("body").append("plottable_color_testing");
+                var colorTester = d3.select("body").append("plottable-color-tester");
                 var i = 0;
                 var colorHex;
                 while ((colorHex = Plottable._Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null) {

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -60,7 +60,7 @@ export module Scale {
 
     private static _getPlottableColors(): string[] {
       var plottableDefaultColors: string[] = [];
-      var colorTester = d3.select("body").append("plottable_color_testing");
+      var colorTester = d3.select("body").append("plottable-color-tester");
       var i = 0;
       var colorHex: string;
       while ((colorHex = _Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null) {

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -68,7 +68,6 @@ export module Scale {
         i++;
       }
       colorTester.remove();
-      console.log("AAA", plottableDefaultColors);
       return plottableDefaultColors;
     }
 

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -6,6 +6,7 @@ export module Scale {
 
     private static HEX_SCALE_FACTOR = 20;
     private static LOOP_LIGHTEN_FACTOR = 1.6;
+    private static MAXIMUM_COLORS = 256;
 
     /**
      * Constructs a ColorScale.
@@ -63,7 +64,8 @@ export module Scale {
       var colorTester = d3.select("body").append("plottable-color-tester");
       var i = 0;
       var colorHex: string;
-      while ((colorHex = _Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null) {
+      while ((colorHex = _Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null &&
+              i < this.MAXIMUM_COLORS) {
         plottableDefaultColors.push(colorHex);
         i++;
       }

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -60,7 +60,7 @@ export module Scale {
 
     private static _getPlottableColors(): string[] {
       var plottableDefaultColors: string[] = [];
-      var colorTester = d3.select("body").append("div");
+      var colorTester = d3.select("body").append("plottable");
       var i = 0;
       var colorHex: string;
       while ((colorHex = _Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null) {
@@ -68,6 +68,7 @@ export module Scale {
         i++;
       }
       colorTester.remove();
+      console.log("AAA", plottableDefaultColors);
       return plottableDefaultColors;
     }
 

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -6,6 +6,8 @@ export module Scale {
 
     private static HEX_SCALE_FACTOR = 20;
     private static LOOP_LIGHTEN_FACTOR = 1.6;
+    //The maximum number of colors we are getting from CSS stylesheets
+    private static MAXIMUM_COLORS_FROM_CSS = 256;
 
     /**
      * Constructs a ColorScale.
@@ -65,7 +67,8 @@ export module Scale {
       var defaultColorHex: string = _Util.Methods.colorTest(colorTester, "");
       var i = 0;
       var colorHex: string;
-      while ((colorHex = _Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null) {
+      while ((colorHex = _Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null &&
+        i < this.MAXIMUM_COLORS_FROM_CSS) {
         if (colorHex === defaultColorHex && colorHex === plottableDefaultColors[plottableDefaultColors.length - 1]) {
           break;
         }

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -6,7 +6,6 @@ export module Scale {
 
     private static HEX_SCALE_FACTOR = 20;
     private static LOOP_LIGHTEN_FACTOR = 1.6;
-    private static MAXIMUM_COLORS = 256;
 
     /**
      * Constructs a ColorScale.
@@ -62,11 +61,15 @@ export module Scale {
     private static _getPlottableColors(): string[] {
       var plottableDefaultColors: string[] = [];
       var colorTester = d3.select("body").append("plottable-color-tester");
+
+      var defaultColorHex: string = _Util.Methods.colorTest(colorTester, "");
       var i = 0;
       var colorHex: string;
-      while ((colorHex = _Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null &&
-              i < this.MAXIMUM_COLORS) {
+      while ((colorHex = _Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null) {
         plottableDefaultColors.push(colorHex);
+        if (colorHex === defaultColorHex && colorHex === plottableDefaultColors[plottableDefaultColors.length - 1]) {
+          break;
+        }
         i++;
       }
       colorTester.remove();

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -60,7 +60,7 @@ export module Scale {
 
     private static _getPlottableColors(): string[] {
       var plottableDefaultColors: string[] = [];
-      var colorTester = d3.select("body").append("plottable");
+      var colorTester = d3.select("body").append("plottable_color_testing");
       var i = 0;
       var colorHex: string;
       while ((colorHex = _Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null) {

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -66,10 +66,10 @@ export module Scale {
       var i = 0;
       var colorHex: string;
       while ((colorHex = _Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null) {
-        plottableDefaultColors.push(colorHex);
         if (colorHex === defaultColorHex && colorHex === plottableDefaultColors[plottableDefaultColors.length - 1]) {
           break;
         }
+        plottableDefaultColors.push(colorHex);
         i++;
       }
       colorTester.remove();

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -68,7 +68,7 @@ export module Scale {
       var i = 0;
       var colorHex: string;
       while ((colorHex = _Util.Methods.colorTest(colorTester, "plottable-colors-" + i)) !== null &&
-        i < this.MAXIMUM_COLORS_FROM_CSS) {
+              i < this.MAXIMUM_COLORS_FROM_CSS) {
         if (colorHex === defaultColorHex && colorHex === plottableDefaultColors[plottableDefaultColors.length - 1]) {
           break;
         }

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -291,6 +291,26 @@ describe("Scales", () => {
       assert.equal(scale.scale("a"), "#ff0000");
       assert.equal(scale.scale("b"), "#0000ff");
     });
+
+    it("accepts CSS specified colors", () => {
+      var svg = generateSVG();
+
+      svg.append("style").html(".plottable-colors-0 {background-color: #ff0000 !important; }");
+
+      var scale = new Plottable.Scale.Color();
+      assert.strictEqual(scale.range()[0], "#ff0000", "User has specified red color for first color scale color");
+      assert.strictEqual(scale.range()[1], "#fd373e", "The second color of the color scale should be the same");
+
+      // note that the remove unloads the stylesheet as well
+      svg.remove();
+
+      var defaultScale = new Plottable.Scale.Color();
+      assert.strictEqual(scale.range()[0], "#ff0000",
+        "Unloading the CSS should not modify the first scale color (this will not be the case if we support dynamic CSS");
+      assert.strictEqual(defaultScale.range()[0], "#5279c7",
+        "Unloading the CSS should cause color scales fallback to default colors");
+    });
+
   });
 
   describe("Interpolated Color Scales", () => {

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -293,16 +293,15 @@ describe("Scales", () => {
     });
 
     it("accepts CSS specified colors", () => {
-      var svg = generateSVG();
 
-      svg.append("style").html(".plottable-colors-0 {background-color: #ff0000 !important; }");
+      var style = d3.select("body").append("style");
+      style.html(".plottable-colors-0 {background-color: #ff0000 !important; }");
 
       var scale = new Plottable.Scale.Color();
       assert.strictEqual(scale.range()[0], "#ff0000", "User has specified red color for first color scale color");
       assert.strictEqual(scale.range()[1], "#fd373e", "The second color of the color scale should be the same");
 
-      // note that the remove unloads the stylesheet as well
-      svg.remove();
+      style.remove();
 
       var defaultScale = new Plottable.Scale.Color();
       assert.strictEqual(scale.range()[0], "#ff0000",

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -344,7 +344,6 @@ describe("Scales", () => {
 
       var affectedScale = new Plottable.Scale.Color();
       var maximumColorsFromCss = (<any> Plottable.Scale.Color).MAXIMUM_COLORS_FROM_CSS;
-
       assert.strictEqual(affectedScale.range().length, maximumColorsFromCss,
         "current malicious CSS countermeasure is to cap maximum number of colors to 256");
 

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -296,12 +296,11 @@ describe("Scales", () => {
 
       var style = d3.select("body").append("style");
       style.html(".plottable-colors-0 {background-color: #ff0000 !important; }");
-
       var scale = new Plottable.Scale.Color();
+      style.remove();
       assert.strictEqual(scale.range()[0], "#ff0000", "User has specified red color for first color scale color");
       assert.strictEqual(scale.range()[1], "#fd373e", "The second color of the color scale should be the same");
 
-      style.remove();
 
       var defaultScale = new Plottable.Scale.Color();
       assert.strictEqual(scale.range()[0], "#ff0000",
@@ -319,8 +318,8 @@ describe("Scales", () => {
 
       var maliciousStyle = d3.select("body").append("style");
       maliciousStyle.html("* {background-color: #fff000;}");
-
       var affectedScale = new Plottable.Scale.Color();
+      maliciousStyle.remove();
       var colorRange = affectedScale.range();
       assert.strictEqual(colorRange.length, defaultNumberOfColors + 1,
         "it should detect the end of the given colors and the fallback to the * selector, " +
@@ -331,8 +330,6 @@ describe("Scales", () => {
 
       assert.notStrictEqual(colorRange[colorRange.length - 2], "#fff000",
         "the * selector background color should be added at most once at the end");
-
-      maliciousStyle.remove();
     });
 
     it("does not crash by malicious CSS stylesheets", () => {
@@ -341,13 +338,11 @@ describe("Scales", () => {
 
       var maliciousStyle = d3.select("body").append("style");
       maliciousStyle.html("[class^='plottable-'] {background-color: pink;}");
-
       var affectedScale = new Plottable.Scale.Color();
+      maliciousStyle.remove();
       var maximumColorsFromCss = (<any> Plottable.Scale.Color).MAXIMUM_COLORS_FROM_CSS;
       assert.strictEqual(affectedScale.range().length, maximumColorsFromCss,
         "current malicious CSS countermeasure is to cap maximum number of colors to 256");
-
-      maliciousStyle.remove();
     });
 
   });

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -310,6 +310,38 @@ describe("Scales", () => {
         "Unloading the CSS should cause color scales fallback to default colors");
     });
 
+    it("should try to recover from malicious CSS styleseets", () => {
+      var defaultNumberOfColors = 10;
+
+      var initialScale = new Plottable.Scale.Color();
+      assert.strictEqual(initialScale.range().length, defaultNumberOfColors,
+        "there should initially be " + defaultNumberOfColors + " default colors");
+
+      var maliciousStyle = d3.select("body").append("style");
+      maliciousStyle.html("* {background-color: pink;}");
+
+      var affectedScale = new Plottable.Scale.Color();
+      assert.strictEqual(affectedScale.range().length, defaultNumberOfColors + 1,
+        "it should detect the end of the given colors and the fallback to the * selector, " +
+        "but should still include the last occurance of the * selector color");
+      maliciousStyle.remove();
+    });
+
+    it("does not crash by malicious CSS stylesheets", () => {
+      var initialScale = new Plottable.Scale.Color();
+      assert.strictEqual(initialScale.range().length, 10, "there should initially be 10 default colors");
+
+      var maliciousStyle = d3.select("body").append("style");
+      maliciousStyle.html("[class^='plottable-'] {background-color: pink;}");
+
+      var affectedScale = new Plottable.Scale.Color();
+      var maximumColorsFromCss = (<any> Plottable.Scale.Color).MAXIMUM_COLORS_FROM_CSS;
+      assert.strictEqual(affectedScale.range().length, maximumColorsFromCss,
+        "current malicious CSS countermeasure is to cap maximum number of colors to 256");
+
+      maliciousStyle.remove();
+    });
+
   });
 
   describe("Interpolated Color Scales", () => {

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -318,12 +318,20 @@ describe("Scales", () => {
         "there should initially be " + defaultNumberOfColors + " default colors");
 
       var maliciousStyle = d3.select("body").append("style");
-      maliciousStyle.html("* {background-color: pink;}");
+      maliciousStyle.html("* {background-color: #fff000;}");
 
       var affectedScale = new Plottable.Scale.Color();
-      assert.strictEqual(affectedScale.range().length, defaultNumberOfColors + 1,
+      var colorRange = affectedScale.range();
+      assert.strictEqual(colorRange.length, defaultNumberOfColors + 1,
         "it should detect the end of the given colors and the fallback to the * selector, " +
         "but should still include the last occurance of the * selector color");
+
+      assert.strictEqual(colorRange[colorRange.length - 1], "#fff000",
+        "the * selector background color should be added at least once at the end");
+
+      assert.notStrictEqual(colorRange[colorRange.length - 2], "#fff000",
+        "the * selector background color should be added at most once at the end");
+
       maliciousStyle.remove();
     });
 
@@ -336,6 +344,7 @@ describe("Scales", () => {
 
       var affectedScale = new Plottable.Scale.Color();
       var maximumColorsFromCss = (<any> Plottable.Scale.Color).MAXIMUM_COLORS_FROM_CSS;
+
       assert.strictEqual(affectedScale.range().length, maximumColorsFromCss,
         "current malicious CSS countermeasure is to cap maximum number of colors to 256");
 

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -293,14 +293,12 @@ describe("Scales", () => {
     });
 
     it("accepts CSS specified colors", () => {
-
       var style = d3.select("body").append("style");
       style.html(".plottable-colors-0 {background-color: #ff0000 !important; }");
       var scale = new Plottable.Scale.Color();
       style.remove();
       assert.strictEqual(scale.range()[0], "#ff0000", "User has specified red color for first color scale color");
       assert.strictEqual(scale.range()[1], "#fd373e", "The second color of the color scale should be the same");
-
 
       var defaultScale = new Plottable.Scale.Color();
       assert.strictEqual(scale.range()[0], "#ff0000",

--- a/test/tests.js
+++ b/test/tests.js
@@ -6681,9 +6681,12 @@ describe("Scales", function () {
             var initialScale = new Plottable.Scale.Color();
             assert.strictEqual(initialScale.range().length, defaultNumberOfColors, "there should initially be " + defaultNumberOfColors + " default colors");
             var maliciousStyle = d3.select("body").append("style");
-            maliciousStyle.html("* {background-color: pink;}");
+            maliciousStyle.html("* {background-color: #fff000;}");
             var affectedScale = new Plottable.Scale.Color();
-            assert.strictEqual(affectedScale.range().length, defaultNumberOfColors + 1, "it should detect the end of the given colors and the fallback to the * selector, " + "but should still include the last occurance of the * selector color");
+            var colorRange = affectedScale.range();
+            assert.strictEqual(colorRange.length, defaultNumberOfColors + 1, "it should detect the end of the given colors and the fallback to the * selector, " + "but should still include the last occurance of the * selector color");
+            assert.strictEqual(colorRange[colorRange.length - 1], "#fff000", "the * selector background color should be added at least once at the end");
+            assert.notStrictEqual(colorRange[colorRange.length - 2], "#fff000", "the * selector background color should be added at most once at the end");
             maliciousStyle.remove();
         });
         it("does not crash by malicious CSS stylesheets", function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -6669,9 +6669,9 @@ describe("Scales", function () {
             var style = d3.select("body").append("style");
             style.html(".plottable-colors-0 {background-color: #ff0000 !important; }");
             var scale = new Plottable.Scale.Color();
+            style.remove();
             assert.strictEqual(scale.range()[0], "#ff0000", "User has specified red color for first color scale color");
             assert.strictEqual(scale.range()[1], "#fd373e", "The second color of the color scale should be the same");
-            style.remove();
             var defaultScale = new Plottable.Scale.Color();
             assert.strictEqual(scale.range()[0], "#ff0000", "Unloading the CSS should not modify the first scale color (this will not be the case if we support dynamic CSS");
             assert.strictEqual(defaultScale.range()[0], "#5279c7", "Unloading the CSS should cause color scales fallback to default colors");
@@ -6683,11 +6683,11 @@ describe("Scales", function () {
             var maliciousStyle = d3.select("body").append("style");
             maliciousStyle.html("* {background-color: #fff000;}");
             var affectedScale = new Plottable.Scale.Color();
+            maliciousStyle.remove();
             var colorRange = affectedScale.range();
             assert.strictEqual(colorRange.length, defaultNumberOfColors + 1, "it should detect the end of the given colors and the fallback to the * selector, " + "but should still include the last occurance of the * selector color");
             assert.strictEqual(colorRange[colorRange.length - 1], "#fff000", "the * selector background color should be added at least once at the end");
             assert.notStrictEqual(colorRange[colorRange.length - 2], "#fff000", "the * selector background color should be added at most once at the end");
-            maliciousStyle.remove();
         });
         it("does not crash by malicious CSS stylesheets", function () {
             var initialScale = new Plottable.Scale.Color();
@@ -6695,9 +6695,9 @@ describe("Scales", function () {
             var maliciousStyle = d3.select("body").append("style");
             maliciousStyle.html("[class^='plottable-'] {background-color: pink;}");
             var affectedScale = new Plottable.Scale.Color();
+            maliciousStyle.remove();
             var maximumColorsFromCss = Plottable.Scale.Color.MAXIMUM_COLORS_FROM_CSS;
             assert.strictEqual(affectedScale.range().length, maximumColorsFromCss, "current malicious CSS countermeasure is to cap maximum number of colors to 256");
-            maliciousStyle.remove();
         });
     });
     describe("Interpolated Color Scales", function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -6666,13 +6666,12 @@ describe("Scales", function () {
             assert.equal(scale.scale("b"), "#0000ff");
         });
         it("accepts CSS specified colors", function () {
-            var svg = generateSVG();
-            svg.append("style").html(".plottable-colors-0 {background-color: #ff0000 !important; }");
+            var style = d3.select("body").append("style");
+            style.html(".plottable-colors-0 {background-color: #ff0000 !important; }");
             var scale = new Plottable.Scale.Color();
             assert.strictEqual(scale.range()[0], "#ff0000", "User has specified red color for first color scale color");
             assert.strictEqual(scale.range()[1], "#fd373e", "The second color of the color scale should be the same");
-            // note that the remove unloads the stylesheet as well
-            svg.remove();
+            style.remove();
             var defaultScale = new Plottable.Scale.Color();
             assert.strictEqual(scale.range()[0], "#ff0000", "Unloading the CSS should not modify the first scale color (this will not be the case if we support dynamic CSS");
             assert.strictEqual(defaultScale.range()[0], "#5279c7", "Unloading the CSS should cause color scales fallback to default colors");

--- a/test/tests.js
+++ b/test/tests.js
@@ -6676,6 +6676,26 @@ describe("Scales", function () {
             assert.strictEqual(scale.range()[0], "#ff0000", "Unloading the CSS should not modify the first scale color (this will not be the case if we support dynamic CSS");
             assert.strictEqual(defaultScale.range()[0], "#5279c7", "Unloading the CSS should cause color scales fallback to default colors");
         });
+        it("should try to recover from malicious CSS styleseets", function () {
+            var defaultNumberOfColors = 10;
+            var initialScale = new Plottable.Scale.Color();
+            assert.strictEqual(initialScale.range().length, defaultNumberOfColors, "there should initially be " + defaultNumberOfColors + " default colors");
+            var maliciousStyle = d3.select("body").append("style");
+            maliciousStyle.html("* {background-color: pink;}");
+            var affectedScale = new Plottable.Scale.Color();
+            assert.strictEqual(affectedScale.range().length, defaultNumberOfColors + 1, "it should detect the end of the given colors and the fallback to the * selector, " + "but should still include the last occurance of the * selector color");
+            maliciousStyle.remove();
+        });
+        it("does not crash by malicious CSS stylesheets", function () {
+            var initialScale = new Plottable.Scale.Color();
+            assert.strictEqual(initialScale.range().length, 10, "there should initially be 10 default colors");
+            var maliciousStyle = d3.select("body").append("style");
+            maliciousStyle.html("[class^='plottable-'] {background-color: pink;}");
+            var affectedScale = new Plottable.Scale.Color();
+            var maximumColorsFromCss = Plottable.Scale.Color.MAXIMUM_COLORS_FROM_CSS;
+            assert.strictEqual(affectedScale.range().length, maximumColorsFromCss, "current malicious CSS countermeasure is to cap maximum number of colors to 256");
+            maliciousStyle.remove();
+        });
     });
     describe("Interpolated Color Scales", function () {
         it("default scale uses reds and a linear scale type", function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -6665,6 +6665,18 @@ describe("Scales", function () {
             assert.equal(scale.scale("a"), "#ff0000");
             assert.equal(scale.scale("b"), "#0000ff");
         });
+        it("accepts CSS specified colors", function () {
+            var svg = generateSVG();
+            svg.append("style").html(".plottable-colors-0 {background-color: #ff0000 !important; }");
+            var scale = new Plottable.Scale.Color();
+            assert.strictEqual(scale.range()[0], "#ff0000", "User has specified red color for first color scale color");
+            assert.strictEqual(scale.range()[1], "#fd373e", "The second color of the color scale should be the same");
+            // note that the remove unloads the stylesheet as well
+            svg.remove();
+            var defaultScale = new Plottable.Scale.Color();
+            assert.strictEqual(scale.range()[0], "#ff0000", "Unloading the CSS should not modify the first scale color (this will not be the case if we support dynamic CSS");
+            assert.strictEqual(defaultScale.range()[0], "#5279c7", "Unloading the CSS should cause color scales fallback to default colors");
+        });
     });
     describe("Interpolated Color Scales", function () {
         it("default scale uses reds and a linear scale type", function () {


### PR DESCRIPTION
BLUF Creating a `<plottable_color_testing>` element is less likely to be background-colored by an external stylesheet

Added unit test. Testing the exact bug fix is not a good idea, since the bug itself freezes the entire browser. Instead UnitTest is testing if the CSS specified color is applied. By doing this we can test cross-browser solution of the fix.

Introduction: We are having an internal representation of all Components. The ColorScale knows the possible colors it can have. It does this by creating `<div>` elements and getting their color (such that CSS is also taken into account). 
Problem: Since the user can specify more than the `20` colors we use by default, the JS keeps creating `<div>`s until the divs don't have a color anymore. Also, the JS cannot read the CSS directly. Now, if the `<div>`s themselves have color set, the loop that gets the colors is infinite (and crashes browser)
```css
div { background-color: blue}
``` 
Solution (hack): Create a `<plottable-color-testing>` element, of which we get the color. There is little to no chance this will be specified in the CSS

Also added extra layers of security
- We cap the maximum number of colors we read from the CSS to 256 (such that we never ever crash the browser with an infinite loop)
- We try to recover if someone uses the * selector and we detect such thing. The way this works is: we check what is the default `background-color` of the `<plottable-color-testing>` element, call it x. We read colors until we find color x occurring twice in a row, at which point we stop, adding it only once to the final color array.

Better solutions might exist

Closes #1834 