### PR TITLE
[TSLint Rule] - setting class-name to true

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,6 @@
 {
   "rules": {
-    "class-name": false,
+    "class-name": true,
     "curly": true,
     "eofline": true,
     "forin": true,


### PR DESCRIPTION
class-name enforces that our classes and interfaces are CamelCased