### PR TITLE
Fix the logic in RenderController.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -245,6 +245,7 @@ declare module Plottable {
             constructor();
             add(value: T): Set<T>;
             delete(value: T): boolean;
+            has(value: T): boolean;
             values(): T[];
         }
     }

--- a/plottable.js
+++ b/plottable.js
@@ -1237,7 +1237,6 @@ var Plottable;
         var _componentsNeedingRender = new Plottable.Utils.Set();
         var _componentsNeedingComputeLayout = new Plottable.Utils.Set();
         var _animationRequested = false;
-        var _isCurrentlyFlushing = false;
         RenderController._renderPolicy = new Plottable.RenderPolicies.AnimationFrame();
         function setRenderPolicy(policy) {
             if (typeof (policy) === "string") {
@@ -3219,7 +3218,6 @@ var Plottable;
          */
         Component.prototype.render = function (immediately) {
             if (immediately === void 0) { immediately = false; }
-            console.log("render(" + immediately + "): " + this.constructor.name);
             if (immediately) {
                 this._render();
                 return this;

--- a/plottable.js
+++ b/plottable.js
@@ -502,7 +502,7 @@ var Plottable;
                 this._values = [];
             }
             Set.prototype.add = function (value) {
-                if (this._values.indexOf(value) === -1) {
+                if (!this.has(value)) {
                     this._values.push(value);
                 }
                 return this;
@@ -514,6 +514,9 @@ var Plottable;
                     return true;
                 }
                 return false;
+            };
+            Set.prototype.has = function (value) {
+                return this._values.indexOf(value) !== -1;
             };
             Set.prototype.values = function () {
                 return this._values;

--- a/src/core/renderController.ts
+++ b/src/core/renderController.ts
@@ -23,7 +23,6 @@ module Plottable {
     var _componentsNeedingRender = new Utils.Set<Component>();
     var _componentsNeedingComputeLayout = new Utils.Set<Component>();
     var _animationRequested: boolean = false;
-    var _isCurrentlyFlushing: boolean = false;
     export var _renderPolicy: RenderPolicies.RenderPolicy = new RenderPolicies.AnimationFrame();
 
     export function setRenderPolicy(policy: string | RenderPolicies.RenderPolicy): void {

--- a/src/core/renderController.ts
+++ b/src/core/renderController.ts
@@ -53,9 +53,6 @@ module Plottable {
      * @param {Component} component Any Plottable component.
      */
     export function registerToRender(component: Component) {
-      if (_isCurrentlyFlushing) {
-        Utils.Methods.warn("Registered to render while other components are flushing: request may be ignored");
-      }
       _componentsNeedingRender.add(component);
       requestRender();
     }
@@ -68,8 +65,7 @@ module Plottable {
      */
     export function registerToComputeLayout(component: Component) {
       _componentsNeedingComputeLayout.add(component);
-      _componentsNeedingRender.add(component);
-      requestRender();
+      registerToRender(component);
     }
 
     function requestRender() {
@@ -89,23 +85,24 @@ module Plottable {
     export function flush() {
       if (_animationRequested) {
         // Layout
-        _componentsNeedingComputeLayout.values().forEach((component: Component) => component.computeLayout());
+        _componentsNeedingComputeLayout.values().forEach((component) => component.computeLayout());
+        _componentsNeedingComputeLayout = new Utils.Set<Component>();
 
-        _isCurrentlyFlushing = true;
-        var failed = new Utils.Set<Component>();
-        _componentsNeedingRender.values().forEach((component: Component) => {
+        var toRender = _componentsNeedingRender;
+        _componentsNeedingRender = new Utils.Set<Component>();
+        toRender.values().forEach((component) => {
           try {
             component.render(true);
           } catch (err) {
             // throw error with timeout to avoid interrupting further renders
             window.setTimeout(() => { throw err; }, 0);
-            failed.add(component);
+            registerToRender(component); // try again later
           }
         });
-        _componentsNeedingComputeLayout = new Utils.Set<Component>();
-        _componentsNeedingRender = failed;
         _animationRequested = false;
-        _isCurrentlyFlushing = false;
+      }
+      if (_componentsNeedingRender.values().length !== 0) {
+        requestRender();
       }
     }
   }

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -14,7 +14,7 @@ module Plottable {
       }
 
       public add(value: T) {
-        if (this._values.indexOf(value) === -1) {
+        if (!this.has(value)) {
           this._values.push(value);
         }
         return this;
@@ -27,6 +27,10 @@ module Plottable {
           return true;
         }
         return false;
+      }
+
+      public has(value: T) {
+        return this._values.indexOf(value) !== -1;
       }
 
       public values() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -7931,6 +7931,16 @@ describe("Utils", function () {
             set.delete(value2);
             assert.lengthOf(set.values(), 1, "removing a non-existent value does nothing");
         });
+        it("has()", function () {
+            var set = new Plottable.Utils.Set();
+            var value1 = { value: "one" };
+            set.add(value1);
+            assert.isTrue(set.has(value1), "correctly checks that value is in the set");
+            var similarValue1 = { value: "one" };
+            assert.isFalse(set.has(similarValue1), "correctly determines that similar object is not in the set");
+            set.delete(value1);
+            assert.isFalse(set.has(value1), "correctly checks that value is no longer in the set");
+        });
     });
 });
 

--- a/test/utils/setTests.ts
+++ b/test/utils/setTests.ts
@@ -40,5 +40,19 @@ describe("Utils", () => {
       set.delete(value2);
       assert.lengthOf(set.values(), 1, "removing a non-existent value does nothing");
     });
+    
+    it("has()", () => {
+      var set = new Plottable.Utils.Set();
+
+      var value1 = { value: "one" };
+      set.add(value1);
+      assert.isTrue(set.has(value1), "correctly checks that value is in the set");
+
+      var similarValue1 = { value: "one" };
+      assert.isFalse(set.has(similarValue1), "correctly determines that similar object is not in the set");
+
+      set.delete(value1);
+      assert.isFalse(set.has(value1), "correctly checks that value is no longer in the set");
+    })
   });
 });

--- a/test/utils/setTests.ts
+++ b/test/utils/setTests.ts
@@ -40,7 +40,7 @@ describe("Utils", () => {
       set.delete(value2);
       assert.lengthOf(set.values(), 1, "removing a non-existent value does nothing");
     });
-    
+
     it("has()", () => {
       var set = new Plottable.Utils.Set();
 
@@ -53,6 +53,6 @@ describe("Utils", () => {
 
       set.delete(value1);
       assert.isFalse(set.has(value1), "correctly checks that value is no longer in the set");
-    })
+    });
   });
 });


### PR DESCRIPTION
>"The loop was kind of pointless."

@jtlan, a155f04

In fact, the loop was super critical, but because the logic was so convoluted, it was difficult to tell. New logic for `RenderController`'s `flush()`:

* Save off current `Set` of `Component`s that have requested a render.
* Create a new `Set` for `Component`s that request a render while we're drawing.
* Draw all `Component`s in the saved-off `Set`.
* If there are `Component`s that have requested a render while we were drawing, request another frame.