### PR TITLE
[TSLint Rule] - adding one-line check-whitespace rule

### DIFF
--- a/src/animators/baseAnimator.ts
+++ b/src/animators/baseAnimator.ts
@@ -88,7 +88,7 @@ export module Animator {
      * @returns {Default} The calling Default Animator.
      */
     public duration(duration: number): Base;
-    public duration(duration?: number): any{
+    public duration(duration?: number): any {
       if (duration == null) {
         return this._duration;
       } else {
@@ -110,7 +110,7 @@ export module Animator {
      * @returns {Default} The calling Default Animator.
      */
     public delay(delay: number): Base;
-    public delay(delay?: number): any{
+    public delay(delay?: number): any {
       if (delay == null) {
         return this._delay;
       } else {
@@ -132,7 +132,7 @@ export module Animator {
      * @returns {Default} The calling Default Animator.
      */
     public easing(easing: string): Base;
-    public easing(easing?: string): any{
+    public easing(easing?: string): any {
       if (easing == null) {
         return this._easing;
       } else {

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -202,7 +202,7 @@ export module Axis {
      */
     public axisConfigurations(configurations: TimeAxisConfiguration[]): Time;
     public axisConfigurations(configurations?: any): any {
-      if(configurations == null){
+      if (configurations == null) {
         return this._possibleTimeAxisConfigurations;
       }
       this._possibleTimeAxisConfigurations = configurations;

--- a/src/components/componentGroup.ts
+++ b/src/components/componentGroup.ts
@@ -17,7 +17,7 @@ export module Component {
      * @constructor
      * @param {Component[]} components The Components in the resultant Component.Group (default = []).
      */
-    constructor(components: AbstractComponent[] = []){
+    constructor(components: AbstractComponent[] = []) {
       super();
       this.classed("component-group", true);
       components.forEach((c: AbstractComponent) => this._addComponent(c));

--- a/src/components/plots/abstractPlot.ts
+++ b/src/components/plots/abstractPlot.ts
@@ -296,7 +296,7 @@ export module Plot {
      */
     public animator(animatorKey: string, animator: Animator.PlotAnimator): AbstractPlot;
     public animator(animatorKey: string, animator?: Animator.PlotAnimator): any {
-      if (animator === undefined){
+      if (animator === undefined) {
         return this._animators[animatorKey];
       } else {
         this._animators[animatorKey] = animator;

--- a/src/components/plots/clusteredBarPlot.ts
+++ b/src/components/plots/clusteredBarPlot.ts
@@ -50,7 +50,7 @@ export module Plot {
       });
     }
 
-    private _makeInnerScale(){
+    private _makeInnerScale() {
       var innerScale = new Scale.Category();
       innerScale.domain(this._datasetKeysInOrder);
       if (!this._projections["width"]) {

--- a/src/core/dataset.ts
+++ b/src/core/dataset.ts
@@ -90,7 +90,7 @@ module Plottable {
     private _computeExtent(accessor: _Accessor, typeCoercer: (d: any) => any, plotMetadata: any): any[] {
       var appliedAccessor = (d: any, i: number) => accessor(d, i, this._metadata, plotMetadata);
       var mappedData = this._data.map(appliedAccessor).map(typeCoercer);
-      if (mappedData.length === 0){
+      if (mappedData.length === 0) {
         return [];
       } else if (typeof(mappedData[0]) === "string") {
         return _Util.Methods.uniq(mappedData);

--- a/src/scales/interpolatedColorScale.ts
+++ b/src/scales/interpolatedColorScale.ts
@@ -67,7 +67,7 @@ export module Scale {
      */
     private static _getD3InterpolatedScale(colors: string[], scaleType: string): D3.Scale.QuantitativeScale {
       var scale: D3.Scale.QuantitativeScale;
-      switch(scaleType){
+      switch(scaleType) {
         case "linear":
           scale = d3.scale.linear();
           break;
@@ -81,7 +81,7 @@ export module Scale {
           scale = d3.scale.pow();
           break;
       }
-      if (scale == null){
+      if (scale == null) {
         throw new Error("unknown Quantitative scale type " + scaleType);
       }
       return scale
@@ -181,7 +181,7 @@ export module Scale {
      */
     public scaleType(scaleType: string): InterpolatedColor;
     public scaleType(scaleType?: string): any {
-      if (scaleType == null){
+      if (scaleType == null) {
         return this._scaleType;
       }
       this._scaleType = scaleType;

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -46,7 +46,7 @@ export module _Util {
       return (n == null);
     }
 
-    export function getElementWidth(elem: HTMLScriptElement): number{
+    export function getElementWidth(elem: HTMLScriptElement): number {
       var style: CSSStyleDeclaration = window.getComputedStyle(elem);
       return getParsedStyleValue(style, "width")
         + getParsedStyleValue(style, "padding-left")
@@ -55,7 +55,7 @@ export module _Util {
         + getParsedStyleValue(style, "border-right-width");
     }
 
-    export function getElementHeight(elem: HTMLScriptElement): number{
+    export function getElementHeight(elem: HTMLScriptElement): number {
       var style: CSSStyleDeclaration = window.getComputedStyle(elem);
       return getParsedStyleValue(style, "height")
         + getParsedStyleValue(style, "padding-top")

--- a/tslint.json
+++ b/tslint.json
@@ -36,9 +36,10 @@
     "no-unused-variable": true,
     "no-use-before-declare": true,
     "one-line": [true,
-        "check-open-brace",
         "check-catch",
-        "check-else"
+        "check-else",
+        "check-open-brace",
+        "check-whitespace"
     ],
     "quotemark": [true, "double"],
     "radix": true,


### PR DESCRIPTION
This rule checks to make sure there is whitespace in front of specified tokens that are specified via the one-line rule.

Example specified token: `{` after an if like `if (foo) {`

Messy:
```typescript
if (foo){
...
```

Neat:
```typescript
if (foo) {
...
```