### PR TITLE
[TSLint Rule] - adding no-switch-case-fall-through rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -24,6 +24,7 @@
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
+    "no-switch-case-fall-through": true,
     "no-trailing-comma": true,
     "no-trailing-whitespace": true,
     "no-unused-variable": false,


### PR DESCRIPTION
Disallowing having cases in a switch statement to fall into each other

Neat:
```typescript
switch(foo) {
    case 1:
        doStuff(foo);
        break;
     case 2:
         doStuff2(foo);
}
```

Messy:
```typescript
switch(foo) {
    case 1:
        doStuff(foo);
    case 2:
         doStuff2(foo);
}
```