### PR TITLE
[abstractStackedPlot] stackedBar fail gracefully when presented with wrong data

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -115,8 +115,7 @@ declare module Plottable {
             function min<C>(arr: C[], default_val: C): C;
             function min<T, C>(arr: T[], acc: (x?: T, i?: number) => C, default_val: C): C;
             /**
-             * Returns true if and only if x is NaN
-             * Will return false for values like undefined, null, infinity, strings
+             * Returns true **only** if x is NaN
              */
             function isNaN(n: any): boolean;
             /**

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -115,6 +115,11 @@ declare module Plottable {
             function min<C>(arr: C[], default_val: C): C;
             function min<T, C>(arr: T[], acc: (x?: T, i?: number) => C, default_val: C): C;
             /**
+             * Returns true if and only if x is NaN
+             * Will return false for values like undefined, null, infinity, strings
+             */
+            function isNaN(n: any): boolean;
+            /**
              * Creates shallow copy of map.
              * @param {{ [key: string]: any }} oldMap Map to copy
              *

--- a/plottable.js
+++ b/plottable.js
@@ -8516,12 +8516,12 @@ var Plottable;
                 var domainKeys = this._getDomainKeys();
                 var positiveDataMapArray = dataMapArray.map(function (dataMap) {
                     return Plottable._Util.Methods.populateMap(domainKeys, function (domainKey) {
-                        return { key: domainKey, value: Math.max(0, dataMap.get(domainKey).value) };
+                        return { key: domainKey, value: Math.max(0, dataMap.get(domainKey).value) || 0 };
                     });
                 });
                 var negativeDataMapArray = dataMapArray.map(function (dataMap) {
                     return Plottable._Util.Methods.populateMap(domainKeys, function (domainKey) {
-                        return { key: domainKey, value: Math.min(dataMap.get(domainKey).value, 0) };
+                        return { key: domainKey, value: Math.min(dataMap.get(domainKey).value, 0) || 0 };
                     });
                 });
                 this._setDatasetStackOffsets(this._stack(positiveDataMapArray), this._stack(negativeDataMapArray));

--- a/plottable.js
+++ b/plottable.js
@@ -8516,14 +8516,12 @@ var Plottable;
                 var domainKeys = this._getDomainKeys();
                 var positiveDataMapArray = dataMapArray.map(function (dataMap) {
                     return Plottable._Util.Methods.populateMap(domainKeys, function (domainKey) {
-                        // return { key: domainKey, value: Math.max(0, dataMap.get(domainKey).value) || 0 };
-                        return { key: domainKey, value: Math.max(0, dataMap.get(domainKey).value) };
+                        return { key: domainKey, value: Math.max(0, dataMap.get(domainKey).value) || 0 };
                     });
                 });
                 var negativeDataMapArray = dataMapArray.map(function (dataMap) {
                     return Plottable._Util.Methods.populateMap(domainKeys, function (domainKey) {
-                        // return { key: domainKey, value: Math.min(dataMap.get(domainKey).value, 0) || 0 };
-                        return { key: domainKey, value: Math.min(dataMap.get(domainKey).value, 0) };
+                        return { key: domainKey, value: Math.min(dataMap.get(domainKey).value, 0) || 0 };
                     });
                 });
                 this._setDatasetStackOffsets(this._stack(positiveDataMapArray), this._stack(negativeDataMapArray));

--- a/plottable.js
+++ b/plottable.js
@@ -8516,12 +8516,14 @@ var Plottable;
                 var domainKeys = this._getDomainKeys();
                 var positiveDataMapArray = dataMapArray.map(function (dataMap) {
                     return Plottable._Util.Methods.populateMap(domainKeys, function (domainKey) {
-                        return { key: domainKey, value: Math.max(0, dataMap.get(domainKey).value) || 0 };
+                        // return { key: domainKey, value: Math.max(0, dataMap.get(domainKey).value) || 0 };
+                        return { key: domainKey, value: Math.max(0, dataMap.get(domainKey).value) };
                     });
                 });
                 var negativeDataMapArray = dataMapArray.map(function (dataMap) {
                     return Plottable._Util.Methods.populateMap(domainKeys, function (domainKey) {
-                        return { key: domainKey, value: Math.min(dataMap.get(domainKey).value, 0) || 0 };
+                        // return { key: domainKey, value: Math.min(dataMap.get(domainKey).value, 0) || 0 };
+                        return { key: domainKey, value: Math.min(dataMap.get(domainKey).value, 0) };
                     });
                 });
                 this._setDatasetStackOffsets(this._stack(positiveDataMapArray), this._stack(negativeDataMapArray));

--- a/plottable.js
+++ b/plottable.js
@@ -247,8 +247,7 @@ var Plottable;
             }
             Methods.min = min;
             /**
-             * Returns true if and only if x is NaN
-             * Will return false for values like undefined, null, infinity, strings
+             * Returns true **only** if x is NaN
              */
             function isNaN(n) {
                 return n !== n;

--- a/plottable.js
+++ b/plottable.js
@@ -247,6 +247,14 @@ var Plottable;
             }
             Methods.min = min;
             /**
+             * Returns true if and only if x is NaN
+             * Will return false for values like undefined, null, infinity, strings
+             */
+            function isNaN(n) {
+                return n !== n;
+            }
+            Methods.isNaN = isNaN;
+            /**
              * Creates shallow copy of map.
              * @param {{ [key: string]: any }} oldMap Map to copy
              *

--- a/src/components/plots/abstractStackedPlot.ts
+++ b/src/components/plots/abstractStackedPlot.ts
@@ -43,13 +43,15 @@ export module Plot {
 
       var positiveDataMapArray: D3.Map<StackedDatum>[] = dataMapArray.map((dataMap) => {
         return _Util.Methods.populateMap(domainKeys, (domainKey) => {
-          return { key: domainKey, value: Math.max(0, dataMap.get(domainKey).value) || 0 };
+          // return { key: domainKey, value: Math.max(0, dataMap.get(domainKey).value) || 0 };
+          return { key: domainKey, value: Math.max(0, dataMap.get(domainKey).value) };
         });
       });
 
       var negativeDataMapArray: D3.Map<StackedDatum>[] = dataMapArray.map((dataMap) => {
         return _Util.Methods.populateMap(domainKeys, (domainKey) => {
-          return { key: domainKey, value: Math.min(dataMap.get(domainKey).value, 0) || 0 };
+          // return { key: domainKey, value: Math.min(dataMap.get(domainKey).value, 0) || 0 };
+          return { key: domainKey, value: Math.min(dataMap.get(domainKey).value, 0) };
         });
       });
 

--- a/src/components/plots/abstractStackedPlot.ts
+++ b/src/components/plots/abstractStackedPlot.ts
@@ -43,15 +43,13 @@ export module Plot {
 
       var positiveDataMapArray: D3.Map<StackedDatum>[] = dataMapArray.map((dataMap) => {
         return _Util.Methods.populateMap(domainKeys, (domainKey) => {
-          // return { key: domainKey, value: Math.max(0, dataMap.get(domainKey).value) || 0 };
-          return { key: domainKey, value: Math.max(0, dataMap.get(domainKey).value) };
+          return { key: domainKey, value: Math.max(0, dataMap.get(domainKey).value) || 0 };
         });
       });
 
       var negativeDataMapArray: D3.Map<StackedDatum>[] = dataMapArray.map((dataMap) => {
         return _Util.Methods.populateMap(domainKeys, (domainKey) => {
-          // return { key: domainKey, value: Math.min(dataMap.get(domainKey).value, 0) || 0 };
-          return { key: domainKey, value: Math.min(dataMap.get(domainKey).value, 0) };
+          return { key: domainKey, value: Math.min(dataMap.get(domainKey).value, 0) || 0 };
         });
       });
 

--- a/src/components/plots/abstractStackedPlot.ts
+++ b/src/components/plots/abstractStackedPlot.ts
@@ -43,13 +43,13 @@ export module Plot {
 
       var positiveDataMapArray: D3.Map<StackedDatum>[] = dataMapArray.map((dataMap) => {
         return _Util.Methods.populateMap(domainKeys, (domainKey) => {
-          return { key: domainKey, value: Math.max(0, dataMap.get(domainKey).value) };
+          return { key: domainKey, value: Math.max(0, dataMap.get(domainKey).value) || 0 };
         });
       });
 
       var negativeDataMapArray: D3.Map<StackedDatum>[] = dataMapArray.map((dataMap) => {
         return _Util.Methods.populateMap(domainKeys, (domainKey) => {
-          return { key: domainKey, value: Math.min(dataMap.get(domainKey).value, 0) };
+          return { key: domainKey, value: Math.min(dataMap.get(domainKey).value, 0) || 0 };
         });
       });
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -248,8 +248,7 @@ export module _Util {
     }
 
     /**
-     * Returns true if and only if x is NaN
-     * Will return false for values like undefined, null, infinity, strings
+     * Returns true **only** if x is NaN
      */
     export function isNaN(n: any) {
       return n !== n;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -248,6 +248,14 @@ export module _Util {
     }
 
     /**
+     * Returns true if and only if x is NaN
+     * Will return false for values like undefined, null, infinity, strings
+     */
+    export function isNaN(n: any) {
+      return n !== n;
+    }
+
+    /**
      * Creates shallow copy of map.
      * @param {{ [key: string]: any }} oldMap Map to copy
      *

--- a/test/components/plots/stackedBarPlotTests.ts
+++ b/test/components/plots/stackedBarPlotTests.ts
@@ -407,4 +407,66 @@ describe("Plots", () => {
       svg.remove();
     });
   });
+
+
+  describe("fail safe tests", () => {
+
+    var svg: D3.Selection;
+    var xScale: Plottable.Scale.Category;
+    var yScale: Plottable.Scale.Linear;
+    var plot: Plottable.Plot.StackedBar<string, number>;
+    var data1: Object[];
+    var data2: Object[];
+
+    beforeEach(() => {
+      svg = generateSVG(600, 400);
+
+      data1 = [
+          { x: "A", y: "s", fill: "blue" },
+      ];
+      data2 = [
+          { x: "A", y: 1, fill: "red"},
+      ];
+      xScale = new Plottable.Scale.Category();
+      yScale = new Plottable.Scale.Linear();
+
+      plot = new Plottable.Plot.StackedBar(xScale, yScale);
+      plot.addDataset("d1", data1);
+      plot.addDataset("d2", data2);
+      plot.project("fill", "fill");
+      plot.project("x", "x", xScale).project("y", "y", yScale);
+    });
+
+    afterEach(() => {
+      svg.remove();
+    });
+
+    it("conversion fails should be silent in Plot.StackedBar", () => {
+      var ds1PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d1").plotMetadata;
+      var ds2PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d2").plotMetadata;
+      var ds1FirstColumnOffset = ds1PlotMetadata.offsets.get("A");
+      var ds2FirstColumnOffset = ds2PlotMetadata.offsets.get("A");
+
+      assert.strictEqual(typeof ds1FirstColumnOffset, "number", "ds1 offset should be a number");
+      assert.strictEqual(typeof ds2FirstColumnOffset, "number", "ds2 offset should be a number");
+
+      assert.isFalse(Plottable._Util.Methods.isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should not be NaN");
+      assert.isFalse(Plottable._Util.Methods.isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should not be NaN");
+    });
+
+    it("bad values on the primary axis default to 0", () => {
+      var ds1PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d1").plotMetadata;
+      var ds2PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d2").plotMetadata;
+      var ds1FirstColumnOffset = ds1PlotMetadata.offsets.get("A");
+      var ds2FirstColumnOffset = ds2PlotMetadata.offsets.get("A");
+
+      assert.strictEqual(ds1FirstColumnOffset, 0,
+        "Plot columns should start from offset 0 (at the very bottom)");
+      assert.strictEqual(ds1FirstColumnOffset, 0,
+        "Second bar should have offset 0 (be at the very bottom) because first bar was not rendered");
+    });
+
+  });
+
+
 });

--- a/test/components/plots/stackedBarPlotTests.ts
+++ b/test/components/plots/stackedBarPlotTests.ts
@@ -411,62 +411,71 @@ describe("Plots", () => {
 
   describe("fail safe tests", () => {
 
-    var svg: D3.Selection;
-    var xScale: Plottable.Scale.Category;
-    var yScale: Plottable.Scale.Linear;
-    var plot: Plottable.Plot.StackedBar<string, number>;
-    var data1: Object[];
-    var data2: Object[];
-
-    beforeEach(() => {
-      svg = generateSVG(600, 400);
-
-      data1 = [
+    it("conversion fails should be silent in Plot.StackedBar", () => {
+      var data1 = [
           { x: "A", y: "s", fill: "blue" },
       ];
-      data2 = [
+      var data2 = [
           { x: "A", y: 1, fill: "red"},
       ];
-      xScale = new Plottable.Scale.Category();
-      yScale = new Plottable.Scale.Linear();
+      var xScale = new Plottable.Scale.Category();
+      var yScale = new Plottable.Scale.Linear();
 
-      plot = new Plottable.Plot.StackedBar(xScale, yScale);
+      var plot = new Plottable.Plot.StackedBar(xScale, yScale);
       plot.addDataset("d1", data1);
       plot.addDataset("d2", data2);
       plot.project("fill", "fill");
       plot.project("x", "x", xScale).project("y", "y", yScale);
-    });
 
-    afterEach(() => {
-      svg.remove();
-    });
-
-    it("conversion fails should be silent in Plot.StackedBar", () => {
-      var ds1PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d1").plotMetadata;
-      var ds2PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d2").plotMetadata;
-      var ds1FirstColumnOffset = ds1PlotMetadata.offsets.get("A");
-      var ds2FirstColumnOffset = ds2PlotMetadata.offsets.get("A");
+      var ds1FirstColumnOffset = (<any> plot)._key2PlotDatasetKey.get("d1").plotMetadata.offsets.get("A");
+      var ds2FirstColumnOffset = (<any> plot)._key2PlotDatasetKey.get("d2").plotMetadata.offsets.get("A");
 
       assert.strictEqual(typeof ds1FirstColumnOffset, "number", "ds1 offset should be a number");
       assert.strictEqual(typeof ds2FirstColumnOffset, "number", "ds2 offset should be a number");
 
-      assert.isFalse(Plottable._Util.Methods.isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should not be NaN");
-      assert.isFalse(Plottable._Util.Methods.isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should not be NaN");
+      assert.isFalse(Plottable._Util.Methods.isNaN(ds1FirstColumnOffset, "ds1 offset should not be NaN"));
+      assert.isFalse(Plottable._Util.Methods.isNaN(ds1FirstColumnOffset, "ds2 offset should not be NaN"));
     });
 
-    it("bad values on the primary axis default to 0", () => {
-      var ds1PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d1").plotMetadata;
-      var ds2PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d2").plotMetadata;
-      var ds1FirstColumnOffset = ds1PlotMetadata.offsets.get("A");
-      var ds2FirstColumnOffset = ds2PlotMetadata.offsets.get("A");
+    it("bad values on the primary axis should default to 0 (be ignored)", () => {
+      var data1 = [
+          { x: "A", y: 1, fill: "blue" },
+      ];
+      var data2 = [
+          { x: "A", y: "s", fill: "red"},
+      ];
+      var data3 = [
+          { x: "A", y: 2, fill: "green"},
+      ];
+      var data4 = [
+          { x: "A", y: "0", fill: "purple"},
+      ];
+      var data5 = [
+          { x: "A", y: 3, fill: "pink"},
+      ];
 
-      assert.strictEqual(ds1FirstColumnOffset, 0,
+      var xScale = new Plottable.Scale.Category();
+      var yScale = new Plottable.Scale.Linear();
+
+      var plot = new Plottable.Plot.StackedBar(xScale, yScale);
+      plot.addDataset("d1", data1);
+      plot.addDataset("d2", data2);
+      plot.addDataset("d3", data3);
+      plot.addDataset("d4", data4);
+      plot.addDataset("d5", data5);
+      plot.project("fill", "fill");
+      plot.project("x", "x", xScale).project("y", "y", yScale);
+
+      var offset1 = (<any> plot)._key2PlotDatasetKey.get("d1").plotMetadata.offsets.get("A");
+      var offset3 = (<any> plot)._key2PlotDatasetKey.get("d3").plotMetadata.offsets.get("A");
+      var offset5 = (<any> plot)._key2PlotDatasetKey.get("d5").plotMetadata.offsets.get("A");
+
+      assert.strictEqual(offset1, 0,
         "Plot columns should start from offset 0 (at the very bottom)");
-      assert.strictEqual(ds1FirstColumnOffset, 0,
-        "Second bar should have offset 0 (be at the very bottom) because first bar was not rendered");
+      assert.strictEqual(offset3, 1,
+        "Bar 3 should have offset 1, because bar 2 was not rendered");
+      assert.strictEqual(offset5, 3,
+        "Bar 5 should have offset 3, because bar 4 was not rendered");
     });
-
   });
-
-
 });

--- a/test/components/plots/stackedBarPlotTests.ts
+++ b/test/components/plots/stackedBarPlotTests.ts
@@ -433,8 +433,8 @@ describe("Plots", () => {
       assert.strictEqual(typeof ds1FirstColumnOffset, "number", "ds1 offset should be a number");
       assert.strictEqual(typeof ds2FirstColumnOffset, "number", "ds2 offset should be a number");
 
-      assert.isFalse(Plottable._Util.Methods.isNaN(ds1FirstColumnOffset, "ds1 offset should not be NaN"));
-      assert.isFalse(Plottable._Util.Methods.isNaN(ds1FirstColumnOffset, "ds2 offset should not be NaN"));
+      assert.isFalse(Plottable._Util.Methods.isNaN(ds1FirstColumnOffset), "ds1 offset should not be NaN");
+      assert.isFalse(Plottable._Util.Methods.isNaN(ds1FirstColumnOffset), "ds2 offset should not be NaN");
     });
 
     it("bad values on the primary axis should default to 0 (be ignored)", () => {

--- a/test/components/plots/stackedPlotTests.ts
+++ b/test/components/plots/stackedPlotTests.ts
@@ -267,52 +267,6 @@ describe("Plots", () => {
     });
   });
 
-  describe("fail safe tests", () => {
-
-    var svg: D3.Selection;
-    var xScale: Plottable.Scale.Category;
-    var yScale: Plottable.Scale.Linear;
-    var data1: Object[];
-    var data2: Object[];
-
-    beforeEach(() => {
-      svg = generateSVG(600, 400);
-
-      data1 = [
-          { x: "A", y: "s", fill: "blue" },
-      ];
-      data2 = [
-          { x: "A", y: 1, fill: "red"},
-      ];
-      xScale = new Plottable.Scale.Category();
-      yScale = new Plottable.Scale.Linear();
-    });
-
-    afterEach(() => {
-      svg.remove();
-    });
-
-    it("conversion fails should be silent in Plot.StackedBar", () => {
-      var plot = new Plottable.Plot.StackedBar(xScale, yScale);
-      plot.addDataset("d1", data1);
-      plot.addDataset("d2", data2);
-      plot.project("fill", "fill");
-      plot.project("x", "x", xScale).project("y", "y", yScale);
-
-      var ds1PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d1").plotMetadata;
-      var ds2PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d2").plotMetadata;
-      var ds1FirstColumnOffset = ds1PlotMetadata.offsets.get("A");
-      var ds2FirstColumnOffset = ds2PlotMetadata.offsets.get("A");
-
-      assert.strictEqual(typeof ds1FirstColumnOffset, "number", "ds1 offset should be a valid number");
-      assert.strictEqual(typeof ds2FirstColumnOffset, "number", "ds2 offset should be a valid number");
-
-      assert.isFalse(Plottable._Util.Methods.isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a valid number");
-      assert.isFalse(Plottable._Util.Methods.isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a valid number");
-    });
-
-  });
-
   describe("scale extent updates", () => {
     var svg: D3.Selection;
     var xScale: Plottable.Scale.Category;

--- a/test/components/plots/stackedPlotTests.ts
+++ b/test/components/plots/stackedPlotTests.ts
@@ -292,7 +292,7 @@ describe("Plots", () => {
       svg.remove();
     });
 
-    it("conversion fails should be silent in stackedBarPlot", () => {
+    it("conversion fails should be silent in Plot.StackedBar", () => {
       var plot = new Plottable.Plot.StackedBar(xScale, yScale);
       plot.addDataset("d1", data1);
       plot.addDataset("d2", data2);
@@ -301,12 +301,17 @@ describe("Plots", () => {
 
       var ds1PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d1").plotMetadata;
       var ds2PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d2").plotMetadata;
+      var ds1FirstColumnOffset = ds1PlotMetadata.offsets.get("A");
+      var ds2FirstColumnOffset = ds2PlotMetadata.offsets.get("A");
 
-      assert.isFalse(isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a number");
-      assert.isFalse(isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a number");
+      assert.strictEqual(typeof ds1FirstColumnOffset, "number", "ds1 offset should be a valid number");
+      assert.strictEqual(typeof ds2FirstColumnOffset, "number", "ds2 offset should be a valid number");
+
+      assert.isFalse(Plottable._Util.Methods.isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a valid number");
+      assert.isFalse(Plottable._Util.Methods.isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a valid number");
     });
 
-    it("conversion fails should be silent in stackedAreaPlot", () => {
+    it("conversion fails should be silent in Plot.StackedArea", () => {
       var plot = new Plottable.Plot.StackedArea(xScale, yScale);
       plot.addDataset("d1", data1);
       plot.addDataset("d2", data2);
@@ -315,9 +320,14 @@ describe("Plots", () => {
 
       var ds1PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d1").plotMetadata;
       var ds2PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d2").plotMetadata;
+      var ds1FirstColumnOffset = ds1PlotMetadata.offsets.get("A");
+      var ds2FirstColumnOffset = ds2PlotMetadata.offsets.get("A");
 
-      assert.isFalse(isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a number");
-      assert.isFalse(isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a number");
+      assert.strictEqual(typeof ds1FirstColumnOffset, "number", "ds1 offset should be a valid number");
+      assert.strictEqual(typeof ds2FirstColumnOffset, "number", "ds2 offset should be a valid number");
+
+      assert.isFalse(Plottable._Util.Methods.isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a valid number");
+      assert.isFalse(Plottable._Util.Methods.isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a valid number");
     });
 
   });

--- a/test/components/plots/stackedPlotTests.ts
+++ b/test/components/plots/stackedPlotTests.ts
@@ -294,24 +294,30 @@ describe("Plots", () => {
 
     it("conversion fails should be silent in stackedBarPlot", () => {
       var plot = new Plottable.Plot.StackedBar(xScale, yScale);
-      plot.addDataset(data1);
-      plot.addDataset(data2);
+      plot.addDataset("d1", data1);
+      plot.addDataset("d2", data2);
       plot.project("fill", "fill");
       plot.project("x", "x", xScale).project("y", "y", yScale);
 
-      window.onerror = function(message, file, lineNumber) {
-        console.log('a');
-        alert('what');
-        return false;
-      }
+      var ds1PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d1").plotMetadata;
+      var ds2PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d2").plotMetadata;
 
-      plot.renderTo(svg);
+      assert.isFalse(isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a number");
+      assert.isFalse(isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a number");
+    });
 
-      assert.isTrue(true);
+    it("conversion fails should be silent in stackedAreaPlot", () => {
+      var plot = new Plottable.Plot.StackedArea(xScale, yScale);
+      plot.addDataset("d1", data1);
+      plot.addDataset("d2", data2);
+      plot.project("fill", "fill");
+      plot.project("x", "x", xScale).project("y", "y", yScale);
 
+      var ds1PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d1").plotMetadata;
+      var ds2PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d2").plotMetadata;
 
-      console.log(window.onerror);
-
+      assert.isFalse(isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a number");
+      assert.isFalse(isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a number");
     });
 
   });

--- a/test/components/plots/stackedPlotTests.ts
+++ b/test/components/plots/stackedPlotTests.ts
@@ -267,6 +267,55 @@ describe("Plots", () => {
     });
   });
 
+  describe("fail safe tests", () => {
+
+    var svg: D3.Selection;
+    var xScale: Plottable.Scale.Category;
+    var yScale: Plottable.Scale.Linear;
+    var data1: Object[];
+    var data2: Object[];
+
+    beforeEach(() => {
+      svg = generateSVG(600, 400);
+
+      data1 = [
+          { x: "A", y: "s", fill: "blue" },
+      ];
+      data2 = [
+          { x: "A", y: 1, fill: "red"},
+      ];
+      xScale = new Plottable.Scale.Category();
+      yScale = new Plottable.Scale.Linear();
+    });
+
+    afterEach(() => {
+      svg.remove();
+    });
+
+    it("conversion fails should be silent in stackedBarPlot", () => {
+      var plot = new Plottable.Plot.StackedBar(xScale, yScale);
+      plot.addDataset(data1);
+      plot.addDataset(data2);
+      plot.project("fill", "fill");
+      plot.project("x", "x", xScale).project("y", "y", yScale);
+
+      window.onerror = function(message, file, lineNumber) {
+        console.log('a');
+        alert('what');
+        return false;
+      }
+
+      plot.renderTo(svg);
+
+      assert.isTrue(true);
+
+
+      console.log(window.onerror);
+
+    });
+
+  });
+
   describe("scale extent updates", () => {
     var svg: D3.Selection;
     var xScale: Plottable.Scale.Category;

--- a/test/components/plots/stackedPlotTests.ts
+++ b/test/components/plots/stackedPlotTests.ts
@@ -311,25 +311,6 @@ describe("Plots", () => {
       assert.isFalse(Plottable._Util.Methods.isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a valid number");
     });
 
-    it("conversion fails should be silent in Plot.StackedArea", () => {
-      var plot = new Plottable.Plot.StackedArea(xScale, yScale);
-      plot.addDataset("d1", data1);
-      plot.addDataset("d2", data2);
-      plot.project("fill", "fill");
-      plot.project("x", "x", xScale).project("y", "y", yScale);
-
-      var ds1PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d1").plotMetadata;
-      var ds2PlotMetadata = <Plottable.Plot.StackedPlotMetadata>(<any> plot)._key2PlotDatasetKey.get("d2").plotMetadata;
-      var ds1FirstColumnOffset = ds1PlotMetadata.offsets.get("A");
-      var ds2FirstColumnOffset = ds2PlotMetadata.offsets.get("A");
-
-      assert.strictEqual(typeof ds1FirstColumnOffset, "number", "ds1 offset should be a valid number");
-      assert.strictEqual(typeof ds2FirstColumnOffset, "number", "ds2 offset should be a valid number");
-
-      assert.isFalse(Plottable._Util.Methods.isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a valid number");
-      assert.isFalse(Plottable._Util.Methods.isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a valid number");
-    });
-
   });
 
   describe("scale extent updates", () => {

--- a/test/tests.js
+++ b/test/tests.js
@@ -5324,8 +5324,8 @@ describe("Plots", function () {
             var ds2FirstColumnOffset = plot._key2PlotDatasetKey.get("d2").plotMetadata.offsets.get("A");
             assert.strictEqual(typeof ds1FirstColumnOffset, "number", "ds1 offset should be a number");
             assert.strictEqual(typeof ds2FirstColumnOffset, "number", "ds2 offset should be a number");
-            assert.isFalse(Plottable._Util.Methods.isNaN(ds1FirstColumnOffset, "ds1 offset should not be NaN"));
-            assert.isFalse(Plottable._Util.Methods.isNaN(ds1FirstColumnOffset, "ds2 offset should not be NaN"));
+            assert.isFalse(Plottable._Util.Methods.isNaN(ds1FirstColumnOffset), "ds1 offset should not be NaN");
+            assert.isFalse(Plottable._Util.Methods.isNaN(ds1FirstColumnOffset), "ds2 offset should not be NaN");
         });
         it("bad values on the primary axis should default to 0 (be ignored)", function () {
             var data1 = [

--- a/test/tests.js
+++ b/test/tests.js
@@ -4603,6 +4603,42 @@ describe("Plots", function () {
             svg.remove();
         });
     });
+    describe("fail safe tests", function () {
+        var svg;
+        var xScale;
+        var yScale;
+        var data1;
+        var data2;
+        beforeEach(function () {
+            svg = generateSVG(600, 400);
+            data1 = [
+                { x: "A", y: "s", fill: "blue" },
+            ];
+            data2 = [
+                { x: "A", y: 1, fill: "red" },
+            ];
+            xScale = new Plottable.Scale.Category();
+            yScale = new Plottable.Scale.Linear();
+        });
+        afterEach(function () {
+            svg.remove();
+        });
+        it("conversion fails should be silent in stackedBarPlot", function () {
+            var plot = new Plottable.Plot.StackedBar(xScale, yScale);
+            plot.addDataset(data1);
+            plot.addDataset(data2);
+            plot.project("fill", "fill");
+            plot.project("x", "x", xScale).project("y", "y", yScale);
+            window.onerror = function (message, file, lineNumber) {
+                console.log('a');
+                alert('what');
+                return false;
+            };
+            plot.renderTo(svg);
+            assert.isTrue(true);
+            console.log(window.onerror);
+        });
+    });
     describe("scale extent updates", function () {
         var svg;
         var xScale;

--- a/test/tests.js
+++ b/test/tests.js
@@ -4623,7 +4623,7 @@ describe("Plots", function () {
         afterEach(function () {
             svg.remove();
         });
-        it("conversion fails should be silent in stackedBarPlot", function () {
+        it("conversion fails should be silent in Plot.StackedBar", function () {
             var plot = new Plottable.Plot.StackedBar(xScale, yScale);
             plot.addDataset("d1", data1);
             plot.addDataset("d2", data2);
@@ -4631,10 +4631,14 @@ describe("Plots", function () {
             plot.project("x", "x", xScale).project("y", "y", yScale);
             var ds1PlotMetadata = plot._key2PlotDatasetKey.get("d1").plotMetadata;
             var ds2PlotMetadata = plot._key2PlotDatasetKey.get("d2").plotMetadata;
-            assert.isFalse(isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a number");
-            assert.isFalse(isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a number");
+            var ds1FirstColumnOffset = ds1PlotMetadata.offsets.get("A");
+            var ds2FirstColumnOffset = ds2PlotMetadata.offsets.get("A");
+            assert.strictEqual(typeof ds1FirstColumnOffset, "number", "ds1 offset should be a valid number");
+            assert.strictEqual(typeof ds2FirstColumnOffset, "number", "ds2 offset should be a valid number");
+            assert.isFalse(Plottable._Util.Methods.isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a valid number");
+            assert.isFalse(Plottable._Util.Methods.isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a valid number");
         });
-        it("conversion fails should be silent in stackedAreaPlot", function () {
+        it("conversion fails should be silent in Plot.StackedArea", function () {
             var plot = new Plottable.Plot.StackedArea(xScale, yScale);
             plot.addDataset("d1", data1);
             plot.addDataset("d2", data2);
@@ -4642,8 +4646,12 @@ describe("Plots", function () {
             plot.project("x", "x", xScale).project("y", "y", yScale);
             var ds1PlotMetadata = plot._key2PlotDatasetKey.get("d1").plotMetadata;
             var ds2PlotMetadata = plot._key2PlotDatasetKey.get("d2").plotMetadata;
-            assert.isFalse(isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a number");
-            assert.isFalse(isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a number");
+            var ds1FirstColumnOffset = ds1PlotMetadata.offsets.get("A");
+            var ds2FirstColumnOffset = ds2PlotMetadata.offsets.get("A");
+            assert.strictEqual(typeof ds1FirstColumnOffset, "number", "ds1 offset should be a valid number");
+            assert.strictEqual(typeof ds2FirstColumnOffset, "number", "ds2 offset should be a valid number");
+            assert.isFalse(Plottable._Util.Methods.isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a valid number");
+            assert.isFalse(Plottable._Util.Methods.isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a valid number");
         });
     });
     describe("scale extent updates", function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -4625,18 +4625,25 @@ describe("Plots", function () {
         });
         it("conversion fails should be silent in stackedBarPlot", function () {
             var plot = new Plottable.Plot.StackedBar(xScale, yScale);
-            plot.addDataset(data1);
-            plot.addDataset(data2);
+            plot.addDataset("d1", data1);
+            plot.addDataset("d2", data2);
             plot.project("fill", "fill");
             plot.project("x", "x", xScale).project("y", "y", yScale);
-            window.onerror = function (message, file, lineNumber) {
-                console.log('a');
-                alert('what');
-                return false;
-            };
-            plot.renderTo(svg);
-            assert.isTrue(true);
-            console.log(window.onerror);
+            var ds1PlotMetadata = plot._key2PlotDatasetKey.get("d1").plotMetadata;
+            var ds2PlotMetadata = plot._key2PlotDatasetKey.get("d2").plotMetadata;
+            assert.isFalse(isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a number");
+            assert.isFalse(isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a number");
+        });
+        it("conversion fails should be silent in stackedAreaPlot", function () {
+            var plot = new Plottable.Plot.StackedArea(xScale, yScale);
+            plot.addDataset("d1", data1);
+            plot.addDataset("d2", data2);
+            plot.project("fill", "fill");
+            plot.project("x", "x", xScale).project("y", "y", yScale);
+            var ds1PlotMetadata = plot._key2PlotDatasetKey.get("d1").plotMetadata;
+            var ds2PlotMetadata = plot._key2PlotDatasetKey.get("d2").plotMetadata;
+            assert.isFalse(isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a number");
+            assert.isFalse(isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a number");
         });
     });
     describe("scale extent updates", function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -4638,21 +4638,6 @@ describe("Plots", function () {
             assert.isFalse(Plottable._Util.Methods.isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a valid number");
             assert.isFalse(Plottable._Util.Methods.isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a valid number");
         });
-        it("conversion fails should be silent in Plot.StackedArea", function () {
-            var plot = new Plottable.Plot.StackedArea(xScale, yScale);
-            plot.addDataset("d1", data1);
-            plot.addDataset("d2", data2);
-            plot.project("fill", "fill");
-            plot.project("x", "x", xScale).project("y", "y", yScale);
-            var ds1PlotMetadata = plot._key2PlotDatasetKey.get("d1").plotMetadata;
-            var ds2PlotMetadata = plot._key2PlotDatasetKey.get("d2").plotMetadata;
-            var ds1FirstColumnOffset = ds1PlotMetadata.offsets.get("A");
-            var ds2FirstColumnOffset = ds2PlotMetadata.offsets.get("A");
-            assert.strictEqual(typeof ds1FirstColumnOffset, "number", "ds1 offset should be a valid number");
-            assert.strictEqual(typeof ds2FirstColumnOffset, "number", "ds2 offset should be a valid number");
-            assert.isFalse(Plottable._Util.Methods.isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a valid number");
-            assert.isFalse(Plottable._Util.Methods.isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a valid number");
-        });
     });
     describe("scale extent updates", function () {
         var svg;

--- a/test/tests.js
+++ b/test/tests.js
@@ -4603,42 +4603,6 @@ describe("Plots", function () {
             svg.remove();
         });
     });
-    describe("fail safe tests", function () {
-        var svg;
-        var xScale;
-        var yScale;
-        var data1;
-        var data2;
-        beforeEach(function () {
-            svg = generateSVG(600, 400);
-            data1 = [
-                { x: "A", y: "s", fill: "blue" },
-            ];
-            data2 = [
-                { x: "A", y: 1, fill: "red" },
-            ];
-            xScale = new Plottable.Scale.Category();
-            yScale = new Plottable.Scale.Linear();
-        });
-        afterEach(function () {
-            svg.remove();
-        });
-        it("conversion fails should be silent in Plot.StackedBar", function () {
-            var plot = new Plottable.Plot.StackedBar(xScale, yScale);
-            plot.addDataset("d1", data1);
-            plot.addDataset("d2", data2);
-            plot.project("fill", "fill");
-            plot.project("x", "x", xScale).project("y", "y", yScale);
-            var ds1PlotMetadata = plot._key2PlotDatasetKey.get("d1").plotMetadata;
-            var ds2PlotMetadata = plot._key2PlotDatasetKey.get("d2").plotMetadata;
-            var ds1FirstColumnOffset = ds1PlotMetadata.offsets.get("A");
-            var ds2FirstColumnOffset = ds2PlotMetadata.offsets.get("A");
-            assert.strictEqual(typeof ds1FirstColumnOffset, "number", "ds1 offset should be a valid number");
-            assert.strictEqual(typeof ds2FirstColumnOffset, "number", "ds2 offset should be a valid number");
-            assert.isFalse(Plottable._Util.Methods.isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should be a valid number");
-            assert.isFalse(Plottable._Util.Methods.isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should be a valid number");
-        });
-    });
     describe("scale extent updates", function () {
         var svg;
         var xScale;
@@ -5339,6 +5303,51 @@ describe("Plots", function () {
             assert.closeTo(numAttr(cBars[0], "y"), numAttr(cBars[1], "y"), 0.01, "C bars at same y position");
             assert.operator(numAttr(cBars[0], "x"), "<", numAttr(cBars[1], "x"), "first dataset C bar under second");
             svg.remove();
+        });
+    });
+    describe("fail safe tests", function () {
+        var svg;
+        var xScale;
+        var yScale;
+        var plot;
+        var data1;
+        var data2;
+        beforeEach(function () {
+            svg = generateSVG(600, 400);
+            data1 = [
+                { x: "A", y: "s", fill: "blue" },
+            ];
+            data2 = [
+                { x: "A", y: 1, fill: "red" },
+            ];
+            xScale = new Plottable.Scale.Category();
+            yScale = new Plottable.Scale.Linear();
+            plot = new Plottable.Plot.StackedBar(xScale, yScale);
+            plot.addDataset("d1", data1);
+            plot.addDataset("d2", data2);
+            plot.project("fill", "fill");
+            plot.project("x", "x", xScale).project("y", "y", yScale);
+        });
+        afterEach(function () {
+            svg.remove();
+        });
+        it("conversion fails should be silent in Plot.StackedBar", function () {
+            var ds1PlotMetadata = plot._key2PlotDatasetKey.get("d1").plotMetadata;
+            var ds2PlotMetadata = plot._key2PlotDatasetKey.get("d2").plotMetadata;
+            var ds1FirstColumnOffset = ds1PlotMetadata.offsets.get("A");
+            var ds2FirstColumnOffset = ds2PlotMetadata.offsets.get("A");
+            assert.strictEqual(typeof ds1FirstColumnOffset, "number", "ds1 offset should be a number");
+            assert.strictEqual(typeof ds2FirstColumnOffset, "number", "ds2 offset should be a number");
+            assert.isFalse(Plottable._Util.Methods.isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should not be NaN");
+            assert.isFalse(Plottable._Util.Methods.isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should not be NaN");
+        });
+        it("bad values on the primary axis default to 0", function () {
+            var ds1PlotMetadata = plot._key2PlotDatasetKey.get("d1").plotMetadata;
+            var ds2PlotMetadata = plot._key2PlotDatasetKey.get("d2").plotMetadata;
+            var ds1FirstColumnOffset = ds1PlotMetadata.offsets.get("A");
+            var ds2FirstColumnOffset = ds2PlotMetadata.offsets.get("A");
+            assert.strictEqual(ds1FirstColumnOffset, 0, "Plot columns should start from offset 0 (at the very bottom)");
+            assert.strictEqual(ds1FirstColumnOffset, 0, "Second bar should have offset 0 (be at the very bottom) because first bar was not rendered");
         });
     });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -5306,48 +5306,59 @@ describe("Plots", function () {
         });
     });
     describe("fail safe tests", function () {
-        var svg;
-        var xScale;
-        var yScale;
-        var plot;
-        var data1;
-        var data2;
-        beforeEach(function () {
-            svg = generateSVG(600, 400);
-            data1 = [
+        it("conversion fails should be silent in Plot.StackedBar", function () {
+            var data1 = [
                 { x: "A", y: "s", fill: "blue" },
             ];
-            data2 = [
+            var data2 = [
                 { x: "A", y: 1, fill: "red" },
             ];
-            xScale = new Plottable.Scale.Category();
-            yScale = new Plottable.Scale.Linear();
-            plot = new Plottable.Plot.StackedBar(xScale, yScale);
+            var xScale = new Plottable.Scale.Category();
+            var yScale = new Plottable.Scale.Linear();
+            var plot = new Plottable.Plot.StackedBar(xScale, yScale);
             plot.addDataset("d1", data1);
             plot.addDataset("d2", data2);
             plot.project("fill", "fill");
             plot.project("x", "x", xScale).project("y", "y", yScale);
-        });
-        afterEach(function () {
-            svg.remove();
-        });
-        it("conversion fails should be silent in Plot.StackedBar", function () {
-            var ds1PlotMetadata = plot._key2PlotDatasetKey.get("d1").plotMetadata;
-            var ds2PlotMetadata = plot._key2PlotDatasetKey.get("d2").plotMetadata;
-            var ds1FirstColumnOffset = ds1PlotMetadata.offsets.get("A");
-            var ds2FirstColumnOffset = ds2PlotMetadata.offsets.get("A");
+            var ds1FirstColumnOffset = plot._key2PlotDatasetKey.get("d1").plotMetadata.offsets.get("A");
+            var ds2FirstColumnOffset = plot._key2PlotDatasetKey.get("d2").plotMetadata.offsets.get("A");
             assert.strictEqual(typeof ds1FirstColumnOffset, "number", "ds1 offset should be a number");
             assert.strictEqual(typeof ds2FirstColumnOffset, "number", "ds2 offset should be a number");
-            assert.isFalse(Plottable._Util.Methods.isNaN(ds1PlotMetadata.offsets.get("A")), "ds1 offset should not be NaN");
-            assert.isFalse(Plottable._Util.Methods.isNaN(ds2PlotMetadata.offsets.get("A")), "ds2 offset should not be NaN");
+            assert.isFalse(Plottable._Util.Methods.isNaN(ds1FirstColumnOffset, "ds1 offset should not be NaN"));
+            assert.isFalse(Plottable._Util.Methods.isNaN(ds1FirstColumnOffset, "ds2 offset should not be NaN"));
         });
-        it("bad values on the primary axis default to 0", function () {
-            var ds1PlotMetadata = plot._key2PlotDatasetKey.get("d1").plotMetadata;
-            var ds2PlotMetadata = plot._key2PlotDatasetKey.get("d2").plotMetadata;
-            var ds1FirstColumnOffset = ds1PlotMetadata.offsets.get("A");
-            var ds2FirstColumnOffset = ds2PlotMetadata.offsets.get("A");
-            assert.strictEqual(ds1FirstColumnOffset, 0, "Plot columns should start from offset 0 (at the very bottom)");
-            assert.strictEqual(ds1FirstColumnOffset, 0, "Second bar should have offset 0 (be at the very bottom) because first bar was not rendered");
+        it("bad values on the primary axis should default to 0 (be ignored)", function () {
+            var data1 = [
+                { x: "A", y: 1, fill: "blue" },
+            ];
+            var data2 = [
+                { x: "A", y: "s", fill: "red" },
+            ];
+            var data3 = [
+                { x: "A", y: 2, fill: "green" },
+            ];
+            var data4 = [
+                { x: "A", y: "0", fill: "purple" },
+            ];
+            var data5 = [
+                { x: "A", y: 3, fill: "pink" },
+            ];
+            var xScale = new Plottable.Scale.Category();
+            var yScale = new Plottable.Scale.Linear();
+            var plot = new Plottable.Plot.StackedBar(xScale, yScale);
+            plot.addDataset("d1", data1);
+            plot.addDataset("d2", data2);
+            plot.addDataset("d3", data3);
+            plot.addDataset("d4", data4);
+            plot.addDataset("d5", data5);
+            plot.project("fill", "fill");
+            plot.project("x", "x", xScale).project("y", "y", yScale);
+            var offset1 = plot._key2PlotDatasetKey.get("d1").plotMetadata.offsets.get("A");
+            var offset3 = plot._key2PlotDatasetKey.get("d3").plotMetadata.offsets.get("A");
+            var offset5 = plot._key2PlotDatasetKey.get("d5").plotMetadata.offsets.get("A");
+            assert.strictEqual(offset1, 0, "Plot columns should start from offset 0 (at the very bottom)");
+            assert.strictEqual(offset3, 1, "Bar 3 should have offset 1, because bar 2 was not rendered");
+            assert.strictEqual(offset5, 3, "Bar 5 should have offset 3, because bar 4 was not rendered");
         });
     });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -8119,6 +8119,18 @@ describe("_Util.Methods", function () {
             assert.deepEqual(max([], today), today, "correct default non-numeric value returned");
         });
     });
+    it("isNaN works as expected", function () {
+        var isNaN = Plottable._Util.Methods.isNaN;
+        assert.isTrue(isNaN(NaN), "Only NaN should pass the isNaN check");
+        assert.isFalse(isNaN(undefined), "undefined should fail the isNaN check");
+        assert.isFalse(isNaN(null), "null should fail the isNaN check");
+        assert.isFalse(isNaN(Infinity), "Infinity should fail the isNaN check");
+        assert.isFalse(isNaN(1), "numbers should fail the isNaN check");
+        assert.isFalse(isNaN(0), "0 should fail the isNaN check");
+        assert.isFalse(isNaN("foo"), "strings should fail the isNaN check");
+        assert.isFalse(isNaN(""), "empty strings should fail the isNaN check");
+        assert.isFalse(isNaN({}), "empty Objects should fail the isNaN check");
+    });
     it("objEq works as expected", function () {
         assert.isTrue(Plottable._Util.Methods.objEq({}, {}));
         assert.isTrue(Plottable._Util.Methods.objEq({ a: 5 }, { a: 5 }));

--- a/test/utils/utilsTests.ts
+++ b/test/utils/utilsTests.ts
@@ -93,6 +93,21 @@ describe("_Util.Methods", () => {
     });
   });
 
+  it("isNaN works as expected", () => {
+    var isNaN = Plottable._Util.Methods.isNaN;
+
+    assert.isTrue(isNaN(NaN), "Only NaN should pass the isNaN check");
+
+    assert.isFalse(isNaN(undefined), "undefined should fail the isNaN check");
+    assert.isFalse(isNaN(null), "null should fail the isNaN check");
+    assert.isFalse(isNaN(Infinity), "Infinity should fail the isNaN check");
+    assert.isFalse(isNaN(1), "numbers should fail the isNaN check");
+    assert.isFalse(isNaN(0), "0 should fail the isNaN check");
+    assert.isFalse(isNaN("foo"), "strings should fail the isNaN check");
+    assert.isFalse(isNaN(""), "empty strings should fail the isNaN check");
+    assert.isFalse(isNaN({}), "empty Objects should fail the isNaN check");
+  });
+
   it("objEq works as expected", () => {
     assert.isTrue(Plottable._Util.Methods.objEq({}, {}));
     assert.isTrue(Plottable._Util.Methods.objEq({a: 5}, {a: 5}));


### PR DESCRIPTION
Closes #1838

Before: http://jsfiddle.net/d2te4yct/
After: http://jsfiddle.net/d2te4yct/2/

Technical description: If the y-value of one of the data sets was not convertible to string for a given x-value, all subsequent bars that would stack on top of the broken bar for that x-value (for example in the fiddle the red bar is in air)
Exception thrown: `Error: Invalid value for <rect> attribute y="NaN"`
Solution: Default y-values to 0, when the string cannot be converted to the number

**Alternative approach**
Throw an exception when user presents such data. The difference is that the exception should be more meaningful. User most probably did not want to specify a non-convertible string for a numeric y-axis. @jtlan @bluong What do you think?
**Decision** : We do not want that behavior