### PR TITLE
StrictEqualityAssociativeArray --> Map

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -176,11 +176,9 @@ declare module Plottable {
 declare module Plottable {
     module Utils {
         /**
-         * An associative array that can be keyed by anything (inc objects).
-         * Uses pointer equality checks which is why this works.
-         * This power has a price: everything is linear time since it is actually backed by an array...
+         * Shim for the ES6 map (although NaN is not allowed as a key).
          */
-        class StrictEqualityAssociativeArray {
+        class Map {
             /**
              * Set a new key/value pair in the store.
              *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -875,7 +875,7 @@ declare module Plottable {
          */
         constructor(scale: D3.Scale.Scale);
         protected _getAllExtents(): D[][];
-        protected _getExtent(): D[];
+        protected _combinedDomainFromExtents(): D[];
         /**
          * Modifies the domain on the scale so that it includes the extent of all
          * perspectives it depends on. This will normally happen automatically, but
@@ -979,7 +979,7 @@ declare module Plottable {
          * backing the QuantitativeScaleScale.
          */
         constructor(scale: D3.Scale.QuantitativeScale);
-        protected _getExtent(): D[];
+        protected _combinedDomainFromExtents(): D[];
         /**
          * Retrieves the domain value corresponding to a supplied range value.
          *
@@ -1070,7 +1070,7 @@ declare module Plottable {
          * @return {QuantitativeScale} The calling QuantitativeScaleScale.
          */
         domainer(domainer: Domainer): QuantitativeScale<D>;
-        _defaultExtent(): any[];
+        _defaultDomain(): any[];
         /**
          * Gets the tick generator of the QuantitativeScale.
          *
@@ -1214,7 +1214,7 @@ declare module Plottable {
              * @constructor
              */
             constructor(scale?: D3.Scale.OrdinalScale);
-            protected _getExtent(): string[];
+            protected _combinedDomainFromExtents(): string[];
             domain(): string[];
             domain(values: string[]): Category;
             protected _setDomain(values: string[]): void;
@@ -1290,7 +1290,7 @@ declare module Plottable {
              * See https://github.com/mbostock/d3/wiki/Ordinal-Scales#categorical-colors
              */
             constructor(scaleType?: string);
-            protected _getExtent(): string[];
+            protected _combinedDomainFromExtents(): string[];
             scale(value: string): string;
         }
     }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -178,58 +178,35 @@ declare module Plottable {
         /**
          * Shim for the ES6 map (although NaN is not allowed as a key).
          */
-        class Map {
+        class Map<K, V> {
             /**
              * Set a new key/value pair in the store.
              *
-             * @param {any} key Key to set in the store
-             * @param {any} value Value to set in the store
              * @return {boolean} True if key already in store, false otherwise
              */
-            set(key: any, value: any): boolean;
+            set(key: K, value: V): boolean;
             /**
              * Get a value from the store, given a key.
              *
-             * @param {any} key Key associated with value to retrieve
-             * @return {any} Value if found, undefined otherwise
+             * @return {V} value if found, undefined otherwise
              */
-            get(key: any): any;
+            get(key: K): V;
             /**
              * Test whether store has a value associated with given key.
              *
              * Will return true if there is a key/value entry,
              * even if the value is explicitly `undefined`.
              *
-             * @param {any} key Key to test for presence of an entry
-             * @return {boolean} Whether there was a matching entry for that key
              */
-            has(key: any): boolean;
+            has(key: K): boolean;
+            values(): V[];
+            keys(): K[];
             /**
-             * Return an array of the values in the key-value store
+             * Delete a key from the key-value store.
              *
-             * @return {any[]} The values in the store
-             */
-            values(): any[];
-            /**
-             * Return an array of keys in the key-value store
-             *
-             * @return {any[]} The keys in the store
-             */
-            keys(): any[];
-            /**
-             * Execute a callback for each entry in the array.
-             *
-             * @param {(key: any, val?: any, index?: number) => any} callback The callback to eecute
-             * @return {any[]} The results of mapping the callback over the entries
-             */
-            map(cb: (key?: any, val?: any, index?: number) => any): any[];
-            /**
-             * Delete a key from the key-value store. Return whether the key was present.
-             *
-             * @param {any} The key to remove
              * @return {boolean} Whether a matching entry was found and removed
              */
-            delete(key: any): boolean;
+            delete(key: K): boolean;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -402,8 +402,6 @@ var Plottable;
             /**
              * Set a new key/value pair in the store.
              *
-             * @param {any} key Key to set in the store
-             * @param {any} value Value to set in the store
              * @return {boolean} True if key already in store, false otherwise
              */
             Map.prototype.set = function (key, value) {
@@ -411,24 +409,26 @@ var Plottable;
                     throw new Error("NaN may not be used as a key to Map");
                 }
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
-                    if (this._keyValuePairs[i][0] === key) {
-                        this._keyValuePairs[i][1] = value;
+                    if (this._keyValuePairs[i].key === key) {
+                        this._keyValuePairs[i].value = value;
                         return true;
                     }
                 }
-                this._keyValuePairs.push([key, value]);
+                this._keyValuePairs.push({
+                    key: key,
+                    value: value
+                });
                 return false;
             };
             /**
              * Get a value from the store, given a key.
              *
-             * @param {any} key Key associated with value to retrieve
-             * @return {any} Value if found, undefined otherwise
+             * @return {V} value if found, undefined otherwise
              */
             Map.prototype.get = function (key) {
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
-                    if (this._keyValuePairs[i][0] === key) {
-                        return this._keyValuePairs[i][1];
+                    if (this._keyValuePairs[i].key === key) {
+                        return this._keyValuePairs[i].value;
                     }
                 }
                 return undefined;
@@ -439,53 +439,29 @@ var Plottable;
              * Will return true if there is a key/value entry,
              * even if the value is explicitly `undefined`.
              *
-             * @param {any} key Key to test for presence of an entry
-             * @return {boolean} Whether there was a matching entry for that key
              */
             Map.prototype.has = function (key) {
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
-                    if (this._keyValuePairs[i][0] === key) {
+                    if (this._keyValuePairs[i].key === key) {
                         return true;
                     }
                 }
                 return false;
             };
-            /**
-             * Return an array of the values in the key-value store
-             *
-             * @return {any[]} The values in the store
-             */
             Map.prototype.values = function () {
-                return this._keyValuePairs.map(function (x) { return x[1]; });
+                return this._keyValuePairs.map(function (pair) { return pair.value; });
             };
-            /**
-             * Return an array of keys in the key-value store
-             *
-             * @return {any[]} The keys in the store
-             */
             Map.prototype.keys = function () {
-                return this._keyValuePairs.map(function (x) { return x[0]; });
+                return this._keyValuePairs.map(function (pair) { return pair.key; });
             };
             /**
-             * Execute a callback for each entry in the array.
+             * Delete a key from the key-value store.
              *
-             * @param {(key: any, val?: any, index?: number) => any} callback The callback to eecute
-             * @return {any[]} The results of mapping the callback over the entries
-             */
-            Map.prototype.map = function (cb) {
-                return this._keyValuePairs.map(function (kv, index) {
-                    return cb(kv[0], kv[1], index);
-                });
-            };
-            /**
-             * Delete a key from the key-value store. Return whether the key was present.
-             *
-             * @param {any} The key to remove
              * @return {boolean} Whether a matching entry was found and removed
              */
             Map.prototype.delete = function (key) {
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
-                    if (this._keyValuePairs[i][0] === key) {
+                    if (this._keyValuePairs[i].key === key) {
                         this._keyValuePairs.splice(i, 1);
                         return true;
                     }

--- a/plottable.js
+++ b/plottable.js
@@ -393,12 +393,10 @@ var Plottable;
     var Utils;
     (function (Utils) {
         /**
-         * An associative array that can be keyed by anything (inc objects).
-         * Uses pointer equality checks which is why this works.
-         * This power has a price: everything is linear time since it is actually backed by an array...
+         * Shim for the ES6 map (although NaN is not allowed as a key).
          */
-        var StrictEqualityAssociativeArray = (function () {
-            function StrictEqualityAssociativeArray() {
+        var Map = (function () {
+            function Map() {
                 this._keyValuePairs = [];
             }
             /**
@@ -408,9 +406,9 @@ var Plottable;
              * @param {any} value Value to set in the store
              * @return {boolean} True if key already in store, false otherwise
              */
-            StrictEqualityAssociativeArray.prototype.set = function (key, value) {
+            Map.prototype.set = function (key, value) {
                 if (key !== key) {
-                    throw new Error("NaN may not be used as a key to the StrictEqualityAssociativeArray");
+                    throw new Error("NaN may not be used as a key to Map");
                 }
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
                     if (this._keyValuePairs[i][0] === key) {
@@ -427,7 +425,7 @@ var Plottable;
              * @param {any} key Key associated with value to retrieve
              * @return {any} Value if found, undefined otherwise
              */
-            StrictEqualityAssociativeArray.prototype.get = function (key) {
+            Map.prototype.get = function (key) {
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
                     if (this._keyValuePairs[i][0] === key) {
                         return this._keyValuePairs[i][1];
@@ -444,7 +442,7 @@ var Plottable;
              * @param {any} key Key to test for presence of an entry
              * @return {boolean} Whether there was a matching entry for that key
              */
-            StrictEqualityAssociativeArray.prototype.has = function (key) {
+            Map.prototype.has = function (key) {
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
                     if (this._keyValuePairs[i][0] === key) {
                         return true;
@@ -457,7 +455,7 @@ var Plottable;
              *
              * @return {any[]} The values in the store
              */
-            StrictEqualityAssociativeArray.prototype.values = function () {
+            Map.prototype.values = function () {
                 return this._keyValuePairs.map(function (x) { return x[1]; });
             };
             /**
@@ -465,7 +463,7 @@ var Plottable;
              *
              * @return {any[]} The keys in the store
              */
-            StrictEqualityAssociativeArray.prototype.keys = function () {
+            Map.prototype.keys = function () {
                 return this._keyValuePairs.map(function (x) { return x[0]; });
             };
             /**
@@ -474,7 +472,7 @@ var Plottable;
              * @param {(key: any, val?: any, index?: number) => any} callback The callback to eecute
              * @return {any[]} The results of mapping the callback over the entries
              */
-            StrictEqualityAssociativeArray.prototype.map = function (cb) {
+            Map.prototype.map = function (cb) {
                 return this._keyValuePairs.map(function (kv, index) {
                     return cb(kv[0], kv[1], index);
                 });
@@ -485,7 +483,7 @@ var Plottable;
              * @param {any} The key to remove
              * @return {boolean} Whether a matching entry was found and removed
              */
-            StrictEqualityAssociativeArray.prototype.delete = function (key) {
+            Map.prototype.delete = function (key) {
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
                     if (this._keyValuePairs[i][0] === key) {
                         this._keyValuePairs.splice(i, 1);
@@ -494,9 +492,9 @@ var Plottable;
                 }
                 return false;
             };
-            return StrictEqualityAssociativeArray;
+            return Map;
         })();
-        Utils.StrictEqualityAssociativeArray = StrictEqualityAssociativeArray;
+        Utils.Map = Map;
     })(Utils = Plottable.Utils || (Plottable.Utils = {}));
 })(Plottable || (Plottable = {}));
 
@@ -1177,7 +1175,7 @@ var Plottable;
              */
             function Broadcaster(listenable) {
                 _super.call(this);
-                this._key2callback = new Plottable.Utils.StrictEqualityAssociativeArray();
+                this._key2callback = new Plottable.Utils.Map();
                 this._listenable = listenable;
             }
             /**
@@ -1236,7 +1234,7 @@ var Plottable;
              * @returns {Broadcaster} The calling Broadcaster
              */
             Broadcaster.prototype.deregisterAllListeners = function () {
-                this._key2callback = new Plottable.Utils.StrictEqualityAssociativeArray();
+                this._key2callback = new Plottable.Utils.Map();
             };
             return Broadcaster;
         })(Core.PlottableObject);
@@ -1271,7 +1269,7 @@ var Plottable;
             _super.call(this);
             this._data = data;
             this._metadata = metadata;
-            this._accessor2cachedExtent = new Plottable.Utils.StrictEqualityAssociativeArray();
+            this._accessor2cachedExtent = new Plottable.Utils.Map();
             this.broadcaster = new Plottable.Core.Broadcaster(this);
         }
         Dataset.prototype.data = function (data) {
@@ -1280,7 +1278,7 @@ var Plottable;
             }
             else {
                 this._data = data;
-                this._accessor2cachedExtent = new Plottable.Utils.StrictEqualityAssociativeArray();
+                this._accessor2cachedExtent = new Plottable.Utils.Map();
                 this.broadcaster.broadcast();
                 return this;
             }
@@ -1291,7 +1289,7 @@ var Plottable;
             }
             else {
                 this._metadata = metadata;
-                this._accessor2cachedExtent = new Plottable.Utils.StrictEqualityAssociativeArray();
+                this._accessor2cachedExtent = new Plottable.Utils.Map();
                 this.broadcaster.broadcast();
                 return this;
             }

--- a/plottable.js
+++ b/plottable.js
@@ -1559,7 +1559,7 @@ var Plottable;
                 domain = this._combineExtents(extents);
             }
             else if (extents.length === 0) {
-                domain = scale._defaultExtent();
+                domain = scale._defaultDomain();
             }
             else {
                 domain = [Plottable.Utils.Methods.min(extents, function (e) { return e[0]; }, 0), Plottable.Utils.Methods.max(extents, function (e) { return e[1]; }, 0)];
@@ -1759,7 +1759,7 @@ var Plottable;
         Scale.prototype._getAllExtents = function () {
             return d3.values(this._rendererAttrID2Extent);
         };
-        Scale.prototype._getExtent = function () {
+        Scale.prototype._combinedDomainFromExtents = function () {
             return []; // this should be overwritten
         };
         /**
@@ -1779,7 +1779,7 @@ var Plottable;
          */
         Scale.prototype.autoDomain = function () {
             this._autoDomainAutomatically = true;
-            this._setDomain(this._getExtent());
+            this._setDomain(this._combinedDomainFromExtents());
             return this;
         };
         Scale.prototype._autoDomainIfAutomaticMode = function () {
@@ -1891,7 +1891,7 @@ var Plottable;
             this._typeCoercer = function (d) { return +d; };
             this._tickGenerator = function (scale) { return scale.getDefaultTicks(); };
         }
-        QuantitativeScale.prototype._getExtent = function () {
+        QuantitativeScale.prototype._combinedDomainFromExtents = function () {
             return this._domainer.computeDomain(this._getAllExtents(), this);
         };
         /**
@@ -1984,7 +1984,7 @@ var Plottable;
                 return this;
             }
         };
-        QuantitativeScale.prototype._defaultExtent = function () {
+        QuantitativeScale.prototype._defaultDomain = function () {
             return [0, 1];
         };
         QuantitativeScale.prototype.tickGenerator = function (generator) {
@@ -2114,7 +2114,7 @@ var Plottable;
                 this._showIntermediateTicks = false;
                 this.base = base;
                 this.pivot = this.base;
-                this.untransformedDomain = this._defaultExtent();
+                this.untransformedDomain = this._defaultDomain();
                 this.numTicks(10);
                 if (base <= 1) {
                     throw new Error("ModifiedLogScale: The base must be > 1");
@@ -2282,7 +2282,7 @@ var Plottable;
                 this._innerPadding = Category._convertToPlottableInnerPadding(d3InnerPadding);
                 this._outerPadding = Category._convertToPlottableOuterPadding(0.5, d3InnerPadding);
             }
-            Category.prototype._getExtent = function () {
+            Category.prototype._combinedDomainFromExtents = function () {
                 var extents = this._getAllExtents();
                 return Plottable.Utils.Methods.uniq(Plottable.Utils.Methods.flatten(extents));
             };
@@ -2415,7 +2415,7 @@ var Plottable;
                 _super.call(this, scale);
             }
             // Duplicated from OrdinalScale._getExtent - should be removed in #388
-            Color.prototype._getExtent = function () {
+            Color.prototype._combinedDomainFromExtents = function () {
                 var extents = this._getAllExtents();
                 var concatenatedExtents = [];
                 extents.forEach(function (e) {

--- a/src/core/broadcaster.ts
+++ b/src/core/broadcaster.ts
@@ -23,7 +23,7 @@ export module Core {
    * The listeners are called synchronously.
    */
   export class Broadcaster<L> extends Core.PlottableObject {
-    private _key2callback = new Utils.StrictEqualityAssociativeArray();
+    private _key2callback = new Utils.Map();
     private _listenable: L;
 
     /**
@@ -92,7 +92,7 @@ export module Core {
      * @returns {Broadcaster} The calling Broadcaster
      */
     public deregisterAllListeners() {
-      this._key2callback = new Utils.StrictEqualityAssociativeArray();
+      this._key2callback = new Utils.Map();
     }
   }
 }

--- a/src/core/broadcaster.ts
+++ b/src/core/broadcaster.ts
@@ -23,7 +23,7 @@ export module Core {
    * The listeners are called synchronously.
    */
   export class Broadcaster<L> extends Core.PlottableObject {
-    private _key2callback = new Utils.Map();
+    private _key2callback = new Utils.Map<any, Function>();
     private _listenable: L;
 
     /**
@@ -92,7 +92,7 @@ export module Core {
      * @returns {Broadcaster} The calling Broadcaster
      */
     public deregisterAllListeners() {
-      this._key2callback = new Utils.Map();
+      this._key2callback = new Utils.Map<any, Function>();
     }
   }
 }

--- a/src/core/dataset.ts
+++ b/src/core/dataset.ts
@@ -8,7 +8,7 @@ module Plottable {
   export class Dataset extends Core.PlottableObject {
     private _data: any[];
     private _metadata: any;
-    private _accessor2cachedExtent: Utils.StrictEqualityAssociativeArray;
+    private _accessor2cachedExtent: Utils.Map;
     public broadcaster: Core.Broadcaster<Dataset>;
 
     /**
@@ -25,7 +25,7 @@ module Plottable {
       super();
       this._data = data;
       this._metadata = metadata;
-      this._accessor2cachedExtent = new Utils.StrictEqualityAssociativeArray();
+      this._accessor2cachedExtent = new Utils.Map();
       this.broadcaster = new Core.Broadcaster(this);
     }
 
@@ -47,7 +47,7 @@ module Plottable {
         return this._data;
       } else {
         this._data = data;
-        this._accessor2cachedExtent = new Utils.StrictEqualityAssociativeArray();
+        this._accessor2cachedExtent = new Utils.Map();
         this.broadcaster.broadcast();
         return this;
       }
@@ -72,7 +72,7 @@ module Plottable {
         return this._metadata;
       } else {
         this._metadata = metadata;
-        this._accessor2cachedExtent = new Utils.StrictEqualityAssociativeArray();
+        this._accessor2cachedExtent = new Utils.Map();
         this.broadcaster.broadcast();
         return this;
       }

--- a/src/core/dataset.ts
+++ b/src/core/dataset.ts
@@ -8,7 +8,7 @@ module Plottable {
   export class Dataset extends Core.PlottableObject {
     private _data: any[];
     private _metadata: any;
-    private _accessor2cachedExtent: Utils.Map;
+    private _accessor2cachedExtent: Utils.Map<any, any>;
     public broadcaster: Core.Broadcaster<Dataset>;
 
     /**

--- a/src/core/domainer.ts
+++ b/src/core/domainer.ts
@@ -47,7 +47,7 @@ module Plottable {
       if (this._combineExtents != null) {
         domain = this._combineExtents(extents);
       } else if (extents.length === 0) {
-        domain = scale._defaultExtent();
+        domain = scale._defaultDomain();
       } else {
         domain = [Utils.Methods.min(extents, (e) => e[0], 0), Utils.Methods.max(extents, (e) => e[1], 0)];
       }

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -1,7 +1,7 @@
 /// <reference path="../bower_components/svg-typewriter/svgtypewriter.d.ts" />
 
 /// <reference path="utils/utils.ts" />
-/// <reference path="utils/strictEqualityAssociativeArray.ts" />
+/// <reference path="utils/map.ts" />
 /// <reference path="utils/domUtils.ts" />
 /// <reference path="utils/color.ts" />
 /// <reference path="utils/callbackSet.ts" />

--- a/src/scales/abstractScale.ts
+++ b/src/scales/abstractScale.ts
@@ -28,7 +28,7 @@ module Plottable {
       return d3.values(this._rendererAttrID2Extent);
     }
 
-    protected _getExtent(): D[] {
+    protected _combinedDomainFromExtents(): D[] {
       return []; // this should be overwritten
     }
 
@@ -49,7 +49,7 @@ module Plottable {
      */
     public autoDomain() {
       this._autoDomainAutomatically = true;
-      this._setDomain(this._getExtent());
+      this._setDomain(this._combinedDomainFromExtents());
       return this;
     }
 

--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -26,7 +26,7 @@ export module Scales {
       this._outerPadding = Category._convertToPlottableOuterPadding(0.5, d3InnerPadding);
     }
 
-    protected _getExtent(): string[] {
+    protected _combinedDomainFromExtents(): string[] {
       var extents: string[][] = this._getAllExtents();
       return Utils.Methods.uniq(Utils.Methods.flatten(extents));
     }

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -51,7 +51,7 @@ export module Scales {
     }
 
     // Duplicated from OrdinalScale._getExtent - should be removed in #388
-    protected _getExtent(): string[] {
+    protected _combinedDomainFromExtents(): string[] {
       var extents = this._getAllExtents();
       var concatenatedExtents: string[] = [];
       extents.forEach((e) => {

--- a/src/scales/modifiedLogScale.ts
+++ b/src/scales/modifiedLogScale.ts
@@ -37,7 +37,7 @@ export module Scales {
       super(d3.scale.linear());
       this.base = base;
       this.pivot = this.base;
-      this.untransformedDomain = this._defaultExtent();
+      this.untransformedDomain = this._defaultDomain();
       this.numTicks(10);
       if (base <= 1) {
         throw new Error("ModifiedLogScale: The base must be > 1");

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -25,7 +25,7 @@ module Plottable {
       super(scale);
     }
 
-    protected _getExtent(): D[] {
+    protected _combinedDomainFromExtents(): D[] {
       return this._domainer.computeDomain(this._getAllExtents(), this);
     }
 
@@ -185,7 +185,7 @@ module Plottable {
       }
     }
 
-    public _defaultExtent(): any[] {
+    public _defaultDomain(): any[] {
       return [0, 1];
     }
 

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -3,13 +3,11 @@
 module Plottable {
 export module Utils {
   /**
-   * An associative array that can be keyed by anything (inc objects).
-   * Uses pointer equality checks which is why this works.
-   * This power has a price: everything is linear time since it is actually backed by an array...
+   * Shim for the ES6 map (although NaN is not allowed as a key).
    */
-  export class StrictEqualityAssociativeArray {
+  export class Map {
     private _keyValuePairs: any[][] = [];
-
+    
     /**
      * Set a new key/value pair in the store.
      *
@@ -19,7 +17,7 @@ export module Utils {
      */
     public set(key: any, value: any) {
       if (key !== key) {
-        throw new Error("NaN may not be used as a key to the StrictEqualityAssociativeArray");
+        throw new Error("NaN may not be used as a key to Map");
       }
       for (var i = 0; i < this._keyValuePairs.length; i++) {
         if (this._keyValuePairs[i][0] === key) {

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -5,40 +5,40 @@ export module Utils {
   /**
    * Shim for the ES6 map (although NaN is not allowed as a key).
    */
-  export class Map {
-    private _keyValuePairs: any[][] = [];
+  export class Map<K, V> {
+    private _keyValuePairs: { key: K; value: V; }[] = [];
     
     /**
      * Set a new key/value pair in the store.
      *
-     * @param {any} key Key to set in the store
-     * @param {any} value Value to set in the store
      * @return {boolean} True if key already in store, false otherwise
      */
-    public set(key: any, value: any) {
+    public set(key: K, value: V) {
       if (key !== key) {
         throw new Error("NaN may not be used as a key to Map");
       }
       for (var i = 0; i < this._keyValuePairs.length; i++) {
-        if (this._keyValuePairs[i][0] === key) {
-          this._keyValuePairs[i][1] = value;
+        if (this._keyValuePairs[i].key === key) {
+          this._keyValuePairs[i].value = value;
           return true;
         }
       }
-      this._keyValuePairs.push([key, value]);
+      this._keyValuePairs.push({
+        key: key,
+        value: value
+      });
       return false;
     }
 
     /**
      * Get a value from the store, given a key.
      *
-     * @param {any} key Key associated with value to retrieve
-     * @return {any} Value if found, undefined otherwise
+     * @return {V} value if found, undefined otherwise
      */
-    public get(key: any): any {
+    public get(key: K): V {
       for (var i = 0; i < this._keyValuePairs.length; i++) {
-        if (this._keyValuePairs[i][0] === key) {
-          return this._keyValuePairs[i][1];
+        if (this._keyValuePairs[i].key === key) {
+          return this._keyValuePairs[i].value;
         }
       }
       return undefined;
@@ -50,57 +50,32 @@ export module Utils {
      * Will return true if there is a key/value entry,
      * even if the value is explicitly `undefined`.
      *
-     * @param {any} key Key to test for presence of an entry
-     * @return {boolean} Whether there was a matching entry for that key
      */
-    public has(key: any): boolean {
+    public has(key: K): boolean {
       for (var i = 0; i < this._keyValuePairs.length; i++) {
-        if (this._keyValuePairs[i][0] === key) {
+        if (this._keyValuePairs[i].key === key) {
           return true;
         }
       }
       return false;
     }
 
-    /**
-     * Return an array of the values in the key-value store
-     *
-     * @return {any[]} The values in the store
-     */
-    public values(): any[] {
-      return this._keyValuePairs.map((x) => x[1]);
+    public values(): V[] {
+      return this._keyValuePairs.map((pair) => pair.value);
+    }
+    
+    public keys(): K[] {
+      return this._keyValuePairs.map((pair) => pair.key);
     }
 
     /**
-     * Return an array of keys in the key-value store
+     * Delete a key from the key-value store.
      *
-     * @return {any[]} The keys in the store
-     */
-    public keys(): any[] {
-      return this._keyValuePairs.map((x) => x[0]);
-    }
-
-    /**
-     * Execute a callback for each entry in the array.
-     *
-     * @param {(key: any, val?: any, index?: number) => any} callback The callback to eecute
-     * @return {any[]} The results of mapping the callback over the entries
-     */
-     public map(cb: (key?: any, val?: any, index?: number) => any) {
-      return this._keyValuePairs.map((kv: any[], index: number) => {
-        return cb(kv[0], kv[1], index);
-      });
-     }
-
-    /**
-     * Delete a key from the key-value store. Return whether the key was present.
-     *
-     * @param {any} The key to remove
      * @return {boolean} Whether a matching entry was found and removed
      */
-    public delete(key: any): boolean {
+    public delete(key: K): boolean {
       for (var i = 0; i < this._keyValuePairs.length; i++) {
-        if (this._keyValuePairs[i][0] === key) {
+        if (this._keyValuePairs[i].key === key) {
           this._keyValuePairs.splice(i, 1);
           return true;
         }

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -55,7 +55,7 @@
 
 ///<reference path="utils/domUtilsTests.ts" />
 ///<reference path="utils/formattersTests.ts" />
-///<reference path="utils/strictEqualityAssociativeArrayTests.ts" />
+///<reference path="utils/mapTests.ts" />
 ///<reference path="utils/clientToSVGTranslatorTests.ts" />
 ///<reference path="utils/utilsTests.ts" />
 ///<reference path="utils/callbackSetTests.ts" />

--- a/test/tests.js
+++ b/test/tests.js
@@ -8177,14 +8177,13 @@ describe("Map", function () {
         assert.equal(s.get(o2), "baz");
         assert.equal(s.get("3"), "ball");
     });
-    it("Array-level operations (retrieve keys, vals, and map)", function () {
+    it("Array-level operations (retrieve keys, vals)", function () {
         var s = new Plottable.Utils.Map();
         s.set(2, "foo");
         s.set(3, "bar");
         s.set(4, "baz");
         assert.deepEqual(s.values(), ["foo", "bar", "baz"]);
         assert.deepEqual(s.keys(), [2, 3, 4]);
-        assert.deepEqual(s.map(function (k, v, i) { return [k, v, i]; }), [[2, "foo", 0], [3, "bar", 1], [4, "baz", 2]]);
     });
 });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -8153,9 +8153,9 @@ describe("Formatters", function () {
 
 ///<reference path="../testReference.ts" />
 var assert = chai.assert;
-describe("StrictEqualityAssociativeArray", function () {
-    it("StrictEqualityAssociativeArray works as expected", function () {
-        var s = new Plottable.Utils.StrictEqualityAssociativeArray();
+describe("Map", function () {
+    it("Map works as expected", function () {
+        var s = new Plottable.Utils.Map();
         var o1 = {};
         var o2 = {};
         assert.isFalse(s.has(o1));
@@ -8178,7 +8178,7 @@ describe("StrictEqualityAssociativeArray", function () {
         assert.equal(s.get("3"), "ball");
     });
     it("Array-level operations (retrieve keys, vals, and map)", function () {
-        var s = new Plottable.Utils.StrictEqualityAssociativeArray();
+        var s = new Plottable.Utils.Map();
         s.set(2, "foo");
         s.set(3, "bar");
         s.set(4, "baz");

--- a/test/utils/mapTests.ts
+++ b/test/utils/mapTests.ts
@@ -2,10 +2,10 @@
 
 var assert = chai.assert;
 
-describe("StrictEqualityAssociativeArray", () => {
+describe("Map", () => {
 
-  it("StrictEqualityAssociativeArray works as expected", () => {
-    var s = new Plottable.Utils.StrictEqualityAssociativeArray();
+  it("Map works as expected", () => {
+    var s = new Plottable.Utils.Map();
     var o1 = {};
     var o2 = {};
     assert.isFalse(s.has(o1));
@@ -29,7 +29,7 @@ describe("StrictEqualityAssociativeArray", () => {
   });
 
   it("Array-level operations (retrieve keys, vals, and map)", () => {
-    var s = new Plottable.Utils.StrictEqualityAssociativeArray();
+    var s = new Plottable.Utils.Map();
     s.set(2, "foo");
     s.set(3, "bar");
     s.set(4, "baz");

--- a/test/utils/mapTests.ts
+++ b/test/utils/mapTests.ts
@@ -28,13 +28,12 @@ describe("Map", () => {
     assert.equal(s.get("3"), "ball");
   });
 
-  it("Array-level operations (retrieve keys, vals, and map)", () => {
+  it("Array-level operations (retrieve keys, vals)", () => {
     var s = new Plottable.Utils.Map();
     s.set(2, "foo");
     s.set(3, "bar");
     s.set(4, "baz");
     assert.deepEqual(s.values(), ["foo", "bar", "baz"]);
     assert.deepEqual(s.keys(), [2, 3, 4]);
-    assert.deepEqual(s.map((k, v, i) => [k, v, i]), [[2, "foo", 0], [3, "bar", 1], [4, "baz", 2]]);
   });
 });


### PR DESCRIPTION
Seriously, it's just a shim for an [ES6 Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map).

While we're removing `Broadcaster`, I'm going to need `Utils.Map` to fix `Scale` autodomain calculations.