### PR TITLE
Use a D3.Map for the attribute-projector bindings.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2582,10 +2582,8 @@ declare module Plottable {
         protected _key2PlotDatasetKey: D3.Map<Plots.PlotDatasetKey>;
         protected _datasetKeysInOrder: string[];
         protected _renderArea: D3.Selection;
-        protected _projections: {
-            [attrToSet: string]: _Projection;
-        };
-        protected _attrToExtents: D3.Map<any[]>;
+        protected _attrBindings: D3.Map<_Projection>;
+        protected _attrExtents: D3.Map<any[]>;
         protected _animate: boolean;
         protected _animateOnNextRender: boolean;
         /**

--- a/plottable.js
+++ b/plottable.js
@@ -6550,9 +6550,7 @@ var Plottable;
          */
         Plot.prototype._updateExtents = function () {
             var _this = this;
-            this._attrBindings.forEach(function (attr) {
-                _this._updateExtentsForAttr(attr);
-            });
+            this._attrBindings.forEach(function (attr) { return _this._updateExtentsForAttr(attr); });
             this._scales().forEach(function (scale) { return scale._autoDomainIfAutomaticMode(); });
         };
         Plot.prototype._updateExtentsForAttr = function (attr) {

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -390,7 +390,7 @@ export module Plots {
         return (originalPos > scaledBaseline) ? scaledBaseline : originalPos;
       };
 
-      var primaryAccessor = this._projections[primaryAttr].accessor;
+      var primaryAccessor = this._attrBindings.get(primaryAttr).accessor;
       if (this._labelsEnabled && this._labelFormatter) {
         attrToProjector["label"] = (d: any, i: number, u: any, m: PlotMetadata) => {
           return this._labelFormatter(primaryAccessor(d, i, u, m));
@@ -418,7 +418,7 @@ export module Plots {
       if (barScale instanceof Plottable.Scales.Category) {
         barPixelWidth = (<Plottable.Scales.Category> barScale).rangeBand();
       } else {
-        var barAccessor = this._isVertical ? this._projections["x"].accessor : this._projections["y"].accessor;
+        var barAccessor = this._isVertical ? this._attrBindings.get("x").accessor : this._attrBindings.get("y").accessor;
 
         var numberBarAccessorData = d3.set(Utils.Methods.flatten(this._datasetKeysInOrder.map((k) => {
           var dataset = this._key2PlotDatasetKey.get(k).dataset;

--- a/src/components/plots/clusteredBarPlot.ts
+++ b/src/components/plots/clusteredBarPlot.ts
@@ -53,10 +53,10 @@ export module Plots {
     private _makeInnerScale() {
       var innerScale = new Scales.Category();
       innerScale.domain(this._datasetKeysInOrder);
-      if (!this._projections["width"]) {
+      if (!this._attrBindings.get("width")) {
         innerScale.range([0, this._getBarPixelWidth()]);
       } else {
-        var projection = this._projections["width"];
+        var projection = this._attrBindings.get("width");
         var accessor = projection.accessor;
         var scale = projection.scale;
         var fn = scale ? (d: any, i: number, u: any, m: PlotMetadata) => scale.scale(accessor(d, i, u, m)) : accessor;

--- a/src/components/plots/gridPlot.ts
+++ b/src/components/plots/gridPlot.ts
@@ -57,15 +57,15 @@ export module Plots {
       if (attrToSet === "x") {
         if (scale instanceof Scales.Category) {
           this.project("x1", (d: any, i: number, u: any, m: Plots.PlotMetadata) => {
-            return scale.scale(this._projections["x"].accessor(d, i, u, m)) - scale.rangeBand() / 2;
+            return scale.scale(this._attrBindings.get("x").accessor(d, i, u, m)) - scale.rangeBand() / 2;
           });
           this.project("x2", (d: any, i: number, u: any, m: Plots.PlotMetadata) => {
-            return scale.scale(this._projections["x"].accessor(d, i, u, m)) + scale.rangeBand() / 2;
+            return scale.scale(this._attrBindings.get("x").accessor(d, i, u, m)) + scale.rangeBand() / 2;
           });
         }
         if (scale instanceof QuantitativeScale) {
           this.project("x1", (d: any, i: number, u: any, m: Plots.PlotMetadata) => {
-            return scale.scale(this._projections["x"].accessor(d, i, u, m));
+            return scale.scale(this._attrBindings.get("x").accessor(d, i, u, m));
           });
         }
       }
@@ -73,21 +73,21 @@ export module Plots {
       if (attrToSet === "y") {
         if (scale instanceof Scales.Category) {
           this.project("y1", (d: any, i: number, u: any, m: Plots.PlotMetadata) => {
-            return scale.scale(this._projections["y"].accessor(d, i, u, m)) - scale.rangeBand() / 2;
+            return scale.scale(this._attrBindings.get("y").accessor(d, i, u, m)) - scale.rangeBand() / 2;
           });
           this.project("y2", (d: any, i: number, u: any, m: Plots.PlotMetadata) => {
-            return scale.scale(this._projections["y"].accessor(d, i, u, m)) + scale.rangeBand() / 2;
+            return scale.scale(this._attrBindings.get("y").accessor(d, i, u, m)) + scale.rangeBand() / 2;
           });
         }
         if (scale instanceof QuantitativeScale) {
           this.project("y1", (d: any, i: number, u: any, m: Plots.PlotMetadata) => {
-            return scale.scale(this._projections["y"].accessor(d, i, u, m));
+            return scale.scale(this._attrBindings.get("y").accessor(d, i, u, m));
           });
         }
       }
 
       if (attrToSet === "fill") {
-        this._colorScale = this._projections["fill"].scale;
+        this._colorScale = this._attrBindings.get("fill").scale;
       }
 
       return this;

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -32,7 +32,7 @@ module Plottable {
 
     protected _renderArea: D3.Selection;
     protected _projections: { [attrToSet: string]: _Projection; } = {};
-    protected _attrToExtents: D3.Map<any[]>;
+    protected _attrExtents: D3.Map<any[]>;
     private _extentProvider: Scales.ExtentProvider<any>;
 
     protected _animate: boolean = false;
@@ -58,7 +58,7 @@ module Plottable {
       this.clipPathEnabled = true;
       this.classed("plot", true);
       this._key2PlotDatasetKey = d3.map();
-      this._attrToExtents = d3.map();
+      this._attrExtents = d3.map();
       this._extentProvider = (scale: Scale<any, any>) => this._extentsForScale(scale);
       this._datasetKeysInOrder = [];
       this._nextSeriesIndex = 0;
@@ -279,7 +279,7 @@ module Plottable {
         var plotMetadata = plotDatasetKey.plotMetadata;
         return this._computeExtent(dataset, accessor, coercer, plotMetadata);
       });
-      this._attrToExtents.set(attr, extents);
+      this._attrExtents.set(attr, extents);
     }
 
     private _computeExtent(dataset: Dataset, accessor: _Accessor, typeCoercer: (d: any) => any, plotMetadata: any): any[] {
@@ -305,7 +305,7 @@ module Plottable {
      * Override in subclass to add special extents, such as included values
      */
     protected _extentsForAttr(attr: string) {
-      return this._attrToExtents.get(attr);
+      return this._attrExtents.get(attr);
     }
 
     private _extentsForScale<D>(scale: Scale<D, any>): D[][] {

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -265,7 +265,7 @@ module Plottable {
      * Updates the extents associated with each attribute, then autodomains all scales the Plot uses.
      */
     protected _updateExtents() {
-      this._attrBindings.forEach((attr) => { this._updateExtentsForAttr(attr); });
+      this._attrBindings.forEach((attr) => this._updateExtentsForAttr(attr));
       this._scales().forEach((scale) => scale._autoDomainIfAutomaticMode());
     }
 

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -31,7 +31,7 @@ module Plottable {
     protected _datasetKeysInOrder: string[];
 
     protected _renderArea: D3.Selection;
-    protected _projections: { [attrToSet: string]: _Projection; } = {};
+    protected _attrBindings: D3.Map<_Projection>;
     protected _attrExtents: D3.Map<any[]>;
     private _extentProvider: Scales.ExtentProvider<any>;
 
@@ -58,6 +58,7 @@ module Plottable {
       this.clipPathEnabled = true;
       this.classed("plot", true);
       this._key2PlotDatasetKey = d3.map();
+      this._attrBindings = d3.map();
       this._attrExtents = d3.map();
       this._extentProvider = (scale: Scale<any, any>) => this._extentsForScale(scale);
       this._datasetKeysInOrder = [];
@@ -162,11 +163,11 @@ module Plottable {
      */
     public project(attrToSet: string, accessor: any, scale?: Scale<any, any>) {
       attrToSet = attrToSet.toLowerCase();
-      var previousProjection = this._projections[attrToSet];
+      var previousProjection = this._attrBindings.get(attrToSet);
       var previousScale = previousProjection && previousProjection.scale;
 
       accessor = Utils.Methods.accessorize(accessor);
-      this._projections[attrToSet] = {accessor: accessor, scale: scale, attribute: attrToSet};
+      this._attrBindings.set(attrToSet, {accessor: accessor, scale: scale, attribute: attrToSet});
       this._updateExtentsForAttr(attrToSet);
 
       if (previousScale) {
@@ -188,12 +189,11 @@ module Plottable {
 
     protected _generateAttrToProjector(): AttributeToProjector {
       var h: AttributeToProjector = {};
-      d3.keys(this._projections).forEach((a) => {
-        var projection = this._projections[a];
-        var accessor = projection.accessor;
-        var scale = projection.scale;
+      this._attrBindings.forEach((attr, binding) => {
+        var accessor = binding.accessor;
+        var scale = binding.scale;
         var fn = scale ? (d: any, i: number, u: any, m: Plots.PlotMetadata) => scale.scale(accessor(d, i, u, m)) : accessor;
-        h[a] = fn;
+        h[attr] = fn;
       });
       return h;
     }
@@ -252,8 +252,8 @@ module Plottable {
      */
     private _scales() {
       var scales: Scale<any, any>[] = [];
-      Object.keys(this._projections).forEach((attr: string) => {
-        var scale = this._projections[attr].scale;
+      this._attrBindings.forEach((attr, binding) => {
+        var scale = binding.scale;
         if (scale != null && scales.indexOf(scale) === -1) {
           scales.push(scale);
         }
@@ -265,13 +265,14 @@ module Plottable {
      * Updates the extents associated with each attribute, then autodomains all scales the Plot uses.
      */
     protected _updateExtents() {
-      Object.keys(this._projections).forEach((attr: string) => { this._updateExtentsForAttr(attr); });
+      this._attrBindings.forEach((attr) => { this._updateExtentsForAttr(attr); });
       this._scales().forEach((scale) => scale._autoDomainIfAutomaticMode());
     }
 
     private _updateExtentsForAttr(attr: string) {
-      var accessor = this._projections[attr].accessor;
-      var scale = this._projections[attr].scale;
+      var binding = this._attrBindings.get(attr);
+      var accessor = binding.accessor;
+      var scale = binding.scale;
       var coercer = (scale != null) ? scale._typeCoercer : (d: any) => d;
       var extents = this._datasetKeysInOrder.map((key) => {
         var plotDatasetKey = this._key2PlotDatasetKey.get(key);
@@ -313,8 +314,8 @@ module Plottable {
         return [];
       }
       var allSetsOfExtents: D[][][] = [];
-      Object.keys(this._projections).forEach((attr: string) => {
-        if (this._projections[attr].scale === scale) {
+      this._attrBindings.forEach((attr, binding) => {
+        if (binding.scale === scale) {
           var extents = this._extentsForAttr(attr);
           if (extents != null) {
             allSetsOfExtents.push(extents);

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -72,12 +72,12 @@ export module Plots {
     protected _generateAttrToProjector() {
       var attrToProjector = super._generateAttrToProjector();
 
-      if (this._projections["fill-opacity"] == null) {
+      if (this._attrBindings.get("fill-opacity") == null) {
         attrToProjector["fill-opacity"] = d3.functor(1);
       }
 
-      var yAccessor = this._projections["y"].accessor;
-      var xAccessor = this._projections["x"].accessor;
+      var yAccessor = this._attrBindings.get("y").accessor;
+      var xAccessor = this._attrBindings.get("x").accessor;
       attrToProjector["y"] = (d: any, i: number, u: any, m: StackedPlotMetadata) =>
         this._yScale.scale(+yAccessor(d, i, u, m) + m.offsets.get(xAccessor(d, i, u, m)));
       attrToProjector["y0"] = (d: any, i: number, u: any, m: StackedPlotMetadata) =>
@@ -94,7 +94,7 @@ export module Plots {
     public _updateStackOffsets() {
       if (!this._projectorsReady()) { return; }
       var domainKeys = this._getDomainKeys();
-      var keyAccessor = this._isVertical ? this._projections["x"].accessor : this._projections["y"].accessor;
+      var keyAccessor = this._isVertical ? this._attrBindings.get("x").accessor : this._attrBindings.get("y").accessor;
       var keySets = this._datasetKeysInOrder.map((k) => {
         var dataset = this._key2PlotDatasetKey.get(k).dataset;
         var plotMetadata = this._key2PlotDatasetKey.get(k).plotMetadata;

--- a/src/components/plots/stackedBarPlot.ts
+++ b/src/components/plots/stackedBarPlot.ts
@@ -37,8 +37,8 @@ export module Plots {
       var valueAttr = this._isVertical ? "y" : "x";
       var keyAttr = this._isVertical ? "x" : "y";
       var primaryScale: Scale<any, number> = this._isVertical ? this._yScale : this._xScale;
-      var primaryAccessor = this._projections[valueAttr].accessor;
-      var keyAccessor = this._projections[keyAttr].accessor;
+      var primaryAccessor = this._attrBindings.get(valueAttr).accessor;
+      var keyAccessor = this._attrBindings.get(keyAttr).accessor;
       var getStart = (d: any, i: number, u: any, m: StackedPlotMetadata) =>
         primaryScale.scale(m.offsets.get(keyAccessor(d, i, u, m)));
       var getEnd = (d: any, i: number, u: any, m: StackedPlotMetadata) =>

--- a/src/components/plots/stackedPlot.ts
+++ b/src/components/plots/stackedPlot.ts
@@ -26,7 +26,7 @@ module Plottable {
 
     public project(attrToSet: string, accessor: any, scale?: Scale<any, any>) {
       super.project(attrToSet, accessor, scale);
-      if (this._projections["x"] && this._projections["y"] && (attrToSet === "x" || attrToSet === "y")) {
+      if (this._attrBindings.get("x") && this._attrBindings.get("y") && (attrToSet === "x" || attrToSet === "y")) {
         this._updateStackOffsets();
       }
       return this;
@@ -185,8 +185,8 @@ module Plottable {
     }
 
     public _normalizeDatasets<A, B>(fromX: boolean): {a: A; b: B}[] {
-      var aAccessor = this._projections[fromX ? "x" : "y"].accessor;
-      var bAccessor = this._projections[fromX ? "y" : "x"].accessor;
+      var aAccessor = this._attrBindings.get(fromX ? "x" : "y").accessor;
+      var bAccessor = this._attrBindings.get(fromX ? "y" : "x").accessor;
       var aStackedAccessor = (d: any, i: number, u: any, m: Plots.StackedPlotMetadata) => {
         var value = aAccessor(d, i, u, m);
         if (this._isVertical ? !fromX : fromX) {
@@ -216,11 +216,11 @@ module Plottable {
     }
 
     public _keyAccessor(): _Accessor {
-       return this._isVertical ? this._projections["x"].accessor : this._projections["y"].accessor;
+       return this._isVertical ? this._attrBindings.get("x").accessor : this._attrBindings.get("y").accessor;
     }
 
     public _valueAccessor(): _Accessor {
-       return this._isVertical ? this._projections["y"].accessor : this._projections["x"].accessor;
+       return this._isVertical ? this._attrBindings.get("y").accessor : this._attrBindings.get("x").accessor;
     }
   }
 }

--- a/src/components/plots/xyPlot.ts
+++ b/src/components/plots/xyPlot.ts
@@ -203,8 +203,8 @@ module Plottable {
     }
 
     protected _normalizeDatasets<A, B>(fromX: boolean): {a: A; b: B}[] {
-      var aAccessor: (d: any, i: number, u: any, m: Plots.PlotMetadata) => A = this._projections[fromX ? "x" : "y"].accessor;
-      var bAccessor: (d: any, i: number, u: any, m: Plots.PlotMetadata) => B = this._projections[fromX ? "y" : "x"].accessor;
+      var aAccessor: (d: any, i: number, u: any, m: Plots.PlotMetadata) => A = this._attrBindings.get(fromX ? "x" : "y").accessor;
+      var bAccessor: (d: any, i: number, u: any, m: Plots.PlotMetadata) => B = this._attrBindings.get(fromX ? "y" : "x").accessor;
       return Utils.Methods.flatten(this._datasetKeysInOrder.map((key: string) => {
         var dataset = this._key2PlotDatasetKey.get(key).dataset;
         var plotMetadata = this._key2PlotDatasetKey.get(key).plotMetadata;
@@ -224,7 +224,7 @@ module Plottable {
     }
 
     protected _projectorsReady() {
-      return this._projections["x"] && this._projections["y"];
+      return this._attrBindings.get("x") && this._attrBindings.get("y");
     }
   }
 }

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -1,3 +1,4 @@
+/// <reference path="../typings/d3/d3.d.ts" />
 /// <reference path="../bower_components/svg-typewriter/svgtypewriter.d.ts" />
 
 /// <reference path="utils/utils.ts" />


### PR DESCRIPTION
Based on discussions in #1966, we're using a parallel structure for attributes and properties.

Signature of `_Projection` should be changed to match `_AccessorScaleBinding` from #1966.

Also, added **d3.d.ts** to **reference.ts** so Typescript tooling can actually resolve D3 methods.