### PR TITLE
Utils.min() and Utils.max() now return defaultValue in all bad cases.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -101,19 +101,17 @@ declare module Plottable {
              */
             function objEq(a: any, b: any): boolean;
             /**
-             * Computes the max value from the array.
-             *
-             * If type is not comparable then t will be converted to a comparable before computing max.
+             * Applies the accessor, if provided, to each element of `array` and returns the maximum value.
+             * If no maximum value can be computed, returns defaultValue.
              */
-            function max<C>(arr: C[], default_val: C): C;
-            function max<T, C>(arr: T[], acc: (x?: T, i?: number) => C, default_val: C): C;
+            function max<C>(array: C[], defaultValue: C): C;
+            function max<T, C>(array: T[], accessor: (t?: T, i?: number) => C, defaultValue: C): C;
             /**
-             * Computes the min value from the array.
-             *
-             * If type is not comparable then t will be converted to a comparable before computing min.
+             * Applies the accessor, if provided, to each element of `array` and returns the minimum value.
+             * If no minimum value can be computed, returns defaultValue.
              */
-            function min<C>(arr: C[], default_val: C): C;
-            function min<T, C>(arr: T[], acc: (x?: T, i?: number) => C, default_val: C): C;
+            function min<C>(array: C[], defaultValue: C): C;
+            function min<T, C>(array: T[], accessor: (t?: T, i?: number) => C, defaultValue: C): C;
             /**
              * Returns true **only** if x is NaN
              */

--- a/plottable.js
+++ b/plottable.js
@@ -216,34 +216,22 @@ var Plottable;
                 return arrayEq(keysA, keysB) && arrayEq(valuesA, valuesB);
             }
             Methods.objEq = objEq;
-            function max(arr, one, two) {
-                if (arr.length === 0) {
-                    if (typeof (one) !== "function") {
-                        return one;
-                    }
-                    else {
-                        return two;
-                    }
-                }
+            function max(array, firstArg, secondArg) {
+                var accessor = typeof (firstArg) === "function" ? firstArg : null;
+                var defaultValue = accessor == null ? firstArg : secondArg;
                 /* tslint:disable:ban */
-                var acc = typeof (one) === "function" ? one : typeof (two) === "function" ? two : undefined;
-                return acc === undefined ? d3.max(arr) : d3.max(arr, acc);
+                var maxValue = accessor == null ? d3.max(array) : d3.max(array, accessor);
                 /* tslint:enable:ban */
+                return maxValue !== undefined ? maxValue : defaultValue;
             }
             Methods.max = max;
-            function min(arr, one, two) {
-                if (arr.length === 0) {
-                    if (typeof (one) !== "function") {
-                        return one;
-                    }
-                    else {
-                        return two;
-                    }
-                }
+            function min(array, firstArg, secondArg) {
+                var accessor = typeof (firstArg) === "function" ? firstArg : null;
+                var defaultValue = accessor == null ? firstArg : secondArg;
                 /* tslint:disable:ban */
-                var acc = typeof (one) === "function" ? one : typeof (two) === "function" ? two : undefined;
-                return acc === undefined ? d3.min(arr) : d3.min(arr, acc);
+                var minValue = accessor == null ? d3.min(array) : d3.min(array, accessor);
                 /* tslint:enable:ban */
+                return minValue !== undefined ? minValue : defaultValue;
             }
             Methods.min = min;
             /**

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -206,45 +206,33 @@ export module Utils {
     }
 
     /**
-     * Computes the max value from the array.
-     *
-     * If type is not comparable then t will be converted to a comparable before computing max.
+     * Applies the accessor, if provided, to each element of `array` and returns the maximum value.
+     * If no maximum value can be computed, returns defaultValue.
      */
-    export function max<C>(arr: C[], default_val: C): C;
-    export function max<T, C>(arr: T[], acc: (x?: T, i?: number) => C, default_val: C): C;
-    export function max(arr: any[], one: any, two?: any): any {
-      if (arr.length === 0) {
-        if (typeof(one) !== "function") {
-          return one;
-        } else {
-          return two;
-        }
-      }
+    export function max<C>(array: C[], defaultValue: C): C;
+    export function max<T, C>(array: T[], accessor: (t?: T, i?: number) => C, defaultValue: C): C;
+    export function max(array: any[], firstArg: any, secondArg?: any): any {
+      var accessor = typeof(firstArg) === "function" ? firstArg : null;
+      var defaultValue = accessor == null ? firstArg : secondArg;
       /* tslint:disable:ban */
-      var acc = typeof(one) === "function" ? one : typeof(two) === "function" ? two : undefined;
-      return acc === undefined ? d3.max(arr) : d3.max(arr, acc);
+      var maxValue = accessor == null ? d3.max(array) : d3.max(array, accessor);
       /* tslint:enable:ban */
+      return maxValue !== undefined ? maxValue : defaultValue;
     }
 
     /**
-     * Computes the min value from the array.
-     *
-     * If type is not comparable then t will be converted to a comparable before computing min.
+     * Applies the accessor, if provided, to each element of `array` and returns the minimum value.
+     * If no minimum value can be computed, returns defaultValue.
      */
-    export function min<C>(arr: C[], default_val: C): C;
-    export function min<T, C>(arr: T[], acc: (x?: T, i?: number) => C, default_val: C): C;
-    export function min(arr: any[], one: any, two?: any): any {
-      if (arr.length === 0) {
-        if (typeof(one) !== "function") {
-          return one;
-        } else {
-          return two;
-        }
-      }
+    export function min<C>(array: C[], defaultValue: C): C;
+    export function min<T, C>(array: T[], accessor: (t?: T, i?: number) => C, defaultValue: C): C;
+    export function min(array: any[], firstArg: any, secondArg?: any): any {
+      var accessor = typeof(firstArg) === "function" ? firstArg : null;
+      var defaultValue = accessor == null ? firstArg : secondArg;
       /* tslint:disable:ban */
-      var acc = typeof(one) === "function" ? one : typeof(two) === "function" ? two : undefined;
-      return acc === undefined ? d3.min(arr) : d3.min(arr, acc);
+      var minValue = accessor == null ? d3.min(array) : d3.min(array, accessor);
       /* tslint:enable:ban */
+      return minValue !== undefined ? minValue : defaultValue;
     }
 
     /**

--- a/test/tests.js
+++ b/test/tests.js
@@ -8245,11 +8245,30 @@ describe("Utils.Methods", function () {
         var strings = ["foo", "bar", "foo", "foo", "baz", "bam"];
         assert.deepEqual(Plottable.Utils.Methods.uniq(strings), ["foo", "bar", "baz", "bam"]);
     });
-    describe("min/max", function () {
+    describe("max() and min()", function () {
         var max = Plottable.Utils.Methods.max;
         var min = Plottable.Utils.Methods.min;
         var today = new Date();
-        it("max/min work as expected", function () {
+        it("return the default value if max or min can't be computed", function () {
+            var minValue = 1;
+            var maxValue = 5;
+            var defaultValue = 3;
+            var goodArray = [
+                [minValue],
+                [maxValue]
+            ];
+            // bad array is technically of type number[][], but subarrays are empty!
+            var badArray = [
+                [],
+                []
+            ];
+            var accessor = function (arr) { return arr[0]; };
+            assert.strictEqual(min(goodArray, accessor, defaultValue), minValue, "min(): minimum value is returned in good case");
+            assert.strictEqual(min(badArray, accessor, defaultValue), defaultValue, "min(): default value is returned in bad case");
+            assert.strictEqual(max(goodArray, accessor, defaultValue), maxValue, "max(): maximum value is returned in good case");
+            assert.strictEqual(max(badArray, accessor, defaultValue), defaultValue, "max(): default value is returned in bad case");
+        });
+        it("max() and min() work on numbers", function () {
             var alist = [1, 2, 3, 4, 5];
             var dbl = function (x) { return x * 2; };
             var dblIndexOffset = function (x, i) { return x * 2 - i; };
@@ -8272,12 +8291,12 @@ describe("Utils.Methods", function () {
             assert.deepEqual(min([], dbl, 5), 5, "min accepts custom default and function");
             assert.deepEqual(min([], numToDate, today), today, "min accepts non-numeric default and function");
         });
-        it("max/min works as expected on non-numeric values (strings)", function () {
+        it("max() and min() work on strings", function () {
             var strings = ["a", "bb", "ccc", "ddd"];
             assert.deepEqual(max(strings, function (s) { return s.length; }, 0), 3, "works on arrays of non-numbers with a function");
             assert.deepEqual(max([], function (s) { return s.length; }, 5), 5, "defaults work even with non-number function type");
         });
-        it("max/min works as expected on non-numeric values (dates)", function () {
+        it("max() and min() work on dates", function () {
             var tomorrow = new Date(today.getTime());
             tomorrow.setDate(today.getDate() + 1);
             var dayAfterTomorrow = new Date(today.getTime());
@@ -8285,8 +8304,8 @@ describe("Utils.Methods", function () {
             var dates = [today, tomorrow, dayAfterTomorrow, null];
             assert.deepEqual(min(dates, dayAfterTomorrow), today, "works on arrays of non-numeric values but comparable");
             assert.deepEqual(max(dates, today), dayAfterTomorrow, "works on arrays of non-number values but comparable");
-            assert.deepEqual(max([null], today), undefined, "returns undefined from array of null values");
-            assert.deepEqual(max([], today), today, "correct default non-numeric value returned");
+            assert.deepEqual(max([null], today), today, "returns default value if passed array of null values");
+            assert.deepEqual(max([], today), today, "returns default value if passed empty");
         });
     });
     it("isNaN works as expected", function () {

--- a/test/utils/utilsTests.ts
+++ b/test/utils/utilsTests.ts
@@ -35,12 +35,36 @@ describe("Utils.Methods", () => {
   });
 
 
-  describe("min/max", () => {
+  describe("max() and min()", () => {
     var max = Plottable.Utils.Methods.max;
     var min = Plottable.Utils.Methods.min;
     var today = new Date();
 
-    it("max/min work as expected", () => {
+    it("return the default value if max or min can't be computed", () => {
+      var minValue = 1;
+      var maxValue = 5;
+      var defaultValue = 3;
+      var goodArray: number[][] = [
+        [minValue],
+        [maxValue]
+      ];
+      // bad array is technically of type number[][], but subarrays are empty!
+      var badArray: number[][] = [
+        [],
+        []
+      ];
+      var accessor = (arr: number[]) => arr[0];
+      assert.strictEqual(min<number[], number>(goodArray, accessor, defaultValue),
+        minValue, "min(): minimum value is returned in good case");
+      assert.strictEqual(min<number[], number>(badArray, accessor, defaultValue),
+        defaultValue, "min(): default value is returned in bad case");
+      assert.strictEqual(max<number[], number>(goodArray, accessor, defaultValue),
+        maxValue, "max(): maximum value is returned in good case");
+      assert.strictEqual(max<number[], number>(badArray, accessor, defaultValue),
+        defaultValue, "max(): default value is returned in bad case");
+    });
+
+    it("max() and min() work on numbers", () => {
       var alist = [1, 2, 3, 4, 5];
       var dbl = (x: number) => x * 2;
       var dblIndexOffset = (x: number, i: number) => x * 2 - i;
@@ -66,13 +90,13 @@ describe("Utils.Methods", () => {
       assert.deepEqual(min([], numToDate, today), today, "min accepts non-numeric default and function");
     });
 
-    it("max/min works as expected on non-numeric values (strings)", () => {
+    it("max() and min() work on strings", () => {
       var strings = ["a", "bb", "ccc", "ddd"];
       assert.deepEqual(max(strings, (s: string) => s.length, 0), 3, "works on arrays of non-numbers with a function");
       assert.deepEqual(max([], (s: string) => s.length, 5), 5, "defaults work even with non-number function type");
     });
 
-    it("max/min works as expected on non-numeric values (dates)", () => {
+    it("max() and min() work on dates", () => {
       var tomorrow = new Date(today.getTime());
       tomorrow.setDate(today.getDate() + 1);
       var dayAfterTomorrow = new Date(today.getTime());
@@ -80,8 +104,8 @@ describe("Utils.Methods", () => {
       var dates: Date[] = [today, tomorrow, dayAfterTomorrow, null];
       assert.deepEqual(min<Date>(dates, dayAfterTomorrow), today, "works on arrays of non-numeric values but comparable");
       assert.deepEqual(max<Date>(dates, today), dayAfterTomorrow, "works on arrays of non-number values but comparable");
-      assert.deepEqual(max<Date>([null], today), undefined, "returns undefined from array of null values");
-      assert.deepEqual(max<Date>([], today), today, "correct default non-numeric value returned");
+      assert.deepEqual(max<Date>([null], today), today, "returns default value if passed array of null values");
+      assert.deepEqual(max<Date>([], today), today, "returns default value if passed empty");
     });
   });
 


### PR DESCRIPTION
Previously, a bad accessor-function or a weird input array would cause `undefined` to be returned. Since the entire point of `Utils.min()` and `Utils.max()` was to be safer than the d3 versions, they now return
the default value whenever `undefined` would be returned.