### PR TITLE
Refactor colon whitespace

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3090,7 +3090,7 @@ declare module Plottable {
             /**
              * Sets the hover mode for hover interactions. There are two modes:
              *     - "point": Selects the bar under the mouse cursor (default).
-             *     - "line" : Selects any bar that would be hit by a line extending
+             *     - "line": Selects any bar that would be hit by a line extending
              *                in the same direction as the bar and passing through
              *                the cursor.
              *

--- a/plottable.js
+++ b/plottable.js
@@ -1865,7 +1865,7 @@ var Plottable;
             return new QuantitativeScale(this._d3Scale.copy());
         };
         QuantitativeScale.prototype.domain = function (values) {
-            return _super.prototype.domain.call(this, values); // need to override type sig to enable method chaining :/
+            return _super.prototype.domain.call(this, values); // need to override type sig to enable method chaining:/
         };
         QuantitativeScale.prototype._setDomain = function (values) {
             var isNaNOrInfinity = function (x) { return x !== x || x === Infinity || x === -Infinity; };

--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -93,7 +93,7 @@ module Plottable {
       this._isSetup = true;
     }
 
-    public _requestedSpace(availableWidth : number, availableHeight: number): _SpaceRequest {
+    public _requestedSpace(availableWidth: number, availableHeight: number): _SpaceRequest {
       return {width: 0, height: 0, wantsWidth: false, wantsHeight: false};
     }
 
@@ -165,8 +165,8 @@ module Plottable {
     public _doRender() {/* overwrite */}
 
     public _useLastCalculatedLayout(): boolean;
-    public _useLastCalculatedLayout(useLast: boolean) : Component;
-    public _useLastCalculatedLayout(useLast?: boolean) : any {
+    public _useLastCalculatedLayout(useLast: boolean): Component;
+    public _useLastCalculatedLayout(useLast?: boolean): any {
       if (useLast == null) {
         return this._usedLastLayout;
       } else {

--- a/src/components/abstractComponentContainer.ts
+++ b/src/components/abstractComponentContainer.ts
@@ -80,8 +80,8 @@ module Plottable {
     }
 
     public _useLastCalculatedLayout(): boolean;
-    public _useLastCalculatedLayout(calculated: boolean) : Component;
-    public _useLastCalculatedLayout(calculated?: boolean) : any {
+    public _useLastCalculatedLayout(calculated: boolean): Component;
+    public _useLastCalculatedLayout(calculated?: boolean): any {
       if (calculated != null) {
         this.components().slice().forEach((c: Component) => c._useLastCalculatedLayout(calculated));
       }

--- a/src/components/axes/abstractAxis.ts
+++ b/src/components/axes/abstractAxis.ts
@@ -95,7 +95,7 @@ module Plottable {
       }
 
       return {
-        width : requestedWidth,
+        width: requestedWidth,
         height: requestedHeight,
         wantsWidth: !this._isHorizontal() && offeredWidth < requestedWidth,
         wantsHeight: this._isHorizontal() && offeredHeight < requestedHeight

--- a/src/components/axes/categoryAxis.ts
+++ b/src/components/axes/categoryAxis.ts
@@ -56,9 +56,9 @@ export module Axes {
                                           fakeScale,
                                           categoryScale.domain());
       return {
-        width : textResult.usedWidth  + widthRequiredByTicks,
+        width: textResult.usedWidth  + widthRequiredByTicks,
         height: textResult.usedHeight + heightRequiredByTicks,
-        wantsWidth : !textResult.textFits,
+        wantsWidth: !textResult.textFits,
         wantsHeight: !textResult.textFits
       };
     }

--- a/src/components/componentGroup.ts
+++ b/src/components/componentGroup.ts
@@ -26,9 +26,9 @@ export module Components {
     public _requestedSpace(offeredWidth: number, offeredHeight: number): _SpaceRequest {
       var requests = this.components().map((c: Component) => c._requestedSpace(offeredWidth, offeredHeight));
       return {
-        width : Utils.Methods.max<_SpaceRequest, number>(requests, (request: _SpaceRequest) => request.width, 0),
+        width: Utils.Methods.max<_SpaceRequest, number>(requests, (request: _SpaceRequest) => request.width, 0),
         height: Utils.Methods.max<_SpaceRequest, number>(requests, (request: _SpaceRequest) => request.height, 0),
-        wantsWidth : requests.map((r: _SpaceRequest) => r.wantsWidth ).some((x: boolean) => x),
+        wantsWidth: requests.map((r: _SpaceRequest) => r.wantsWidth ).some((x: boolean) => x),
         wantsHeight: requests.map((r: _SpaceRequest) => r.wantsHeight).some((x: boolean) => x)
       };
     }

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -155,7 +155,7 @@ export module Components {
       }
 
       return {
-        width : desiredWidth,
+        width: desiredWidth,
         height: desiredHeight,
         wantsWidth: offeredWidth < desiredWidth,
         wantsHeight: offeredHeight < desiredHeight

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -68,9 +68,9 @@ export module Components {
       var desiredHeight = (this.orient() === "horizontal" ? desiredWH.height : desiredWH.width) + 2 * this.padding();
 
       return {
-        width : desiredWidth,
+        width: desiredWidth,
         height: desiredHeight,
-        wantsWidth : desiredWidth  > offeredWidth,
+        wantsWidth: desiredWidth  > offeredWidth,
         wantsHeight: desiredHeight > offeredHeight
       };
     }

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -183,7 +183,7 @@ export module Components {
       var desiredNumRows = Math.max(Math.ceil(this._scale.domain().length / this._maxEntriesPerRow), 1);
       var wantsFitMoreEntriesInRow = estimatedLayout.rows.length > desiredNumRows;
       return {
-        width : this._padding + longestRowLength,
+        width: this._padding + longestRowLength,
         height: acceptableHeight,
         wantsWidth: offeredWidth < desiredWidth || wantsFitMoreEntriesInRow,
         wantsHeight: offeredHeight < desiredHeight

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -464,7 +464,7 @@ export module Plots {
     /**
      * Sets the hover mode for hover interactions. There are two modes:
      *     - "point": Selects the bar under the mouse cursor (default).
-     *     - "line" : Selects any bar that would be hit by a line extending
+     *     - "line": Selects any bar that would be hit by a line extending
      *                in the same direction as the bar and passing through
      *                the cursor.
      *

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -217,12 +217,12 @@ export module Components {
       colProportionalSpace = Table._calcProportionalSpace(colWeights, freeWidth );
       rowProportionalSpace = Table._calcProportionalSpace(rowWeights, freeHeight);
 
-      return {colProportionalSpace: colProportionalSpace        ,
-              rowProportionalSpace: rowProportionalSpace        ,
-              guaranteedWidths   : guarantees.guaranteedWidths ,
-              guaranteedHeights  : guarantees.guaranteedHeights,
-              wantsWidth         : wantsWidth                  ,
-              wantsHeight        : wantsHeight                 };
+      return {colProportionalSpace: colProportionalSpace,
+              rowProportionalSpace: rowProportionalSpace,
+              guaranteedWidths: guarantees.guaranteedWidths,
+              guaranteedHeights: guarantees.guaranteedHeights,
+              wantsWidth: wantsWidth,
+              wantsHeight: wantsHeight};
     }
 
     private _determineGuarantees(offeredWidths: number[], offeredHeights: number[]): _LayoutAllocation {
@@ -248,10 +248,10 @@ export module Components {
           layoutWantsHeight[rowIndex] = layoutWantsHeight[rowIndex] || spaceRequest.wantsHeight;
         });
       });
-      return {guaranteedWidths: requestedWidths  ,
-              guaranteedHeights: requestedHeights ,
-              wantsWidthArr   : layoutWantsWidth ,
-              wantsHeightArr  : layoutWantsHeight};
+      return {guaranteedWidths: requestedWidths,
+              guaranteedHeights: requestedHeights,
+              wantsWidthArr: layoutWantsWidth,
+              wantsHeightArr: layoutWantsHeight};
     }
 
 

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -3,19 +3,19 @@
 module Plottable {
 export module Components {
   type _LayoutAllocation = {
-    guaranteedWidths : number[];
+    guaranteedWidths: number[];
     guaranteedHeights: number[];
-    wantsWidthArr : boolean[];
+    wantsWidthArr: boolean[];
     wantsHeightArr: boolean[];
   }
 
   export type _IterateLayoutResult = {
     colProportionalSpace: number[];
     rowProportionalSpace: number[];
-    guaranteedWidths    : number[];
-    guaranteedHeights   : number[];
-    wantsWidth          : boolean;
-    wantsHeight         : boolean;
+    guaranteedWidths: number[];
+    guaranteedHeights: number[];
+    wantsWidth: boolean;
+    wantsHeight: boolean;
   };
 
   export class Table extends ComponentContainer {
@@ -106,7 +106,7 @@ export module Components {
       super._removeComponent(component);
       var rowpos: number;
       var colpos: number;
-      outer : for (var i = 0; i < this._nRows; i++) {
+      outer: for (var i = 0; i < this._nRows; i++) {
         for (var j = 0; j < this._nCols; j++) {
           if (this._rows[i][j] === component) {
             rowpos = i;
@@ -121,7 +121,7 @@ export module Components {
       }
     }
 
-    private _iterateLayout(availableWidth : number, availableHeight: number): _IterateLayoutResult {
+    private _iterateLayout(availableWidth: number, availableHeight: number): _IterateLayoutResult {
     /*
      * Given availableWidth and availableHeight, figure out how to allocate it between rows and columns using an iterative algorithm.
      *
@@ -162,7 +162,7 @@ export module Components {
       var guaranteedWidths  = Utils.Methods.createFilledArray(0, this._nCols);
       var guaranteedHeights = Utils.Methods.createFilledArray(0, this._nRows);
 
-      var freeWidth : number;
+      var freeWidth: number;
       var freeHeight: number;
 
       var nIterations = 0;
@@ -219,10 +219,10 @@ export module Components {
 
       return {colProportionalSpace: colProportionalSpace        ,
               rowProportionalSpace: rowProportionalSpace        ,
-              guaranteedWidths    : guarantees.guaranteedWidths ,
-              guaranteedHeights   : guarantees.guaranteedHeights,
-              wantsWidth          : wantsWidth                  ,
-              wantsHeight         : wantsHeight                 };
+              guaranteedWidths   : guarantees.guaranteedWidths ,
+              guaranteedHeights  : guarantees.guaranteedHeights,
+              wantsWidth         : wantsWidth                  ,
+              wantsHeight        : wantsHeight                 };
     }
 
     private _determineGuarantees(offeredWidths: number[], offeredHeights: number[]): _LayoutAllocation {
@@ -248,16 +248,16 @@ export module Components {
           layoutWantsHeight[rowIndex] = layoutWantsHeight[rowIndex] || spaceRequest.wantsHeight;
         });
       });
-      return {guaranteedWidths : requestedWidths  ,
+      return {guaranteedWidths: requestedWidths  ,
               guaranteedHeights: requestedHeights ,
-              wantsWidthArr    : layoutWantsWidth ,
-              wantsHeightArr   : layoutWantsHeight};
+              wantsWidthArr   : layoutWantsWidth ,
+              wantsHeightArr  : layoutWantsHeight};
     }
 
 
-    public _requestedSpace(offeredWidth : number, offeredHeight: number): _SpaceRequest {
+    public _requestedSpace(offeredWidth: number, offeredHeight: number): _SpaceRequest {
       this._calculatedLayout = this._iterateLayout(offeredWidth , offeredHeight);
-      return {width : d3.sum(this._calculatedLayout.guaranteedWidths ),
+      return {width: d3.sum(this._calculatedLayout.guaranteedWidths ),
               height: d3.sum(this._calculatedLayout.guaranteedHeights),
               wantsWidth: this._calculatedLayout.wantsWidth,
               wantsHeight: this._calculatedLayout.wantsHeight};

--- a/src/core/animator.ts
+++ b/src/core/animator.ts
@@ -24,7 +24,7 @@ export module Animators {
     getTiming(numberOfIterations: number): number;
   }
 
-  export type PlotAnimatorMap = { [animatorKey: string] : PlotAnimator; };
+  export type PlotAnimatorMap = { [animatorKey: string]: PlotAnimator; };
 
 }
 }

--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -69,7 +69,7 @@ export module Scales {
      *
      * @returns {number} The range band width
      */
-    public rangeBand() : number {
+    public rangeBand(): number {
       return this._d3Scale.rangeBand();
     }
 

--- a/src/scales/interpolatedColorScale.ts
+++ b/src/scales/interpolatedColorScale.ts
@@ -13,7 +13,7 @@ export module Scales {
    */
   export class InterpolatedColor extends Scale<number, string> {
     private static _COLOR_SCALES: ColorGroups = {
-      reds : [
+      reds: [
         "#FFFFFF", // white
         "#FFF6E1",
         "#FEF4C0",
@@ -24,7 +24,7 @@ export module Scales {
         "#E31A1C",
         "#B10026"  // red
       ],
-      blues : [
+      blues: [
         "#FFFFFF", // white
         "#CCFFFF",
         "#A5FFFD",
@@ -35,7 +35,7 @@ export module Scales {
         "#2545D3",
         "#0B02E1"  // blue
       ],
-      posneg : [
+      posneg: [
         "#0B02E1", // blue
         "#2545D3",
         "#417FD0",

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -51,7 +51,7 @@ module Plottable {
     public domain(): D[];
     public domain(values: D[]): QuantitativeScale<D>;
     public domain(values?: D[]): any {
-      return super.domain(values); // need to override type sig to enable method chaining :/
+      return super.domain(values); // need to override type sig to enable method chaining:/
     }
 
     protected _setDomain(values: D[]) {

--- a/src/scales/tickGenerators.ts
+++ b/src/scales/tickGenerators.ts
@@ -17,7 +17,7 @@ module Plottable {
        *
        * @returns {TickGenerator} A tick generator using the specified interval.
        */
-      export function intervalTickGenerator(interval: number) : TickGenerator<number> {
+      export function intervalTickGenerator(interval: number): TickGenerator<number> {
         if (interval <= 0) {
            throw new Error("interval must be positive number");
         }

--- a/test/components/plots/plotTests.ts
+++ b/test/components/plots/plotTests.ts
@@ -427,7 +427,7 @@ describe("Plots", () => {
       plot2.renderTo(svg);
 
       function assertDomainIsClose(actualDomain: number[], expectedDomain: number[], msg: string) {
-        // to avoid floating point issues :/
+        // to avoid floating point issues:/
         assert.closeTo(actualDomain[0], expectedDomain[0], 0.01, msg);
         assert.closeTo(actualDomain[1], expectedDomain[1], 0.01, msg);
       }

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -13,11 +13,11 @@ module Mocks {
       this._fixedHeightFlag = true;
     }
 
-    public _requestedSpace(availableWidth : number, availableHeight: number): Plottable._SpaceRequest {
+    public _requestedSpace(availableWidth: number, availableHeight: number): Plottable._SpaceRequest {
       return {
         width:  this.fixedWidth,
         height: this.fixedHeight,
-        wantsWidth : availableWidth < this.fixedWidth,
+        wantsWidth: availableWidth < this.fixedWidth,
         wantsHeight: availableHeight < this.fixedHeight
       };
     }

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -44,7 +44,7 @@ function fixComponentSize(c: Plottable.Component, fixedWidth?: number, fixedHeig
     return {
       width:  fixedWidth  == null ? 0 : fixedWidth,
       height: fixedHeight == null ? 0 : fixedHeight,
-      wantsWidth : fixedWidth  == null ? false : w < fixedWidth ,
+      wantsWidth: fixedWidth  == null ? false : w < fixedWidth ,
       wantsHeight: fixedHeight == null ? false : h < fixedHeight
     };
   };

--- a/test/tests.js
+++ b/test/tests.js
@@ -2467,7 +2467,7 @@ describe("Plots", function () {
             plot1.renderTo(svg);
             plot2.renderTo(svg);
             function assertDomainIsClose(actualDomain, expectedDomain, msg) {
-                // to avoid floating point issues :/
+                // to avoid floating point issues:/
                 assert.closeTo(actualDomain[0], expectedDomain[0], 0.01, msg);
                 assert.closeTo(actualDomain[1], expectedDomain[1], 0.01, msg);
             }

--- a/tslint.json
+++ b/tslint.json
@@ -42,6 +42,13 @@
     "triple-equals": [true,
         "allow-null-check"
     ],
+    "typedef-whitespace": [true, {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+    }],
     "variable-name": false,
     "whitespace": [true,
         "check-branch",


### PR DESCRIPTION
We no longer have space before `:`. Also updated the tslint rules to enforce that