### PR TITLE
[TSLint Rule] - adding variable-declaration rule

### DIFF
--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -162,7 +162,7 @@ export module Component {
       var guaranteedWidths  = _Util.Methods.createFilledArray(0, this._nCols);
       var guaranteedHeights = _Util.Methods.createFilledArray(0, this._nRows);
 
-      var freeWidth : number;
+      var freeWidth: number;
       var freeHeight: number;
 
       var nIterations = 0;

--- a/tslint.json
+++ b/tslint.json
@@ -44,6 +44,9 @@
     "radix": true,
     "semicolon": true,
     "triple-equals": [true, "allow-null-check"],
+    "typedef-whitespace": [true, {
+        "variable-declaration": "nospace"
+    }],
     "variable-name": false,
     "whitespace": ["check-branch", "check-decl", "check-operator", "check-separator", "check-type"],
     "ban": [true, ["d3", "max"], ["d3", "min"]]


### PR DESCRIPTION
This rule enforces no whitespace in front of colons for arbitrary variable declarations.

Messy:
```typescript
var foo : number;
```

Neat:
```typescript
var foo: number;
```