### PR TITLE
[TSLint Rule] - adding no-constructor-vars rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -10,7 +10,6 @@
     "max-line-length": [true, 140],
     "no-arg": true,
     "no-bitwise": true,
-    "no-construct": true,
     "no-console": [true,
         "log",
         "debug",
@@ -20,6 +19,8 @@
         "trace",
         "warn"
     ],
+    "no-construct": true,
+    "no-constructor-vars": true,
     "no-duplicate-key": true,
     "no-duplicate-variable": true,
     "no-empty": true,


### PR DESCRIPTION
This disallows the usage of placing public/private into the parameters of the constructor.

Neat:
```typescript
constructor(foo: number) {}
```

Messy:
```typescript
constructor(private foo: number) {}
```