### PR TITLE
[DO NOT MERGE] Add CallbackSet.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -345,6 +345,27 @@ declare module Plottable {
 
 
 declare module Plottable {
+    module Utils {
+        class Set<T> {
+            constructor();
+            add(value: T): Set<T>;
+            remove(value: T): Set<T>;
+            values(): T[];
+        }
+    }
+}
+
+
+declare module Plottable {
+    module Utils {
+        class CallbackSet extends Set<Function> {
+            callCallbacks(...args: any[]): CallbackSet;
+        }
+    }
+}
+
+
+declare module Plottable {
     type Formatter = (d: any) => string;
     var MILLISECONDS_IN_ONE_DAY: number;
     module Formatters {

--- a/plottable.js
+++ b/plottable.js
@@ -805,6 +805,70 @@ var Plottable;
 ///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
+    var Utils;
+    (function (Utils) {
+        var Set = (function () {
+            function Set() {
+                this._values = [];
+            }
+            Set.prototype.add = function (value) {
+                if (this._values.indexOf(value) === -1) {
+                    this._values.push(value);
+                }
+                return this;
+            };
+            Set.prototype.remove = function (value) {
+                var index = this._values.indexOf(value);
+                if (index !== -1) {
+                    this._values.splice(index, 1);
+                }
+                return this;
+            };
+            Set.prototype.values = function () {
+                return this._values;
+            };
+            return Set;
+        })();
+        Utils.Set = Set;
+    })(Utils = Plottable.Utils || (Plottable.Utils = {}));
+})(Plottable || (Plottable = {}));
+
+///<reference path="../reference.ts" />
+var __extends = this.__extends || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    __.prototype = b.prototype;
+    d.prototype = new __();
+};
+var Plottable;
+(function (Plottable) {
+    var Utils;
+    (function (Utils) {
+        var CallbackSet = (function (_super) {
+            __extends(CallbackSet, _super);
+            function CallbackSet() {
+                _super.apply(this, arguments);
+            }
+            CallbackSet.prototype.callCallbacks = function () {
+                var args = [];
+                for (var _i = 0; _i < arguments.length; _i++) {
+                    args[_i - 0] = arguments[_i];
+                }
+                // no fat-arrow notation to set "this" to current "this" context
+                this.values().forEach(function (callback) {
+                    callback.apply(this, args);
+                });
+                return this;
+            };
+            return CallbackSet;
+        })(Utils.Set);
+        Utils.CallbackSet = CallbackSet;
+    })(Utils = Plottable.Utils || (Plottable.Utils = {}));
+})(Plottable || (Plottable = {}));
+
+///<reference path="../reference.ts" />
+var Plottable;
+(function (Plottable) {
     Plottable.MILLISECONDS_IN_ONE_DAY = 24 * 60 * 60 * 1000;
     var Formatters;
     (function (Formatters) {

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -5,6 +5,8 @@
 /// <reference path="utils/strictEqualityAssociativeArray.ts" />
 /// <reference path="utils/domUtils.ts" />
 /// <reference path="utils/color.ts" />
+/// <reference path="utils/set.ts" />
+/// <reference path="utils/callbackSet.ts" />
 
 /// <reference path="utils/formatters.ts" />
 /// <reference path="utils/symbolFactories.ts" />

--- a/src/utils/callbackSet.ts
+++ b/src/utils/callbackSet.ts
@@ -1,0 +1,13 @@
+///<reference path="../reference.ts" />
+
+module Plottable {
+  export module Utils {
+    export class CallbackSet extends Set<Function> {
+      public callCallbacks(...args: any[]) {
+        // no fat-arrow notation to set "this" to current "this" context
+        this.values().forEach(function(callback) { callback.apply(this, args); });
+        return this;
+      }
+    }
+  }
+}

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -1,0 +1,32 @@
+///<reference path="../reference.ts" />
+
+module Plottable {
+  export module Utils {
+    export class Set<T> {
+      private _values: T[];
+
+      constructor() {
+        this._values = [];
+      }
+
+      public add(value: T) {
+        if (this._values.indexOf(value) === -1) {
+          this._values.push(value);
+        }
+        return this;
+      }
+
+      public remove(value: T) {
+        var index = this._values.indexOf(value);
+        if (index !== -1) {
+          this._values.splice(index, 1);
+        }
+        return this;
+      }
+
+      public values() {
+        return this._values;
+      }
+    }
+  }
+}

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -58,6 +58,7 @@
 ///<reference path="utils/strictEqualityAssociativeArrayTests.ts" />
 ///<reference path="utils/clientToSVGTranslatorTests.ts" />
 ///<reference path="utils/utilsTests.ts" />
+///<reference path="utils/callbackSetTests.ts" />
 
 ///<reference path="interactions/interactionTests.ts" />
 ///<reference path="interactions/pointerInteractionTests.ts" />

--- a/test/tests.js
+++ b/test/tests.js
@@ -8306,6 +8306,51 @@ describe("_Util.Methods", function () {
 
 ///<reference path="../testReference.ts" />
 var assert = chai.assert;
+describe("CallbackSet", function () {
+    it("callCallbacks()", function () {
+        var cb1called = false;
+        var cb1 = function () { return cb1called = true; };
+        var cb2called = false;
+        var cb2 = function () { return cb2called = true; };
+        var callbackSet = new Plottable.Utils.CallbackSet();
+        callbackSet.add(cb1);
+        callbackSet.add(cb2);
+        callbackSet.callCallbacks();
+        assert.isTrue(cb1called, "callback 1 was called");
+        assert.isTrue(cb2called, "callback 2 was called");
+        cb1called = false;
+        cb2called = false;
+        callbackSet.remove(cb2);
+        callbackSet.callCallbacks();
+        assert.isTrue(cb1called, "callback 1 was called");
+        assert.isFalse(cb2called, "callback 2 was called");
+    });
+    it("passes arguments to callbacks", function () {
+        var expectedS = "Plottable";
+        var expectedI = 1;
+        var cb1called = false;
+        var cb1 = function (s, i) {
+            assert.strictEqual(s, expectedS, "was passed the correct first argument");
+            assert.strictEqual(i, expectedI, "was passed the correct second argument");
+            cb1called = true;
+        };
+        var cb2called = false;
+        var cb2 = function (s, i) {
+            assert.strictEqual(s, expectedS, "was passed the correct first argument");
+            assert.strictEqual(i, expectedI, "was passed the correct second argument");
+            cb2called = true;
+        };
+        var callbackSet = new Plottable.Utils.CallbackSet();
+        callbackSet.add(cb1);
+        callbackSet.add(cb2);
+        callbackSet.callCallbacks(expectedS, expectedI);
+        assert.isTrue(cb1called, "callback 1 was called");
+        assert.isTrue(cb2called, "callback 2 was called");
+    });
+});
+
+///<reference path="../testReference.ts" />
+var assert = chai.assert;
 describe("Interactions", function () {
     describe("PanZoomInteraction", function () {
         it("Pans properly", function () {

--- a/test/utils/callbackSetTests.ts
+++ b/test/utils/callbackSetTests.ts
@@ -1,0 +1,53 @@
+///<reference path="../testReference.ts" />
+
+var assert = chai.assert;
+
+describe("CallbackSet", () => {
+  it("callCallbacks()", () => {
+    var cb1called = false;
+    var cb1 = () => cb1called = true;
+    var cb2called = false;
+    var cb2 = () => cb2called = true;
+
+    var callbackSet = new Plottable.Utils.CallbackSet();
+    callbackSet.add(cb1);
+    callbackSet.add(cb2);
+
+    callbackSet.callCallbacks();
+    assert.isTrue(cb1called, "callback 1 was called");
+    assert.isTrue(cb2called, "callback 2 was called");
+
+    cb1called = false;
+    cb2called = false;
+    callbackSet.remove(cb2);
+    callbackSet.callCallbacks();
+    assert.isTrue(cb1called, "callback 1 was called");
+    assert.isFalse(cb2called, "callback 2 was called");
+  });
+
+  it("passes arguments to callbacks", () => {
+    var expectedS = "Plottable";
+    var expectedI = 1;
+
+    var cb1called = false;
+    var cb1 = (s: string, i: number) => {
+      assert.strictEqual(s, expectedS, "was passed the correct first argument");
+      assert.strictEqual(i, expectedI, "was passed the correct second argument");
+      cb1called = true;
+    };
+    var cb2called = false;
+    var cb2 = (s: string, i: number) => {
+      assert.strictEqual(s, expectedS, "was passed the correct first argument");
+      assert.strictEqual(i, expectedI, "was passed the correct second argument");
+      cb2called = true;
+    };
+
+    var callbackSet = new Plottable.Utils.CallbackSet();
+    callbackSet.add(cb1);
+    callbackSet.add(cb2);
+
+    callbackSet.callCallbacks(expectedS, expectedI);
+    assert.isTrue(cb1called, "callback 1 was called");
+    assert.isTrue(cb2called, "callback 2 was called");
+  });
+});


### PR DESCRIPTION
A set of callbacks. You can call them all with `callCallbacks()`.

Question 1: Should we be using [ES6 Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) instead? I need to extend it to add `callCallbacks()`, so I don't think that would work. We'd also need to get a shim.

Question 2: Do we need the generic `Set` at all? I expect we'll want it if we convert `Dataset`s to be added by direct-reference, but maybe we should just write out the `push()` and `splice()` lines when it comes to that.