### PR TITLE
restructure piePlot to use old arcDrawer architecture

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1454,8 +1454,8 @@ declare module Plottable {
 
 declare module Plottable {
     module Drawers {
-        class Arc<D> extends Element {
-            constructor(key: string, plot: Plots.Pie<D>);
+        class Arc extends Element {
+            constructor(key: string);
             _drawStep(step: AppliedDrawStep): void;
             draw(data: any[], drawSteps: DrawStep[], dataset: Dataset, plotMetadata: Plots.PlotMetadata): number;
             _getPixelPoint(datum: any, index: number): Point;

--- a/plottable.js
+++ b/plottable.js
@@ -2987,16 +2987,12 @@ var Plottable;
     (function (Drawers) {
         var Arc = (function (_super) {
             __extends(Arc, _super);
-            function Arc(key, plot) {
+            function Arc(key) {
                 _super.call(this, key);
-                this._piePlot = plot;
                 this._svgElement = "path";
             }
-            Arc.prototype._createArc = function () {
-                var _this = this;
-                var dataset = this._piePlot._key2PlotDatasetKey.get(this.key).dataset;
-                var plotMetadata = this._piePlot._key2PlotDatasetKey.get(this.key).plotMetadata;
-                return d3.svg.arc().innerRadius(function (d, i) { return Arc._scaledAccessor(_this._piePlot.innerRadius())(d.data, i, dataset, plotMetadata); }).outerRadius(function (d, i) { return Arc._scaledAccessor(_this._piePlot.outerRadius())(d.data, i, dataset, plotMetadata); });
+            Arc.prototype._createArc = function (innerRadiusF, outerRadiusF) {
+                return d3.svg.arc().innerRadius(innerRadiusF).outerRadius(outerRadiusF);
             };
             Arc.prototype.retargetProjectors = function (attrToProjector) {
                 var retargetedAttrToProjector = {};
@@ -3008,15 +3004,20 @@ var Plottable;
             Arc.prototype._drawStep = function (step) {
                 var attrToProjector = Plottable.Utils.Methods.copyMap(step.attrToProjector);
                 attrToProjector = this.retargetProjectors(attrToProjector);
-                attrToProjector["d"] = this._createArc();
+                this._attrToProjector = this.retargetProjectors(this._attrToProjector);
+                var innerRadiusAccessor = attrToProjector["inner-radius"];
+                var outerRadiusAccessor = attrToProjector["outer-radius"];
+                delete attrToProjector["inner-radius"];
+                delete attrToProjector["outer-radius"];
+                attrToProjector["d"] = this._createArc(innerRadiusAccessor, outerRadiusAccessor);
                 return _super.prototype._drawStep.call(this, { attrToProjector: attrToProjector, animator: step.animator });
             };
             Arc.prototype.draw = function (data, drawSteps, dataset, plotMetadata) {
-                var _this = this;
                 // HACKHACK Applying metadata should be done in base class
-                var valueAccessor = function (d, i) { return Arc._scaledAccessor(_this._piePlot.sectorValue())(d, i, dataset, plotMetadata); };
+                var valueAccessor = function (d, i) { return drawSteps[0].attrToProjector["sector-value"](d, i, dataset, plotMetadata); };
                 data = data.filter(function (e) { return Plottable.Utils.Methods.isValidNumber(+valueAccessor(e, null)); });
                 var pie = d3.layout.pie().sort(null).value(valueAccessor)(data);
+                drawSteps.forEach(function (s) { return delete s.attrToProjector["sector-value"]; });
                 pie.forEach(function (slice) {
                     if (slice.value < 0) {
                         Plottable.Utils.Methods.warn("Negative values will not render correctly in a pie chart.");
@@ -3025,18 +3026,13 @@ var Plottable;
                 return _super.prototype.draw.call(this, pie, drawSteps, dataset, plotMetadata);
             };
             Arc.prototype._getPixelPoint = function (datum, index) {
-                var dataset = this._piePlot._key2PlotDatasetKey.get(this.key).dataset;
-                var plotMetadata = this._piePlot._key2PlotDatasetKey.get(this.key).plotMetadata;
-                var innerRadius = Arc._scaledAccessor(this._piePlot.innerRadius())(datum, index, dataset, plotMetadata);
-                var outerRadius = Arc._scaledAccessor(this._piePlot.outerRadius())(datum, index, dataset, plotMetadata);
-                var avgRadius = (innerRadius + outerRadius) / 2;
+                var innerRadiusAccessor = this._attrToProjector["inner-radius"];
+                var outerRadiusAccessor = this._attrToProjector["outer-radius"];
+                var avgRadius = (innerRadiusAccessor(datum, index) + outerRadiusAccessor(datum, index)) / 2;
                 var startAngle = +this._getSelection(index).datum().startAngle;
                 var endAngle = +this._getSelection(index).datum().endAngle;
                 var avgAngle = (startAngle + endAngle) / 2;
                 return { x: avgRadius * Math.sin(avgAngle), y: -avgRadius * Math.cos(avgAngle) };
-            };
-            Arc._scaledAccessor = function (accScaleBinding) {
-                return accScaleBinding.scale == null ? accScaleBinding.accessor : function (d, i, dataset, m) { return accScaleBinding.scale.scale(accScaleBinding.accessor(d, i, dataset, m)); };
             };
             return Arc;
         })(Drawers.Element);
@@ -6823,10 +6819,11 @@ var Plottable;
                 var attrToProjector = _super.prototype._generateAttrToProjector.call(this);
                 var defaultFillFunction = function (d, i) { return _this._colorScale.scale(String(i)); };
                 attrToProjector["fill"] = attrToProjector["fill"] || defaultFillFunction;
+                this._propertyBindings.forEach(function (key, binding) { return attrToProjector[key] = Pie._scaledAccessor(binding); });
                 return attrToProjector;
             };
             Pie.prototype._getDrawer = function (key) {
-                return new Plottable.Drawers.Arc(key, this).setClass("arc");
+                return new Plottable.Drawers.Arc(key).setClass("arc");
             };
             Pie.prototype.getAllPlotData = function (datasets) {
                 var _this = this;
@@ -6936,6 +6933,9 @@ var Plottable;
                     }
                 });
                 return propertyScales;
+            };
+            Pie._scaledAccessor = function (accScaleBinding) {
+                return accScaleBinding.scale == null ? accScaleBinding.accessor : function (d, i, dataset, m) { return accScaleBinding.scale.scale(accScaleBinding.accessor(d, i, dataset, m)); };
             };
             Pie._INNER_RADIUS_KEY = "inner-radius";
             Pie._OUTER_RADIUS_KEY = "outer-radius";

--- a/plottable.js
+++ b/plottable.js
@@ -6816,10 +6816,12 @@ var Plottable;
             };
             Pie.prototype._generateAttrToProjector = function () {
                 var _this = this;
-                var attrToProjector = _super.prototype._generateAttrToProjector.call(this);
+                var attrToProjector = {};
+                this._propertyBindings.forEach(function (key, binding) { return attrToProjector[key] = Pie._scaledAccessor(binding); });
+                var superAttrToProjector = _super.prototype._generateAttrToProjector.call(this);
+                Object.keys(superAttrToProjector).forEach(function (key) { return attrToProjector[key] = superAttrToProjector[key]; });
                 var defaultFillFunction = function (d, i) { return _this._colorScale.scale(String(i)); };
                 attrToProjector["fill"] = attrToProjector["fill"] || defaultFillFunction;
-                this._propertyBindings.forEach(function (key, binding) { return attrToProjector[key] = Pie._scaledAccessor(binding); });
                 return attrToProjector;
             };
             Pie.prototype._getDrawer = function (key) {

--- a/plottable.js
+++ b/plottable.js
@@ -6816,12 +6816,20 @@ var Plottable;
             };
             Pie.prototype._generateAttrToProjector = function () {
                 var _this = this;
-                var attrToProjector = {};
-                this._propertyBindings.forEach(function (key, binding) { return attrToProjector[key] = Pie._scaledAccessor(binding); });
-                var superAttrToProjector = _super.prototype._generateAttrToProjector.call(this);
-                Object.keys(superAttrToProjector).forEach(function (key) { return attrToProjector[key] = superAttrToProjector[key]; });
+                var attrToProjector = _super.prototype._generateAttrToProjector.call(this);
+                var propertyProjectors = this._propertyToProjectors();
+                Object.keys(propertyProjectors).forEach(function (key) {
+                    if (attrToProjector[key] == null) {
+                        attrToProjector[key] = propertyProjectors[key];
+                    }
+                });
                 var defaultFillFunction = function (d, i) { return _this._colorScale.scale(String(i)); };
                 attrToProjector["fill"] = attrToProjector["fill"] || defaultFillFunction;
+                return attrToProjector;
+            };
+            Pie.prototype._propertyToProjectors = function () {
+                var attrToProjector = {};
+                this._propertyBindings.forEach(function (key, binding) { return attrToProjector[key] = Pie._scaledAccessor(binding); });
                 return attrToProjector;
             };
             Pie.prototype._getDrawer = function (key) {

--- a/src/components/plots/piePlot.ts
+++ b/src/components/plots/piePlot.ts
@@ -74,11 +74,13 @@ export module Plots {
       var defaultFillFunction = (d: any, i: number) => this._colorScale.scale(String(i));
       attrToProjector["fill"] = attrToProjector["fill"] || defaultFillFunction;
 
+      this._propertyBindings.forEach((key, binding) => attrToProjector[key] = Pie._scaledAccessor(binding));
+
       return attrToProjector;
     }
 
     protected _getDrawer(key: string) {
-      return new Plottable.Drawers.Arc(key, this).setClass("arc");
+      return new Plottable.Drawers.Arc(key).setClass("arc");
     }
 
     public getAllPlotData(datasets = this.datasets()): Plots.PlotData {
@@ -200,6 +202,13 @@ export module Plots {
         }
       });
       return propertyScales;
+    }
+
+    private static _scaledAccessor<SD, SR>(accScaleBinding: Plots.AccessorScaleBinding<SD, SR>): _Accessor {
+      return accScaleBinding.scale == null ?
+               accScaleBinding.accessor :
+               (d: any, i: number, dataset: Dataset, m: Plots.PlotMetadata) =>
+                 accScaleBinding.scale.scale(accScaleBinding.accessor(d, i, dataset, m));
     }
   }
 }

--- a/src/components/plots/piePlot.ts
+++ b/src/components/plots/piePlot.ts
@@ -69,12 +69,14 @@ export module Plots {
     }
 
     protected _generateAttrToProjector(): AttributeToProjector {
-      var attrToProjector = super._generateAttrToProjector();
+      var attrToProjector: AttributeToProjector = {};
+      this._propertyBindings.forEach((key, binding) => attrToProjector[key] = Pie._scaledAccessor(binding));
+
+      var superAttrToProjector = super._generateAttrToProjector();
+      Object.keys(superAttrToProjector).forEach((key) => attrToProjector[key] = superAttrToProjector[key]);
 
       var defaultFillFunction = (d: any, i: number) => this._colorScale.scale(String(i));
       attrToProjector["fill"] = attrToProjector["fill"] || defaultFillFunction;
-
-      this._propertyBindings.forEach((key, binding) => attrToProjector[key] = Pie._scaledAccessor(binding));
 
       return attrToProjector;
     }

--- a/src/components/plots/piePlot.ts
+++ b/src/components/plots/piePlot.ts
@@ -69,15 +69,23 @@ export module Plots {
     }
 
     protected _generateAttrToProjector(): AttributeToProjector {
-      var attrToProjector: AttributeToProjector = {};
-      this._propertyBindings.forEach((key, binding) => attrToProjector[key] = Pie._scaledAccessor(binding));
-
-      var superAttrToProjector = super._generateAttrToProjector();
-      Object.keys(superAttrToProjector).forEach((key) => attrToProjector[key] = superAttrToProjector[key]);
+      var attrToProjector = super._generateAttrToProjector();
+      var propertyProjectors = this._propertyToProjectors();
+      Object.keys(propertyProjectors).forEach((key) => {
+        if (attrToProjector[key] == null) {
+          attrToProjector[key] = propertyProjectors[key];
+        }
+      });
 
       var defaultFillFunction = (d: any, i: number) => this._colorScale.scale(String(i));
       attrToProjector["fill"] = attrToProjector["fill"] || defaultFillFunction;
 
+      return attrToProjector;
+    }
+
+    private _propertyToProjectors(): AttributeToProjector {
+      var attrToProjector: AttributeToProjector = {};
+      this._propertyBindings.forEach((key, binding) => attrToProjector[key] = Pie._scaledAccessor(binding));
       return attrToProjector;
     }
 

--- a/test/drawers/arcDrawerTests.ts
+++ b/test/drawers/arcDrawerTests.ts
@@ -7,7 +7,7 @@ describe("Drawers", () => {
       var data = [{value: 10}, {value: 10}, {value: 10}, {value: 10}];
       var piePlot = new Plottable.Plots.Pie();
 
-      var drawer = new Plottable.Drawers.Arc("_0", piePlot); // HACKHACK #1984: Dataset keys are being removed, so this is the internal key
+      var drawer = new Plottable.Drawers.Arc("_0"); // HACKHACK #1984: Dataset keys are being removed, so this is the internal key
       (<any> piePlot)._getDrawer = () => drawer;
 
       piePlot.addDataset(new Plottable.Dataset(data));

--- a/test/tests.js
+++ b/test/tests.js
@@ -383,7 +383,7 @@ describe("Drawers", function () {
             var svg = TestMethods.generateSVG(300, 300);
             var data = [{ value: 10 }, { value: 10 }, { value: 10 }, { value: 10 }];
             var piePlot = new Plottable.Plots.Pie();
-            var drawer = new Plottable.Drawers.Arc("_0", piePlot); // HACKHACK #1984: Dataset keys are being removed, so this is the internal key
+            var drawer = new Plottable.Drawers.Arc("_0"); // HACKHACK #1984: Dataset keys are being removed, so this is the internal key
             piePlot._getDrawer = function () { return drawer; };
             piePlot.addDataset(new Plottable.Dataset(data));
             piePlot.sectorValue(function (d) { return d.value; });


### PR DESCRIPTION
Restoring _Drawers back to their previous state.  Utiliize generateAttrToProjector to stay as consistent with the current codebase as possible