### PR TITLE
Component.origin() returned cloned point.

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -3822,7 +3822,10 @@ var Plottable;
          * @return {Point} The x-y position of the Component relative to its parent.
          */
         Component.prototype.origin = function () {
-            return this._origin;
+            return {
+                x: this._origin.x,
+                y: this._origin.y
+            };
         };
         /**
          * Gets the origin of the Component relative to the root <svg>.

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -538,7 +538,10 @@ module Plottable {
      * @return {Point} The x-y position of the Component relative to its parent.
      */
     public origin(): Point {
-      return this._origin;
+      return {
+        x: this._origin.x,
+        y: this._origin.y
+      };
     }
 
     /**

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -403,6 +403,18 @@ describe("Component behavior", () => {
   describe("origin methods", () => {
     var cWidth = 100;
     var cHeight = 100;
+    
+    it("returns cloned point", () => {
+      TestMethods.fixComponentSize(c, cWidth, cHeight);
+      c.renderTo(svg);
+      var originCall1 = c.origin();
+      var originCall2 = c.origin();
+      assert.strictEqual(originCall1.x, originCall2.x, "returned points have same x value");
+      assert.strictEqual(originCall1.y, originCall2.y, "returned points have same y value");
+      assert.notStrictEqual(originCall1, originCall2, "returned points not the same object");
+      svg.remove();
+    });
+    
     it("origin() (top-level component)", () => {
       TestMethods.fixComponentSize(c, cWidth, cHeight);
       c.renderTo(svg);

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -404,14 +404,14 @@ describe("Component behavior", () => {
     var cWidth = 100;
     var cHeight = 100;
 
-    it("returns cloned point", () => {
-      TestMethods.fixComponentSize(c, cWidth, cHeight);
+    it("modifying returned value does not affect origin", () => {
       c.renderTo(svg);
-      var originCall1 = c.origin();
-      var originCall2 = c.origin();
-      assert.strictEqual(originCall1.x, originCall2.x, "returned points have same x value");
-      assert.strictEqual(originCall1.y, originCall2.y, "returned points have same y value");
-      assert.notStrictEqual(originCall1, originCall2, "returned points not the same object");
+      var receivedOrigin = c.origin();
+      var delta = 10;
+      receivedOrigin.x += delta;
+      receivedOrigin.y += delta;
+      assert.strictEqual(receivedOrigin.x - delta, c.origin().x, "receieved point can be modified without affecting origin (x)");
+      assert.strictEqual(receivedOrigin.y - delta, c.origin().y, "receieved point can be modified without affecting origin (y)");
       svg.remove();
     });
 

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -403,7 +403,7 @@ describe("Component behavior", () => {
   describe("origin methods", () => {
     var cWidth = 100;
     var cHeight = 100;
-    
+
     it("returns cloned point", () => {
       TestMethods.fixComponentSize(c, cWidth, cHeight);
       c.renderTo(svg);
@@ -414,7 +414,7 @@ describe("Component behavior", () => {
       assert.notStrictEqual(originCall1, originCall2, "returned points not the same object");
       svg.remove();
     });
-    
+
     it("origin() (top-level component)", () => {
       TestMethods.fixComponentSize(c, cWidth, cHeight);
       c.renderTo(svg);

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -410,8 +410,8 @@ describe("Component behavior", () => {
       var delta = 10;
       receivedOrigin.x += delta;
       receivedOrigin.y += delta;
-      assert.strictEqual(receivedOrigin.x - delta, c.origin().x, "receieved point can be modified without affecting origin (x)");
-      assert.strictEqual(receivedOrigin.y - delta, c.origin().y, "receieved point can be modified without affecting origin (y)");
+      assert.notStrictEqual(receivedOrigin.x, c.origin().x, "receieved point can be modified without affecting origin (x)");
+      assert.notStrictEqual(receivedOrigin.y, c.origin().y, "receieved point can be modified without affecting origin (y)");
       svg.remove();
     });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -6662,14 +6662,14 @@ describe("Component behavior", function () {
     describe("origin methods", function () {
         var cWidth = 100;
         var cHeight = 100;
-        it("returns cloned point", function () {
-            TestMethods.fixComponentSize(c, cWidth, cHeight);
+        it("modifying returned value does not affect origin", function () {
             c.renderTo(svg);
-            var originCall1 = c.origin();
-            var originCall2 = c.origin();
-            assert.strictEqual(originCall1.x, originCall2.x, "returned points have same x value");
-            assert.strictEqual(originCall1.y, originCall2.y, "returned points have same y value");
-            assert.notStrictEqual(originCall1, originCall2, "returned points not the same object");
+            var receivedOrigin = c.origin();
+            var delta = 10;
+            receivedOrigin.x += delta;
+            receivedOrigin.y += delta;
+            assert.strictEqual(receivedOrigin.x - delta, c.origin().x, "receieved point can be modified without affecting origin (x)");
+            assert.strictEqual(receivedOrigin.y - delta, c.origin().y, "receieved point can be modified without affecting origin (y)");
             svg.remove();
         });
         it("origin() (top-level component)", function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -6662,6 +6662,16 @@ describe("Component behavior", function () {
     describe("origin methods", function () {
         var cWidth = 100;
         var cHeight = 100;
+        it("returns cloned point", function () {
+            TestMethods.fixComponentSize(c, cWidth, cHeight);
+            c.renderTo(svg);
+            var originCall1 = c.origin();
+            var originCall2 = c.origin();
+            assert.strictEqual(originCall1.x, originCall2.x, "returned points have same x value");
+            assert.strictEqual(originCall1.y, originCall2.y, "returned points have same y value");
+            assert.notStrictEqual(originCall1, originCall2, "returned points not the same object");
+            svg.remove();
+        });
         it("origin() (top-level component)", function () {
             TestMethods.fixComponentSize(c, cWidth, cHeight);
             c.renderTo(svg);

--- a/test/tests.js
+++ b/test/tests.js
@@ -6668,8 +6668,8 @@ describe("Component behavior", function () {
             var delta = 10;
             receivedOrigin.x += delta;
             receivedOrigin.y += delta;
-            assert.strictEqual(receivedOrigin.x - delta, c.origin().x, "receieved point can be modified without affecting origin (x)");
-            assert.strictEqual(receivedOrigin.y - delta, c.origin().y, "receieved point can be modified without affecting origin (y)");
+            assert.notStrictEqual(receivedOrigin.x, c.origin().x, "receieved point can be modified without affecting origin (x)");
+            assert.notStrictEqual(receivedOrigin.y, c.origin().y, "receieved point can be modified without affecting origin (y)");
             svg.remove();
         });
         it("origin() (top-level component)", function () {


### PR DESCRIPTION
As before, to avoid accidentally mutating the internal origin.