### PR TITLE
Pass Dataset to Accessors instead of metadata.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -45,7 +45,7 @@ declare module Plottable {
             function intersection<T>(set1: D3.Set<T>, set2: D3.Set<T>): D3.Set<string>;
             /**
              * Take an accessor object (may be a string to be made into a key, or a value, or a color code)
-             * and "activate" it by turning it into a function in (datum, index, metadata)
+             * and "activate" it by turning it into a function in (datum, index,  dataset)
              */
             function accessorize(accessor: any): _Accessor;
             /**
@@ -607,13 +607,13 @@ declare module Plottable {
     /**
      * Access specific datum property.
      */
-    type _Accessor = (datum: any, index?: number, userMetadata?: any, plotMetadata?: Plots.PlotMetadata) => any;
+    type _Accessor = (datum: any, index?: number, dataset?: Dataset, plotMetadata?: Plots.PlotMetadata) => any;
     /**
      * Retrieves scaled datum property.
      */
-    type _Projector = (datum: any, index: number, userMetadata: any, plotMetadata: Plots.PlotMetadata) => any;
+    type _Projector = (datum: any, index: number, dataset: Dataset, plotMetadata: Plots.PlotMetadata) => any;
     /**
-     * Projector with applied user and plot metadata
+     * Projector with dataset and plot metadata
      */
     type AppliedProjector = (datum: any, index: number) => any;
     /**
@@ -1376,10 +1376,10 @@ declare module Plottable {
              *
              * @param{any[]} data The data to be drawn
              * @param{DrawStep[]} drawSteps The list of steps, which needs to be drawn
-             * @param{any} userMetadata The metadata provided by user
+             * @param{Dataset} dataset The Dataset
              * @param{any} plotMetadata The metadata provided by plot
              */
-            draw(data: any[], drawSteps: DrawStep[], userMetadata: any, plotMetadata: Plots.PlotMetadata): number;
+            draw(data: any[], drawSteps: DrawStep[], dataset: Dataset, plotMetadata: Plots.PlotMetadata): number;
             /**
              * Retrieves the renderArea selection for the drawer
              *
@@ -1469,7 +1469,7 @@ declare module Plottable {
         class Arc extends Element {
             constructor(key: string);
             _drawStep(step: AppliedDrawStep): void;
-            draw(data: any[], drawSteps: DrawStep[], userMetadata: any, plotMetadata: Plots.PlotMetadata): number;
+            draw(data: any[], drawSteps: DrawStep[], dataset: Dataset, plotMetadata: Plots.PlotMetadata): number;
             _getPixelPoint(datum: any, index: number): Point;
         }
     }
@@ -2806,7 +2806,7 @@ declare module Plottable {
             b: B;
         }[];
         protected _projectorsReady(): {
-            accessor: (datum: any, index?: number, userMetadata?: any, plotMetadata?: Plots.PlotMetadata) => any;
+            accessor: (datum: any, index?: number, dataset?: Dataset, plotMetadata?: Plots.PlotMetadata) => any;
             scale?: Scale<any, any>;
             attribute: string;
         };
@@ -2831,7 +2831,7 @@ declare module Plottable {
             constructor(xScale: Scale<X, any>, yScale: Scale<Y, any>);
             protected _getDrawer(key: string): Drawers.Rect;
             protected _generateAttrToProjector(): {
-                [attrToSet: string]: (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+                [attrToSet: string]: (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
             };
             protected _generateDrawSteps(): Drawers.DrawStep[];
         }
@@ -2852,7 +2852,7 @@ declare module Plottable {
             constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>);
             protected _getDrawer(key: string): Drawers.Symbol;
             protected _generateAttrToProjector(): {
-                [attrToSet: string]: (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+                [attrToSet: string]: (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
             };
             protected _generateDrawSteps(): Drawers.DrawStep[];
             protected _isVisibleOnPlot(datum: any, pixelPoint: Point, selection: D3.Selection): boolean;
@@ -2992,7 +2992,7 @@ declare module Plottable {
             protected _drawLabels(): void;
             protected _generateDrawSteps(): Drawers.DrawStep[];
             protected _generateAttrToProjector(): {
-                [attrToSet: string]: (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+                [attrToSet: string]: (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
             };
             /**
              * Computes the barPixelWidth of all the bars in the plot.
@@ -3021,12 +3021,12 @@ declare module Plottable {
              * @param {QuantitativeScaleScale} yScale The y scale to use.
              */
             constructor(xScale: QuantitativeScale<X>, yScale: QuantitativeScale<number>);
-            protected _rejectNullsAndNaNs(d: any, i: number, userMetdata: any, plotMetadata: any, accessor: _Accessor): boolean;
+            protected _rejectNullsAndNaNs(d: any, i: number, dataset: Dataset, plotMetadata: any, accessor: _Accessor): boolean;
             protected _getDrawer(key: string): Drawers.Line;
-            protected _getResetYFunction(): (d: any, i: number, u: any, m: PlotMetadata) => number;
+            protected _getResetYFunction(): (d: any, i: number, dataset: Dataset, m: PlotMetadata) => number;
             protected _generateDrawSteps(): Drawers.DrawStep[];
             protected _generateAttrToProjector(): {
-                [attrToSet: string]: (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+                [attrToSet: string]: (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
             };
             protected _wholeDatumAttributes(): string[];
             getAllPlotData(datasets?: Dataset[]): Plots.PlotData;
@@ -3064,10 +3064,10 @@ declare module Plottable {
             protected _getDrawer(key: string): Drawers.Area;
             protected _updateYDomainer(): void;
             project(attrToSet: string, accessor: any, scale?: Scale<any, any>): Area<X>;
-            protected _getResetYFunction(): (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+            protected _getResetYFunction(): (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
             protected _wholeDatumAttributes(): string[];
             protected _generateAttrToProjector(): {
-                [attrToSet: string]: (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+                [attrToSet: string]: (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
             };
         }
     }
@@ -3094,7 +3094,7 @@ declare module Plottable {
              */
             constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, isVertical?: boolean);
             protected _generateAttrToProjector(): {
-                [attrToSet: string]: (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+                [attrToSet: string]: (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
             };
             protected _getDataToDraw(): D3.Map<any[]>;
             protected _getPlotMetadataForDataset(key: string): ClusteredPlotMetadata;
@@ -3163,7 +3163,7 @@ declare module Plottable {
             project(attrToSet: string, accessor: any, scale?: Scale<any, any>): StackedArea<X>;
             protected _onDatasetUpdate(): StackedArea<X>;
             protected _generateAttrToProjector(): {
-                [attrToSet: string]: (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+                [attrToSet: string]: (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
             };
             protected _wholeDatumAttributes(): string[];
             _updateStackOffsets(): void;
@@ -3200,7 +3200,7 @@ declare module Plottable {
             constructor(xScale?: Scale<X, number>, yScale?: Scale<Y, number>, isVertical?: boolean);
             protected _getAnimator(key: string): Animators.PlotAnimator;
             protected _generateAttrToProjector(): {
-                [attrToSet: string]: (datum: any, index: number, userMetadata: any, plotMetadata: PlotMetadata) => any;
+                [attrToSet: string]: (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
             };
             protected _generateDrawSteps(): Drawers.DrawStep[];
             project(attrToSet: string, accessor: any, scale?: Scale<any, any>): StackedBar<X, Y>;
@@ -3390,7 +3390,7 @@ declare module Plottable {
             isReverse: boolean;
             constructor(isVertical?: boolean, isReverse?: boolean);
             animate(selection: any, attrToProjector: AttributeToProjector): D3.Transition.Transition;
-            protected _startMovingProjector(attrToProjector: AttributeToProjector): (datum: any, index: number, userMetadata: any, plotMetadata: Plots.PlotMetadata) => any;
+            protected _startMovingProjector(attrToProjector: AttributeToProjector): (datum: any, index: number, dataset: Dataset, plotMetadata: Plots.PlotMetadata) => any;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -90,17 +90,17 @@ var Plottable;
             Methods.intersection = intersection;
             /**
              * Take an accessor object (may be a string to be made into a key, or a value, or a color code)
-             * and "activate" it by turning it into a function in (datum, index, metadata)
+             * and "activate" it by turning it into a function in (datum, index,  dataset)
              */
             function accessorize(accessor) {
                 if (typeof (accessor) === "function") {
                     return accessor;
                 }
                 else if (typeof (accessor) === "string" && accessor[0] !== "#") {
-                    return function (d, i, s) { return d[accessor]; };
+                    return function (datum, index, dataset) { return datum[accessor]; };
                 }
                 else {
-                    return function (d, i, s) { return accessor; };
+                    return function (datum, index, dataset) { return accessor; };
                 }
                 ;
             }
@@ -2597,10 +2597,10 @@ var Plottable;
             AbstractDrawer.prototype._numberOfAnimationIterations = function (data) {
                 return data.length;
             };
-            AbstractDrawer.prototype._applyMetadata = function (attrToProjector, userMetadata, plotMetadata) {
+            AbstractDrawer.prototype._applyMetadata = function (attrToProjector, dataset, plotMetadata) {
                 var modifiedAttrToProjector = {};
                 d3.keys(attrToProjector).forEach(function (attr) {
-                    modifiedAttrToProjector[attr] = function (datum, index) { return attrToProjector[attr](datum, index, userMetadata, plotMetadata); };
+                    modifiedAttrToProjector[attr] = function (datum, index) { return attrToProjector[attr](datum, index, dataset, plotMetadata); };
                 });
                 return modifiedAttrToProjector;
             };
@@ -2615,13 +2615,13 @@ var Plottable;
              *
              * @param{any[]} data The data to be drawn
              * @param{DrawStep[]} drawSteps The list of steps, which needs to be drawn
-             * @param{any} userMetadata The metadata provided by user
+             * @param{Dataset} dataset The Dataset
              * @param{any} plotMetadata The metadata provided by plot
              */
-            AbstractDrawer.prototype.draw = function (data, drawSteps, userMetadata, plotMetadata) {
+            AbstractDrawer.prototype.draw = function (data, drawSteps, dataset, plotMetadata) {
                 var _this = this;
                 var appliedDrawSteps = drawSteps.map(function (dr) {
-                    var appliedAttrToProjector = _this._applyMetadata(dr.attrToProjector, userMetadata, plotMetadata);
+                    var appliedAttrToProjector = _this._applyMetadata(dr.attrToProjector, dataset, plotMetadata);
                     _this._attrToProjector = Plottable.Utils.Methods.copyMap(appliedAttrToProjector);
                     return {
                         attrToProjector: appliedAttrToProjector,
@@ -3046,9 +3046,9 @@ var Plottable;
                 attrToProjector["d"] = this._createArc(innerRadiusAccessor, outerRadiusAccessor);
                 return _super.prototype._drawStep.call(this, { attrToProjector: attrToProjector, animator: step.animator });
             };
-            Arc.prototype.draw = function (data, drawSteps, userMetadata, plotMetadata) {
+            Arc.prototype.draw = function (data, drawSteps, dataset, plotMetadata) {
                 // HACKHACK Applying metadata should be done in base class
-                var valueAccessor = function (d, i) { return drawSteps[0].attrToProjector["value"](d, i, userMetadata, plotMetadata); };
+                var valueAccessor = function (d, i) { return drawSteps[0].attrToProjector["value"](d, i, dataset, plotMetadata); };
                 data = data.filter(function (e) { return Plottable.Utils.Methods.isValidNumber(+valueAccessor(e, null)); });
                 var pie = d3.layout.pie().sort(null).value(valueAccessor)(data);
                 drawSteps.forEach(function (s) { return delete s.attrToProjector["value"]; });
@@ -3057,7 +3057,7 @@ var Plottable;
                         Plottable.Utils.Methods.warn("Negative values will not render correctly in a pie chart.");
                     }
                 });
-                return _super.prototype.draw.call(this, pie, drawSteps, userMetadata, plotMetadata);
+                return _super.prototype.draw.call(this, pie, drawSteps, dataset, plotMetadata);
             };
             Arc.prototype._getPixelPoint = function (datum, index) {
                 var innerRadiusAccessor = this._attrToProjector["inner-radius"];
@@ -6482,7 +6482,7 @@ var Plottable;
             this._attrBindings.forEach(function (attr, binding) {
                 var accessor = binding.accessor;
                 var scale = binding.scale;
-                var fn = scale ? function (d, i, u, m) { return scale.scale(accessor(d, i, u, m)); } : accessor;
+                var fn = scale ? function (d, i, dataset, m) { return scale.scale(accessor(d, i, dataset, m)); } : accessor;
                 h[attr] = fn;
             });
             return h;
@@ -6503,9 +6503,10 @@ var Plottable;
                 var attrToProjector = this._generateAttrToProjector();
                 var plotDatasetKey = this._key2PlotDatasetKey.get(datasetKey);
                 var plotMetadata = plotDatasetKey.plotMetadata;
-                var userMetadata = plotDatasetKey.dataset.metadata();
                 d3.entries(attrToProjector).forEach(function (keyValue) {
-                    attrToAppliedProjector[keyValue.key] = function (datum, index) { return keyValue.value(datum, index, userMetadata, plotMetadata); };
+                    attrToAppliedProjector[keyValue.key] = function (datum, index) {
+                        return keyValue.value(datum, index, plotDatasetKey.dataset, plotMetadata);
+                    };
                 });
             }
             return attrToAppliedProjector;
@@ -6569,8 +6570,7 @@ var Plottable;
         };
         Plot.prototype._computeExtent = function (dataset, accessor, typeCoercer, plotMetadata) {
             var data = dataset.data();
-            var metadata = dataset.metadata();
-            var appliedAccessor = function (d, i) { return accessor(d, i, metadata, plotMetadata); };
+            var appliedAccessor = function (d, i) { return accessor(d, i, dataset, plotMetadata); };
             var mappedData = data.map(appliedAccessor).map(typeCoercer);
             if (mappedData.length === 0) {
                 return [];
@@ -6691,8 +6691,7 @@ var Plottable;
             var drawSteps = this._generateDrawSteps();
             var dataToDraw = this._getDataToDraw();
             var drawers = this._getDrawersInOrder();
-            // TODO: Use metadata instead of dataToDraw #1297.
-            var times = this._datasetKeysInOrder.map(function (k, i) { return drawers[i].draw(dataToDraw.get(k), drawSteps, _this._key2PlotDatasetKey.get(k).dataset.metadata(), _this._key2PlotDatasetKey.get(k).plotMetadata); });
+            var times = this._datasetKeysInOrder.map(function (k, i) { return drawers[i].draw(dataToDraw.get(k), drawSteps, _this._key2PlotDatasetKey.get(k).dataset, _this._key2PlotDatasetKey.get(k).plotMetadata); });
             var maxTime = Plottable.Utils.Methods.max(times, 0);
             this._additionalPaint(maxTime);
         };
@@ -6976,9 +6975,9 @@ var Plottable;
             var attrToProjector = _super.prototype._generateAttrToProjector.call(this);
             var positionXFn = attrToProjector["x"];
             var positionYFn = attrToProjector["y"];
-            attrToProjector["defined"] = function (d, i, u, m) {
-                var positionX = positionXFn(d, i, u, m);
-                var positionY = positionYFn(d, i, u, m);
+            attrToProjector["defined"] = function (d, i, dataset, m) {
+                var positionX = positionXFn(d, i, dataset, m);
+                var positionY = positionYFn(d, i, dataset, m);
                 return positionX != null && positionX === positionX && positionY != null && positionY === positionY;
             };
             return attrToProjector;
@@ -7066,7 +7065,7 @@ var Plottable;
                 var dataset = _this._key2PlotDatasetKey.get(key).dataset;
                 var plotMetadata = _this._key2PlotDatasetKey.get(key).plotMetadata;
                 return dataset.data().map(function (d, i) {
-                    return { a: aAccessor(d, i, dataset.metadata(), plotMetadata), b: bAccessor(d, i, dataset.metadata(), plotMetadata) };
+                    return { a: aAccessor(d, i, dataset, plotMetadata), b: bAccessor(d, i, dataset, plotMetadata) };
                 });
             }));
         };
@@ -7126,11 +7125,13 @@ var Plottable;
                 var x2Attr = attrToProjector["x2"];
                 var y2Attr = attrToProjector["y2"];
                 // Generate width based on difference, then adjust for the correct x origin
-                attrToProjector["width"] = function (d, i, u, m) { return Math.abs(x2Attr(d, i, u, m) - x1Attr(d, i, u, m)); };
-                attrToProjector["x"] = function (d, i, u, m) { return Math.min(x1Attr(d, i, u, m), x2Attr(d, i, u, m)); };
+                attrToProjector["width"] = function (d, i, dataset, m) { return Math.abs(x2Attr(d, i, dataset, m) - x1Attr(d, i, dataset, m)); };
+                attrToProjector["x"] = function (d, i, dataset, m) { return Math.min(x1Attr(d, i, dataset, m), x2Attr(d, i, dataset, m)); };
                 // Generate height based on difference, then adjust for the correct y origin
-                attrToProjector["height"] = function (d, i, u, m) { return Math.abs(y2Attr(d, i, u, m) - y1Attr(d, i, u, m)); };
-                attrToProjector["y"] = function (d, i, u, m) { return Math.max(y1Attr(d, i, u, m), y2Attr(d, i, u, m)) - attrToProjector["height"](d, i, u, m); };
+                attrToProjector["height"] = function (d, i, dataset, m) { return Math.abs(y2Attr(d, i, dataset, m) - y1Attr(d, i, dataset, m)); };
+                attrToProjector["y"] = function (d, i, dataset, m) {
+                    return Math.max(y1Attr(d, i, dataset, m), y2Attr(d, i, dataset, m)) - attrToProjector["height"](d, i, dataset, m);
+                };
                 // Clean up the attributes projected onto the SVG elements
                 delete attrToProjector["x1"];
                 delete attrToProjector["y1"];
@@ -7273,31 +7274,31 @@ var Plottable;
                 _super.prototype.project.call(this, attrToSet, accessor, scale);
                 if (attrToSet === "x") {
                     if (scale instanceof Plottable.Scales.Category) {
-                        this.project("x1", function (d, i, u, m) {
-                            return scale.scale(_this._attrBindings.get("x").accessor(d, i, u, m)) - scale.rangeBand() / 2;
+                        this.project("x1", function (d, i, dataset, m) {
+                            return scale.scale(_this._attrBindings.get("x").accessor(d, i, dataset, m)) - scale.rangeBand() / 2;
                         });
-                        this.project("x2", function (d, i, u, m) {
-                            return scale.scale(_this._attrBindings.get("x").accessor(d, i, u, m)) + scale.rangeBand() / 2;
+                        this.project("x2", function (d, i, dataset, m) {
+                            return scale.scale(_this._attrBindings.get("x").accessor(d, i, dataset, m)) + scale.rangeBand() / 2;
                         });
                     }
                     if (scale instanceof Plottable.QuantitativeScale) {
-                        this.project("x1", function (d, i, u, m) {
-                            return scale.scale(_this._attrBindings.get("x").accessor(d, i, u, m));
+                        this.project("x1", function (d, i, dataset, m) {
+                            return scale.scale(_this._attrBindings.get("x").accessor(d, i, dataset, m));
                         });
                     }
                 }
                 if (attrToSet === "y") {
                     if (scale instanceof Plottable.Scales.Category) {
-                        this.project("y1", function (d, i, u, m) {
-                            return scale.scale(_this._attrBindings.get("y").accessor(d, i, u, m)) - scale.rangeBand() / 2;
+                        this.project("y1", function (d, i, dataset, m) {
+                            return scale.scale(_this._attrBindings.get("y").accessor(d, i, dataset, m)) - scale.rangeBand() / 2;
                         });
-                        this.project("y2", function (d, i, u, m) {
-                            return scale.scale(_this._attrBindings.get("y").accessor(d, i, u, m)) + scale.rangeBand() / 2;
+                        this.project("y2", function (d, i, dataset, m) {
+                            return scale.scale(_this._attrBindings.get("y").accessor(d, i, dataset, m)) + scale.rangeBand() / 2;
                         });
                     }
                     if (scale instanceof Plottable.QuantitativeScale) {
-                        this.project("y1", function (d, i, u, m) {
-                            return scale.scale(_this._attrBindings.get("y").accessor(d, i, u, m));
+                        this.project("y1", function (d, i, dataset, m) {
+                            return scale.scale(_this._attrBindings.get("y").accessor(d, i, dataset, m));
                         });
                     }
                 }
@@ -7568,7 +7569,7 @@ var Plottable;
                 var drawers = this._getDrawersInOrder();
                 var attrToProjector = this._generateAttrToProjector();
                 var dataToDraw = this._getDataToDraw();
-                this._datasetKeysInOrder.forEach(function (k, i) { return drawers[i].drawText(dataToDraw.get(k), attrToProjector, _this._key2PlotDatasetKey.get(k).dataset.metadata(), _this._key2PlotDatasetKey.get(k).plotMetadata); });
+                this._datasetKeysInOrder.forEach(function (k, i) { return drawers[i].drawText(dataToDraw.get(k), attrToProjector, _this._key2PlotDatasetKey.get(k).dataset, _this._key2PlotDatasetKey.get(k).plotMetadata); });
                 if (this._hideBarsIfAnyAreTooWide && drawers.some(function (d) { return d._getIfLabelsTooWide(); })) {
                     drawers.forEach(function (d) { return d.removeLabels(); });
                 }
@@ -7604,19 +7605,19 @@ var Plottable;
                     widthF = function () { return _this._getBarPixelWidth(); };
                 }
                 var originalPositionFn = attrToProjector[primaryAttr];
-                var heightF = function (d, i, u, m) {
-                    return Math.abs(scaledBaseline - originalPositionFn(d, i, u, m));
+                var heightF = function (d, i, dataset, m) {
+                    return Math.abs(scaledBaseline - originalPositionFn(d, i, dataset, m));
                 };
                 attrToProjector["width"] = this._isVertical ? widthF : heightF;
                 attrToProjector["height"] = this._isVertical ? heightF : widthF;
                 if (secondaryScale instanceof Plottable.Scales.Category) {
-                    attrToProjector[secondaryAttr] = function (d, i, u, m) { return positionF(d, i, u, m) - widthF(d, i, u, m) / 2; };
+                    attrToProjector[secondaryAttr] = function (d, i, dataset, m) { return positionF(d, i, dataset, m) - widthF(d, i, dataset, m) / 2; };
                 }
                 else {
-                    attrToProjector[secondaryAttr] = function (d, i, u, m) { return positionF(d, i, u, m) - widthF(d, i, u, m) * _this._barAlignmentFactor; };
+                    attrToProjector[secondaryAttr] = function (d, i, dataset, m) { return positionF(d, i, dataset, m) - widthF(d, i, dataset, m) * _this._barAlignmentFactor; };
                 }
-                attrToProjector[primaryAttr] = function (d, i, u, m) {
-                    var originalPos = originalPositionFn(d, i, u, m);
+                attrToProjector[primaryAttr] = function (d, i, dataset, m) {
+                    var originalPos = originalPositionFn(d, i, dataset, m);
                     // If it is past the baseline, it should start at the baselin then width/height
                     // carries it over. If it's not past the baseline, leave it at original position and
                     // then width/height carries it to baseline
@@ -7624,10 +7625,10 @@ var Plottable;
                 };
                 var primaryAccessor = this._attrBindings.get(primaryAttr).accessor;
                 if (this._labelsEnabled && this._labelFormatter) {
-                    attrToProjector["label"] = function (d, i, u, m) {
-                        return _this._labelFormatter(primaryAccessor(d, i, u, m));
+                    attrToProjector["label"] = function (d, i, dataset, m) {
+                        return _this._labelFormatter(primaryAccessor(d, i, dataset, m));
                     };
-                    attrToProjector["positive"] = function (d, i, u, m) { return originalPositionFn(d, i, u, m) <= scaledBaseline; };
+                    attrToProjector["positive"] = function (d, i, dataset, m) { return originalPositionFn(d, i, dataset, m) <= scaledBaseline; };
                 }
                 attrToProjector["fill"] = attrToProjector["fill"] || d3.functor(this._defaultFillColor);
                 return attrToProjector;
@@ -7652,7 +7653,7 @@ var Plottable;
                     var numberBarAccessorData = d3.set(Plottable.Utils.Methods.flatten(this._datasetKeysInOrder.map(function (k) {
                         var dataset = _this._key2PlotDatasetKey.get(k).dataset;
                         var plotMetadata = _this._key2PlotDatasetKey.get(k).plotMetadata;
-                        return dataset.data().map(function (d, i) { return barAccessor(d, i, dataset.metadata(), plotMetadata).valueOf(); });
+                        return dataset.data().map(function (d, i) { return barAccessor(d, i, dataset, plotMetadata).valueOf(); });
                     }))).values().map(function (value) { return +value; });
                     numberBarAccessorData.sort(function (a, b) { return a - b; });
                     var barAccessorDataPairs = d3.pairs(numberBarAccessorData);
@@ -7735,8 +7736,8 @@ var Plottable;
                 this.animator("main", new Plottable.Animators.Base().duration(600).easing("exp-in-out"));
                 this._defaultStrokeColor = new Plottable.Scales.Color().range()[0];
             }
-            Line.prototype._rejectNullsAndNaNs = function (d, i, userMetdata, plotMetadata, accessor) {
-                var value = accessor(d, i, userMetdata, plotMetadata);
+            Line.prototype._rejectNullsAndNaNs = function (d, i, dataset, plotMetadata, accessor) {
+                var value = accessor(d, i, dataset, plotMetadata);
                 return value != null && value === value;
             };
             Line.prototype._getDrawer = function (key) {
@@ -7751,7 +7752,7 @@ var Plottable;
                 // avoids lines zooming on from offscreen.
                 var startValue = (domainMax < 0 && domainMax) || (domainMin > 0 && domainMin) || 0;
                 var scaledStartValue = this._yScale.scale(startValue);
-                return function (d, i, u, m) { return scaledStartValue; };
+                return function (d, i, dataset, m) { return scaledStartValue; };
             };
             Line.prototype._generateDrawSteps = function () {
                 var drawSteps = [];
@@ -7771,11 +7772,11 @@ var Plottable;
                 var singleDatumAttributes = d3.keys(attrToProjector).filter(isSingleDatumAttr);
                 singleDatumAttributes.forEach(function (attribute) {
                     var projector = attrToProjector[attribute];
-                    attrToProjector[attribute] = function (data, i, u, m) { return data.length > 0 ? projector(data[0], i, u, m) : null; };
+                    attrToProjector[attribute] = function (data, i, dataset, m) { return data.length > 0 ? projector(data[0], i, dataset, m) : null; };
                 });
                 var xFunction = attrToProjector["x"];
                 var yFunction = attrToProjector["y"];
-                attrToProjector["defined"] = function (d, i, u, m) { return _this._rejectNullsAndNaNs(d, i, u, m, xFunction) && _this._rejectNullsAndNaNs(d, i, u, m, yFunction); };
+                attrToProjector["defined"] = function (d, i, dataset, m) { return _this._rejectNullsAndNaNs(d, i, dataset, m, xFunction) && _this._rejectNullsAndNaNs(d, i, dataset, m, yFunction); };
                 attrToProjector["stroke"] = attrToProjector["stroke"] || d3.functor(this._defaultStrokeColor);
                 attrToProjector["stroke-width"] = attrToProjector["stroke-width"] || d3.functor("2px");
                 return attrToProjector;
@@ -7986,8 +7987,8 @@ var Plottable;
                 attrToProjector["height"] = !this._isVertical ? innerWidthF : attrToProjector["height"];
                 var xAttr = attrToProjector["x"];
                 var yAttr = attrToProjector["y"];
-                attrToProjector["x"] = function (d, i, u, m) { return _this._isVertical ? xAttr(d, i, u, m) + m.position : xAttr(d, u, u, m); };
-                attrToProjector["y"] = function (d, i, u, m) { return _this._isVertical ? yAttr(d, i, u, m) : yAttr(d, i, u, m) + m.position; };
+                attrToProjector["x"] = function (d, i, dataset, m) { return _this._isVertical ? xAttr(d, i, dataset, m) + m.position : xAttr(d, i, dataset, m); };
+                attrToProjector["y"] = function (d, i, dataset, m) { return _this._isVertical ? yAttr(d, i, dataset, m) : yAttr(d, i, dataset, m) + m.position; };
                 return attrToProjector;
             };
             ClusteredBar.prototype._updateClusterPosition = function () {
@@ -8008,7 +8009,7 @@ var Plottable;
                     var projection = this._attrBindings.get("width");
                     var accessor = projection.accessor;
                     var scale = projection.scale;
-                    var fn = scale ? function (d, i, u, m) { return scale.scale(accessor(d, i, u, m)); } : accessor;
+                    var fn = scale ? function (d, i, dataset, m) { return scale.scale(accessor(d, i, dataset, m)); } : accessor;
                     innerScale.range([0, fn(null, 0, null, null)]);
                 }
                 return innerScale;
@@ -8088,14 +8089,14 @@ var Plottable;
                 var dataset = _this._key2PlotDatasetKey.get(k).dataset;
                 var plotMetadata = _this._key2PlotDatasetKey.get(k).plotMetadata;
                 return Plottable.Utils.Methods.max(dataset.data(), function (datum, i) {
-                    return +valueAccessor(datum, i, dataset.metadata(), plotMetadata) + plotMetadata.offsets.get(keyAccessor(datum, i, dataset.metadata(), plotMetadata));
+                    return +valueAccessor(datum, i, dataset, plotMetadata) + plotMetadata.offsets.get(keyAccessor(datum, i, dataset, plotMetadata));
                 }, 0);
             }, 0);
             var minStackExtent = Plottable.Utils.Methods.min(this._datasetKeysInOrder, function (k) {
                 var dataset = _this._key2PlotDatasetKey.get(k).dataset;
                 var plotMetadata = _this._key2PlotDatasetKey.get(k).plotMetadata;
                 return Plottable.Utils.Methods.min(dataset.data(), function (datum, i) {
-                    return +valueAccessor(datum, i, dataset.metadata(), plotMetadata) + plotMetadata.offsets.get(keyAccessor(datum, i, dataset.metadata(), plotMetadata));
+                    return +valueAccessor(datum, i, dataset, plotMetadata) + plotMetadata.offsets.get(keyAccessor(datum, i, dataset, plotMetadata));
                 }, 0);
             }, 0);
             this._stackedExtent = [Math.min(minStackExtent, 0), Math.max(0, maxStackExtent)];
@@ -8125,12 +8126,12 @@ var Plottable;
                 var plotMetadata = _this._key2PlotDatasetKey.get(k).plotMetadata;
                 var positiveDataMap = positiveDataMapArray[index];
                 var negativeDataMap = negativeDataMapArray[index];
-                var isAllNegativeValues = dataset.data().every(function (datum, i) { return valueAccessor(datum, i, dataset.metadata(), plotMetadata) <= 0; });
+                var isAllNegativeValues = dataset.data().every(function (datum, i) { return valueAccessor(datum, i, dataset, plotMetadata) <= 0; });
                 dataset.data().forEach(function (datum, datumIndex) {
-                    var key = keyAccessor(datum, datumIndex, dataset.metadata(), plotMetadata);
+                    var key = keyAccessor(datum, datumIndex, dataset, plotMetadata);
                     var positiveOffset = positiveDataMap.get(key).offset;
                     var negativeOffset = negativeDataMap.get(key).offset;
-                    var value = valueAccessor(datum, datumIndex, dataset.metadata(), plotMetadata);
+                    var value = valueAccessor(datum, datumIndex, dataset, plotMetadata);
                     var offset;
                     if (!+value) {
                         offset = isAllNegativeValues ? negativeOffset : positiveOffset;
@@ -8150,7 +8151,7 @@ var Plottable;
                 var dataset = _this._key2PlotDatasetKey.get(k).dataset;
                 var plotMetadata = _this._key2PlotDatasetKey.get(k).plotMetadata;
                 dataset.data().forEach(function (datum, index) {
-                    domainKeys.add(keyAccessor(datum, index, dataset.metadata(), plotMetadata));
+                    domainKeys.add(keyAccessor(datum, index, dataset, plotMetadata));
                 });
             });
             return domainKeys.values();
@@ -8169,8 +8170,8 @@ var Plottable;
                 var dataset = _this._key2PlotDatasetKey.get(k).dataset;
                 var plotMetadata = _this._key2PlotDatasetKey.get(k).plotMetadata;
                 dataset.data().forEach(function (datum, index) {
-                    var key = keyAccessor(datum, index, dataset.metadata(), plotMetadata);
-                    var value = valueAccessor(datum, index, dataset.metadata(), plotMetadata);
+                    var key = keyAccessor(datum, index, dataset, plotMetadata);
+                    var value = valueAccessor(datum, index, dataset, plotMetadata);
                     dataMapArray[datasetIndex].set(key, { key: key, value: value });
                 });
             });
@@ -8192,17 +8193,17 @@ var Plottable;
             var _this = this;
             var aAccessor = this._attrBindings.get(fromX ? "x" : "y").accessor;
             var bAccessor = this._attrBindings.get(fromX ? "y" : "x").accessor;
-            var aStackedAccessor = function (d, i, u, m) {
-                var value = aAccessor(d, i, u, m);
+            var aStackedAccessor = function (d, i, dataset, m) {
+                var value = aAccessor(d, i, dataset, m);
                 if (_this._isVertical ? !fromX : fromX) {
-                    value += m.offsets.get(bAccessor(d, i, u, m));
+                    value += m.offsets.get(bAccessor(d, i, dataset, m));
                 }
                 return value;
             };
-            var bStackedAccessor = function (d, i, u, m) {
-                var value = bAccessor(d, i, u, m);
+            var bStackedAccessor = function (d, i, dataset, m) {
+                var value = bAccessor(d, i, dataset, m);
                 if (_this._isVertical ? fromX : !fromX) {
-                    value += m.offsets.get(aAccessor(d, i, u, m));
+                    value += m.offsets.get(aAccessor(d, i, dataset, m));
                 }
                 return value;
             };
@@ -8211,8 +8212,8 @@ var Plottable;
                 var plotMetadata = _this._key2PlotDatasetKey.get(key).plotMetadata;
                 return dataset.data().map(function (d, i) {
                     return {
-                        a: aStackedAccessor(d, i, dataset.metadata(), plotMetadata),
-                        b: bStackedAccessor(d, i, dataset.metadata(), plotMetadata)
+                        a: aStackedAccessor(d, i, dataset, plotMetadata),
+                        b: bStackedAccessor(d, i, dataset, plotMetadata)
                     };
                 });
             }));
@@ -8301,8 +8302,8 @@ var Plottable;
                 }
                 var yAccessor = this._attrBindings.get("y").accessor;
                 var xAccessor = this._attrBindings.get("x").accessor;
-                attrToProjector["y"] = function (d, i, u, m) { return _this._yScale.scale(+yAccessor(d, i, u, m) + m.offsets.get(xAccessor(d, i, u, m))); };
-                attrToProjector["y0"] = function (d, i, u, m) { return _this._yScale.scale(m.offsets.get(xAccessor(d, i, u, m))); };
+                attrToProjector["y"] = function (d, i, dataset, m) { return _this._yScale.scale(+yAccessor(d, i, dataset, m) + m.offsets.get(xAccessor(d, i, dataset, m))); };
+                attrToProjector["y0"] = function (d, i, dataset, m) { return _this._yScale.scale(m.offsets.get(xAccessor(d, i, dataset, m))); };
                 return attrToProjector;
             };
             StackedArea.prototype._wholeDatumAttributes = function () {
@@ -8319,7 +8320,7 @@ var Plottable;
                 var keySets = this._datasetKeysInOrder.map(function (k) {
                     var dataset = _this._key2PlotDatasetKey.get(k).dataset;
                     var plotMetadata = _this._key2PlotDatasetKey.get(k).plotMetadata;
-                    return d3.set(dataset.data().map(function (datum, i) { return keyAccessor(datum, i, dataset.metadata(), plotMetadata).toString(); })).values();
+                    return d3.set(dataset.data().map(function (datum, i) { return keyAccessor(datum, i, dataset, plotMetadata).toString(); })).values();
                 });
                 if (keySets.some(function (keySet) { return keySet.length !== domainKeys.length; })) {
                     Plottable.Utils.Methods.warn("the domains across the datasets are not the same.  Plot may produce unintended behavior.");
@@ -8409,11 +8410,13 @@ var Plottable;
                 var primaryScale = this._isVertical ? this._yScale : this._xScale;
                 var primaryAccessor = this._attrBindings.get(valueAttr).accessor;
                 var keyAccessor = this._attrBindings.get(keyAttr).accessor;
-                var getStart = function (d, i, u, m) { return primaryScale.scale(m.offsets.get(keyAccessor(d, i, u, m))); };
-                var getEnd = function (d, i, u, m) { return primaryScale.scale(+primaryAccessor(d, i, u, m) + m.offsets.get(keyAccessor(d, i, u, m))); };
-                var heightF = function (d, i, u, m) { return Math.abs(getEnd(d, i, u, m) - getStart(d, i, u, m)); };
-                var attrFunction = function (d, i, u, m) { return +primaryAccessor(d, i, u, m) < 0 ? getStart(d, i, u, m) : getEnd(d, i, u, m); };
-                attrToProjector[valueAttr] = function (d, i, u, m) { return _this._isVertical ? attrFunction(d, i, u, m) : attrFunction(d, i, u, m) - heightF(d, i, u, m); };
+                var getStart = function (d, i, dataset, m) { return primaryScale.scale(m.offsets.get(keyAccessor(d, i, dataset, m))); };
+                var getEnd = function (d, i, dataset, m) { return primaryScale.scale(+primaryAccessor(d, i, dataset, m) + m.offsets.get(keyAccessor(d, i, dataset, m))); };
+                var heightF = function (d, i, dataset, m) {
+                    return Math.abs(getEnd(d, i, dataset, m) - getStart(d, i, dataset, m));
+                };
+                var attrFunction = function (d, i, dataset, m) { return +primaryAccessor(d, i, dataset, m) < 0 ? getStart(d, i, dataset, m) : getEnd(d, i, dataset, m); };
+                attrToProjector[valueAttr] = function (d, i, dataset, m) { return _this._isVertical ? attrFunction(d, i, dataset, m) : attrFunction(d, i, dataset, m) - heightF(d, i, dataset, m); };
                 return attrToProjector;
             };
             StackedBar.prototype._generateDrawSteps = function () {
@@ -8652,7 +8655,9 @@ var Plottable;
                 }
                 var movingAttrProjector = attrToProjector[this._getMovingAttr()];
                 var growingAttrProjector = attrToProjector[this._getGrowingAttr()];
-                return function (d, i, u, m) { return movingAttrProjector(d, i, u, m) + growingAttrProjector(d, i, u, m); };
+                return function (d, i, dataset, m) {
+                    return movingAttrProjector(d, i, dataset, m) + growingAttrProjector(d, i, dataset, m);
+                };
             };
             Rect.prototype._getGrowingAttr = function () {
                 return this.isVertical ? "height" : "width";

--- a/src/animators/rectAnimator.ts
+++ b/src/animators/rectAnimator.ts
@@ -36,7 +36,9 @@ export module Animators {
       }
       var movingAttrProjector = attrToProjector[this._getMovingAttr()];
       var growingAttrProjector = attrToProjector[this._getGrowingAttr()];
-      return (d: any, i: number, u: any, m: Plots.PlotMetadata) => movingAttrProjector(d, i, u, m) + growingAttrProjector(d, i, u, m);
+      return (d: any, i: number, dataset: Dataset, m: Plots.PlotMetadata) => {
+        return movingAttrProjector(d, i, dataset, m) + growingAttrProjector(d, i, dataset, m);
+      };
     }
 
     private _getGrowingAttr() {

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -330,7 +330,7 @@ export module Plots {
       this._datasetKeysInOrder.forEach((k, i) =>
         drawers[i].drawText(dataToDraw.get(k),
                             attrToProjector,
-                            this._key2PlotDatasetKey.get(k).dataset.metadata(),
+                            this._key2PlotDatasetKey.get(k).dataset,
                             this._key2PlotDatasetKey.get(k).plotMetadata));
       if (this._hideBarsIfAnyAreTooWide && drawers.some((d: Drawers.Rect) => d._getIfLabelsTooWide())) {
         drawers.forEach((d: Drawers.Rect) => d.removeLabels());
@@ -367,23 +367,23 @@ export module Plots {
       var widthF = attrToProjector["width"];
       if (widthF == null) { widthF = () => this._getBarPixelWidth(); }
       var originalPositionFn = attrToProjector[primaryAttr];
-      var heightF = (d: any, i: number, u: any, m: PlotMetadata) => {
-        return Math.abs(scaledBaseline - originalPositionFn(d, i, u, m));
+      var heightF = (d: any, i: number, dataset: Dataset, m: PlotMetadata) => {
+        return Math.abs(scaledBaseline - originalPositionFn(d, i, dataset, m));
       };
 
       attrToProjector["width"] = this._isVertical ? widthF : heightF;
       attrToProjector["height"] = this._isVertical ? heightF : widthF;
 
       if (secondaryScale instanceof Plottable.Scales.Category) {
-        attrToProjector[secondaryAttr] = (d: any, i: number, u: any, m: PlotMetadata) =>
-          positionF(d, i, u, m) - widthF(d, i, u, m) / 2;
+        attrToProjector[secondaryAttr] = (d: any, i: number, dataset: Dataset, m: PlotMetadata) =>
+          positionF(d, i, dataset, m) - widthF(d, i, dataset, m) / 2;
       } else {
-        attrToProjector[secondaryAttr] = (d: any, i: number, u: any, m: PlotMetadata) =>
-          positionF(d, i, u, m) - widthF(d, i, u, m) * this._barAlignmentFactor;
+        attrToProjector[secondaryAttr] = (d: any, i: number, dataset: Dataset, m: PlotMetadata) =>
+          positionF(d, i, dataset, m) - widthF(d, i, dataset, m) * this._barAlignmentFactor;
       }
 
-      attrToProjector[primaryAttr] = (d: any, i: number, u: any, m: PlotMetadata) => {
-        var originalPos = originalPositionFn(d, i, u, m);
+      attrToProjector[primaryAttr] = (d: any, i: number, dataset: Dataset, m: PlotMetadata) => {
+        var originalPos = originalPositionFn(d, i, dataset, m);
         // If it is past the baseline, it should start at the baselin then width/height
         // carries it over. If it's not past the baseline, leave it at original position and
         // then width/height carries it to baseline
@@ -392,11 +392,11 @@ export module Plots {
 
       var primaryAccessor = this._attrBindings.get(primaryAttr).accessor;
       if (this._labelsEnabled && this._labelFormatter) {
-        attrToProjector["label"] = (d: any, i: number, u: any, m: PlotMetadata) => {
-          return this._labelFormatter(primaryAccessor(d, i, u, m));
+        attrToProjector["label"] = (d: any, i: number, dataset: Dataset, m: PlotMetadata) => {
+          return this._labelFormatter(primaryAccessor(d, i, dataset, m));
         };
-        attrToProjector["positive"] = (d: any, i: number, u: any, m: PlotMetadata) =>
-          originalPositionFn(d, i, u, m) <= scaledBaseline;
+        attrToProjector["positive"] = (d: any, i: number, dataset: Dataset, m: PlotMetadata) =>
+          originalPositionFn(d, i, dataset, m) <= scaledBaseline;
       }
 
       attrToProjector["fill"] = attrToProjector["fill"] || d3.functor(this._defaultFillColor);
@@ -423,7 +423,7 @@ export module Plots {
         var numberBarAccessorData = d3.set(Utils.Methods.flatten(this._datasetKeysInOrder.map((k) => {
           var dataset = this._key2PlotDatasetKey.get(k).dataset;
           var plotMetadata = this._key2PlotDatasetKey.get(k).plotMetadata;
-          return dataset.data().map((d, i) => barAccessor(d, i, dataset.metadata(), plotMetadata).valueOf());
+          return dataset.data().map((d, i) => barAccessor(d, i, dataset, plotMetadata).valueOf());
         }))).values().map((value) => +value);
 
         numberBarAccessorData.sort((a, b) => a - b);

--- a/src/components/plots/clusteredBarPlot.ts
+++ b/src/components/plots/clusteredBarPlot.ts
@@ -34,10 +34,10 @@ export module Plots {
 
       var xAttr = attrToProjector["x"];
       var yAttr = attrToProjector["y"];
-      attrToProjector["x"] = (d: any, i: number, u: any, m: ClusteredPlotMetadata) =>
-        this._isVertical ? xAttr(d, i, u, m) + m.position : xAttr(d, u, u, m);
-      attrToProjector["y"] = (d: any, i: number, u: any, m: ClusteredPlotMetadata) =>
-        this._isVertical ? yAttr(d, i, u, m) : yAttr(d, i, u, m) + m.position;
+      attrToProjector["x"] = (d: any, i: number, dataset: Dataset, m: ClusteredPlotMetadata) =>
+        this._isVertical ? xAttr(d, i, dataset, m) + m.position : xAttr(d, i, dataset, m);
+      attrToProjector["y"] = (d: any, i: number, dataset: Dataset, m: ClusteredPlotMetadata) =>
+        this._isVertical ? yAttr(d, i, dataset, m) : yAttr(d, i, dataset, m) + m.position;
 
       return attrToProjector;
     }
@@ -59,7 +59,7 @@ export module Plots {
         var projection = this._attrBindings.get("width");
         var accessor = projection.accessor;
         var scale = projection.scale;
-        var fn = scale ? (d: any, i: number, u: any, m: PlotMetadata) => scale.scale(accessor(d, i, u, m)) : accessor;
+        var fn = scale ? (d: any, i: number, dataset: Dataset, m: PlotMetadata) => scale.scale(accessor(d, i, dataset, m)) : accessor;
         innerScale.range([0, fn(null, 0, null, null)]);
       }
       return innerScale;

--- a/src/components/plots/gridPlot.ts
+++ b/src/components/plots/gridPlot.ts
@@ -56,32 +56,32 @@ export module Plots {
 
       if (attrToSet === "x") {
         if (scale instanceof Scales.Category) {
-          this.project("x1", (d: any, i: number, u: any, m: Plots.PlotMetadata) => {
-            return scale.scale(this._attrBindings.get("x").accessor(d, i, u, m)) - scale.rangeBand() / 2;
+          this.project("x1", (d: any, i: number, dataset: Dataset, m: Plots.PlotMetadata) => {
+            return scale.scale(this._attrBindings.get("x").accessor(d, i, dataset, m)) - scale.rangeBand() / 2;
           });
-          this.project("x2", (d: any, i: number, u: any, m: Plots.PlotMetadata) => {
-            return scale.scale(this._attrBindings.get("x").accessor(d, i, u, m)) + scale.rangeBand() / 2;
+          this.project("x2", (d: any, i: number, dataset: Dataset, m: Plots.PlotMetadata) => {
+            return scale.scale(this._attrBindings.get("x").accessor(d, i, dataset, m)) + scale.rangeBand() / 2;
           });
         }
         if (scale instanceof QuantitativeScale) {
-          this.project("x1", (d: any, i: number, u: any, m: Plots.PlotMetadata) => {
-            return scale.scale(this._attrBindings.get("x").accessor(d, i, u, m));
+          this.project("x1", (d: any, i: number, dataset: Dataset, m: Plots.PlotMetadata) => {
+            return scale.scale(this._attrBindings.get("x").accessor(d, i, dataset, m));
           });
         }
       }
 
       if (attrToSet === "y") {
         if (scale instanceof Scales.Category) {
-          this.project("y1", (d: any, i: number, u: any, m: Plots.PlotMetadata) => {
-            return scale.scale(this._attrBindings.get("y").accessor(d, i, u, m)) - scale.rangeBand() / 2;
+          this.project("y1", (d: any, i: number, dataset: Dataset, m: Plots.PlotMetadata) => {
+            return scale.scale(this._attrBindings.get("y").accessor(d, i, dataset, m)) - scale.rangeBand() / 2;
           });
-          this.project("y2", (d: any, i: number, u: any, m: Plots.PlotMetadata) => {
-            return scale.scale(this._attrBindings.get("y").accessor(d, i, u, m)) + scale.rangeBand() / 2;
+          this.project("y2", (d: any, i: number, dataset: Dataset, m: Plots.PlotMetadata) => {
+            return scale.scale(this._attrBindings.get("y").accessor(d, i, dataset, m)) + scale.rangeBand() / 2;
           });
         }
         if (scale instanceof QuantitativeScale) {
-          this.project("y1", (d: any, i: number, u: any, m: Plots.PlotMetadata) => {
-            return scale.scale(this._attrBindings.get("y").accessor(d, i, u, m));
+          this.project("y1", (d: any, i: number, dataset: Dataset, m: Plots.PlotMetadata) => {
+            return scale.scale(this._attrBindings.get("y").accessor(d, i, dataset, m));
           });
         }
       }

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -25,8 +25,8 @@ export module Plots {
       this._defaultStrokeColor = new Scales.Color().range()[0];
     }
 
-    protected _rejectNullsAndNaNs(d: any, i: number, userMetdata: any, plotMetadata: any, accessor: _Accessor) {
-      var value = accessor(d, i, userMetdata, plotMetadata);
+    protected _rejectNullsAndNaNs(d: any, i: number, dataset: Dataset, plotMetadata: any, accessor: _Accessor) {
+      var value = accessor(d, i, dataset, plotMetadata);
       return value != null && value === value;
     }
 
@@ -43,7 +43,7 @@ export module Plots {
       // avoids lines zooming on from offscreen.
       var startValue = (domainMax < 0 && domainMax) || (domainMin > 0 && domainMin) || 0;
       var scaledStartValue = this._yScale.scale(startValue);
-      return (d: any, i: number, u: any, m: PlotMetadata) => scaledStartValue;
+      return (d: any, i: number, dataset: Dataset, m: PlotMetadata) => scaledStartValue;
     }
 
     protected _generateDrawSteps(): Drawers.DrawStep[] {
@@ -66,15 +66,15 @@ export module Plots {
       var singleDatumAttributes = d3.keys(attrToProjector).filter(isSingleDatumAttr);
       singleDatumAttributes.forEach((attribute: string) => {
         var projector = attrToProjector[attribute];
-        attrToProjector[attribute] = (data: any[], i: number, u: any, m: any) =>
-          data.length > 0 ? projector(data[0], i, u, m) : null;
+        attrToProjector[attribute] = (data: any[], i: number, dataset: Dataset, m: any) =>
+          data.length > 0 ? projector(data[0], i, dataset, m) : null;
       });
 
       var xFunction = attrToProjector["x"];
       var yFunction = attrToProjector["y"];
 
-      attrToProjector["defined"] = (d: any, i: number, u: any, m: any) =>
-          this._rejectNullsAndNaNs(d, i, u, m, xFunction) && this._rejectNullsAndNaNs(d, i, u, m, yFunction);
+      attrToProjector["defined"] = (d: any, i: number, dataset: Dataset, m: any) =>
+          this._rejectNullsAndNaNs(d, i, dataset, m, xFunction) && this._rejectNullsAndNaNs(d, i, dataset, m, yFunction);
       attrToProjector["stroke"] = attrToProjector["stroke"] || d3.functor(this._defaultStrokeColor);
       attrToProjector["stroke-width"] = attrToProjector["stroke-width"] || d3.functor("2px");
 

--- a/src/components/plots/rectanglePlot.ts
+++ b/src/components/plots/rectanglePlot.ts
@@ -36,12 +36,14 @@ export module Plots {
       var y2Attr = attrToProjector["y2"];
 
       // Generate width based on difference, then adjust for the correct x origin
-      attrToProjector["width"] = (d, i, u, m) => Math.abs(x2Attr(d, i, u, m) - x1Attr(d, i, u, m));
-      attrToProjector["x"] = (d, i, u, m) => Math.min(x1Attr(d, i, u, m), x2Attr(d, i, u, m));
+      attrToProjector["width"] = (d, i, dataset, m) => Math.abs(x2Attr(d, i, dataset, m) - x1Attr(d, i, dataset, m));
+      attrToProjector["x"] = (d, i, dataset, m) => Math.min(x1Attr(d, i, dataset, m), x2Attr(d, i, dataset, m));
 
       // Generate height based on difference, then adjust for the correct y origin
-      attrToProjector["height"] = (d, i, u, m) => Math.abs(y2Attr(d, i, u, m) - y1Attr(d, i, u, m));
-      attrToProjector["y"] = (d, i, u, m) => Math.max(y1Attr(d, i, u, m), y2Attr(d, i, u, m)) - attrToProjector["height"](d, i, u, m);
+      attrToProjector["height"] = (d, i, dataset, m) => Math.abs(y2Attr(d, i, dataset, m) - y1Attr(d, i, dataset, m));
+      attrToProjector["y"] = (d, i, dataset, m) => {
+        return Math.max(y1Attr(d, i, dataset, m), y2Attr(d, i, dataset, m)) - attrToProjector["height"](d, i, dataset, m);
+      };
 
       // Clean up the attributes projected onto the SVG elements
       delete attrToProjector["x1"];

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -78,10 +78,10 @@ export module Plots {
 
       var yAccessor = this._attrBindings.get("y").accessor;
       var xAccessor = this._attrBindings.get("x").accessor;
-      attrToProjector["y"] = (d: any, i: number, u: any, m: StackedPlotMetadata) =>
-        this._yScale.scale(+yAccessor(d, i, u, m) + m.offsets.get(xAccessor(d, i, u, m)));
-      attrToProjector["y0"] = (d: any, i: number, u: any, m: StackedPlotMetadata) =>
-        this._yScale.scale(m.offsets.get(xAccessor(d, i, u, m)));
+      attrToProjector["y"] = (d: any, i: number, dataset: Dataset, m: StackedPlotMetadata) =>
+        this._yScale.scale(+yAccessor(d, i, dataset, m) + m.offsets.get(xAccessor(d, i, dataset, m)));
+      attrToProjector["y0"] = (d: any, i: number, dataset: Dataset, m: StackedPlotMetadata) =>
+        this._yScale.scale(m.offsets.get(xAccessor(d, i, dataset, m)));
 
       return attrToProjector;
     }
@@ -98,7 +98,7 @@ export module Plots {
       var keySets = this._datasetKeysInOrder.map((k) => {
         var dataset = this._key2PlotDatasetKey.get(k).dataset;
         var plotMetadata = this._key2PlotDatasetKey.get(k).plotMetadata;
-        return d3.set(dataset.data().map((datum, i) => keyAccessor(datum, i, dataset.metadata(), plotMetadata).toString())).values();
+        return d3.set(dataset.data().map((datum, i) => keyAccessor(datum, i, dataset, plotMetadata).toString())).values();
       });
 
       if (keySets.some((keySet) => keySet.length !== domainKeys.length)) {

--- a/src/components/plots/stackedBarPlot.ts
+++ b/src/components/plots/stackedBarPlot.ts
@@ -39,18 +39,20 @@ export module Plots {
       var primaryScale: Scale<any, number> = this._isVertical ? this._yScale : this._xScale;
       var primaryAccessor = this._attrBindings.get(valueAttr).accessor;
       var keyAccessor = this._attrBindings.get(keyAttr).accessor;
-      var getStart = (d: any, i: number, u: any, m: StackedPlotMetadata) =>
-        primaryScale.scale(m.offsets.get(keyAccessor(d, i, u, m)));
-      var getEnd = (d: any, i: number, u: any, m: StackedPlotMetadata) =>
-        primaryScale.scale(+primaryAccessor(d, i, u, m) + m.offsets.get(keyAccessor(d, i, u, m)));
+      var getStart = (d: any, i: number, dataset: Dataset, m: StackedPlotMetadata) =>
+        primaryScale.scale(m.offsets.get(keyAccessor(d, i, dataset, m)));
+      var getEnd = (d: any, i: number, dataset: Dataset, m: StackedPlotMetadata) =>
+        primaryScale.scale(+primaryAccessor(d, i, dataset, m) + m.offsets.get(keyAccessor(d, i, dataset, m)));
 
-      var heightF = (d: any, i: number, u: any, m: StackedPlotMetadata) => Math.abs(getEnd(d, i, u, m) - getStart(d, i, u, m));
+      var heightF = (d: any, i: number, dataset: Dataset, m: StackedPlotMetadata) => {
+        return Math.abs(getEnd(d, i, dataset, m) - getStart(d, i, dataset, m));
+      };
 
-      var attrFunction = (d: any, i: number, u: any, m: StackedPlotMetadata) =>
+      var attrFunction = (d: any, i: number, dataset: Dataset, m: StackedPlotMetadata) =>
 
-        +primaryAccessor(d, i, u, m) < 0 ? getStart(d, i, u, m) : getEnd(d, i, u, m);
-      attrToProjector[valueAttr] = (d: any, i: number, u: any, m: StackedPlotMetadata) =>
-        this._isVertical ? attrFunction(d, i, u, m) : attrFunction(d, i, u, m) - heightF(d, i, u, m);
+        +primaryAccessor(d, i, dataset, m) < 0 ? getStart(d, i, dataset, m) : getEnd(d, i, dataset, m);
+      attrToProjector[valueAttr] = (d: any, i: number, dataset: Dataset, m: StackedPlotMetadata) =>
+        this._isVertical ? attrFunction(d, i, dataset, m) : attrFunction(d, i, dataset, m) - heightF(d, i, dataset, m);
 
       return attrToProjector;
     }

--- a/src/components/plots/stackedPlot.ts
+++ b/src/components/plots/stackedPlot.ts
@@ -66,8 +66,8 @@ module Plottable {
         var dataset = this._key2PlotDatasetKey.get(k).dataset;
         var plotMetadata = <Plots.StackedPlotMetadata>this._key2PlotDatasetKey.get(k).plotMetadata;
         return Utils.Methods.max<any, number>(dataset.data(), (datum: any, i: number) => {
-          return +valueAccessor(datum, i, dataset.metadata(), plotMetadata) +
-            plotMetadata.offsets.get(keyAccessor(datum, i, dataset.metadata(), plotMetadata));
+          return +valueAccessor(datum, i, dataset, plotMetadata) +
+            plotMetadata.offsets.get(keyAccessor(datum, i, dataset, plotMetadata));
         }, 0);
       }, 0);
 
@@ -75,8 +75,8 @@ module Plottable {
         var dataset = this._key2PlotDatasetKey.get(k).dataset;
         var plotMetadata = <Plots.StackedPlotMetadata>this._key2PlotDatasetKey.get(k).plotMetadata;
         return Utils.Methods.min<any, number>(dataset.data(), (datum: any, i: number) => {
-          return +valueAccessor(datum, i, dataset.metadata(), plotMetadata) +
-            plotMetadata.offsets.get(keyAccessor(datum, i, dataset.metadata(), plotMetadata));
+          return +valueAccessor(datum, i, dataset, plotMetadata) +
+            plotMetadata.offsets.get(keyAccessor(datum, i, dataset, plotMetadata));
         }, 0);
       }, 0);
 
@@ -114,14 +114,14 @@ module Plottable {
         var plotMetadata = <Plots.StackedPlotMetadata>this._key2PlotDatasetKey.get(k).plotMetadata;
         var positiveDataMap = positiveDataMapArray[index];
         var negativeDataMap = negativeDataMapArray[index];
-        var isAllNegativeValues = dataset.data().every((datum, i) => valueAccessor(datum, i, dataset.metadata(), plotMetadata) <= 0);
+        var isAllNegativeValues = dataset.data().every((datum, i) => valueAccessor(datum, i, dataset, plotMetadata) <= 0);
 
         dataset.data().forEach((datum: any, datumIndex: number) => {
-          var key = keyAccessor(datum, datumIndex, dataset.metadata(), plotMetadata);
+          var key = keyAccessor(datum, datumIndex, dataset, plotMetadata);
           var positiveOffset = positiveDataMap.get(key).offset;
           var negativeOffset = negativeDataMap.get(key).offset;
 
-          var value = valueAccessor(datum, datumIndex, dataset.metadata(), plotMetadata);
+          var value = valueAccessor(datum, datumIndex, dataset, plotMetadata);
           var offset: number;
           if (!+value) {
             offset = isAllNegativeValues ? negativeOffset : positiveOffset;
@@ -141,7 +141,7 @@ module Plottable {
         var dataset = this._key2PlotDatasetKey.get(k).dataset;
         var plotMetadata = this._key2PlotDatasetKey.get(k).plotMetadata;
         dataset.data().forEach((datum, index) => {
-          domainKeys.add(keyAccessor(datum, index, dataset.metadata(), plotMetadata));
+          domainKeys.add(keyAccessor(datum, index, dataset, plotMetadata));
         });
       });
 
@@ -163,8 +163,8 @@ module Plottable {
         var dataset = this._key2PlotDatasetKey.get(k).dataset;
         var plotMetadata = this._key2PlotDatasetKey.get(k).plotMetadata;
         dataset.data().forEach((datum, index) => {
-          var key = keyAccessor(datum, index, dataset.metadata(), plotMetadata);
-          var value = valueAccessor(datum, index, dataset.metadata(), plotMetadata);
+          var key = keyAccessor(datum, index, dataset, plotMetadata);
+          var value = valueAccessor(datum, index, dataset, plotMetadata);
           dataMapArray[datasetIndex].set(key, {key: key, value: value});
         });
       });
@@ -187,18 +187,18 @@ module Plottable {
     public _normalizeDatasets<A, B>(fromX: boolean): {a: A; b: B}[] {
       var aAccessor = this._attrBindings.get(fromX ? "x" : "y").accessor;
       var bAccessor = this._attrBindings.get(fromX ? "y" : "x").accessor;
-      var aStackedAccessor = (d: any, i: number, u: any, m: Plots.StackedPlotMetadata) => {
-        var value = aAccessor(d, i, u, m);
+      var aStackedAccessor = (d: any, i: number, dataset: Dataset, m: Plots.StackedPlotMetadata) => {
+        var value = aAccessor(d, i, dataset, m);
         if (this._isVertical ? !fromX : fromX) {
-          value += m.offsets.get(bAccessor(d, i, u, m));
+          value += m.offsets.get(bAccessor(d, i, dataset, m));
         }
         return value;
       };
 
-      var bStackedAccessor = (d: any, i: number, u: any, m: Plots.StackedPlotMetadata) => {
-        var value = bAccessor(d, i, u, m);
+      var bStackedAccessor = (d: any, i: number, dataset: Dataset, m: Plots.StackedPlotMetadata) => {
+        var value = bAccessor(d, i, dataset, m);
         if (this._isVertical ? fromX : !fromX) {
-          value += m.offsets.get(aAccessor(d, i, u, m));
+          value += m.offsets.get(aAccessor(d, i, dataset, m));
         }
         return value;
       };
@@ -208,8 +208,8 @@ module Plottable {
         var plotMetadata = <Plots.StackedPlotMetadata>this._key2PlotDatasetKey.get(key).plotMetadata;
         return dataset.data().map((d, i) => {
           return {
-            a: aStackedAccessor(d, i, dataset.metadata(), plotMetadata),
-            b: bStackedAccessor(d, i, dataset.metadata(), plotMetadata)
+            a: aStackedAccessor(d, i, dataset, plotMetadata),
+            b: bStackedAccessor(d, i, dataset, plotMetadata)
           };
         });
       }));

--- a/src/components/plots/xyPlot.ts
+++ b/src/components/plots/xyPlot.ts
@@ -114,9 +114,9 @@ module Plottable {
       var attrToProjector: AttributeToProjector = super._generateAttrToProjector();
       var positionXFn = attrToProjector["x"];
       var positionYFn = attrToProjector["y"];
-      attrToProjector["defined"] = (d: any, i: number, u: any, m: Plots.PlotMetadata) => {
-        var positionX = positionXFn(d, i, u, m);
-        var positionY = positionYFn(d, i, u, m);
+      attrToProjector["defined"] = (d: any, i: number, dataset: Dataset, m: Plots.PlotMetadata) => {
+        var positionX = positionXFn(d, i, dataset, m);
+        var positionY = positionYFn(d, i, dataset, m);
         return positionX != null && positionX === positionX &&
                positionY != null && positionY === positionY;
       };
@@ -203,13 +203,13 @@ module Plottable {
     }
 
     protected _normalizeDatasets<A, B>(fromX: boolean): {a: A; b: B}[] {
-      var aAccessor: (d: any, i: number, u: any, m: Plots.PlotMetadata) => A = this._attrBindings.get(fromX ? "x" : "y").accessor;
-      var bAccessor: (d: any, i: number, u: any, m: Plots.PlotMetadata) => B = this._attrBindings.get(fromX ? "y" : "x").accessor;
+      var aAccessor: (d: any, i: number, dataset: Dataset, m: Plots.PlotMetadata) => A = this._attrBindings.get(fromX ? "x" : "y").accessor;
+      var bAccessor: (d: any, i: number, dataset: Dataset, m: Plots.PlotMetadata) => B = this._attrBindings.get(fromX ? "y" : "x").accessor;
       return Utils.Methods.flatten(this._datasetKeysInOrder.map((key: string) => {
         var dataset = this._key2PlotDatasetKey.get(key).dataset;
         var plotMetadata = this._key2PlotDatasetKey.get(key).plotMetadata;
         return dataset.data().map((d, i) => {
-          return { a: aAccessor(d, i, dataset.metadata(), plotMetadata), b: bAccessor(d, i, dataset.metadata(), plotMetadata) };
+          return { a: aAccessor(d, i, dataset, plotMetadata), b: bAccessor(d, i, dataset, plotMetadata) };
         });
       }));
     }

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -2,15 +2,15 @@ module Plottable {
   /**
    * Access specific datum property.
    */
-  export type _Accessor = (datum: any, index?: number, userMetadata?: any, plotMetadata?: Plots.PlotMetadata) => any;
+  export type _Accessor = (datum: any, index?: number, dataset?: Dataset, plotMetadata?: Plots.PlotMetadata) => any;
 
   /**
    * Retrieves scaled datum property.
    */
-  export type _Projector = (datum: any, index: number, userMetadata: any, plotMetadata: Plots.PlotMetadata) => any;
+  export type _Projector = (datum: any, index: number, dataset: Dataset, plotMetadata: Plots.PlotMetadata) => any;
 
   /**
-   * Projector with applied user and plot metadata
+   * Projector with dataset and plot metadata
    */
   export type AppliedProjector = (datum: any, index: number) => any;
 

--- a/src/drawers/arcDrawer.ts
+++ b/src/drawers/arcDrawer.ts
@@ -36,9 +36,9 @@ export module Drawers {
       return super._drawStep({attrToProjector: attrToProjector, animator: step.animator});
     }
 
-    public draw(data: any[], drawSteps: DrawStep[], userMetadata: any, plotMetadata: Plots.PlotMetadata) {
+    public draw(data: any[], drawSteps: DrawStep[], dataset: Dataset, plotMetadata: Plots.PlotMetadata) {
       // HACKHACK Applying metadata should be done in base class
-      var valueAccessor = (d: any, i: number) => drawSteps[0].attrToProjector["value"](d, i, userMetadata, plotMetadata);
+      var valueAccessor = (d: any, i: number) => drawSteps[0].attrToProjector["value"](d, i, dataset, plotMetadata);
 
       data = data.filter(e => Plottable.Utils.Methods.isValidNumber(+valueAccessor(e, null)));
 
@@ -52,7 +52,7 @@ export module Drawers {
           Utils.Methods.warn("Negative values will not render correctly in a pie chart.");
         }
       });
-      return super.draw(pie, drawSteps, userMetadata, plotMetadata);
+      return super.draw(pie, drawSteps, dataset, plotMetadata);
     }
 
     public _getPixelPoint(datum: any, index: number): Point {

--- a/src/drawers/drawer.ts
+++ b/src/drawers/drawer.ts
@@ -79,12 +79,12 @@ export module Drawers {
     }
 
     private _applyMetadata(attrToProjector: AttributeToProjector,
-                          userMetadata: any,
+                          dataset: Dataset,
                           plotMetadata: Plots.PlotMetadata): AttributeToAppliedProjector {
       var modifiedAttrToProjector: AttributeToAppliedProjector = {};
       d3.keys(attrToProjector).forEach((attr: string) => {
         modifiedAttrToProjector[attr] =
-          (datum: any, index: number) => attrToProjector[attr](datum, index, userMetadata, plotMetadata);
+          (datum: any, index: number) => attrToProjector[attr](datum, index, dataset, plotMetadata);
       });
 
       return modifiedAttrToProjector;
@@ -103,12 +103,12 @@ export module Drawers {
      *
      * @param{any[]} data The data to be drawn
      * @param{DrawStep[]} drawSteps The list of steps, which needs to be drawn
-     * @param{any} userMetadata The metadata provided by user
+     * @param{Dataset} dataset The Dataset
      * @param{any} plotMetadata The metadata provided by plot
      */
-    public draw(data: any[], drawSteps: DrawStep[], userMetadata: any, plotMetadata: Plots.PlotMetadata) {
+    public draw(data: any[], drawSteps: DrawStep[], dataset: Dataset, plotMetadata: Plots.PlotMetadata) {
       var appliedDrawSteps: AppliedDrawStep[] = drawSteps.map((dr: DrawStep) => {
-        var appliedAttrToProjector = this._applyMetadata(dr.attrToProjector, userMetadata, plotMetadata);
+        var appliedAttrToProjector = this._applyMetadata(dr.attrToProjector, dataset, plotMetadata);
         this._attrToProjector = <AttributeToAppliedProjector>Utils.Methods.copyMap(appliedAttrToProjector);
         return {
           attrToProjector: appliedAttrToProjector,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -82,15 +82,15 @@ export module Utils {
 
     /**
      * Take an accessor object (may be a string to be made into a key, or a value, or a color code)
-     * and "activate" it by turning it into a function in (datum, index, metadata)
+     * and "activate" it by turning it into a function in (datum, index,  dataset)
      */
     export function accessorize(accessor: any): _Accessor {
       if (typeof(accessor) === "function") {
         return (<_Accessor> accessor);
       } else if (typeof(accessor) === "string" && accessor[0] !== "#") {
-        return (d: any, i: number, s: any) => d[accessor];
+        return (datum: any, index: number, dataset: Dataset) => datum[accessor];
       } else {
-        return (d: any, i: number, s: any) => accessor;
+        return (datum: any, index: number, dataset: Dataset) => accessor;
       };
     }
 

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -774,8 +774,8 @@ describe("Plots", () => {
 
     it("plot auto domain scale to visible points on Category scale", () => {
       var svg = TestMethods.generateSVG(500, 500);
-      var xAccessor = (d: any, i: number, u: any) => d.a;
-      var yAccessor = (d: any, i: number, u: any) => d.b + u.foo;
+      var xAccessor = (d: any, i: number, dataset: Plottable.Dataset) => d.a;
+      var yAccessor = (d: any, i: number, dataset: Plottable.Dataset) => d.b + dataset.metadata().foo;
       var simpleDataset = new Plottable.Dataset([{a: "a", b: 6}, {a: "b", b: 2}, {a: "c", b: -2}, {a: "d", b: -6}], {foo: 0});
       var xScale = new Plottable.Scales.Category();
       var yScale = new Plottable.Scales.Linear();

--- a/test/components/plots/plotTests.ts
+++ b/test/components/plots/plotTests.ts
@@ -479,8 +479,8 @@ describe("Plots", () => {
     var plot: Plottable.XYPlot<number, number>;
 
     before(() => {
-      xAccessor = (d: any, i: number, u: any) => d.a + u.foo;
-      yAccessor = (d: any, i: number, u: any) => d.b + u.foo;
+      xAccessor = (d: any, i: number, dataset: Plottable.Dataset) => d.a + dataset.metadata().foo;
+      yAccessor = (d: any, i: number, dataset: Plottable.Dataset) => d.b + dataset.metadata().foo;
     });
 
     beforeEach(() => {

--- a/test/components/plots/scatterPlotTests.ts
+++ b/test/components/plots/scatterPlotTests.ts
@@ -17,7 +17,7 @@ describe("Plots", () => {
       svg.remove();
     });
 
-    it("the accessors properly access data, index, and metadata", () => {
+    it("the accessors properly access data, index and Dataset", () => {
       var svg = TestMethods.generateSVG(400, 400);
       var xScale = new Plottable.Scales.Linear();
       var yScale = new Plottable.Scales.Linear();
@@ -25,8 +25,8 @@ describe("Plots", () => {
       yScale.domain([400, 0]);
       var data = [{x: 0, y: 0}, {x: 1, y: 1}];
       var metadata = {foo: 10, bar: 20};
-      var xAccessor = (d: any, i?: number, m?: any) => d.x + i * m.foo;
-      var yAccessor = (d: any, i?: number, m?: any) => m.bar;
+      var xAccessor = (d: any, i: number, dataset: Plottable.Dataset) => d.x + i * dataset.metadata().foo;
+      var yAccessor = (d: any, i: number, dataset: Plottable.Dataset) => dataset.metadata().bar;
       var dataset = new Plottable.Dataset(data, metadata);
       var plot = new Plottable.Plots.Scatter(xScale, yScale)
                                   .project("x", xAccessor)

--- a/test/core/metadataTests.ts
+++ b/test/core/metadataTests.ts
@@ -26,11 +26,11 @@ describe("Metadata", () => {
     });
   });
 
-  it("user metadata is applied", () => {
+  it("Dataset is passed in", () => {
     var svg = TestMethods.generateSVG(400, 400);
     var metadata = {foo: 10, bar: 20};
-    var xAccessor = (d: any, i: number, u: any) => d.x + i * u.foo;
-    var yAccessor = (d: any, i: number, u: any) => u.bar;
+    var xAccessor = (d: any, i: number, dataset: Plottable.Dataset) => d.x + i * dataset.metadata().foo;
+    var yAccessor = (d: any, i: number, dataset: Plottable.Dataset) => dataset.metadata().bar;
     var dataset = new Plottable.Dataset(data1, metadata);
     var plot = new Plottable.Plots.Scatter(xScale, yScale)
                                 .project("x", xAccessor)
@@ -64,7 +64,7 @@ describe("Metadata", () => {
     var svg = TestMethods.generateSVG(400, 400);
     var metadata1 = {foo: 10};
     var metadata2 = {foo: 30};
-    var xAccessor = (d: any, i: number, u: any) => d.x + (i + 1) * u.foo;
+    var xAccessor = (d: any, i: number, dataset: Plottable.Dataset) => d.x + (i + 1) * dataset.metadata().foo;
     var yAccessor = () => 0;
     var dataset1 = new Plottable.Dataset(data1, metadata1);
     var dataset2 = new Plottable.Dataset(data2, metadata2);
@@ -94,7 +94,7 @@ describe("Metadata", () => {
 
   it("plot metadata is applied", () => {
     var svg = TestMethods.generateSVG(400, 400);
-    var xAccessor = (d: any, i: number, u: any, m: any) => d.x + (i + 1) * m.foo;
+    var xAccessor = (d: any, i: number, dataset: Plottable.Dataset, m: any) => d.x + (i + 1) * m.foo;
     var yAccessor = () => 0;
     var plot = new Plottable.Plots.Scatter(xScale, yScale)
                                 .project("x", xAccessor)
@@ -128,7 +128,7 @@ describe("Metadata", () => {
 
   it("plot metadata is per plot", () => {
     var svg = TestMethods.generateSVG(400, 400);
-    var xAccessor = (d: any, i: number, u: any, m: any) => d.x + (i + 1) * m.foo;
+    var xAccessor = (d: any, i: number, dataset: Plottable.Dataset, m: any) => d.x + (i + 1) * m.foo;
     var yAccessor = () => 0;
     var plot1 = new Plottable.Plots.Scatter(xScale, yScale)
                                 .project("x", xAccessor)
@@ -196,10 +196,16 @@ describe("Metadata", () => {
     var dataset2 = new Plottable.Dataset(data2, metadata);
 
     var checkPlot = (plot: Plottable.Plot) => {
+      var xAccessor = (d: any, i: number, dataset: Plottable.Dataset, m: Plottable.Plots.PlotMetadata) => {
+          return d.x + dataset.metadata().foo + m.datasetKey.length;
+      };
+      var yAccessor = (d: any, i: number, dataset: Plottable.Dataset, m: Plottable.Plots.PlotMetadata) => {
+          return d.y + dataset.metadata().foo - m.datasetKey.length;
+      };
       plot.addDataset(dataset1)
           .addDataset(dataset2)
-          .project("x", (d: any, i: number, u: any, m: Plottable.Plots.PlotMetadata) => d.x + u.foo + m.datasetKey.length)
-          .project("y", (d: any, i: number, u: any, m: Plottable.Plots.PlotMetadata) => d.y + u.foo - m.datasetKey.length);
+          .project("x", xAccessor)
+          .project("y", yAccessor);
 
       // This should not crash. If some metadata is not passed, undefined property error will be raised during accessor call.
       plot.renderTo(svg);

--- a/test/tests.js
+++ b/test/tests.js
@@ -2490,8 +2490,8 @@ describe("Plots", function () {
         var simpleDataset;
         var plot;
         before(function () {
-            xAccessor = function (d, i, u) { return d.a + u.foo; };
-            yAccessor = function (d, i, u) { return d.b + u.foo; };
+            xAccessor = function (d, i, dataset) { return d.a + dataset.metadata().foo; };
+            yAccessor = function (d, i, dataset) { return d.b + dataset.metadata().foo; };
         });
         beforeEach(function () {
             svg = TestMethods.generateSVG(500, 500);
@@ -3856,8 +3856,8 @@ describe("Plots", function () {
         });
         it("plot auto domain scale to visible points on Category scale", function () {
             var svg = TestMethods.generateSVG(500, 500);
-            var xAccessor = function (d, i, u) { return d.a; };
-            var yAccessor = function (d, i, u) { return d.b + u.foo; };
+            var xAccessor = function (d, i, dataset) { return d.a; };
+            var yAccessor = function (d, i, dataset) { return d.b + dataset.metadata().foo; };
             var simpleDataset = new Plottable.Dataset([{ a: "a", b: 6 }, { a: "b", b: 2 }, { a: "c", b: -2 }, { a: "d", b: -6 }], { foo: 0 });
             var xScale = new Plottable.Scales.Category();
             var yScale = new Plottable.Scales.Linear();
@@ -4121,7 +4121,7 @@ describe("Plots", function () {
             assert.strictEqual(plot.height(), 400, "was allocated height");
             svg.remove();
         });
-        it("the accessors properly access data, index, and metadata", function () {
+        it("the accessors properly access data, index and Dataset", function () {
             var svg = TestMethods.generateSVG(400, 400);
             var xScale = new Plottable.Scales.Linear();
             var yScale = new Plottable.Scales.Linear();
@@ -4129,8 +4129,8 @@ describe("Plots", function () {
             yScale.domain([400, 0]);
             var data = [{ x: 0, y: 0 }, { x: 1, y: 1 }];
             var metadata = { foo: 10, bar: 20 };
-            var xAccessor = function (d, i, m) { return d.x + i * m.foo; };
-            var yAccessor = function (d, i, m) { return m.bar; };
+            var xAccessor = function (d, i, dataset) { return d.x + i * dataset.metadata().foo; };
+            var yAccessor = function (d, i, dataset) { return dataset.metadata().bar; };
             var dataset = new Plottable.Dataset(data, metadata);
             var plot = new Plottable.Plots.Scatter(xScale, yScale).project("x", xAccessor).project("y", yAccessor);
             plot.addDataset(dataset);
@@ -5641,11 +5641,11 @@ describe("Metadata", function () {
             assert.propertyVal(plotMetadata, "datasetKey", key, "metadata has correct dataset key");
         });
     });
-    it("user metadata is applied", function () {
+    it("Dataset is passed in", function () {
         var svg = TestMethods.generateSVG(400, 400);
         var metadata = { foo: 10, bar: 20 };
-        var xAccessor = function (d, i, u) { return d.x + i * u.foo; };
-        var yAccessor = function (d, i, u) { return u.bar; };
+        var xAccessor = function (d, i, dataset) { return d.x + i * dataset.metadata().foo; };
+        var yAccessor = function (d, i, dataset) { return dataset.metadata().bar; };
         var dataset = new Plottable.Dataset(data1, metadata);
         var plot = new Plottable.Plots.Scatter(xScale, yScale).project("x", xAccessor).project("y", yAccessor);
         plot.addDataset(dataset);
@@ -5673,7 +5673,7 @@ describe("Metadata", function () {
         var svg = TestMethods.generateSVG(400, 400);
         var metadata1 = { foo: 10 };
         var metadata2 = { foo: 30 };
-        var xAccessor = function (d, i, u) { return d.x + (i + 1) * u.foo; };
+        var xAccessor = function (d, i, dataset) { return d.x + (i + 1) * dataset.metadata().foo; };
         var yAccessor = function () { return 0; };
         var dataset1 = new Plottable.Dataset(data1, metadata1);
         var dataset2 = new Plottable.Dataset(data2, metadata2);
@@ -5698,7 +5698,7 @@ describe("Metadata", function () {
     });
     it("plot metadata is applied", function () {
         var svg = TestMethods.generateSVG(400, 400);
-        var xAccessor = function (d, i, u, m) { return d.x + (i + 1) * m.foo; };
+        var xAccessor = function (d, i, dataset, m) { return d.x + (i + 1) * m.foo; };
         var yAccessor = function () { return 0; };
         var plot = new Plottable.Plots.Scatter(xScale, yScale).project("x", xAccessor).project("y", yAccessor);
         plot._getPlotMetadataForDataset = function (key) {
@@ -5727,7 +5727,7 @@ describe("Metadata", function () {
     });
     it("plot metadata is per plot", function () {
         var svg = TestMethods.generateSVG(400, 400);
-        var xAccessor = function (d, i, u, m) { return d.x + (i + 1) * m.foo; };
+        var xAccessor = function (d, i, dataset, m) { return d.x + (i + 1) * m.foo; };
         var yAccessor = function () { return 0; };
         var plot1 = new Plottable.Plots.Scatter(xScale, yScale).project("x", xAccessor).project("y", yAccessor);
         plot1._getPlotMetadataForDataset = function (key) {
@@ -5785,7 +5785,13 @@ describe("Metadata", function () {
         var dataset1 = new Plottable.Dataset(data1, metadata);
         var dataset2 = new Plottable.Dataset(data2, metadata);
         var checkPlot = function (plot) {
-            plot.addDataset(dataset1).addDataset(dataset2).project("x", function (d, i, u, m) { return d.x + u.foo + m.datasetKey.length; }).project("y", function (d, i, u, m) { return d.y + u.foo - m.datasetKey.length; });
+            var xAccessor = function (d, i, dataset, m) {
+                return d.x + dataset.metadata().foo + m.datasetKey.length;
+            };
+            var yAccessor = function (d, i, dataset, m) {
+                return d.y + dataset.metadata().foo - m.datasetKey.length;
+            };
+            plot.addDataset(dataset1).addDataset(dataset2).project("x", xAccessor).project("y", yAccessor);
             // This should not crash. If some metadata is not passed, undefined property error will be raised during accessor call.
             plot.renderTo(svg);
             plot.destroy();


### PR DESCRIPTION
More powerful than just passing the metadata, and it will be useful later when getting rid of `Dataset` keys.