### PR TITLE
[style] Whitespace rule enforced

### DIFF
--- a/src/components/axes/abstractAxis.ts
+++ b/src/components/axes/abstractAxis.ts
@@ -162,7 +162,7 @@ module Plottable {
         y2: 0
       };
 
-      switch(this._orientation) {
+      switch (this._orientation) {
         case "bottom":
           baselineAttrHash.x2 = this.width();
           break;
@@ -206,7 +206,7 @@ module Plottable {
 
       var tickLength = isEndTickMark ? this._endTickLength : this._tickLength;
 
-      switch(this._orientation) {
+      switch (this._orientation) {
         case "bottom":
           tickMarkAttrHash["y2"] = tickLength;
           break;
@@ -236,7 +236,7 @@ module Plottable {
     }
 
     protected _setDefaultAlignment() {
-      switch(this._orientation) {
+      switch (this._orientation) {
         case "bottom":
           this.yAlign("top");
           break;

--- a/src/components/axes/categoryAxis.ts
+++ b/src/components/axes/categoryAxis.ts
@@ -101,7 +101,7 @@ export module Axes {
       var self = this;
       var xAlign: {[s: string]: string};
       var yAlign: {[s: string]: string};
-      switch(this.tickLabelAngle()) {
+      switch (this.tickLabelAngle()) {
         case 0:
           xAlign = {left: "right",  right: "left", top: "center", bottom: "center"};
           yAlign = {left: "center",  right: "center", top: "bottom", bottom: "top"};

--- a/src/components/axes/numericAxis.ts
+++ b/src/components/axes/numericAxis.ts
@@ -111,7 +111,7 @@ export module Axes {
       var labelGroupShiftX = 0;
       var labelGroupShiftY = 0;
       if (this._isHorizontal()) {
-        switch(this._tickLabelPositioning) {
+        switch (this._tickLabelPositioning) {
           case "left":
             tickLabelTextAnchor = "end";
             labelGroupTransformX = -tickLabelPadding;
@@ -127,7 +127,7 @@ export module Axes {
             break;
         }
       } else {
-        switch(this._tickLabelPositioning) {
+        switch (this._tickLabelPositioning) {
           case "top":
             tickLabelAttrHash["dy"] = "-0.3em";
             labelGroupShiftX = tickLabelPadding;
@@ -145,7 +145,7 @@ export module Axes {
       }
 
       var tickMarkAttrHash = this._generateTickMarkAttrHash();
-      switch(this.orient()) {
+      switch (this.orient()) {
         case "bottom":
           tickLabelAttrHash["x"] = tickMarkAttrHash["x1"];
           tickLabelAttrHash["dy"] = "0.95em";

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -202,7 +202,7 @@ export module Axes {
      */
     public axisConfigurations(configurations: TimeAxisConfiguration[]): Time;
     public axisConfigurations(configurations?: any): any {
-      if(configurations == null){
+      if (configurations == null){
         return this._possibleTimeAxisConfigurations;
       }
       this._possibleTimeAxisConfigurations = configurations;

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -205,7 +205,7 @@ export module Components {
         spaceLeft -= entryLength;
       });
 
-      if(currentRow.length !== 0) {
+      if (currentRow.length !== 0) {
         rows.push(currentRow);
       }
       return rows;

--- a/src/components/plots/abstractXYPlot.ts
+++ b/src/components/plots/abstractXYPlot.ts
@@ -150,20 +150,20 @@ module Plottable {
      */
     public showAllData() {
       this._xScale.autoDomain();
-      if(!this._autoAdjustYScaleDomain) {
+      if (!this._autoAdjustYScaleDomain) {
         this._yScale.autoDomain();
       }
     }
 
     private _adjustYDomainOnChangeFromX() {
       if (!this._projectorsReady()) { return; }
-      if(this._autoAdjustYScaleDomain) {
+      if (this._autoAdjustYScaleDomain) {
         this._adjustDomainToVisiblePoints<X, Y>(this._xScale, this._yScale, true);
       }
     }
     private _adjustXDomainOnChangeFromY() {
       if (!this._projectorsReady()) { return; }
-      if(this._autoAdjustXScaleDomain) {
+      if (this._autoAdjustXScaleDomain) {
         this._adjustDomainToVisiblePoints<Y, X>(this._yScale, this._xScale, false);
       }
     }
@@ -185,7 +185,7 @@ module Plottable {
         }
 
         var adjustedDomain = this._adjustDomainOverVisiblePoints<A, B>(normalizedData, filterFn);
-        if(adjustedDomain.length === 0) {
+        if (adjustedDomain.length === 0) {
           return;
         }
         adjustedDomain = toScaleQ.domainer().computeDomain([adjustedDomain], toScaleQ);

--- a/src/drawers/areaDrawer.ts
+++ b/src/drawers/areaDrawer.ts
@@ -43,7 +43,7 @@ export module Drawers {
                        y0Function: AppliedProjector,
                        y1Function: AppliedProjector,
                        definedFunction: AppliedProjector) {
-      if(!definedFunction) {
+      if (!definedFunction) {
         definedFunction = () => true;
       }
 

--- a/src/drawers/lineDrawer.ts
+++ b/src/drawers/lineDrawer.ts
@@ -23,7 +23,7 @@ export module Drawers {
     }
 
     private _createLine(xFunction: AppliedProjector, yFunction: AppliedProjector, definedFunction: AppliedProjector) {
-      if(!definedFunction) {
+      if (!definedFunction) {
         definedFunction = (d, i) => true;
       }
 

--- a/src/scales/abstractScale.ts
+++ b/src/scales/abstractScale.ts
@@ -101,7 +101,7 @@ module Plottable {
     }
 
     protected _setDomain(values: D[]) {
-      if(!this._domainModificationInProgress) {
+      if (!this._domainModificationInProgress) {
         this._domainModificationInProgress = true;
         this._d3Scale.domain(values);
         this.broadcaster.broadcast();

--- a/src/scales/interpolatedColorScale.ts
+++ b/src/scales/interpolatedColorScale.ts
@@ -67,7 +67,7 @@ export module Scales {
      */
     private static _getD3InterpolatedScale(colors: string[], scaleType: string): D3.Scale.QuantitativeScale {
       var scale: D3.Scale.QuantitativeScale;
-      switch(scaleType){
+      switch (scaleType){
         case "linear":
           scale = d3.scale.linear();
           break;

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -203,7 +203,7 @@ module Plottable {
      */
     public tickGenerator(generator: Scales.TickGenerators.TickGenerator<D>): QuantitativeScale<D>;
     public tickGenerator(generator?: Scales.TickGenerators.TickGenerator<D>): any {
-      if(generator == null) {
+      if (generator == null) {
         return this._tickGenerator;
       } else {
         this._tickGenerator = generator;

--- a/src/scales/tickGenerators.ts
+++ b/src/scales/tickGenerators.ts
@@ -18,7 +18,7 @@ module Plottable {
        * @returns {TickGenerator} A tick generator using the specified interval.
        */
       export function intervalTickGenerator(interval: number) : TickGenerator<number> {
-        if(interval <= 0) {
+        if (interval <= 0) {
            throw new Error("interval must be positive number");
         }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -73,7 +73,7 @@ export module Utils {
     export function intersection<T>(set1: D3.Set<T>, set2: D3.Set<T>): D3.Set<string> {
       var set: D3.Set<string> = d3.set();
       set1.forEach((v) => {
-        if(set2.has(<any> v)) { // checking a string is always appropriate due to d3.set implementation
+        if (set2.has(<any> v)) { // checking a string is always appropriate due to d3.set implementation
           set.add(v);
         }
       });
@@ -275,7 +275,7 @@ export module Utils {
     }
 
     export function range(start: number, stop: number, step = 1): number[] {
-      if(step === 0) {
+      if (step === 0) {
         throw new Error("step cannot be 0");
       }
       var length = Math.max(Math.ceil((stop - start) / step), 0);

--- a/test/core/tableTests.ts
+++ b/test/core/tableTests.ts
@@ -8,8 +8,8 @@ function generateBasicTable(nRows: number, nCols: number) {
   var table = new Plottable.Components.Table();
   var rows: Plottable.Component[][] = [];
   var components: Plottable.Component[] = [];
-  for(var i = 0; i < nRows; i++) {
-    for(var j = 0; j < nCols; j++) {
+  for (var i = 0; i < nRows; i++) {
+    for (var j = 0; j < nCols; j++) {
       var r = new Plottable.Component();
       table.addComponent(i, j, r);
       components.push(r);

--- a/tslint.json
+++ b/tslint.json
@@ -34,12 +34,22 @@
         "check-catch",
         "check-else"
     ],
-    "quotemark": [true, "double"],
+    "quotemark": [true,
+        "double"
+    ],
     "radix": true,
     "semicolon": true,
-    "triple-equals": [true, "allow-null-check"],
+    "triple-equals": [true,
+        "allow-null-check"
+    ],
     "variable-name": false,
-    "whitespace": ["check-branch", "check-decl", "check-operator", "check-separator", "check-type"],
+    "whitespace": [true,
+        "check-branch",
+        "check-decl",
+        "check-operator",
+        "check-separator",
+        "check-type"
+    ],
     "ban": [true, ["d3", "max"], ["d3", "min"]]
   }
 }


### PR DESCRIPTION
`tslint.json` rule for `whitespace: check-branch` was previously broken. After reading this https://github.com/palantir/tslint/blob/master/docs/sample.tslint.json it seems like the first argument of the array has to be boolean true, which meant that the check-branch was not actually passed as an argument, but instead coerced the string to `true`. 

In this commit: fixed that, applied the changes through regex replace and rearranged the rules to be consistent with the suggested style