### PR TITLE
[TSLint Rule] - adding no-consecutive-blank-lines rule

### DIFF
--- a/src/components/plots/rectanglePlot.ts
+++ b/src/components/plots/rectanglePlot.ts
@@ -49,7 +49,6 @@ export module Plot {
       delete attrToProjector["x2"];
       delete attrToProjector["y2"];
 
-
       attrToProjector["fill"] = attrToProjector["fill"] || d3.functor(this._defaultFillColor);
       return attrToProjector;
     }

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -249,7 +249,6 @@ export module Component {
               wantsHeightArr   : layoutWantsHeight};
     }
 
-
     public _requestedSpace(offeredWidth : number, offeredHeight: number): _SpaceRequest {
       this._calculatedLayout = this._iterateLayout(offeredWidth , offeredHeight);
       return {width : d3.sum(this._calculatedLayout.guaranteedWidths ),

--- a/src/core/colors.ts
+++ b/src/core/colors.ts
@@ -17,7 +17,6 @@ export module Core {
     public static BRIGHT_SUN      = "#fad419";
     public static JACARTA         = "#2c2b6f";
 
-
     public static PLOTTABLE_COLORS = [
       Colors.INDIGO,
       Colors.CORAL_RED,

--- a/src/core/domainer.ts
+++ b/src/core/domainer.ts
@@ -96,7 +96,6 @@ module Plottable {
       return this;
     }
 
-
     /**
      * Removes a padding exception, allowing the domain to pad out that value again.
      *

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -11,7 +11,6 @@ export module Scale {
     public _typeCoercer = (d: any) => +d;
     private _tickGenerator: TickGenerators.TickGenerator<D> = (scale: Plottable.Scale.AbstractQuantitative<D>) => scale.getDefaultTicks();
 
-
     /**
      * Constructs a new QuantitativeScale.
      *

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -2,7 +2,6 @@
 
 var assert = chai.assert;
 
-
 describe("Labels", () => {
 
   it("Standard text title label generates properly", () => {

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -2,7 +2,6 @@
 
 var assert = chai.assert;
 
-
 describe("Legend", () => {
   var svg: D3.Selection;
   var color: Plottable.Scale.Color;
@@ -114,7 +113,6 @@ describe("Legend", () => {
     var newColorScale = new Plottable.Scale.Color("20");
     newColorScale.domain(newDomain);
     legend.scale(newColorScale);
-
 
     (<any> legend)._content.selectAll(entrySelector).each(function(d: any, i: number) {
       assert.equal(d, newDomain[i], "the data is set correctly");

--- a/test/components/numericAxisTests.ts
+++ b/test/components/numericAxisTests.ts
@@ -181,7 +181,6 @@ describe("NumericAxis", () => {
     svg.remove();
   });
 
-
   it("tick labels don't overlap in a constrained space", () => {
     var SVG_WIDTH = 100;
     var SVG_HEIGHT = 100;
@@ -269,7 +268,6 @@ describe("NumericAxis", () => {
       labelBox = label.getBoundingClientRect();
       assertBoxInside(labelBox, boundingBox, 0, "long tick " + label.textContent + " is inside the bounding box");
     });
-
 
     svg.remove();
   });

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -663,7 +663,6 @@ describe("Plots", () => {
         svg.remove();
       });
 
-
       it("bar labels render properly", () => {
         plot.renderTo(svg);
         plot.barLabelsEnabled(true);

--- a/test/components/plots/gridPlotTests.ts
+++ b/test/components/plots/gridPlotTests.ts
@@ -61,7 +61,6 @@ describe("Plots", () => {
       svg.remove();
     });
 
-
     it("renders correctly when data is set after construction", () => {
       var xScale: Plottable.Scale.Category = new Plottable.Scale.Category();
       var yScale: Plottable.Scale.Category = new Plottable.Scale.Category();

--- a/test/components/plots/plotTests.ts
+++ b/test/components/plots/plotTests.ts
@@ -39,7 +39,6 @@ describe("Plots", () => {
       dFoo.broadcaster.broadcast();
       assert.equal(2, r.renders, "we re-render when our dataset changes");
 
-
       r.addDataset("bar", dBar);
       assert.equal(3, r.renders, "we should redraw when we add a dataset");
 

--- a/test/components/plots/stackedBarPlotTests.ts
+++ b/test/components/plots/stackedBarPlotTests.ts
@@ -408,7 +408,6 @@ describe("Plots", () => {
     });
   });
 
-
   describe("fail safe tests", () => {
 
     it("conversion fails should be silent in Plot.StackedBar", () => {

--- a/test/core/componentContainerTests.ts
+++ b/test/core/componentContainerTests.ts
@@ -2,7 +2,6 @@
 
 var assert = chai.assert;
 
-
 describe("ComponentContainer", () => {
 
   it("_addComponent()", () => {

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -2,7 +2,6 @@
 
 var assert = chai.assert;
 
-
 describe("ComponentGroups", () => {
   it("components in componentGroups overlap", () => {
     var c1 = makeFixedSizeComponent(10, 10);

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -2,7 +2,6 @@
 
 var assert = chai.assert;
 
-
 function assertComponentXY(component: Plottable.Component.AbstractComponent, x: number, y: number, message: string) {
   // use <any> to examine the private variables
   var translate = d3.transform((<any> component)._element.attr("transform")).translate;
@@ -76,7 +75,6 @@ describe("Component behavior", () => {
       assert.equal(c.height(), 200, "defaults to height of parent if width is not specified on <svg>");
       assert.equal((<any> c)._xOrigin, 0, "xOrigin defaulted to 0");
       assert.equal((<any> c)._yOrigin, 0, "yOrigin defaulted to 0");
-
 
       svg.style("width", "50%").style("height", "50%");
       c._computeLayout();

--- a/test/drawers/drawerTests.ts
+++ b/test/drawers/drawerTests.ts
@@ -11,7 +11,6 @@ class MockAnimator implements Plottable.Animator.PlotAnimator {
     return this.time;
   }
 
-
   public animate(selection: any, attrToProjector: Plottable.AttributeToProjector): any {
     if (this.callback) {
       this.callback();

--- a/test/interactions/hoverInteractionTests.ts
+++ b/test/interactions/hoverInteractionTests.ts
@@ -44,7 +44,6 @@ describe("Interactions", () => {
     var outData: Plottable.Interaction.HoverData;
     var outCallbackCalled = false;
 
-
     beforeEach(() => {
       svg = generateSVG();
       testTarget = new TestHoverable();

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -27,7 +27,6 @@ describe("Scales", () => {
     scale.domain([0, 10]);
     assert.isTrue(callbackWasCalled, "The registered callback was called");
 
-
     (<any> scale)._autoDomainAutomatically = true;
     scale._updateExtent("1", "x", [0.08, 9.92]);
     callbackWasCalled = false;

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -116,7 +116,6 @@ function assertWidthHeight(el: D3.Selection, widthExpected: number, heightExpect
   assert.equal(height, heightExpected, "height: " + message);
 }
 
-
 function makeLinearSeries(n: number): {x: number; y: number}[] {
   function makePoint(x: number) {
     return {x: x, y: x};

--- a/test/utils/utilsTests.ts
+++ b/test/utils/utilsTests.ts
@@ -42,7 +42,6 @@ describe("_Util.Methods", () => {
     assert.deepEqual(Plottable._Util.Methods.uniq(strings), ["foo", "bar", "baz", "bam"]);
   });
 
-
   describe("min/max", () => {
     var max = Plottable._Util.Methods.max;
     var min = Plottable._Util.Methods.min;

--- a/tslint.json
+++ b/tslint.json
@@ -10,7 +10,7 @@
     "max-line-length": [true, 140],
     "no-arg": true,
     "no-bitwise": true,
-    "no-construct": true,
+    "no-consecutive-blank-lines": true,
     "no-console": [true,
         "log",
         "debug",
@@ -20,7 +20,7 @@
         "trace",
         "warn"
     ],
-    "no-consecutive-blank-lines": true,
+    "no-construct": true,
     "no-duplicate-key": true,
     "no-duplicate-variable": true,
     "no-empty": true,

--- a/tslint.json
+++ b/tslint.json
@@ -20,6 +20,7 @@
         "trace",
         "warn"
     ],
+    "no-consecutive-blank-lines": true,
     "no-duplicate-key": true,
     "no-duplicate-variable": true,
     "no-empty": true,


### PR DESCRIPTION
The rule disallows the usage of consecutive blank lines

Neat:
```typescript
var foo = "foo";

var bar = "bar;
```

Messy:
```typescript
var foo = "foo";


var bar = "bar";
```