### PR TITLE
[TSLint Rule] - adding comment-format check-space rule

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2171,6 +2171,7 @@ declare module Plottable {
     }
 }
 
+
 declare module Plottable {
     module Axis {
         class Numeric extends AbstractAxis {

--- a/plottable.js
+++ b/plottable.js
@@ -2399,7 +2399,7 @@ var Plottable;
                 return new Category(this._d3Scale.copy());
             };
             Category.prototype.scale = function (value) {
-                //scale it to the middle
+                // scale it to the middle
                 return _super.prototype.scale.call(this, value) + this.rangeBand() / 2;
             };
             return Category;
@@ -2497,7 +2497,7 @@ var Plottable;
             };
             Color.HEX_SCALE_FACTOR = 20;
             Color.LOOP_LIGHTEN_FACTOR = 1.6;
-            //The maximum number of colors we are getting from CSS stylesheets
+            // The maximum number of colors we are getting from CSS stylesheets
             Color.MAXIMUM_COLORS_FROM_CSS = 256;
             return Color;
         })(Scale.AbstractScale);
@@ -4908,7 +4908,7 @@ var Plottable;
     })(Axis = Plottable.Axis || (Plottable.Axis = {}));
 })(Plottable || (Plottable = {}));
 
-//<reference path="../../reference.ts" />
+///<reference path="../../reference.ts" />
 var __extends = this.__extends || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -7462,7 +7462,7 @@ var Plottable;
                 };
                 return Plottable._Util.Methods.intersectsBBox(xRange, yRange, translatedBbox);
             };
-            //===== Hover logic =====
+            // ===== Hover logic =====
             Scatter.prototype._hoverOverComponent = function (p) {
                 // no-op
             };
@@ -7956,7 +7956,7 @@ var Plottable;
                     d._getRenderArea().selectAll("rect").classed("not-hovered hovered", false);
                 });
             };
-            //===== Hover logic =====
+            // ===== Hover logic =====
             Bar.prototype._hoverOverComponent = function (p) {
                 // no-op
             };
@@ -8022,7 +8022,7 @@ var Plottable;
                     selection: barsSelection
                 };
             };
-            //===== /Hover logic =====
+            // ===== /Hover logic =====
             Bar.prototype._getAllPlotData = function (datasetKeys) {
                 var plotData = _super.prototype._getAllPlotData.call(this, datasetKeys);
                 var valueScale = this._isVertical ? this._yScale : this._xScale;
@@ -8242,7 +8242,7 @@ var Plottable;
                     selection: d3.selectAll(closestElements)
                 };
             };
-            //===== Hover logic =====
+            // ===== Hover logic =====
             Line.prototype._hoverOverComponent = function (p) {
                 // no-op
             };
@@ -8732,7 +8732,7 @@ var Plottable;
             StackedArea.prototype._wholeDatumAttributes = function () {
                 return ["x", "y", "defined"];
             };
-            //===== Stack logic from AbstractStackedPlot =====
+            // ===== Stack logic from AbstractStackedPlot =====
             StackedArea.prototype._updateStackOffsets = function () {
                 var _this = this;
                 if (!this._projectorsReady()) {
@@ -8859,7 +8859,7 @@ var Plottable;
             StackedBar.prototype._normalizeDatasets = function (fromX) {
                 return Plot.AbstractStacked.prototype._normalizeDatasets.call(this, fromX);
             };
-            //===== Stack logic from AbstractStackedPlot =====
+            // ===== Stack logic from AbstractStackedPlot =====
             StackedBar.prototype._updateStackOffsets = function () {
                 Plot.AbstractStacked.prototype._updateStackOffsets.call(this);
             };

--- a/src/components/axes/numericAxis.ts
+++ b/src/components/axes/numericAxis.ts
@@ -1,4 +1,4 @@
-//<reference path="../../reference.ts" />
+///<reference path="../../reference.ts" />
 
 module Plottable {
 export module Axis {

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -490,7 +490,7 @@ export module Plot {
       });
     }
 
-    //===== Hover logic =====
+    // ===== Hover logic =====
     public _hoverOverComponent(p: Point) {
       // no-op
     }
@@ -564,7 +564,7 @@ export module Plot {
         selection: barsSelection
       };
     }
-    //===== /Hover logic =====
+    // ===== /Hover logic =====
 
     protected _getAllPlotData(datasetKeys: string[]): PlotData {
       var plotData = super._getAllPlotData(datasetKeys);

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -213,7 +213,7 @@ export module Plot {
       };
     }
 
-    //===== Hover logic =====
+    // ===== Hover logic =====
     public _hoverOverComponent(p: Point) {
       // no-op
     }
@@ -245,7 +245,7 @@ export module Plot {
         selection: this._hoverTarget
       };
     }
-    //===== /Hover logic =====
+    // ===== /Hover logic =====
   }
 }
 }

--- a/src/components/plots/scatterPlot.ts
+++ b/src/components/plots/scatterPlot.ts
@@ -131,7 +131,7 @@ export module Plot {
       return Plottable._Util.Methods.intersectsBBox(xRange, yRange, translatedBbox);
     }
 
-    //===== Hover logic =====
+    // ===== Hover logic =====
     public _hoverOverComponent(p: Point) {
       // no-op
     }
@@ -143,7 +143,7 @@ export module Plot {
     public _doHover(p: Point): Interaction.HoverData {
       return this._getClosestStruckPoint(p, this._closeDetectionRadius);
     }
-    //===== /Hover logic =====
+    // ===== /Hover logic =====
   }
 }
 }

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -90,7 +90,7 @@ export module Plot {
       return ["x", "y", "defined"];
     }
 
-    //===== Stack logic from AbstractStackedPlot =====
+    // ===== Stack logic from AbstractStackedPlot =====
     public _updateStackOffsets() {
       if (!this._projectorsReady()) { return; }
       var domainKeys = this._getDomainKeys();
@@ -146,7 +146,7 @@ export module Plot {
     protected _normalizeDatasets<A, B>(fromX: boolean): {a: A; b: B}[] {
       return AbstractStacked.prototype._normalizeDatasets.call(this, fromX);
     }
-    //===== /Stack logic =====
+    // ===== /Stack logic =====
   }
 }
 }

--- a/src/components/plots/stackedBarPlot.ts
+++ b/src/components/plots/stackedBarPlot.ts
@@ -79,7 +79,7 @@ export module Plot {
       return AbstractStacked.prototype._normalizeDatasets.call(this, fromX);
     }
 
-    //===== Stack logic from AbstractStackedPlot =====
+    // ===== Stack logic from AbstractStackedPlot =====
     public _updateStackOffsets() {
       AbstractStacked.prototype._updateStackOffsets.call(this);
     }
@@ -115,7 +115,7 @@ export module Plot {
     public _valueAccessor(): _Accessor {
       return AbstractStacked.prototype._valueAccessor.call(this);
     }
-    //===== /Stack logic =====
+    // ===== /Stack logic =====
   }
 }
 }

--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -146,7 +146,7 @@ export module Scale {
     }
 
     public scale(value: string): number {
-      //scale it to the middle
+      // scale it to the middle
       return super.scale(value) + this.rangeBand() / 2;
     }
   }

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -6,7 +6,7 @@ export module Scale {
 
     private static HEX_SCALE_FACTOR = 20;
     private static LOOP_LIGHTEN_FACTOR = 1.6;
-    //The maximum number of colors we are getting from CSS stylesheets
+    // The maximum number of colors we are getting from CSS stylesheets
     private static MAXIMUM_COLORS_FROM_CSS = 256;
 
     /**

--- a/test/core/tableTests.ts
+++ b/test/core/tableTests.ts
@@ -112,7 +112,7 @@ describe("Tables", () => {
     var svg = generateSVG();
     t.addComponent(1, 0, new Plottable.Component.AbstractComponent());
     t.addComponent(0, 2, new Plottable.Component.AbstractComponent());
-    t.renderTo(svg); //would throw an error without the fix (tested);
+    t.renderTo(svg); // would throw an error without the fix (tested);
     svg.remove();
   });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -6742,7 +6742,7 @@ describe("Tables", function () {
         var svg = generateSVG();
         t.addComponent(1, 0, new Plottable.Component.AbstractComponent());
         t.addComponent(0, 2, new Plottable.Component.AbstractComponent());
-        t.renderTo(svg); //would throw an error without the fix (tested);
+        t.renderTo(svg); // would throw an error without the fix (tested);
         svg.remove();
     });
     it("basic table with 2 rows 2 cols lays out properly", function () {

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
   "rules": {
     "class-name": false,
+    "comment-format": [true, "check-space"],
     "curly": true,
     "eofline": true,
     "forin": true,


### PR DESCRIPTION
This checks if there is a single space in a single line comment between the / and the comment itself

Neat:
```typescript
// Insert comment here
```

Messy:
```typescript
//Insert Comment here
```