### PR TITLE
[Plot] Graphs fail gracefully when presented with badly formatted data

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -119,6 +119,11 @@ declare module Plottable {
              */
             function isNaN(n: any): boolean;
             /**
+             * Returns true if the argument is a number, which is not NaN
+             * Numbers represented as strings do not pass this function
+             */
+            function isValidNumber(n: any): boolean;
+            /**
              * Creates shallow copy of map.
              * @param {{ [key: string]: any }} oldMap Map to copy
              *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1607,6 +1607,7 @@ declare module Plottable {
             _getIfLabelsTooWide(): boolean;
             drawText(data: any[], attrToProjector: AttributeToProjector, userMetadata: any, plotMetadata: Plot.PlotMetadata): void;
             _getPixelPoint(datum: any, index: number): Point;
+            draw(data: any[], drawSteps: DrawStep[], userMetadata: any, plotMetadata: Plot.PlotMetadata): number;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -8556,7 +8556,7 @@ var Plottable;
                         var negativeOffset = negativeDataMap.get(key).offset;
                         var value = valueAccessor(datum, datumIndex, dataset.metadata(), plotMetadata);
                         var offset;
-                        if (!value) {
+                        if (!+value) {
                             offset = isAllNegativeValues ? negativeOffset : positiveOffset;
                         }
                         else {

--- a/plottable.js
+++ b/plottable.js
@@ -8555,7 +8555,8 @@ var Plottable;
                         var negativeOffset = negativeDataMap.get(key).offset;
                         var value = valueAccessor(datum, datumIndex, dataset.metadata(), plotMetadata);
                         var offset;
-                        if (value === 0) {
+                        // We are accepting strings as possible candidates for numbers, hence double equals
+                        if (value == 0) {
                             offset = isAllNegativeValues ? negativeOffset : positiveOffset;
                         }
                         else {

--- a/plottable.js
+++ b/plottable.js
@@ -7319,11 +7319,11 @@ var Plottable;
                 var x2Attr = attrToProjector["x2"];
                 var y2Attr = attrToProjector["y2"];
                 // Generate width based on difference, then adjust for the correct x origin
-                attrToProjector["width"] = function (d, i, u, m) { return Math.abs(x2Attr(d, i, u, m) - x1Attr(d, i, u, m)); };
-                attrToProjector["x"] = function (d, i, u, m) { return Math.min(x1Attr(d, i, u, m), x2Attr(d, i, u, m)); };
+                attrToProjector["width"] = function (d, i, u, m) { return Math.abs(x2Attr(d, i, u, m) - x1Attr(d, i, u, m)) || 0; };
+                attrToProjector["x"] = function (d, i, u, m) { return Math.min(x1Attr(d, i, u, m), x2Attr(d, i, u, m)) || 0; };
                 // Generate height based on difference, then adjust for the correct y origin
-                attrToProjector["height"] = function (d, i, u, m) { return Math.abs(y2Attr(d, i, u, m) - y1Attr(d, i, u, m)); };
-                attrToProjector["y"] = function (d, i, u, m) { return Math.max(y1Attr(d, i, u, m), y2Attr(d, i, u, m)) - attrToProjector["height"](d, i, u, m); };
+                attrToProjector["height"] = function (d, i, u, m) { return Math.abs(y2Attr(d, i, u, m) - y1Attr(d, i, u, m)) || 0; };
+                attrToProjector["y"] = function (d, i, u, m) { return (Math.max(y1Attr(d, i, u, m), y2Attr(d, i, u, m)) || 0) - attrToProjector["height"](d, i, u, m); };
                 // Clean up the attributes projected onto the SVG elements
                 delete attrToProjector["x1"];
                 delete attrToProjector["y1"];

--- a/plottable.js
+++ b/plottable.js
@@ -3328,7 +3328,7 @@ var Plottable;
             Arc.prototype.draw = function (data, drawSteps, userMetadata, plotMetadata) {
                 // HACKHACK Applying metadata should be done in base class
                 var valueAccessor = function (d, i) { return drawSteps[0].attrToProjector["value"](d, i, userMetadata, plotMetadata); };
-                var data = data.filter(function (e) { return !!+valueAccessor(e, null); });
+                data = data.filter(function (e) { return !!+valueAccessor(e, null); });
                 var pie = d3.layout.pie().sort(null).value(valueAccessor)(data);
                 drawSteps.forEach(function (s) { return delete s.attrToProjector["value"]; });
                 pie.forEach(function (slice) {
@@ -8556,8 +8556,7 @@ var Plottable;
                         var negativeOffset = negativeDataMap.get(key).offset;
                         var value = valueAccessor(datum, datumIndex, dataset.metadata(), plotMetadata);
                         var offset;
-                        // We are accepting strings as possible candidates for numbers, hence double equals
-                        if (value == 0) {
+                        if (value === 0 || value === "0") {
                             offset = isAllNegativeValues ? negativeOffset : positiveOffset;
                         }
                         else {

--- a/plottable.js
+++ b/plottable.js
@@ -3328,6 +3328,7 @@ var Plottable;
             Arc.prototype.draw = function (data, drawSteps, userMetadata, plotMetadata) {
                 // HACKHACK Applying metadata should be done in base class
                 var valueAccessor = function (d, i) { return drawSteps[0].attrToProjector["value"](d, i, userMetadata, plotMetadata); };
+                var data = data.filter(function (e) { return +valueAccessor(e); });
                 var pie = d3.layout.pie().sort(null).value(valueAccessor)(data);
                 drawSteps.forEach(function (s) { return delete s.attrToProjector["value"]; });
                 pie.forEach(function (slice) {

--- a/plottable.js
+++ b/plottable.js
@@ -258,7 +258,7 @@ var Plottable;
              * Numbers represented as strings do not pass this function
              */
             function isValidNumber(n) {
-                return typeof n === "number" && !Plottable._Util.Methods.isNaN(n);
+                return typeof n === "number" && !Plottable._Util.Methods.isNaN(n) && isFinite(n);
             }
             Methods.isValidNumber = isValidNumber;
             /**

--- a/plottable.js
+++ b/plottable.js
@@ -254,6 +254,14 @@ var Plottable;
             }
             Methods.isNaN = isNaN;
             /**
+             * Returns true if the argument is a number, which is not NaN
+             * Numbers represented as strings do not pass this function
+             */
+            function isValidNumber(n) {
+                return typeof n === "number" && !Plottable._Util.Methods.isNaN(n);
+            }
+            Methods.isValidNumber = isValidNumber;
+            /**
              * Creates shallow copy of map.
              * @param {{ [key: string]: any }} oldMap Map to copy
              *
@@ -3328,7 +3336,7 @@ var Plottable;
             Arc.prototype.draw = function (data, drawSteps, userMetadata, plotMetadata) {
                 // HACKHACK Applying metadata should be done in base class
                 var valueAccessor = function (d, i) { return drawSteps[0].attrToProjector["value"](d, i, userMetadata, plotMetadata); };
-                data = data.filter(function (e) { return !!+valueAccessor(e, null); });
+                data = data.filter(function (e) { return Plottable._Util.Methods.isValidNumber(+valueAccessor(e, null)); });
                 var pie = d3.layout.pie().sort(null).value(valueAccessor)(data);
                 drawSteps.forEach(function (s) { return delete s.attrToProjector["value"]; });
                 pie.forEach(function (slice) {

--- a/plottable.js
+++ b/plottable.js
@@ -3289,6 +3289,14 @@ var Plottable;
                 var y = this._isVertical ? rectY : rectY + rectHeight / 2;
                 return { x: x, y: y };
             };
+            Rect.prototype.draw = function (data, drawSteps, userMetadata, plotMetadata) {
+                var attrToProjector = drawSteps[0].attrToProjector;
+                var isValidNumber = Plottable._Util.Methods.isValidNumber;
+                data = data.filter(function (e, i) {
+                    return isValidNumber(attrToProjector["x"](e, null, userMetadata, plotMetadata)) && isValidNumber(attrToProjector["y"](e, null, userMetadata, plotMetadata)) && isValidNumber(attrToProjector["width"](e, null, userMetadata, plotMetadata)) && isValidNumber(attrToProjector["height"](e, null, userMetadata, plotMetadata));
+                });
+                return _super.prototype.draw.call(this, data, drawSteps, userMetadata, plotMetadata);
+            };
             return Rect;
         })(_Drawer.Element);
         _Drawer.Rect = Rect;
@@ -7327,11 +7335,11 @@ var Plottable;
                 var x2Attr = attrToProjector["x2"];
                 var y2Attr = attrToProjector["y2"];
                 // Generate width based on difference, then adjust for the correct x origin
-                attrToProjector["width"] = function (d, i, u, m) { return Math.abs(x2Attr(d, i, u, m) - x1Attr(d, i, u, m)) || 0; };
-                attrToProjector["x"] = function (d, i, u, m) { return Math.min(x1Attr(d, i, u, m), x2Attr(d, i, u, m)) || 0; };
+                attrToProjector["width"] = function (d, i, u, m) { return Math.abs(x2Attr(d, i, u, m) - x1Attr(d, i, u, m)); };
+                attrToProjector["x"] = function (d, i, u, m) { return Math.min(x1Attr(d, i, u, m), x2Attr(d, i, u, m)); };
                 // Generate height based on difference, then adjust for the correct y origin
-                attrToProjector["height"] = function (d, i, u, m) { return Math.abs(y2Attr(d, i, u, m) - y1Attr(d, i, u, m)) || 0; };
-                attrToProjector["y"] = function (d, i, u, m) { return (Math.max(y1Attr(d, i, u, m), y2Attr(d, i, u, m)) || 0) - attrToProjector["height"](d, i, u, m); };
+                attrToProjector["height"] = function (d, i, u, m) { return Math.abs(y2Attr(d, i, u, m) - y1Attr(d, i, u, m)); };
+                attrToProjector["y"] = function (d, i, u, m) { return Math.max(y1Attr(d, i, u, m), y2Attr(d, i, u, m)) - attrToProjector["height"](d, i, u, m); };
                 // Clean up the attributes projected onto the SVG elements
                 delete attrToProjector["x1"];
                 delete attrToProjector["y1"];

--- a/plottable.js
+++ b/plottable.js
@@ -3328,7 +3328,7 @@ var Plottable;
             Arc.prototype.draw = function (data, drawSteps, userMetadata, plotMetadata) {
                 // HACKHACK Applying metadata should be done in base class
                 var valueAccessor = function (d, i) { return drawSteps[0].attrToProjector["value"](d, i, userMetadata, plotMetadata); };
-                var data = data.filter(function (e) { return +valueAccessor(e); });
+                var data = data.filter(function (e) { return !!+valueAccessor(e, null); });
                 var pie = d3.layout.pie().sort(null).value(valueAccessor)(data);
                 drawSteps.forEach(function (s) { return delete s.attrToProjector["value"]; });
                 pie.forEach(function (slice) {

--- a/plottable.js
+++ b/plottable.js
@@ -8556,7 +8556,7 @@ var Plottable;
                         var negativeOffset = negativeDataMap.get(key).offset;
                         var value = valueAccessor(datum, datumIndex, dataset.metadata(), plotMetadata);
                         var offset;
-                        if (value === 0 || value === "0") {
+                        if (!value) {
                             offset = isAllNegativeValues ? negativeOffset : positiveOffset;
                         }
                         else {

--- a/src/components/plots/abstractStackedPlot.ts
+++ b/src/components/plots/abstractStackedPlot.ts
@@ -122,7 +122,8 @@ export module Plot {
 
           var value = valueAccessor(datum, datumIndex, dataset.metadata(), plotMetadata);
           var offset: number;
-          if (value === 0) {
+          // We are accepting strings as possible candidates for numbers, hence double equals
+          if (value == 0) {
             offset = isAllNegativeValues ? negativeOffset : positiveOffset;
           } else {
             offset = value > 0 ? positiveOffset : negativeOffset;

--- a/src/components/plots/abstractStackedPlot.ts
+++ b/src/components/plots/abstractStackedPlot.ts
@@ -122,7 +122,7 @@ export module Plot {
 
           var value = valueAccessor(datum, datumIndex, dataset.metadata(), plotMetadata);
           var offset: number;
-          if (!value) {
+          if (!+value) {
             offset = isAllNegativeValues ? negativeOffset : positiveOffset;
           } else {
             offset = value > 0 ? positiveOffset : negativeOffset;

--- a/src/components/plots/abstractStackedPlot.ts
+++ b/src/components/plots/abstractStackedPlot.ts
@@ -122,8 +122,7 @@ export module Plot {
 
           var value = valueAccessor(datum, datumIndex, dataset.metadata(), plotMetadata);
           var offset: number;
-          // We are accepting strings as possible candidates for numbers, hence double equals
-          if (value == 0) {
+          if (value === 0 || value === "0") {
             offset = isAllNegativeValues ? negativeOffset : positiveOffset;
           } else {
             offset = value > 0 ? positiveOffset : negativeOffset;

--- a/src/components/plots/abstractStackedPlot.ts
+++ b/src/components/plots/abstractStackedPlot.ts
@@ -122,7 +122,7 @@ export module Plot {
 
           var value = valueAccessor(datum, datumIndex, dataset.metadata(), plotMetadata);
           var offset: number;
-          if (value === 0 || value === "0") {
+          if (!value) {
             offset = isAllNegativeValues ? negativeOffset : positiveOffset;
           } else {
             offset = value > 0 ? positiveOffset : negativeOffset;

--- a/src/components/plots/rectanglePlot.ts
+++ b/src/components/plots/rectanglePlot.ts
@@ -36,12 +36,12 @@ export module Plot {
       var y2Attr = attrToProjector["y2"];
 
       // Generate width based on difference, then adjust for the correct x origin
-      attrToProjector["width"] = (d, i, u, m) => Math.abs(x2Attr(d, i, u, m) - x1Attr(d, i, u, m));
-      attrToProjector["x"] = (d, i, u, m) => Math.min(x1Attr(d, i, u, m), x2Attr(d, i, u, m));
+      attrToProjector["width"] = (d, i, u, m) => Math.abs(x2Attr(d, i, u, m) - x1Attr(d, i, u, m)) || 0;
+      attrToProjector["x"] = (d, i, u, m) => Math.min(x1Attr(d, i, u, m), x2Attr(d, i, u, m)) || 0;
 
       // Generate height based on difference, then adjust for the correct y origin
-      attrToProjector["height"] = (d, i, u, m) => Math.abs(y2Attr(d, i, u, m) - y1Attr(d, i, u, m));
-      attrToProjector["y"] = (d, i, u, m) => Math.max(y1Attr(d, i, u, m), y2Attr(d, i, u, m)) - attrToProjector["height"](d, i, u, m);
+      attrToProjector["height"] = (d, i, u, m) => Math.abs(y2Attr(d, i, u, m) - y1Attr(d, i, u, m)) || 0;
+      attrToProjector["y"] = (d, i, u, m) => (Math.max(y1Attr(d, i, u, m), y2Attr(d, i, u, m)) || 0) - attrToProjector["height"](d, i, u, m);
 
       // Clean up the attributes projected onto the SVG elements
       delete attrToProjector["x1"];

--- a/src/components/plots/rectanglePlot.ts
+++ b/src/components/plots/rectanglePlot.ts
@@ -41,7 +41,8 @@ export module Plot {
 
       // Generate height based on difference, then adjust for the correct y origin
       attrToProjector["height"] = (d, i, u, m) => Math.abs(y2Attr(d, i, u, m) - y1Attr(d, i, u, m)) || 0;
-      attrToProjector["y"] = (d, i, u, m) => (Math.max(y1Attr(d, i, u, m), y2Attr(d, i, u, m)) || 0) - attrToProjector["height"](d, i, u, m);
+      attrToProjector["y"] = (d, i, u, m) => (Math.max(y1Attr(d, i, u, m), y2Attr(d, i, u, m)) || 0) -
+                                              attrToProjector["height"](d, i, u, m);
 
       // Clean up the attributes projected onto the SVG elements
       delete attrToProjector["x1"];

--- a/src/components/plots/rectanglePlot.ts
+++ b/src/components/plots/rectanglePlot.ts
@@ -36,13 +36,12 @@ export module Plot {
       var y2Attr = attrToProjector["y2"];
 
       // Generate width based on difference, then adjust for the correct x origin
-      attrToProjector["width"] = (d, i, u, m) => Math.abs(x2Attr(d, i, u, m) - x1Attr(d, i, u, m)) || 0;
-      attrToProjector["x"] = (d, i, u, m) => Math.min(x1Attr(d, i, u, m), x2Attr(d, i, u, m)) || 0;
+      attrToProjector["width"] = (d, i, u, m) => Math.abs(x2Attr(d, i, u, m) - x1Attr(d, i, u, m));
+      attrToProjector["x"] = (d, i, u, m) => Math.min(x1Attr(d, i, u, m), x2Attr(d, i, u, m));
 
       // Generate height based on difference, then adjust for the correct y origin
-      attrToProjector["height"] = (d, i, u, m) => Math.abs(y2Attr(d, i, u, m) - y1Attr(d, i, u, m)) || 0;
-      attrToProjector["y"] = (d, i, u, m) => (Math.max(y1Attr(d, i, u, m), y2Attr(d, i, u, m)) || 0) -
-                                              attrToProjector["height"](d, i, u, m);
+      attrToProjector["height"] = (d, i, u, m) => Math.abs(y2Attr(d, i, u, m) - y1Attr(d, i, u, m));
+      attrToProjector["y"] = (d, i, u, m) => Math.max(y1Attr(d, i, u, m), y2Attr(d, i, u, m)) - attrToProjector["height"](d, i, u, m);
 
       // Clean up the attributes projected onto the SVG elements
       delete attrToProjector["x1"];

--- a/src/drawers/arcDrawer.ts
+++ b/src/drawers/arcDrawer.ts
@@ -40,7 +40,7 @@ export module _Drawer {
       // HACKHACK Applying metadata should be done in base class
       var valueAccessor = (d: any, i: number) => drawSteps[0].attrToProjector["value"](d, i, userMetadata, plotMetadata);
 
-      data = data.filter(e => !!+valueAccessor(e, null));
+      data = data.filter(e => Plottable._Util.Methods.isValidNumber(+valueAccessor(e, null)));
 
       var pie = d3.layout.pie()
                           .sort(null)

--- a/src/drawers/arcDrawer.ts
+++ b/src/drawers/arcDrawer.ts
@@ -39,6 +39,9 @@ export module _Drawer {
     public draw(data: any[], drawSteps: DrawStep[], userMetadata: any, plotMetadata: Plot.PlotMetadata) {
       // HACKHACK Applying metadata should be done in base class
       var valueAccessor = (d: any, i: number) => drawSteps[0].attrToProjector["value"](d, i, userMetadata, plotMetadata);
+
+      var data = data.filter(e => +valueAccessor(e));
+
       var pie = d3.layout.pie()
                           .sort(null)
                           .value(valueAccessor)(data);

--- a/src/drawers/arcDrawer.ts
+++ b/src/drawers/arcDrawer.ts
@@ -40,7 +40,7 @@ export module _Drawer {
       // HACKHACK Applying metadata should be done in base class
       var valueAccessor = (d: any, i: number) => drawSteps[0].attrToProjector["value"](d, i, userMetadata, plotMetadata);
 
-      var data = data.filter(e => +valueAccessor(e));
+      var data = data.filter(e => !!+valueAccessor(e, null));
 
       var pie = d3.layout.pie()
                           .sort(null)

--- a/src/drawers/arcDrawer.ts
+++ b/src/drawers/arcDrawer.ts
@@ -40,7 +40,7 @@ export module _Drawer {
       // HACKHACK Applying metadata should be done in base class
       var valueAccessor = (d: any, i: number) => drawSteps[0].attrToProjector["value"](d, i, userMetadata, plotMetadata);
 
-      var data = data.filter(e => !!+valueAccessor(e, null));
+      data = data.filter(e => !!+valueAccessor(e, null));
 
       var pie = d3.layout.pie()
                           .sort(null)

--- a/src/drawers/rectDrawer.ts
+++ b/src/drawers/rectDrawer.ts
@@ -93,7 +93,18 @@ export module _Drawer {
       var y = this._isVertical ? rectY : rectY + rectHeight / 2;
       return { x: x, y: y };
     }
-  }
 
+    public draw(data: any[], drawSteps: DrawStep[], userMetadata: any, plotMetadata: Plot.PlotMetadata) {
+      var attrToProjector = drawSteps[0].attrToProjector;
+      var isValidNumber = Plottable._Util.Methods.isValidNumber;
+      data = data.filter(function(e: any, i: number) {
+        return isValidNumber(attrToProjector["x"](e, null, userMetadata, plotMetadata)) &&
+               isValidNumber(attrToProjector["y"](e, null, userMetadata, plotMetadata)) &&
+               isValidNumber(attrToProjector["width"](e, null, userMetadata, plotMetadata)) &&
+               isValidNumber(attrToProjector["height"](e, null, userMetadata, plotMetadata));
+      });
+      return super.draw(data, drawSteps, userMetadata, plotMetadata);
+    }
+  }
 }
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -259,7 +259,7 @@ export module _Util {
      * Numbers represented as strings do not pass this function
      */
     export function isValidNumber(n: any) {
-      return typeof n === "number" && !Plottable._Util.Methods.isNaN(n);
+      return typeof n === "number" && !Plottable._Util.Methods.isNaN(n) && isFinite(n);
     }
 
     /**

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -255,6 +255,14 @@ export module _Util {
     }
 
     /**
+     * Returns true if the argument is a number, which is not NaN
+     * Numbers represented as strings do not pass this function
+     */
+    export function isValidNumber(n: any) {
+      return typeof n === "number" && !Plottable._Util.Methods.isNaN(n);
+    }
+
+    /**
      * Creates shallow copy of map.
      * @param {{ [key: string]: any }} oldMap Map to copy
      *

--- a/test/components/plots/piePlotTests.ts
+++ b/test/components/plots/piePlotTests.ts
@@ -250,9 +250,9 @@ describe("Plots", () => {
 
       plot.renderTo(svg);
 
-      var elementsDrawn = (<any> plot)._element.selectAll(".arc").size();
+      var elementsDrawnSel = (<any> plot)._element.selectAll(".arc");
 
-      assert.strictEqual(elementsDrawn, 4,
+      assert.strictEqual(elementsDrawnSel.size(), 4,
         "There should be exactly 4 slices in the pie chart, representing the valid values");
 
       svg.remove();
@@ -275,10 +275,16 @@ describe("Plots", () => {
 
       plot.renderTo(svg);
 
-      var elementsDrawn = (<any> plot)._element.selectAll(".arc").size();
+      var elementsDrawnSel = (<any> plot)._element.selectAll(".arc");
 
-      assert.strictEqual(elementsDrawn, 4,
-        "There should be exactly 4 slices in the pie chart, representing the valid values");
+      assert.strictEqual(elementsDrawnSel.size(), 4,
+        "All 4 elements of the pie chart should have a DOM node");
+
+      assert.closeTo(elementsDrawnSel[0][1].getBBox().width, 0, 0.001,
+        "0 as a value should not be visible");
+
+      assert.closeTo(elementsDrawnSel[0][2].getBBox().width, 0, 0.001,
+        "null as a value should not be visible");
 
       svg.remove();
     });

--- a/test/components/plots/piePlotTests.ts
+++ b/test/components/plots/piePlotTests.ts
@@ -229,4 +229,36 @@ describe("Plots", () => {
       svg.remove();
     });
   });
+
+  describe("fail safe tests", () => {
+    it("null, undefined, NaN and non-numeric strings default to 0 in a Pie Chart", () => {
+      var svg = generateSVG();
+
+      var data1 = [
+        { v: 1 },
+        { v: undefined },
+        { v: 1 },
+        { v: null },
+        { v: 1 },
+        { v: NaN },
+        { v: 1 },
+        { v: "Bad String" },
+        { v: 1 },
+      ];
+
+      var plot = new Plottable.Plot.Pie();
+      plot.addDataset(data1);
+      plot.project("value", "v");
+
+      plot.renderTo(svg);
+
+      var elementsDrawn = (<any> plot)._element.selectAll(".arc").size();
+
+      assert.strictEqual(elementsDrawn, 5,
+        "There should be exactly 5 slices in the pie chart, representing the valid values");
+
+      svg.remove();
+
+    });
+  });
 });

--- a/test/components/plots/piePlotTests.ts
+++ b/test/components/plots/piePlotTests.ts
@@ -231,14 +231,12 @@ describe("Plots", () => {
   });
 
   describe("fail safe tests", () => {
-    it("null, undefined, NaN and non-numeric strings default to 0 in a Pie Chart", () => {
+    it("undefined, NaN and non-numeric strings not be represented in a Pie Chart", () => {
       var svg = generateSVG();
 
       var data1 = [
         { v: 1 },
         { v: undefined },
-        { v: 1 },
-        { v: null },
         { v: 1 },
         { v: NaN },
         { v: 1 },
@@ -254,11 +252,35 @@ describe("Plots", () => {
 
       var elementsDrawn = (<any> plot)._element.selectAll(".arc").size();
 
-      assert.strictEqual(elementsDrawn, 5,
-        "There should be exactly 5 slices in the pie chart, representing the valid values");
+      assert.strictEqual(elementsDrawn, 4,
+        "There should be exactly 4 slices in the pie chart, representing the valid values");
 
       svg.remove();
 
+    });
+
+    it("nulls and 0s should be represented in a Pie Chart as DOM elements, but have radius 0", () => {
+      var svg = generateSVG();
+
+      var data1 = [
+        { v: 1 },
+        { v: 0 },
+        { v: null },
+        { v: 1 },
+      ];
+
+      var plot = new Plottable.Plot.Pie();
+      plot.addDataset(data1);
+      plot.project("value", "v");
+
+      plot.renderTo(svg);
+
+      var elementsDrawn = (<any> plot)._element.selectAll(".arc").size();
+
+      assert.strictEqual(elementsDrawn, 4,
+        "There should be exactly 4 slices in the pie chart, representing the valid values");
+
+      svg.remove();
     });
   });
 });

--- a/test/components/plots/rectanglePlotTests.ts
+++ b/test/components/plots/rectanglePlotTests.ts
@@ -42,4 +42,51 @@ describe("Plots", () => {
       svg.remove();
     });
   });
+
+  describe("fail safe tests", () => {
+    it("illegal rectangles don't get displayed", () => {
+      var svg = generateSVG();
+
+      var data1 = [
+        { x: "A", y1: 1, y2: 2, v: 1 },
+        { x: "B", y1: 2, y2: 3, v: 2 },
+        { x: "C", y1: 3, y2: NaN, v: 3 },
+        { x: "D", y1: 4, y2: 5, v: 4 },
+        { x: "E", y1: 5, y2: 6, v: 5 },
+        { x: "F", y1: 6, y2: 7, v: 6 }
+      ];
+
+      var xScale = new Plottable.Scale.Category();
+      var yScale = new Plottable.Scale.Linear();
+
+      var plot = new Plottable.Plot.Grid(xScale, yScale);
+      plot
+        .project("x", "x", xScale)
+        .project("y", "y1", yScale)
+        .project("y2", "y2", yScale);
+      plot.addDataset(data1);
+
+      plot.renderTo(svg);
+
+      plot._element.selectAll(".bar-area rect").each(function(d: any, i: number) {
+        var sel = d3.select(this);
+        assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("x")),
+          "x attribute should be valid for rectangle # " + i);
+        assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("y")),
+          "y attribute should be valid for rectangle # " + i);
+        assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("height")),
+          "height attribute should be valid for rectangle # " + i);
+        assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("width")),
+          "width attribute should be valid for rectangle # " + i);
+      });
+
+      var brokenRectHeight = d3.select(plot._element.selectAll(".bar-area rect")[0][2]).attr("height");
+
+      assert.strictEqual(brokenRectHeight, "0",
+        "the broken rectangle (third one) should have no height, hence not displayed");
+
+      svg.remove();
+    });
+  });
+
 });

--- a/test/components/plots/rectanglePlotTests.ts
+++ b/test/components/plots/rectanglePlotTests.ts
@@ -71,14 +71,14 @@ describe("Plots", () => {
 
       (<any> plot)._element.selectAll(".bar-area rect").each(function(d: any, i: number) {
         var sel = d3.select(this);
-        assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("x")),
-          "x attribute should be valid for rectangle # " + i);
-        assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("y")),
-          "y attribute should be valid for rectangle # " + i);
-        assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("height")),
-          "height attribute should be valid for rectangle # " + i);
-        assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("width")),
-          "width attribute should be valid for rectangle # " + i);
+        assert.isFalse(Plottable._Util.Methods.isNaN(+sel.attr("x")),
+          "x attribute should be valid for rectangle # " + i + ". Currently " + sel.attr("x"));
+        assert.isFalse(Plottable._Util.Methods.isNaN(+sel.attr("y")),
+          "y attribute should be valid for rectangle # " + i + ". Currently " + sel.attr("y"));
+        assert.isFalse(Plottable._Util.Methods.isNaN(+sel.attr("height")),
+          "height attribute should be valid for rectangle # " + i + ". Currently " + sel.attr("height"));
+        assert.isFalse(Plottable._Util.Methods.isNaN(+sel.attr("width")),
+          "width attribute should be valid for rectangle # " + i + ". Currently " + sel.attr("width"));
       });
 
       var brokenRectHeight = d3.select((<any> plot)._element.selectAll(".bar-area rect")[0][2]).attr("height");

--- a/test/components/plots/rectanglePlotTests.ts
+++ b/test/components/plots/rectanglePlotTests.ts
@@ -69,7 +69,12 @@ describe("Plots", () => {
 
       plot.renderTo(svg);
 
-      (<any> plot)._element.selectAll(".bar-area rect").each(function(d: any, i: number) {
+      var rectanglesSelection = (<any> plot)._element.selectAll(".bar-area rect");
+
+      assert.strictEqual(rectanglesSelection.size(), 5,
+        "only 5 rectangles should be displayed");
+
+      rectanglesSelection.each(function(d: any, i: number) {
         var sel = d3.select(this);
         assert.isFalse(Plottable._Util.Methods.isNaN(+sel.attr("x")),
           "x attribute should be valid for rectangle # " + i + ". Currently " + sel.attr("x"));
@@ -81,13 +86,7 @@ describe("Plots", () => {
           "width attribute should be valid for rectangle # " + i + ". Currently " + sel.attr("width"));
       });
 
-      var brokenRectHeight = d3.select((<any> plot)._element.selectAll(".bar-area rect")[0][2]).attr("height");
-
-      assert.strictEqual(brokenRectHeight, "0",
-        "the broken rectangle (third one) should have no height, hence not displayed");
-
       svg.remove();
     });
   });
-
 });

--- a/test/components/plots/rectanglePlotTests.ts
+++ b/test/components/plots/rectanglePlotTests.ts
@@ -58,8 +58,9 @@ describe("Plots", () => {
 
       var xScale = new Plottable.Scale.Category();
       var yScale = new Plottable.Scale.Linear();
+      var cScale = new Plottable.Scale.Color();
 
-      var plot = new Plottable.Plot.Grid(xScale, yScale);
+      var plot = new Plottable.Plot.Grid(xScale, yScale, cScale);
       plot
         .project("x", "x", xScale)
         .project("y", "y1", yScale)
@@ -68,7 +69,7 @@ describe("Plots", () => {
 
       plot.renderTo(svg);
 
-      plot._element.selectAll(".bar-area rect").each(function(d: any, i: number) {
+      (<any> plot)._element.selectAll(".bar-area rect").each(function(d: any, i: number) {
         var sel = d3.select(this);
         assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("x")),
           "x attribute should be valid for rectangle # " + i);
@@ -80,7 +81,7 @@ describe("Plots", () => {
           "width attribute should be valid for rectangle # " + i);
       });
 
-      var brokenRectHeight = d3.select(plot._element.selectAll(".bar-area rect")[0][2]).attr("height");
+      var brokenRectHeight = d3.select((<any> plot)._element.selectAll(".bar-area rect")[0][2]).attr("height");
 
       assert.strictEqual(brokenRectHeight, "0",
         "the broken rectangle (third one) should have no height, hence not displayed");

--- a/test/components/plots/stackedAreaPlotTests.ts
+++ b/test/components/plots/stackedAreaPlotTests.ts
@@ -411,6 +411,4 @@ describe("Plots", () => {
         "dataset3 (green) should have this offset because the red dataset (ds2) has no height in this point");
     });
   });
-
-
 });

--- a/test/components/plots/stackedAreaPlotTests.ts
+++ b/test/components/plots/stackedAreaPlotTests.ts
@@ -410,5 +410,44 @@ describe("Plots", () => {
       assert.strictEqual(ds3Point2Offset, 2,
         "dataset3 (green) should have this offset because the red dataset (ds2) has no height in this point");
     });
+
+    it("null defaults to 0", () => {
+      var data1 = [
+        { x: 1, y: 1, fill: "blue" },
+        { x: 2, y: 2, fill: "blue" },
+        { x: 3, y: 3, fill: "blue" },
+      ];
+      var data2 = [
+        { x: 1, y: 1, fill: "red" },
+        { x: 2, y: "0", fill: "red" },
+        { x: 3, y: 3, fill: "red" },
+      ];
+      var data3 = [
+        { x: 1, y: 1, fill: "green" },
+        { x: 2, y: 2, fill: "green" },
+        { x: 3, y: 3, fill: "green" },
+      ];
+      var xScale = new Plottable.Scale.Linear();
+      var yScale = new Plottable.Scale.Linear();
+
+      var plot = new Plottable.Plot.StackedArea(xScale, yScale);
+      plot.addDataset("d1", data1);
+      plot.addDataset("d2", data2);
+      plot.addDataset("d3", data3);
+      plot.project("fill", "fill");
+      plot.project("x", "x", xScale).project("y", "y", yScale);
+
+      var ds1Point2Offset = (<any> plot)._key2PlotDatasetKey.get("d1").plotMetadata.offsets.get(2);
+      var ds2Point2Offset = (<any> plot)._key2PlotDatasetKey.get("d2").plotMetadata.offsets.get(2);
+      var ds3Point2Offset = (<any> plot)._key2PlotDatasetKey.get("d3").plotMetadata.offsets.get(2);
+
+      assert.strictEqual(ds1Point2Offset, 0,
+        "dataset1 (blue) should have no offset on middle point");
+      assert.strictEqual(ds2Point2Offset, 2,
+        "dataset2 (red) should have this offset and be on top of blue dataset");
+      assert.strictEqual(ds3Point2Offset, 2,
+        "dataset3 (green) should have this offset because the red dataset (ds2) has no height in this point");
+    });
+
   });
 });

--- a/test/components/plots/stackedAreaPlotTests.ts
+++ b/test/components/plots/stackedAreaPlotTests.ts
@@ -371,4 +371,46 @@ describe("Plots", () => {
     });
 
   });
+
+  describe("fail safe tests", () => {
+    it("0 as a string coerces correctly and is not subject to off by one errors", () => {
+      var data1 = [
+        { x: 1, y: 1, fill: "blue" },
+        { x: 2, y: 2, fill: "blue" },
+        { x: 3, y: 3, fill: "blue" },
+      ];
+      var data2 = [
+        { x: 1, y: 1, fill: "red" },
+        { x: 2, y: "0", fill: "red" },
+        { x: 3, y: 3, fill: "red" },
+      ];
+      var data3 = [
+        { x: 1, y: 1, fill: "green" },
+        { x: 2, y: 2, fill: "green" },
+        { x: 3, y: 3, fill: "green" },
+      ];
+      var xScale = new Plottable.Scale.Linear();
+      var yScale = new Plottable.Scale.Linear();
+
+      var plot = new Plottable.Plot.StackedArea(xScale, yScale);
+      plot.addDataset("d1", data1);
+      plot.addDataset("d2", data2);
+      plot.addDataset("d3", data3);
+      plot.project("fill", "fill");
+      plot.project("x", "x", xScale).project("y", "y", yScale);
+
+      var ds1Point2Offset = (<any> plot)._key2PlotDatasetKey.get("d1").plotMetadata.offsets.get(2);
+      var ds2Point2Offset = (<any> plot)._key2PlotDatasetKey.get("d2").plotMetadata.offsets.get(2);
+      var ds3Point2Offset = (<any> plot)._key2PlotDatasetKey.get("d3").plotMetadata.offsets.get(2);
+
+      assert.strictEqual(ds1Point2Offset, 0,
+        "dataset1 (blue) should have no offset on middle point");
+      assert.strictEqual(ds2Point2Offset, 2,
+        "dataset2 (red) should have this offset and be on top of blue dataset");
+      assert.strictEqual(ds3Point2Offset, 2,
+        "dataset3 (green) should have this offset because the red dataset (ds2) has no height in this point");
+    });
+  });
+
+
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -4177,10 +4177,10 @@ describe("Plots", function () {
             plot.renderTo(svg);
             plot._element.selectAll(".bar-area rect").each(function (d, i) {
                 var sel = d3.select(this);
-                assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("x")), "x attribute should be valid for rectangle # " + i);
-                assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("y")), "y attribute should be valid for rectangle # " + i);
-                assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("height")), "height attribute should be valid for rectangle # " + i);
-                assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("width")), "width attribute should be valid for rectangle # " + i);
+                assert.isFalse(Plottable._Util.Methods.isNaN(+sel.attr("x")), "x attribute should be valid for rectangle # " + i + ". Currently " + sel.attr("x"));
+                assert.isFalse(Plottable._Util.Methods.isNaN(+sel.attr("y")), "y attribute should be valid for rectangle # " + i + ". Currently " + sel.attr("y"));
+                assert.isFalse(Plottable._Util.Methods.isNaN(+sel.attr("height")), "height attribute should be valid for rectangle # " + i + ". Currently " + sel.attr("height"));
+                assert.isFalse(Plottable._Util.Methods.isNaN(+sel.attr("width")), "width attribute should be valid for rectangle # " + i + ". Currently " + sel.attr("width"));
             });
             var brokenRectHeight = d3.select(plot._element.selectAll(".bar-area rect")[0][2]).attr("height");
             assert.strictEqual(brokenRectHeight, "0", "the broken rectangle (third one) should have no height, hence not displayed");

--- a/test/tests.js
+++ b/test/tests.js
@@ -2699,8 +2699,8 @@ describe("Plots", function () {
             plot.addDataset(data1);
             plot.project("value", "v");
             plot.renderTo(svg);
-            var elementsDrawn = plot._element.selectAll(".arc").size();
-            assert.strictEqual(elementsDrawn, 4, "There should be exactly 4 slices in the pie chart, representing the valid values");
+            var elementsDrawnSel = plot._element.selectAll(".arc");
+            assert.strictEqual(elementsDrawnSel.size(), 4, "There should be exactly 4 slices in the pie chart, representing the valid values");
             svg.remove();
         });
         it("nulls and 0s should be represented in a Pie Chart as DOM elements, but have radius 0", function () {
@@ -2715,8 +2715,10 @@ describe("Plots", function () {
             plot.addDataset(data1);
             plot.project("value", "v");
             plot.renderTo(svg);
-            var elementsDrawn = plot._element.selectAll(".arc").size();
-            assert.strictEqual(elementsDrawn, 4, "There should be exactly 4 slices in the pie chart, representing the valid values");
+            var elementsDrawnSel = plot._element.selectAll(".arc");
+            assert.strictEqual(elementsDrawnSel.size(), 4, "All 4 elements of the pie chart should have a DOM node");
+            assert.closeTo(elementsDrawnSel[0][1].getBBox().width, 0, 0.001, "0 as a value should not be visible");
+            assert.closeTo(elementsDrawnSel[0][2].getBBox().width, 0, 0.001, "null as a value should not be visible");
             svg.remove();
         });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -4954,6 +4954,39 @@ describe("Plots", function () {
             svg.remove();
         });
     });
+    describe("fail safe tests", function () {
+        it("0 as a string coerces correctly and is not subject to off by one errors", function () {
+            var data1 = [
+                { x: 1, y: 1, fill: "blue" },
+                { x: 2, y: 2, fill: "blue" },
+                { x: 3, y: 3, fill: "blue" },
+            ];
+            var data2 = [
+                { x: 1, y: 1, fill: "red" },
+                { x: 2, y: "0", fill: "red" },
+                { x: 3, y: 3, fill: "red" },
+            ];
+            var data3 = [
+                { x: 1, y: 1, fill: "green" },
+                { x: 2, y: 2, fill: "green" },
+                { x: 3, y: 3, fill: "green" },
+            ];
+            var xScale = new Plottable.Scale.Linear();
+            var yScale = new Plottable.Scale.Linear();
+            var plot = new Plottable.Plot.StackedArea(xScale, yScale);
+            plot.addDataset("d1", data1);
+            plot.addDataset("d2", data2);
+            plot.addDataset("d3", data3);
+            plot.project("fill", "fill");
+            plot.project("x", "x", xScale).project("y", "y", yScale);
+            var ds1Point2Offset = plot._key2PlotDatasetKey.get("d1").plotMetadata.offsets.get(2);
+            var ds2Point2Offset = plot._key2PlotDatasetKey.get("d2").plotMetadata.offsets.get(2);
+            var ds3Point2Offset = plot._key2PlotDatasetKey.get("d3").plotMetadata.offsets.get(2);
+            assert.strictEqual(ds1Point2Offset, 0, "dataset1 (blue) should have no offset on middle point");
+            assert.strictEqual(ds2Point2Offset, 2, "dataset2 (red) should have this offset and be on top of blue dataset");
+            assert.strictEqual(ds3Point2Offset, 2, "dataset3 (green) should have this offset because the red dataset (ds2) has no height in this point");
+        });
+    });
 });
 
 ///<reference path="../../testReference.ts" />

--- a/test/tests.js
+++ b/test/tests.js
@@ -4170,7 +4170,8 @@ describe("Plots", function () {
             ];
             var xScale = new Plottable.Scale.Category();
             var yScale = new Plottable.Scale.Linear();
-            var plot = new Plottable.Plot.Grid(xScale, yScale);
+            var cScale = new Plottable.Scale.Color();
+            var plot = new Plottable.Plot.Grid(xScale, yScale, cScale);
             plot.project("x", "x", xScale).project("y", "y1", yScale).project("y2", "y2", yScale);
             plot.addDataset(data1);
             plot.renderTo(svg);

--- a/test/tests.js
+++ b/test/tests.js
@@ -2683,6 +2683,29 @@ describe("Plots", function () {
             svg.remove();
         });
     });
+    describe("fail safe tests", function () {
+        it("null, undefined, NaN and non-numeric strings default to 0 in a Pie Chart", function () {
+            var svg = generateSVG();
+            var data1 = [
+                { v: 1 },
+                { v: undefined },
+                { v: 1 },
+                { v: null },
+                { v: 1 },
+                { v: NaN },
+                { v: 1 },
+                { v: "Bad String" },
+                { v: 1 },
+            ];
+            var plot = new Plottable.Plot.Pie();
+            plot.addDataset(data1);
+            plot.project("value", "v");
+            plot.renderTo(svg);
+            var elementsDrawn = plot._element.selectAll(".arc").size();
+            assert.strictEqual(elementsDrawn, 5, "There should be exactly 5 slices in the pie chart, representing the valid values");
+            svg.remove();
+        });
+    });
 });
 
 ///<reference path="../../testReference.ts" />

--- a/test/tests.js
+++ b/test/tests.js
@@ -2684,13 +2684,11 @@ describe("Plots", function () {
         });
     });
     describe("fail safe tests", function () {
-        it("null, undefined, NaN and non-numeric strings default to 0 in a Pie Chart", function () {
+        it("undefined, NaN and non-numeric strings not be represented in a Pie Chart", function () {
             var svg = generateSVG();
             var data1 = [
                 { v: 1 },
                 { v: undefined },
-                { v: 1 },
-                { v: null },
                 { v: 1 },
                 { v: NaN },
                 { v: 1 },
@@ -2702,7 +2700,23 @@ describe("Plots", function () {
             plot.project("value", "v");
             plot.renderTo(svg);
             var elementsDrawn = plot._element.selectAll(".arc").size();
-            assert.strictEqual(elementsDrawn, 5, "There should be exactly 5 slices in the pie chart, representing the valid values");
+            assert.strictEqual(elementsDrawn, 4, "There should be exactly 4 slices in the pie chart, representing the valid values");
+            svg.remove();
+        });
+        it("nulls and 0s should be represented in a Pie Chart as DOM elements, but have radius 0", function () {
+            var svg = generateSVG();
+            var data1 = [
+                { v: 1 },
+                { v: 0 },
+                { v: null },
+                { v: 1 },
+            ];
+            var plot = new Plottable.Plot.Pie();
+            plot.addDataset(data1);
+            plot.project("value", "v");
+            plot.renderTo(svg);
+            var elementsDrawn = plot._element.selectAll(".arc").size();
+            assert.strictEqual(elementsDrawn, 4, "There should be exactly 4 slices in the pie chart, representing the valid values");
             svg.remove();
         });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -4157,6 +4157,35 @@ describe("Plots", function () {
             svg.remove();
         });
     });
+    describe("fail safe tests", function () {
+        it("illegal rectangles don't get displayed", function () {
+            var svg = generateSVG();
+            var data1 = [
+                { x: "A", y1: 1, y2: 2, v: 1 },
+                { x: "B", y1: 2, y2: 3, v: 2 },
+                { x: "C", y1: 3, y2: NaN, v: 3 },
+                { x: "D", y1: 4, y2: 5, v: 4 },
+                { x: "E", y1: 5, y2: 6, v: 5 },
+                { x: "F", y1: 6, y2: 7, v: 6 }
+            ];
+            var xScale = new Plottable.Scale.Category();
+            var yScale = new Plottable.Scale.Linear();
+            var plot = new Plottable.Plot.Grid(xScale, yScale);
+            plot.project("x", "x", xScale).project("y", "y1", yScale).project("y2", "y2", yScale);
+            plot.addDataset(data1);
+            plot.renderTo(svg);
+            plot._element.selectAll(".bar-area rect").each(function (d, i) {
+                var sel = d3.select(this);
+                assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("x")), "x attribute should be valid for rectangle # " + i);
+                assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("y")), "y attribute should be valid for rectangle # " + i);
+                assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("height")), "height attribute should be valid for rectangle # " + i);
+                assert.isFalse(Plottable._Util.Methods.isNaN(sel.attr("width")), "width attribute should be valid for rectangle # " + i);
+            });
+            var brokenRectHeight = d3.select(plot._element.selectAll(".bar-area rect")[0][2]).attr("height");
+            assert.strictEqual(brokenRectHeight, "0", "the broken rectangle (third one) should have no height, hence not displayed");
+            svg.remove();
+        });
+    });
 });
 
 ///<reference path="../../testReference.ts" />

--- a/test/tests.js
+++ b/test/tests.js
@@ -5039,6 +5039,37 @@ describe("Plots", function () {
             assert.strictEqual(ds2Point2Offset, 2, "dataset2 (red) should have this offset and be on top of blue dataset");
             assert.strictEqual(ds3Point2Offset, 2, "dataset3 (green) should have this offset because the red dataset (ds2) has no height in this point");
         });
+        it("null defaults to 0", function () {
+            var data1 = [
+                { x: 1, y: 1, fill: "blue" },
+                { x: 2, y: 2, fill: "blue" },
+                { x: 3, y: 3, fill: "blue" },
+            ];
+            var data2 = [
+                { x: 1, y: 1, fill: "red" },
+                { x: 2, y: "0", fill: "red" },
+                { x: 3, y: 3, fill: "red" },
+            ];
+            var data3 = [
+                { x: 1, y: 1, fill: "green" },
+                { x: 2, y: 2, fill: "green" },
+                { x: 3, y: 3, fill: "green" },
+            ];
+            var xScale = new Plottable.Scale.Linear();
+            var yScale = new Plottable.Scale.Linear();
+            var plot = new Plottable.Plot.StackedArea(xScale, yScale);
+            plot.addDataset("d1", data1);
+            plot.addDataset("d2", data2);
+            plot.addDataset("d3", data3);
+            plot.project("fill", "fill");
+            plot.project("x", "x", xScale).project("y", "y", yScale);
+            var ds1Point2Offset = plot._key2PlotDatasetKey.get("d1").plotMetadata.offsets.get(2);
+            var ds2Point2Offset = plot._key2PlotDatasetKey.get("d2").plotMetadata.offsets.get(2);
+            var ds3Point2Offset = plot._key2PlotDatasetKey.get("d3").plotMetadata.offsets.get(2);
+            assert.strictEqual(ds1Point2Offset, 0, "dataset1 (blue) should have no offset on middle point");
+            assert.strictEqual(ds2Point2Offset, 2, "dataset2 (red) should have this offset and be on top of blue dataset");
+            assert.strictEqual(ds3Point2Offset, 2, "dataset3 (green) should have this offset because the red dataset (ds2) has no height in this point");
+        });
     });
 });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -4191,15 +4191,15 @@ describe("Plots", function () {
             plot.project("x", "x", xScale).project("y", "y1", yScale).project("y2", "y2", yScale);
             plot.addDataset(data1);
             plot.renderTo(svg);
-            plot._element.selectAll(".bar-area rect").each(function (d, i) {
+            var rectanglesSelection = plot._element.selectAll(".bar-area rect");
+            assert.strictEqual(rectanglesSelection.size(), 5, "only 5 rectangles should be displayed");
+            rectanglesSelection.each(function (d, i) {
                 var sel = d3.select(this);
                 assert.isFalse(Plottable._Util.Methods.isNaN(+sel.attr("x")), "x attribute should be valid for rectangle # " + i + ". Currently " + sel.attr("x"));
                 assert.isFalse(Plottable._Util.Methods.isNaN(+sel.attr("y")), "y attribute should be valid for rectangle # " + i + ". Currently " + sel.attr("y"));
                 assert.isFalse(Plottable._Util.Methods.isNaN(+sel.attr("height")), "height attribute should be valid for rectangle # " + i + ". Currently " + sel.attr("height"));
                 assert.isFalse(Plottable._Util.Methods.isNaN(+sel.attr("width")), "width attribute should be valid for rectangle # " + i + ". Currently " + sel.attr("width"));
             });
-            var brokenRectHeight = d3.select(plot._element.selectAll(".bar-area rect")[0][2]).attr("height");
-            assert.strictEqual(brokenRectHeight, "0", "the broken rectangle (third one) should have no height, hence not displayed");
             svg.remove();
         });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -8252,6 +8252,26 @@ describe("_Util.Methods", function () {
         assert.isFalse(isNaN(""), "empty strings should fail the isNaN check");
         assert.isFalse(isNaN({}), "empty Objects should fail the isNaN check");
     });
+    it("isValidNumber works as expected", function () {
+        var isValidNumber = Plottable._Util.Methods.isValidNumber;
+        assert.isTrue(isValidNumber(0), "(0 is a valid number");
+        assert.isTrue(isValidNumber(1), "(1 is a valid number");
+        assert.isTrue(isValidNumber(-1), "(-1 is a valid number");
+        assert.isTrue(isValidNumber(0.1), "(0.1 is a valid number");
+        assert.isFalse(isValidNumber(null), "(null is not a valid number");
+        assert.isFalse(isValidNumber(NaN), "(NaN is not a valid number");
+        assert.isFalse(isValidNumber(undefined), "(undefined is not a valid number");
+        assert.isFalse(isValidNumber(Infinity), "(Infinity is not a valid number");
+        assert.isFalse(isValidNumber(-Infinity), "(-Infinity is not a valid number");
+        assert.isFalse(isValidNumber("number"), "('number' is not a valid number");
+        assert.isFalse(isValidNumber("string"), "('string' is not a valid number");
+        assert.isFalse(isValidNumber("0"), "('0' is not a valid number");
+        assert.isFalse(isValidNumber("1"), "('1' is not a valid number");
+        assert.isFalse(isValidNumber([]), "([] is not a valid number");
+        assert.isFalse(isValidNumber([1]), "([1] is not a valid number");
+        assert.isFalse(isValidNumber({}), "({} is not a valid number");
+        assert.isFalse(isValidNumber({ 1: 1 }), "({1: 1} is not a valid number");
+    });
     it("objEq works as expected", function () {
         assert.isTrue(Plottable._Util.Methods.objEq({}, {}));
         assert.isTrue(Plottable._Util.Methods.objEq({ a: 5 }, { a: 5 }));

--- a/test/utils/utilsTests.ts
+++ b/test/utils/utilsTests.ts
@@ -108,6 +108,49 @@ describe("_Util.Methods", () => {
     assert.isFalse(isNaN({}), "empty Objects should fail the isNaN check");
   });
 
+  it("isValidNumber works as expected", () => {
+    var isValidNumber = Plottable._Util.Methods.isValidNumber;
+
+    assert.isTrue(isValidNumber(0),
+      "(0 is a valid number");
+    assert.isTrue(isValidNumber(1),
+      "(1 is a valid number");
+    assert.isTrue(isValidNumber(-1),
+      "(-1 is a valid number");
+    assert.isTrue(isValidNumber(0.1),
+      "(0.1 is a valid number");
+
+    assert.isFalse(isValidNumber(null),
+      "(null is not a valid number");
+    assert.isFalse(isValidNumber(NaN),
+      "(NaN is not a valid number");
+    assert.isFalse(isValidNumber(undefined),
+      "(undefined is not a valid number");
+    assert.isFalse(isValidNumber(Infinity),
+      "(Infinity is not a valid number");
+    assert.isFalse(isValidNumber(-Infinity),
+      "(-Infinity is not a valid number");
+
+    assert.isFalse(isValidNumber("number"),
+      "('number' is not a valid number");
+    assert.isFalse(isValidNumber("string"),
+      "('string' is not a valid number");
+    assert.isFalse(isValidNumber("0"),
+      "('0' is not a valid number");
+    assert.isFalse(isValidNumber("1"),
+      "('1' is not a valid number");
+
+    assert.isFalse(isValidNumber([]),
+      "([] is not a valid number");
+    assert.isFalse(isValidNumber([1]),
+      "([1] is not a valid number");
+    assert.isFalse(isValidNumber({}),
+      "({} is not a valid number");
+    assert.isFalse(isValidNumber({1: 1}),
+      "({1: 1} is not a valid number");
+
+  });
+
   it("objEq works as expected", () => {
     assert.isTrue(Plottable._Util.Methods.objEq({}, {}));
     assert.isTrue(Plottable._Util.Methods.objEq({a: 5}, {a: 5}));


### PR DESCRIPTION
Closes #1848 #1850 #1851 

A couple of graphs, when presented with badly formatted data, were just exploding. We want to handle these cases more gracefully now. The ticket is about `Plot.StackedArea`, `Plot.Pie`, `Plot.Grid`


Plot.StackedArea
===
Before: http://jsfiddle.net/d2te4yct/10/
After: http://jsfiddle.net/d2te4yct/11/

Plot.Pie
===
Before: http://jsfiddle.net/vmzfzx88/3/
After: http://jsfiddle.net/vmzfzx88/4/

Plot.Grid
===
(difference here is more subtle, basically now nothing is thrown in the console)
Before: http://jsfiddle.net/wd1mmd38/
After: http://jsfiddle.net/wd1mmd38/1/

Added unit tests for each

Also, there is a discussion about `null` and `undefined` which should behave the same. That is a discussion for #1866