### PR TITLE
[triggerFakeWheelEvent util] - Safari compatible

### DIFF
--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -183,15 +183,15 @@ function triggerFakeWheelEvent(type: string, target: D3.Selection, relativeX: nu
   var xPos = clientRect.left + relativeX;
   var yPos = clientRect.top + relativeY;
   var event: WheelEvent;
-  // Use the WheelEvent Constructor semantics if possible
-  if (typeof WheelEvent === "function") {
+  if (Plottable._Util.Methods.isIE()) {
+    event = document.createEvent("WheelEvent");
+    event.initWheelEvent("wheel", true, true, window, 1, xPos, yPos, xPos, yPos, 0, null, null, 0, deltaY, 0, 0);
+  } else {
     // HACKHACK anycasting constructor to allow for the dictionary argument
     // https://github.com/Microsoft/TypeScript/issues/2416
     event = new (<any> WheelEvent)("wheel", { bubbles: true, clientX: xPos, clientY: yPos, deltaY: deltaY });
-  } else {
-    event = document.createEvent("WheelEvent");
-    event.initWheelEvent("wheel", true, true, window, 1, xPos, yPos, xPos, yPos, 0, null, null, 0, deltaY, 0, 0);
   }
+
   target.node().dispatchEvent(event);
 }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -154,15 +154,14 @@ function triggerFakeWheelEvent(type, target, relativeX, relativeY, deltaY) {
     var xPos = clientRect.left + relativeX;
     var yPos = clientRect.top + relativeY;
     var event;
-    // Use the WheelEvent Constructor semantics if possible
-    if (typeof WheelEvent === "function") {
+    if (Plottable._Util.Methods.isIE()) {
+        event = document.createEvent("WheelEvent");
+        event.initWheelEvent("wheel", true, true, window, 1, xPos, yPos, xPos, yPos, 0, null, null, 0, deltaY, 0, 0);
+    }
+    else {
         // HACKHACK anycasting constructor to allow for the dictionary argument
         // https://github.com/Microsoft/TypeScript/issues/2416
         event = new WheelEvent("wheel", { bubbles: true, clientX: xPos, clientY: yPos, deltaY: deltaY });
-    }
-    else {
-        event = document.createEvent("WheelEvent");
-        event.initWheelEvent("wheel", true, true, window, 1, xPos, yPos, xPos, yPos, 0, null, null, 0, deltaY, 0, 0);
     }
     target.node().dispatchEvent(event);
 }


### PR DESCRIPTION
Util function checks if the browser is IE.  If it is, it uses the initWheelEvent workflow that only IE uses.

Fixes #1837 