### PR TITLE
[TSLint Rule] - adding property-declaration rule

### DIFF
--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -3,19 +3,19 @@
 module Plottable {
 export module Component {
   type _LayoutAllocation = {
-    guaranteedWidths : number[];
+    guaranteedWidths: number[];
     guaranteedHeights: number[];
-    wantsWidthArr : boolean[];
+    wantsWidthArr: boolean[];
     wantsHeightArr: boolean[];
   }
 
   export type _IterateLayoutResult = {
     colProportionalSpace: number[];
     rowProportionalSpace: number[];
-    guaranteedWidths    : number[];
-    guaranteedHeights   : number[];
-    wantsWidth          : boolean;
-    wantsHeight         : boolean;
+    guaranteedWidths: number[];
+    guaranteedHeights: number[];
+    wantsWidth: boolean;
+    wantsHeight: boolean;
   };
 
   export class Table extends AbstractComponentContainer {

--- a/tslint.json
+++ b/tslint.json
@@ -44,6 +44,9 @@
     "radix": true,
     "semicolon": true,
     "triple-equals": [true, "allow-null-check"],
+    "typedef-whitespace": [true, {
+        "property-declaration": "nospace"
+    }],
     "variable-name": false,
     "whitespace": ["check-branch", "check-decl", "check-operator", "check-separator", "check-type"],
     "ban": [true, ["d3", "max"], ["d3", "min"]]


### PR DESCRIPTION
This rule enforces that no whitespace is used before the colon in property declarations.

Messy:
```typescript
class Foo {
  public bar : number;
...
```

Neat:
```typescript
class Foo {
  public bar: number;
...
```