### PR TITLE
[TSLint Rule] - adding typedef-whitespace parameter rule

### DIFF
--- a/src/components/abstractComponent.ts
+++ b/src/components/abstractComponent.ts
@@ -94,7 +94,7 @@ export module Component {
       this._isSetup = true;
     }
 
-    public _requestedSpace(availableWidth : number, availableHeight: number): _SpaceRequest {
+    public _requestedSpace(availableWidth: number, availableHeight: number): _SpaceRequest {
       return {width: 0, height: 0, wantsWidth: false, wantsHeight: false};
     }
 

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -121,7 +121,7 @@ export module Component {
       }
     }
 
-    private _iterateLayout(availableWidth : number, availableHeight: number): _IterateLayoutResult {
+    private _iterateLayout(availableWidth: number, availableHeight: number): _IterateLayoutResult {
     /*
      * Given availableWidth and availableHeight, figure out how to allocate it between rows and columns using an iterative algorithm.
      *
@@ -254,7 +254,7 @@ export module Component {
               wantsHeightArr   : layoutWantsHeight};
     }
 
-    public _requestedSpace(offeredWidth : number, offeredHeight: number): _SpaceRequest {
+    public _requestedSpace(offeredWidth: number, offeredHeight: number): _SpaceRequest {
       this._calculatedLayout = this._iterateLayout(offeredWidth , offeredHeight);
       return {width : d3.sum(this._calculatedLayout.guaranteedWidths ),
               height: d3.sum(this._calculatedLayout.guaranteedHeights),

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -13,7 +13,7 @@ module Mocks {
       this._fixedHeightFlag = true;
     }
 
-    public _requestedSpace(availableWidth : number, availableHeight: number): Plottable._SpaceRequest {
+    public _requestedSpace(availableWidth: number, availableHeight: number): Plottable._SpaceRequest {
       return {
         width:  this.fixedWidth,
         height: this.fixedHeight,

--- a/tslint.json
+++ b/tslint.json
@@ -44,6 +44,9 @@
     "radix": true,
     "semicolon": true,
     "triple-equals": [true, "allow-null-check"],
+    "typedef-whitespace": [true, {
+        "parameter": "nospace"
+    }],
     "variable-name": false,
     "whitespace": ["check-branch", "check-decl", "check-operator", "check-separator", "check-type"],
     "ban": [true, ["d3", "max"], ["d3", "min"]]


### PR DESCRIPTION
Enforces that there is no whitespace before the colon in specifying types for parameters.

Messy:
```typescript
public foo(a : number) {
...
```

Neat:
```typescript
public foo(a: number) {
...
```