### PR TITLE
Implement CallbackSet.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -277,6 +277,19 @@ declare module Plottable {
 
 
 declare module Plottable {
+    module Utils {
+        class CallbackSet<CB extends Function> {
+            constructor();
+            add(value: CB): CallbackSet<CB>;
+            remove(value: CB): CallbackSet<CB>;
+            values(): CB[];
+            callCallbacks(...args: any[]): CallbackSet<CB>;
+        }
+    }
+}
+
+
+declare module Plottable {
     type Formatter = (d: any) => string;
     var MILLISECONDS_IN_ONE_DAY: number;
     module Formatters {

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -278,6 +278,11 @@ declare module Plottable {
 
 declare module Plottable {
     module Utils {
+        /**
+         * A set of callbacks which can be all invoked at once.
+         * Each callback exists at most once in the set (based on reference equality).
+         * Ideally, all callbacks should have the same signature.
+         */
         class CallbackSet<CB extends Function> {
             constructor();
             add(value: CB): CallbackSet<CB>;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -281,7 +281,7 @@ declare module Plottable {
         /**
          * A set of callbacks which can be all invoked at once.
          * Each callback exists at most once in the set (based on reference equality).
-         * Ideally, all callbacks should have the same signature.
+         * All callbacks should have the same signature.
          */
         class CallbackSet<CB extends Function> {
             constructor();

--- a/plottable.js
+++ b/plottable.js
@@ -677,6 +677,48 @@ var Plottable;
 ///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
+    var Utils;
+    (function (Utils) {
+        var CallbackSet = (function () {
+            function CallbackSet() {
+                this._values = [];
+            }
+            CallbackSet.prototype.add = function (value) {
+                if (this._values.indexOf(value) === -1) {
+                    this._values.push(value);
+                }
+                return this;
+            };
+            CallbackSet.prototype.remove = function (value) {
+                var index = this._values.indexOf(value);
+                if (index !== -1) {
+                    this._values.splice(index, 1);
+                }
+                return this;
+            };
+            CallbackSet.prototype.values = function () {
+                return this._values;
+            };
+            CallbackSet.prototype.callCallbacks = function () {
+                var args = [];
+                for (var _i = 0; _i < arguments.length; _i++) {
+                    args[_i - 0] = arguments[_i];
+                }
+                // no fat-arrow notation to set "this" to current "this" context
+                this.values().forEach(function (callback) {
+                    callback.apply(this, args);
+                });
+                return this;
+            };
+            return CallbackSet;
+        })();
+        Utils.CallbackSet = CallbackSet;
+    })(Utils = Plottable.Utils || (Plottable.Utils = {}));
+})(Plottable || (Plottable = {}));
+
+///<reference path="../reference.ts" />
+var Plottable;
+(function (Plottable) {
     Plottable.MILLISECONDS_IN_ONE_DAY = 24 * 60 * 60 * 1000;
     var Formatters;
     (function (Formatters) {

--- a/plottable.js
+++ b/plottable.js
@@ -705,12 +705,13 @@ var Plottable;
                 return this._values;
             };
             CallbackSet.prototype.callCallbacks = function () {
+                var _this = this;
                 var args = [];
                 for (var _i = 0; _i < arguments.length; _i++) {
                     args[_i - 0] = arguments[_i];
                 }
                 this.values().forEach(function (callback) {
-                    callback.apply(this, args);
+                    callback.apply(_this, args);
                 });
                 return this;
             };

--- a/plottable.js
+++ b/plottable.js
@@ -679,6 +679,11 @@ var Plottable;
 (function (Plottable) {
     var Utils;
     (function (Utils) {
+        /**
+         * A set of callbacks which can be all invoked at once.
+         * Each callback exists at most once in the set (based on reference equality).
+         * Ideally, all callbacks should have the same signature.
+         */
         var CallbackSet = (function () {
             function CallbackSet() {
                 this._values = [];

--- a/plottable.js
+++ b/plottable.js
@@ -682,7 +682,7 @@ var Plottable;
         /**
          * A set of callbacks which can be all invoked at once.
          * Each callback exists at most once in the set (based on reference equality).
-         * Ideally, all callbacks should have the same signature.
+         * All callbacks should have the same signature.
          */
         var CallbackSet = (function () {
             function CallbackSet() {

--- a/plottable.js
+++ b/plottable.js
@@ -709,7 +709,6 @@ var Plottable;
                 for (var _i = 0; _i < arguments.length; _i++) {
                     args[_i - 0] = arguments[_i];
                 }
-                // no fat-arrow notation to set "this" to current "this" context
                 this.values().forEach(function (callback) {
                     callback.apply(this, args);
                 });

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -4,6 +4,7 @@
 /// <reference path="utils/strictEqualityAssociativeArray.ts" />
 /// <reference path="utils/domUtils.ts" />
 /// <reference path="utils/color.ts" />
+/// <reference path="utils/callbackSet.ts" />
 
 /// <reference path="utils/formatters.ts" />
 /// <reference path="utils/symbolFactories.ts" />

--- a/src/utils/callbackSet.ts
+++ b/src/utils/callbackSet.ts
@@ -1,0 +1,38 @@
+///<reference path="../reference.ts" />
+
+module Plottable {
+  export module Utils {
+    export class CallbackSet<CB extends Function> {
+      private _values: CB[];
+
+      constructor() {
+        this._values = [];
+      }
+
+      public add(value: CB) {
+        if (this._values.indexOf(value) === -1) {
+          this._values.push(value);
+        }
+        return this;
+      }
+
+      public remove(value: CB) {
+        var index = this._values.indexOf(value);
+        if (index !== -1) {
+          this._values.splice(index, 1);
+        }
+        return this;
+      }
+
+      public values() {
+        return this._values;
+      }
+
+      public callCallbacks(...args: any[]) {
+        // no fat-arrow notation to set "this" to current "this" context
+        this.values().forEach(function(callback) { callback.apply(this, args); });
+        return this;
+      }
+    }
+  }
+}

--- a/src/utils/callbackSet.ts
+++ b/src/utils/callbackSet.ts
@@ -34,7 +34,7 @@ module Plottable {
       }
 
       public callCallbacks(...args: any[]) {
-        this.values().forEach(function(callback) {
+        this.values().forEach((callback) => {
           callback.apply(this, args);
         });
         return this;

--- a/src/utils/callbackSet.ts
+++ b/src/utils/callbackSet.ts
@@ -2,6 +2,11 @@
 
 module Plottable {
   export module Utils {
+    /**
+     * A set of callbacks which can be all invoked at once.
+     * Each callback exists at most once in the set (based on reference equality).
+     * Ideally, all callbacks should have the same signature.
+     */
     export class CallbackSet<CB extends Function> {
       private _values: CB[];
 
@@ -30,7 +35,9 @@ module Plottable {
 
       public callCallbacks(...args: any[]) {
         // no fat-arrow notation to set "this" to current "this" context
-        this.values().forEach(function(callback) { callback.apply(this, args); });
+        this.values().forEach(function(callback) {
+          callback.apply(this, args);
+        });
         return this;
       }
     }

--- a/src/utils/callbackSet.ts
+++ b/src/utils/callbackSet.ts
@@ -34,7 +34,6 @@ module Plottable {
       }
 
       public callCallbacks(...args: any[]) {
-        // no fat-arrow notation to set "this" to current "this" context
         this.values().forEach(function(callback) {
           callback.apply(this, args);
         });

--- a/src/utils/callbackSet.ts
+++ b/src/utils/callbackSet.ts
@@ -5,7 +5,7 @@ module Plottable {
     /**
      * A set of callbacks which can be all invoked at once.
      * Each callback exists at most once in the set (based on reference equality).
-     * Ideally, all callbacks should have the same signature.
+     * All callbacks should have the same signature.
      */
     export class CallbackSet<CB extends Function> {
       private _values: CB[];

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -58,6 +58,7 @@
 ///<reference path="utils/strictEqualityAssociativeArrayTests.ts" />
 ///<reference path="utils/clientToSVGTranslatorTests.ts" />
 ///<reference path="utils/utilsTests.ts" />
+///<reference path="utils/callbackSetTests.ts" />
 
 ///<reference path="interactions/interactionTests.ts" />
 ///<reference path="interactions/pointerInteractionTests.ts" />

--- a/test/tests.js
+++ b/test/tests.js
@@ -8434,6 +8434,63 @@ describe("Utils.Methods", function () {
 
 ///<reference path="../testReference.ts" />
 var assert = chai.assert;
+describe("CallbackSet", function () {
+    it("add()", function () {
+        var callbackSet = new Plottable.Utils.CallbackSet();
+        var cb1 = function () { return "one"; };
+        callbackSet.add(cb1);
+        var assignedCallbacks = callbackSet.values();
+        assert.lengthOf(assignedCallbacks, 1, "set contains one callback");
+        assert.strictEqual(assignedCallbacks[0], cb1, "the callback was added to the list");
+        callbackSet.add(cb1);
+        assignedCallbacks = callbackSet.values();
+        assert.lengthOf(assignedCallbacks, 1, "same callback is not added twice");
+        assert.strictEqual(assignedCallbacks[0], cb1, "list still contains the callback");
+        var cb2 = function () { return "two"; };
+        callbackSet.add(cb2);
+        assignedCallbacks = callbackSet.values();
+        assert.lengthOf(assignedCallbacks, 2, "set now contains two callbacks");
+        assert.strictEqual(assignedCallbacks[0], cb1, "set contains callback 1");
+        assert.strictEqual(assignedCallbacks[1], cb2, "set contains callback 2");
+    });
+    it("remove()", function () {
+        var callbackSet = new Plottable.Utils.CallbackSet();
+        var cb1 = function () { return "one"; };
+        callbackSet.add(cb1);
+        assert.lengthOf(callbackSet.values(), 1, "set contains one callback after adding");
+        callbackSet.remove(cb1);
+        assert.lengthOf(callbackSet.values(), 0, "callback was removed");
+        callbackSet.add(cb1);
+        var cb2 = function () { return "two"; };
+        callbackSet.remove(cb2);
+        assert.lengthOf(callbackSet.values(), 1, "removing a non-existent value does nothing");
+    });
+    it("callCallbacks()", function () {
+        var expectedS = "Plottable";
+        var expectedI = 1;
+        var cb1called = false;
+        var cb1 = function (s, i) {
+            assert.strictEqual(s, expectedS, "was passed the correct first argument");
+            assert.strictEqual(i, expectedI, "was passed the correct second argument");
+            cb1called = true;
+        };
+        var cb2called = false;
+        var cb2 = function (s, i) {
+            assert.strictEqual(s, expectedS, "was passed the correct first argument");
+            assert.strictEqual(i, expectedI, "was passed the correct second argument");
+            cb2called = true;
+        };
+        var callbackSet = new Plottable.Utils.CallbackSet();
+        callbackSet.add(cb1);
+        callbackSet.add(cb2);
+        callbackSet.callCallbacks(expectedS, expectedI);
+        assert.isTrue(cb1called, "callback 1 was called");
+        assert.isTrue(cb2called, "callback 2 was called");
+    });
+});
+
+///<reference path="../testReference.ts" />
+var assert = chai.assert;
 describe("Interactions", function () {
     describe("PanZoomInteraction", function () {
         it("Pans properly", function () {

--- a/test/utils/callbackSetTests.ts
+++ b/test/utils/callbackSetTests.ts
@@ -1,0 +1,68 @@
+///<reference path="../testReference.ts" />
+
+var assert = chai.assert;
+
+describe("CallbackSet", () => {
+  it("add()", () => {
+    var callbackSet = new Plottable.Utils.CallbackSet();
+
+    var cb1 = () => "one";
+    callbackSet.add(cb1);
+    var assignedCallbacks = callbackSet.values();
+    assert.lengthOf(assignedCallbacks, 1, "set contains one callback");
+    assert.strictEqual(assignedCallbacks[0], cb1, "the callback was added to the list");
+
+    callbackSet.add(cb1);
+    assignedCallbacks = callbackSet.values();
+    assert.lengthOf(assignedCallbacks, 1, "same callback is not added twice");
+    assert.strictEqual(assignedCallbacks[0], cb1, "list still contains the callback");
+
+    var cb2 = () => "two";
+    callbackSet.add(cb2);
+    assignedCallbacks = callbackSet.values();
+    assert.lengthOf(assignedCallbacks, 2, "set now contains two callbacks");
+    assert.strictEqual(assignedCallbacks[0], cb1, "set contains callback 1");
+    assert.strictEqual(assignedCallbacks[1], cb2, "set contains callback 2");
+  });
+
+  it("remove()", () => {
+    var callbackSet = new Plottable.Utils.CallbackSet();
+
+    var cb1 = () => "one";
+    callbackSet.add(cb1);
+    assert.lengthOf(callbackSet.values(), 1, "set contains one callback after adding");
+    callbackSet.remove(cb1);
+    assert.lengthOf(callbackSet.values(), 0, "callback was removed");
+
+    callbackSet.add(cb1);
+    var cb2 = () => "two";
+    callbackSet.remove(cb2);
+    assert.lengthOf(callbackSet.values(), 1, "removing a non-existent value does nothing");
+  });
+
+  it("callCallbacks()", () => {
+    var expectedS = "Plottable";
+    var expectedI = 1;
+
+    var cb1called = false;
+    var cb1 = (s: string, i: number) => {
+      assert.strictEqual(s, expectedS, "was passed the correct first argument");
+      assert.strictEqual(i, expectedI, "was passed the correct second argument");
+      cb1called = true;
+    };
+    var cb2called = false;
+    var cb2 = (s: string, i: number) => {
+      assert.strictEqual(s, expectedS, "was passed the correct first argument");
+      assert.strictEqual(i, expectedI, "was passed the correct second argument");
+      cb2called = true;
+    };
+
+    var callbackSet = new Plottable.Utils.CallbackSet<(s: string, i: number) => any>();
+    callbackSet.add(cb1);
+    callbackSet.add(cb2);
+
+    callbackSet.callCallbacks(expectedS, expectedI);
+    assert.isTrue(cb1called, "callback 1 was called");
+    assert.isTrue(cb2called, "callback 2 was called");
+  });
+});


### PR DESCRIPTION
It's ... a set of callbacks. It can be used to implement direct-reference for callback registration, rather than the key model currently used on `Broadcaster`.

We can't use d3.set because it only accepts string keys.
[ES6 set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) isn't available yet, and we'd still have to extend it to enable calling the callbacks.

Hits the first checkbox on #1915.