### PR TITLE
Replace string constants with static members of Alignment class

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1821,6 +1821,13 @@ declare module Plottable {
          */
         background(): D3.Selection;
     }
+    class Alignment {
+        static TOP: string;
+        static BOTTOM: string;
+        static LEFT: string;
+        static RIGHT: string;
+        static CENTER: string;
+    }
 }
 
 

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1588,6 +1588,15 @@ declare module Plottable {
 
 
 declare module Plottable {
+    module Components {
+        class Alignment {
+            static TOP: string;
+            static BOTTOM: string;
+            static LEFT: string;
+            static RIGHT: string;
+            static CENTER: string;
+        }
+    }
     class Component extends Core.PlottableObject {
         protected _element: D3.Selection;
         protected _content: D3.Selection;
@@ -1820,13 +1829,6 @@ declare module Plottable {
          * @return {D3.Selection} background selection for the Component
          */
         background(): D3.Selection;
-    }
-    class Alignment {
-        static TOP: string;
-        static BOTTOM: string;
-        static LEFT: string;
-        static RIGHT: string;
-        static CENTER: string;
     }
 }
 

--- a/plottable.js
+++ b/plottable.js
@@ -3558,13 +3558,13 @@ var Plottable;
          */
         Component.prototype.xAlign = function (alignment) {
             alignment = alignment.toLowerCase();
-            if (alignment === "left") {
+            if (alignment === Alignment.LEFT) {
                 this._xAlignProportion = 0;
             }
-            else if (alignment === "center") {
+            else if (alignment === Alignment.CENTER) {
                 this._xAlignProportion = 0.5;
             }
-            else if (alignment === "right") {
+            else if (alignment === Alignment.RIGHT) {
                 this._xAlignProportion = 1;
             }
             else {
@@ -3586,13 +3586,13 @@ var Plottable;
          */
         Component.prototype.yAlign = function (alignment) {
             alignment = alignment.toLowerCase();
-            if (alignment === "top") {
+            if (alignment === Alignment.TOP) {
                 this._yAlignProportion = 0;
             }
-            else if (alignment === "center") {
+            else if (alignment === Alignment.CENTER) {
                 this._yAlignProportion = 0.5;
             }
-            else if (alignment === "bottom") {
+            else if (alignment === Alignment.BOTTOM) {
                 this._yAlignProportion = 1;
             }
             else {
@@ -3878,6 +3878,17 @@ var Plottable;
         return Component;
     })(Plottable.Core.PlottableObject);
     Plottable.Component = Component;
+    var Alignment = (function () {
+        function Alignment() {
+        }
+        Alignment.TOP = "top";
+        Alignment.BOTTOM = "bottom";
+        Alignment.LEFT = "left";
+        Alignment.RIGHT = "right";
+        Alignment.CENTER = "center";
+        return Alignment;
+    })();
+    Plottable.Alignment = Alignment;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />

--- a/plottable.js
+++ b/plottable.js
@@ -3340,6 +3340,20 @@ var __extends = this.__extends || function (d, b) {
 };
 var Plottable;
 (function (Plottable) {
+    var Components;
+    (function (Components) {
+        var Alignment = (function () {
+            function Alignment() {
+            }
+            Alignment.TOP = "top";
+            Alignment.BOTTOM = "bottom";
+            Alignment.LEFT = "left";
+            Alignment.RIGHT = "right";
+            Alignment.CENTER = "center";
+            return Alignment;
+        })();
+        Components.Alignment = Alignment;
+    })(Components = Plottable.Components || (Plottable.Components = {}));
     var Component = (function (_super) {
         __extends(Component, _super);
         function Component() {
@@ -3558,13 +3572,13 @@ var Plottable;
          */
         Component.prototype.xAlign = function (alignment) {
             alignment = alignment.toLowerCase();
-            if (alignment === Alignment.LEFT) {
+            if (alignment === Components.Alignment.LEFT) {
                 this._xAlignProportion = 0;
             }
-            else if (alignment === Alignment.CENTER) {
+            else if (alignment === Components.Alignment.CENTER) {
                 this._xAlignProportion = 0.5;
             }
-            else if (alignment === Alignment.RIGHT) {
+            else if (alignment === Components.Alignment.RIGHT) {
                 this._xAlignProportion = 1;
             }
             else {
@@ -3586,13 +3600,13 @@ var Plottable;
          */
         Component.prototype.yAlign = function (alignment) {
             alignment = alignment.toLowerCase();
-            if (alignment === Alignment.TOP) {
+            if (alignment === Components.Alignment.TOP) {
                 this._yAlignProportion = 0;
             }
-            else if (alignment === Alignment.CENTER) {
+            else if (alignment === Components.Alignment.CENTER) {
                 this._yAlignProportion = 0.5;
             }
-            else if (alignment === Alignment.BOTTOM) {
+            else if (alignment === Components.Alignment.BOTTOM) {
                 this._yAlignProportion = 1;
             }
             else {
@@ -3878,17 +3892,6 @@ var Plottable;
         return Component;
     })(Plottable.Core.PlottableObject);
     Plottable.Component = Component;
-    var Alignment = (function () {
-        function Alignment() {
-        }
-        Alignment.TOP = "top";
-        Alignment.BOTTOM = "bottom";
-        Alignment.LEFT = "left";
-        Alignment.RIGHT = "right";
-        Alignment.CENTER = "center";
-        return Alignment;
-    })();
-    Plottable.Alignment = Alignment;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -1,6 +1,15 @@
 ///<reference path="../reference.ts" />
 
 module Plottable {
+  export module Components {
+    export class Alignment {
+      static TOP = "top";
+      static BOTTOM = "bottom";
+      static LEFT = "left";
+      static RIGHT = "right";
+      static CENTER = "center";
+    }
+  }
   export class Component extends Core.PlottableObject {
     protected _element: D3.Selection;
     protected _content: D3.Selection;
@@ -242,11 +251,11 @@ module Plottable {
      */
     public xAlign(alignment: string): Component {
       alignment = alignment.toLowerCase();
-      if (alignment === Alignment.LEFT) {
+      if (alignment === Components.Alignment.LEFT) {
         this._xAlignProportion = 0;
-      } else if (alignment === Alignment.CENTER) {
+      } else if (alignment === Components.Alignment.CENTER) {
         this._xAlignProportion = 0.5;
-      } else if (alignment === Alignment.RIGHT) {
+      } else if (alignment === Components.Alignment.RIGHT) {
         this._xAlignProportion = 1;
       } else {
         throw new Error("Unsupported alignment");
@@ -268,11 +277,11 @@ module Plottable {
      */
     public yAlign(alignment: string): Component {
       alignment = alignment.toLowerCase();
-      if (alignment === Alignment.TOP) {
+      if (alignment === Components.Alignment.TOP) {
         this._yAlignProportion = 0;
-      } else if (alignment === Alignment.CENTER) {
+      } else if (alignment === Components.Alignment.CENTER) {
         this._yAlignProportion = 0.5;
-      } else if (alignment === Alignment.BOTTOM) {
+      } else if (alignment === Components.Alignment.BOTTOM) {
         this._yAlignProportion = 1;
       } else {
         throw new Error("Unsupported alignment");
@@ -588,12 +597,5 @@ module Plottable {
     public background(): D3.Selection {
       return this._backgroundContainer;
     }
-  }
-  export class Alignment {
-    static TOP = "top";
-    static BOTTOM = "bottom";
-    static LEFT = "left";
-    static RIGHT = "right";
-    static CENTER = "center";
   }
 }

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -594,6 +594,6 @@ module Plottable {
     static BOTTOM = "bottom";
     static LEFT = "left";
     static RIGHT = "right";
-    static CENTER = "center"; 
+    static CENTER = "center";
   }
 }

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -242,11 +242,11 @@ module Plottable {
      */
     public xAlign(alignment: string): Component {
       alignment = alignment.toLowerCase();
-      if (alignment === "left") {
+      if (alignment === Alignment.LEFT) {
         this._xAlignProportion = 0;
-      } else if (alignment === "center") {
+      } else if (alignment === Alignment.CENTER) {
         this._xAlignProportion = 0.5;
-      } else if (alignment === "right") {
+      } else if (alignment === Alignment.RIGHT) {
         this._xAlignProportion = 1;
       } else {
         throw new Error("Unsupported alignment");
@@ -268,11 +268,11 @@ module Plottable {
      */
     public yAlign(alignment: string): Component {
       alignment = alignment.toLowerCase();
-      if (alignment === "top") {
+      if (alignment === Alignment.TOP) {
         this._yAlignProportion = 0;
-      } else if (alignment === "center") {
+      } else if (alignment === Alignment.CENTER) {
         this._yAlignProportion = 0.5;
-      } else if (alignment === "bottom") {
+      } else if (alignment === Alignment.BOTTOM) {
         this._yAlignProportion = 1;
       } else {
         throw new Error("Unsupported alignment");
@@ -588,5 +588,12 @@ module Plottable {
     public background(): D3.Selection {
       return this._backgroundContainer;
     }
+  }
+  export class Alignment {
+    static TOP = "top";
+    static BOTTOM = "bottom";
+    static LEFT = "left";
+    static RIGHT = "right";
+    static CENTER = "center"; 
   }
 }


### PR DESCRIPTION
Moving from `if (alignment === "top") {` to become `if (alignment === Alignment.TOP) {`

Typescript does not have support for non-number based enums so this was an acceptable substitute that I found (http://stackoverflow.com/questions/15490560/create-an-enum-with-string-values-in-typescript)