### PR TITLE
[TSLint Rule] - adding no-var-requires rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -29,6 +29,7 @@
     "no-unused-variable": false,
     "no-unreachable": true,
     "no-use-before-declare": true,
+    "no-var-requires": true,
     "one-line": [true,
         "check-open-brace",
         "check-catch",


### PR DESCRIPTION
Disallowing the usage of using require to be stored into a variable instead of importing.

Messy:
```typescript
var module = require("moduleName");
```