### PR TITLE
[TSLint Rule] - adding call-signature rule

### DIFF
--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -166,8 +166,8 @@ export module Component {
     public _doRender() {/* overwrite */}
 
     public _useLastCalculatedLayout(): boolean;
-    public _useLastCalculatedLayout(useLast: boolean) : AbstractComponent;
-    public _useLastCalculatedLayout(useLast?: boolean) : any {
+    public _useLastCalculatedLayout(useLast: boolean): AbstractComponent;
+    public _useLastCalculatedLayout(useLast?: boolean): any {
       if (useLast == null) {
         return this._usedLastLayout;
       } else {

--- a/src/components/abstractComponentContainer.ts
+++ b/src/components/abstractComponentContainer.ts
@@ -81,8 +81,8 @@ export module Component {
     }
 
     public _useLastCalculatedLayout(): boolean;
-    public _useLastCalculatedLayout(calculated: boolean) : AbstractComponent;
-    public _useLastCalculatedLayout(calculated?: boolean) : any {
+    public _useLastCalculatedLayout(calculated: boolean): AbstractComponent;
+    public _useLastCalculatedLayout(calculated?: boolean): any {
       if (calculated != null) {
         this.components().slice().forEach((c: AbstractComponent) => c._useLastCalculatedLayout(calculated));
       }

--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -69,7 +69,7 @@ export module Scale {
      *
      * @returns {number} The range band width
      */
-    public rangeBand() : number {
+    public rangeBand(): number {
       return this._d3Scale.rangeBand();
     }
 

--- a/src/scales/tickGenerators.ts
+++ b/src/scales/tickGenerators.ts
@@ -17,7 +17,7 @@ module Plottable {
        *
        * @returns {TickGenerator} A tick generator using the specified interval.
        */
-      export function intervalTickGenerator(interval: number) : TickGenerator<number> {
+      export function intervalTickGenerator(interval: number): TickGenerator<number> {
         if(interval <= 0) {
            throw new Error("interval must be positive number");
         }

--- a/tslint.json
+++ b/tslint.json
@@ -44,6 +44,9 @@
     "radix": true,
     "semicolon": true,
     "triple-equals": [true, "allow-null-check"],
+    "typedef-whitespace": [true, {
+        "call-signature": "nospace"
+    }],
     "variable-name": false,
     "whitespace": ["check-branch", "check-decl", "check-operator", "check-separator", "check-type"],
     "ban": [true, ["d3", "max"], ["d3", "min"]]


### PR DESCRIPTION
This rule enforces having no space in front of the type definition in function signatures.

Messy:
```typescript
public foo() : number {
...
```

Neat:
```typescript
public foo(): number {
...
```