### PR TITLE
[DO NOT MERGE] simplifying _computeLayout()  API

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -742,8 +742,6 @@ declare module Plottable {
     type _SpaceRequest = {
         width: number;
         height: number;
-        wantsWidth: boolean;
-        wantsHeight: boolean;
     };
     /**
      * The range of your current data. For example, [1, 2, 6, -5] has the Extent

--- a/plottable.js
+++ b/plottable.js
@@ -2299,7 +2299,7 @@ var Plottable;
                 return this;
             };
             Category.prototype.copy = function () {
-                return new Category(this._d3Scale.copy());
+                return new Category(this._d3Scale.copy()).range(this.range()).innerPadding(this.innerPadding()).outerPadding(this.outerPadding());
             };
             Category.prototype.scale = function (value) {
                 //scale it to the middle

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -95,7 +95,10 @@ export module Component {
     }
 
     public _requestedSpace(availableWidth : number, availableHeight: number): _SpaceRequest {
-      return {width: 0, height: 0, wantsWidth: false, wantsHeight: false};
+      return {
+        width: 0,
+        height: 0
+      };
     }
 
     /**

--- a/src/components/axes/abstractAxis.ts
+++ b/src/components/axes/abstractAxis.ts
@@ -97,9 +97,7 @@ export module Axis {
 
       return {
         width : requestedWidth,
-        height: requestedHeight,
-        wantsWidth: !this._isHorizontal() && offeredWidth < requestedWidth,
-        wantsHeight: this._isHorizontal() && offeredHeight < requestedHeight
+        height: requestedHeight
       };
     }
 

--- a/src/components/axes/categoryAxis.ts
+++ b/src/components/axes/categoryAxis.ts
@@ -41,7 +41,7 @@ export module Axis {
       var heightRequiredByTicks = this._isHorizontal() ? this._maxLabelTickLength() + this.tickLabelPadding() + this.gutter() : 0;
 
       if (this._scale.domain().length === 0) {
-        return {width: 0, height: 0, wantsWidth: false, wantsHeight: false };
+        return { width: 0, height: 0 };
       }
 
       var categoryScale: Scale.Category = <Scale.Category> this._scale;
@@ -55,11 +55,12 @@ export module Axis {
                                           offeredHeight,
                                           fakeScale,
                                           categoryScale.domain());
+
+      var desiredWidth = textResult.usedWidth + widthRequiredByTicks;
+      var desiredHeight = textResult.usedHeight + heightRequiredByTicks;
       return {
-        width : textResult.usedWidth  + widthRequiredByTicks,
-        height: textResult.usedHeight + heightRequiredByTicks,
-        wantsWidth : !textResult.textFits,
-        wantsHeight: !textResult.textFits
+        width: desiredWidth,
+        height: desiredHeight
       };
     }
 

--- a/src/components/componentGroup.ts
+++ b/src/components/componentGroup.ts
@@ -27,9 +27,7 @@ export module Component {
       var requests = this.components().map((c: AbstractComponent) => c._requestedSpace(offeredWidth, offeredHeight));
       return {
         width : _Util.Methods.max<_SpaceRequest, number>(requests, (request: _SpaceRequest) => request.width, 0),
-        height: _Util.Methods.max<_SpaceRequest, number>(requests, (request: _SpaceRequest) => request.height, 0),
-        wantsWidth : requests.map((r: _SpaceRequest) => r.wantsWidth ).some((x: boolean) => x),
-        wantsHeight: requests.map((r: _SpaceRequest) => r.wantsHeight).some((x: boolean) => x)
+        height: _Util.Methods.max<_SpaceRequest, number>(requests, (request: _SpaceRequest) => request.height, 0)
       };
     }
 

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -156,9 +156,7 @@ export module Component {
 
       return {
         width : desiredWidth,
-        height: desiredHeight,
-        wantsWidth: offeredWidth < desiredWidth,
-        wantsHeight: offeredHeight < desiredHeight
+        height: desiredHeight
       };
     }
 

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -69,9 +69,7 @@ export module Component {
 
       return {
         width : desiredWidth,
-        height: desiredHeight,
-        wantsWidth : desiredWidth  > offeredWidth,
-        wantsHeight: desiredHeight > offeredHeight
+        height: desiredHeight
       };
     }
 

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -184,9 +184,7 @@ export module Component {
       var wantsFitMoreEntriesInRow = estimatedLayout.rows.length > desiredNumRows;
       return {
         width : this._padding + longestRowLength,
-        height: acceptableHeight,
-        wantsWidth: offeredWidth < desiredWidth || wantsFitMoreEntriesInRow,
-        wantsHeight: offeredHeight < desiredHeight
+        height: acceptableHeight
       };
     }
 

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -228,39 +228,42 @@ export module Component {
     private _determineGuarantees(offeredWidths: number[], offeredHeights: number[]): _LayoutAllocation {
       var requestedWidths  = _Util.Methods.createFilledArray(0, this._nCols);
       var requestedHeights = _Util.Methods.createFilledArray(0, this._nRows);
-      var layoutWantsWidth  = _Util.Methods.createFilledArray(false, this._nCols);
-      var layoutWantsHeight = _Util.Methods.createFilledArray(false, this._nRows);
+      var columnNeedsWidth  = _Util.Methods.createFilledArray(false, this._nCols);
+      var rowNeedsHeight = _Util.Methods.createFilledArray(false, this._nRows);
       this._rows.forEach((row: AbstractComponent[], rowIndex: number) => {
         row.forEach((component: AbstractComponent, colIndex: number) => {
           var spaceRequest: _SpaceRequest;
           if (component != null) {
             spaceRequest = component._requestedSpace(offeredWidths[colIndex], offeredHeights[rowIndex]);
           } else {
-            spaceRequest = {width: 0, height: 0, wantsWidth: false, wantsHeight: false};
+            spaceRequest = {width: 0, height: 0};
           }
+
 
           var allocatedWidth = Math.min(spaceRequest.width, offeredWidths[colIndex]);
           var allocatedHeight = Math.min(spaceRequest.height, offeredHeights[rowIndex]);
+          var componentNeedsWidth = spaceRequest.width > offeredWidths[colIndex];
+          var componentNeedsHeight = spaceRequest.height > offeredHeights[rowIndex];
 
-          requestedWidths [colIndex] = Math.max(requestedWidths [colIndex], allocatedWidth );
+          requestedWidths[colIndex] = Math.max(requestedWidths[colIndex], allocatedWidth);
           requestedHeights[rowIndex] = Math.max(requestedHeights[rowIndex], allocatedHeight);
-          layoutWantsWidth [colIndex] = layoutWantsWidth [colIndex] || spaceRequest.wantsWidth;
-          layoutWantsHeight[rowIndex] = layoutWantsHeight[rowIndex] || spaceRequest.wantsHeight;
+
+          columnNeedsWidth[colIndex] = columnNeedsWidth[colIndex] || componentNeedsWidth;
+          rowNeedsHeight[rowIndex] = rowNeedsHeight[rowIndex] || componentNeedsHeight;
         });
       });
       return {guaranteedWidths : requestedWidths  ,
               guaranteedHeights: requestedHeights ,
-              wantsWidthArr    : layoutWantsWidth ,
-              wantsHeightArr   : layoutWantsHeight};
+              wantsWidthArr    : columnNeedsWidth ,
+              wantsHeightArr   : rowNeedsHeight};
     }
-
 
     public _requestedSpace(offeredWidth : number, offeredHeight: number): _SpaceRequest {
       this._calculatedLayout = this._iterateLayout(offeredWidth , offeredHeight);
-      return {width : d3.sum(this._calculatedLayout.guaranteedWidths ),
-              height: d3.sum(this._calculatedLayout.guaranteedHeights),
-              wantsWidth: this._calculatedLayout.wantsWidth,
-              wantsHeight: this._calculatedLayout.wantsHeight};
+      return {
+        width: d3.sum(this._calculatedLayout.guaranteedWidths),
+        height: d3.sum(this._calculatedLayout.guaranteedHeights)
+      };
     }
 
     public _computeLayout(offeredXOrigin?: number, offeredYOrigin?: number, availableWidth?: number, availableHeight?: number) {

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -48,8 +48,6 @@ module Plottable {
   export type _SpaceRequest = {
     width: number;
     height: number;
-    wantsWidth: boolean;
-    wantsHeight: boolean;
   }
 
   /**

--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -142,7 +142,10 @@ export module Scale {
     }
 
     public copy(): Category {
-      return new Category(this._d3Scale.copy());
+      return new Category(this._d3Scale.copy())
+                  .range(this.range())
+                  .innerPadding(this.innerPadding())
+                  .outerPadding(this.outerPadding());
     }
 
     public scale(value: string): number {

--- a/test/components/categoryAxisTests.ts
+++ b/test/components/categoryAxisTests.ts
@@ -21,8 +21,6 @@ describe("Category Axes", () => {
     var s = ca._requestedSpace(400, 400);
     assert.operator(s.width, ">=", 0, "it requested 0 or more width");
     assert.operator(s.height, ">=", 0, "it requested 0 or more height");
-    assert.isFalse(s.wantsWidth, "it doesn't want width");
-    assert.isFalse(s.wantsHeight, "it doesn't want height");
     svg.remove();
   });
 
@@ -131,12 +129,12 @@ describe("Category Axes", () => {
     var scale = new Plottable.Scale.Category().domain(years);
     var axis = new Plottable.Axis.Category(scale, "bottom");
     axis.renderTo(svg);
-    var requestedSpace = axis._requestedSpace(300, 10);
-    assert.isTrue(requestedSpace.wantsHeight, "axis should ask for more space (horizontal orientation)");
+    var smallDimension = 10;
+    var spaceRequest = axis._requestedSpace(300, smallDimension);
+    assert.operator(spaceRequest.height, ">", smallDimension, "horizontal axis requested more height if constrained");
     axis.orient("left");
-    requestedSpace = axis._requestedSpace(10, 300);
-    assert.isTrue(requestedSpace.wantsWidth, "axis should ask for more space (vertical orientation)");
-
+    spaceRequest = axis._requestedSpace(smallDimension, 300);
+    assert.operator(spaceRequest.width, ">", smallDimension, "vertical axis requested more width if constrained");
     svg.remove();
   });
 

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -170,15 +170,11 @@ describe("ComponentGroups", () => {
 
       var request = cg._requestedSpace(SVG_WIDTH, SVG_HEIGHT);
       assert.strictEqual(request.width, SVG_WIDTH / 2, "requested enough space for widest Component");
-      assert.isFalse(request.wantsWidth, "does not request more width if enough was supplied for widest Component");
       assert.strictEqual(request.height, SVG_HEIGHT / 2, "requested enough space for tallest Component");
-      assert.isFalse(request.wantsHeight, "does not request more height if enough was supplied for tallest Component");
 
       var constrainedRequest = cg._requestedSpace(SVG_WIDTH / 10, SVG_HEIGHT / 10);
       assert.strictEqual(constrainedRequest.width, SVG_WIDTH / 2, "requested enough space for widest Component");
-      assert.isTrue(constrainedRequest.wantsWidth, "requests more width if not enough was supplied for widest Component");
       assert.strictEqual(constrainedRequest.height, SVG_HEIGHT / 2, "requested enough space for tallest Component");
-      assert.isTrue(constrainedRequest.wantsHeight, "requests more height if not enough was supplied for tallest Component");
 
       cg.renderTo(svg);
       assert.strictEqual(cg.width(), SVG_WIDTH, "occupies all offered width");

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -189,8 +189,6 @@ describe("Component behavior", () => {
     var layout = c._requestedSpace(1, 1);
     assert.equal(layout.width, 0, "requested width defaults to 0");
     assert.equal(layout.height, 0, "requested height defaults to 0");
-    assert.equal(layout.wantsWidth , false, "_requestedSpace().wantsWidth  defaults to false");
-    assert.equal(layout.wantsHeight, false, "_requestedSpace().wantsHeight defaults to false");
     assert.equal((<any> c)._xAlignProportion, 0, "_xAlignProportion defaults to 0");
     assert.equal((<any> c)._yAlignProportion, 0, "_yAlignProportion defaults to 0");
     assert.equal((<any> c)._xOffset, 0, "xOffset defaults to 0");

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -226,6 +226,21 @@ describe("Scales", () => {
       var widthSum = scale.rangeBand() * (1 + scale.innerPadding());
       assert.strictEqual(scale.stepWidth(), widthSum, "step width is the sum of innerPadding width and band width");
     });
+
+    it("copy()", () => {
+      var original = new Plottable.Scale.Category();
+      original.domain(["1", "2", "3", "4"]);
+      original.range([0, 2679]);
+      // change the padding to get a different value than the default
+      original.innerPadding(0.1 + original.innerPadding());
+      original.outerPadding(0.1 + original.outerPadding());
+
+      var clone = original.copy();
+      assert.deepEqual(clone.domain(), original.domain(), "domain was copied");
+      assert.deepEqual(clone.range(), original.range(), "range was copied");
+      assert.strictEqual(clone.innerPadding(), original.innerPadding(), "inner padding was copied");
+      assert.strictEqual(clone.outerPadding(), original.outerPadding(), "outer padding was copied");
+    });
   });
 
   it("CategoryScale + BarPlot combo works as expected when the data is swapped", () => {

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -35,8 +35,6 @@ function makeFakeEvent(x: number, y: number): D3.D3Event {
 function verifySpaceRequest(sr: Plottable._SpaceRequest, w: number, h: number, ww: boolean, wh: boolean, message: string) {
   assert.equal(sr.width,  w, message + " (space request: width)");
   assert.equal(sr.height, h, message + " (space request: height)");
-  assert.equal(sr.wantsWidth , ww, message + " (space request: wantsWidth)");
-  assert.equal(sr.wantsHeight, wh, message + " (space request: wantsHeight)");
 }
 
 function fixComponentSize(c: Plottable.Component.AbstractComponent, fixedWidth?: number, fixedHeight?: number) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -7624,6 +7624,19 @@ describe("Scales", function () {
             var widthSum = scale.rangeBand() * (1 + scale.innerPadding());
             assert.strictEqual(scale.stepWidth(), widthSum, "step width is the sum of innerPadding width and band width");
         });
+        it("copy()", function () {
+            var original = new Plottable.Scale.Category();
+            original.domain(["1", "2", "3", "4"]);
+            original.range([0, 2679]);
+            // change the padding to get a different value than the default
+            original.innerPadding(0.1 + original.innerPadding());
+            original.outerPadding(0.1 + original.outerPadding());
+            var clone = original.copy();
+            assert.deepEqual(clone.domain(), original.domain(), "domain was copied");
+            assert.deepEqual(clone.range(), original.range(), "range was copied");
+            assert.strictEqual(clone.innerPadding(), original.innerPadding(), "inner padding was copied");
+            assert.strictEqual(clone.outerPadding(), original.outerPadding(), "outer padding was copied");
+        });
     });
     it("CategoryScale + BarPlot combo works as expected when the data is swapped", function () {
         // This unit test taken from SLATE, see SLATE-163 a fix for SLATE-102

--- a/test/tests.js
+++ b/test/tests.js
@@ -34,8 +34,6 @@ function makeFakeEvent(x, y) {
 function verifySpaceRequest(sr, w, h, ww, wh, message) {
     assert.equal(sr.width, w, message + " (space request: width)");
     assert.equal(sr.height, h, message + " (space request: height)");
-    assert.equal(sr.wantsWidth, ww, message + " (space request: wantsWidth)");
-    assert.equal(sr.wantsHeight, wh, message + " (space request: wantsHeight)");
 }
 function fixComponentSize(c, fixedWidth, fixedHeight) {
     c._requestedSpace = function (w, h) {
@@ -1322,8 +1320,6 @@ describe("Category Axes", function () {
         var s = ca._requestedSpace(400, 400);
         assert.operator(s.width, ">=", 0, "it requested 0 or more width");
         assert.operator(s.height, ">=", 0, "it requested 0 or more height");
-        assert.isFalse(s.wantsWidth, "it doesn't want width");
-        assert.isFalse(s.wantsHeight, "it doesn't want height");
         svg.remove();
     });
     it("doesnt blow up for non-string data", function () {
@@ -1413,11 +1409,12 @@ describe("Category Axes", function () {
         var scale = new Plottable.Scale.Category().domain(years);
         var axis = new Plottable.Axis.Category(scale, "bottom");
         axis.renderTo(svg);
-        var requestedSpace = axis._requestedSpace(300, 10);
-        assert.isTrue(requestedSpace.wantsHeight, "axis should ask for more space (horizontal orientation)");
+        var smallDimension = 10;
+        var spaceRequest = axis._requestedSpace(300, smallDimension);
+        assert.operator(spaceRequest.height, ">", smallDimension, "horizontal axis requested more height if constrained");
         axis.orient("left");
-        requestedSpace = axis._requestedSpace(10, 300);
-        assert.isTrue(requestedSpace.wantsWidth, "axis should ask for more space (vertical orientation)");
+        spaceRequest = axis._requestedSpace(smallDimension, 300);
+        assert.operator(spaceRequest.width, ">", smallDimension, "vertical axis requested more width if constrained");
         svg.remove();
     });
     it("axis labels respect tick labels", function () {
@@ -6288,14 +6285,10 @@ describe("ComponentGroups", function () {
             var cg = new Plottable.Component.Group([tall, wide]);
             var request = cg._requestedSpace(SVG_WIDTH, SVG_HEIGHT);
             assert.strictEqual(request.width, SVG_WIDTH / 2, "requested enough space for widest Component");
-            assert.isFalse(request.wantsWidth, "does not request more width if enough was supplied for widest Component");
             assert.strictEqual(request.height, SVG_HEIGHT / 2, "requested enough space for tallest Component");
-            assert.isFalse(request.wantsHeight, "does not request more height if enough was supplied for tallest Component");
             var constrainedRequest = cg._requestedSpace(SVG_WIDTH / 10, SVG_HEIGHT / 10);
             assert.strictEqual(constrainedRequest.width, SVG_WIDTH / 2, "requested enough space for widest Component");
-            assert.isTrue(constrainedRequest.wantsWidth, "requests more width if not enough was supplied for widest Component");
             assert.strictEqual(constrainedRequest.height, SVG_HEIGHT / 2, "requested enough space for tallest Component");
-            assert.isTrue(constrainedRequest.wantsHeight, "requests more height if not enough was supplied for tallest Component");
             cg.renderTo(svg);
             assert.strictEqual(cg.width(), SVG_WIDTH, "occupies all offered width");
             assert.strictEqual(cg.height(), SVG_HEIGHT, "occupies all offered height");
@@ -6570,8 +6563,6 @@ describe("Component behavior", function () {
         var layout = c._requestedSpace(1, 1);
         assert.equal(layout.width, 0, "requested width defaults to 0");
         assert.equal(layout.height, 0, "requested height defaults to 0");
-        assert.equal(layout.wantsWidth, false, "_requestedSpace().wantsWidth  defaults to false");
-        assert.equal(layout.wantsHeight, false, "_requestedSpace().wantsHeight defaults to false");
         assert.equal(c._xAlignProportion, 0, "_xAlignProportion defaults to 0");
         assert.equal(c._yAlignProportion, 0, "_yAlignProportion defaults to 0");
         assert.equal(c._xOffset, 0, "xOffset defaults to 0");


### PR DESCRIPTION
I did this on **develop** instead of the **apiRefactor** branch because I wanted us to be able to regression-test this easily. Once y'all sign off on it I'll merge this to **apiRefactor** instead.

Originally I was going to do a more involved layout-engine refactor, but that's out of scope. Instead, I focused on paring down the `_SpaceRequest` interface to something more reasonable. Later on, it may be helpful to have it have this signature:
```Typescript
type SpaceRequest {
  minWidth: number;
  maxWidth: number;
  minHeight: number;
  maxHeight: number;
}
```

Not sure if "`minWidth`" and "`maxWidth`" are the best names here, since the intention is closer to something like "minimum acceptable width" and "ideal width". For example: a `Plot` would return this:
```Typescript
{
  minWidth: 0,
  maxWidth: Infinity,
  minHeight: 0,
  maxHeight: Infinity
}
```
since it can draw in tiny spaces but is willing to absorb any free space.