### PR TITLE
[Interaction] Interaction fix

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -9102,7 +9102,9 @@ var Plottable;
          * @return {Interaction}
          */
         Interaction.prototype.detachFrom = function (component) {
-            this._unanchor();
+            if (this._isAnchored) {
+                this._unanchor();
+            }
             this._componentAttachedTo = null;
             component.offAnchor(this._anchorCallback);
             return this;

--- a/src/interactions/interaction.ts
+++ b/src/interactions/interaction.ts
@@ -44,7 +44,9 @@ module Plottable {
      * @return {Interaction}
      */
     public detachFrom(component: Component) {
-      this._unanchor();
+      if (this._isAnchored) {
+        this._unanchor();
+      }
       this._componentAttachedTo = null;
       component.offAnchor(this._anchorCallback);
 

--- a/test/interactions/interactionTests.ts
+++ b/test/interactions/interactionTests.ts
@@ -71,7 +71,7 @@ describe("Interactions", () => {
       svg.remove();
     });
 
-    it("calling detachFrom on a detached Interaction has no effect", () => {
+    it("calling detachFrom() on a detached Interaction has no effect", () => {
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var component = new Plottable.Component();
 

--- a/test/interactions/interactionTests.ts
+++ b/test/interactions/interactionTests.ts
@@ -71,6 +71,34 @@ describe("Interactions", () => {
       svg.remove();
     });
 
+    it("calling detach on a detached interaction has no effect", () => {
+      var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      var component = new Plottable.Component();
+
+      var clickInteraction = new Plottable.Interactions.Click();
+
+      assert.doesNotThrow(() => {
+        clickInteraction.detachFrom(component);
+      }, "Detaching an interaction which was not attached should not throw");
+
+      clickInteraction.attachTo(component);
+      clickInteraction.detachFrom(component);
+      assert.doesNotThrow(() => {
+        clickInteraction.detachFrom(component);
+      }, "calling detaching a component twice should not throw");
+
+      component.renderTo(svg);
+
+      clickInteraction.attachTo(component);
+      clickInteraction.detachFrom(component);
+      assert.doesNotThrow(() => {
+        clickInteraction.detachFrom(component);
+      }, "calling detaching a component twice should not throw even when attached to SVG");
+
+      svg.remove();
+
+    });
+
     it("can move interaction from one component to another", () => {
       var svg1 = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var svg2 = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);

--- a/test/interactions/interactionTests.ts
+++ b/test/interactions/interactionTests.ts
@@ -71,7 +71,7 @@ describe("Interactions", () => {
       svg.remove();
     });
 
-    it("calling detach on a detached interaction has no effect", () => {
+    it("calling detachFrom on a detached Interaction has no effect", () => {
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var component = new Plottable.Component();
 
@@ -79,13 +79,13 @@ describe("Interactions", () => {
 
       assert.doesNotThrow(() => {
         clickInteraction.detachFrom(component);
-      }, "Detaching an interaction which was not attached should not throw");
+      }, "detaching an Interaction which was not attached should not throw an error");
 
       clickInteraction.attachTo(component);
       clickInteraction.detachFrom(component);
       assert.doesNotThrow(() => {
         clickInteraction.detachFrom(component);
-      }, "calling detaching a component twice should not throw");
+      }, "calling detachFrom() twice should not throw an error");
 
       component.renderTo(svg);
 
@@ -93,7 +93,7 @@ describe("Interactions", () => {
       clickInteraction.detachFrom(component);
       assert.doesNotThrow(() => {
         clickInteraction.detachFrom(component);
-      }, "calling detaching a component twice should not throw even when attached to SVG");
+      }, "calling detachFrom() twice should not throw an error even if the Component is anchored");
 
       svg.remove();
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -8205,6 +8205,26 @@ describe("Interactions", function () {
             assert.isFalse(callbackCalled, "callback was removed from component and should not be called");
             svg.remove();
         });
+        it("calling detach on a detached interaction has no effect", function () {
+            var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+            var component = new Plottable.Component();
+            var clickInteraction = new Plottable.Interactions.Click();
+            assert.doesNotThrow(function () {
+                clickInteraction.detachFrom(component);
+            }, "Detaching an interaction which was not attached should not throw");
+            clickInteraction.attachTo(component);
+            clickInteraction.detachFrom(component);
+            assert.doesNotThrow(function () {
+                clickInteraction.detachFrom(component);
+            }, "calling detaching a component twice should not throw");
+            component.renderTo(svg);
+            clickInteraction.attachTo(component);
+            clickInteraction.detachFrom(component);
+            assert.doesNotThrow(function () {
+                clickInteraction.detachFrom(component);
+            }, "calling detaching a component twice should not throw even when attached to SVG");
+            svg.remove();
+        });
         it("can move interaction from one component to another", function () {
             var svg1 = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var svg2 = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);

--- a/test/tests.js
+++ b/test/tests.js
@@ -8205,7 +8205,7 @@ describe("Interactions", function () {
             assert.isFalse(callbackCalled, "callback was removed from component and should not be called");
             svg.remove();
         });
-        it("calling detachFrom on a detached Interaction has no effect", function () {
+        it("calling detachFrom() on a detached Interaction has no effect", function () {
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var component = new Plottable.Component();
             var clickInteraction = new Plottable.Interactions.Click();

--- a/test/tests.js
+++ b/test/tests.js
@@ -8205,24 +8205,24 @@ describe("Interactions", function () {
             assert.isFalse(callbackCalled, "callback was removed from component and should not be called");
             svg.remove();
         });
-        it("calling detach on a detached interaction has no effect", function () {
+        it("calling detachFrom on a detached Interaction has no effect", function () {
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var component = new Plottable.Component();
             var clickInteraction = new Plottable.Interactions.Click();
             assert.doesNotThrow(function () {
                 clickInteraction.detachFrom(component);
-            }, "Detaching an interaction which was not attached should not throw");
+            }, "detaching an Interaction which was not attached should not throw an error");
             clickInteraction.attachTo(component);
             clickInteraction.detachFrom(component);
             assert.doesNotThrow(function () {
                 clickInteraction.detachFrom(component);
-            }, "calling detaching a component twice should not throw");
+            }, "calling detachFrom() twice should not throw an error");
             component.renderTo(svg);
             clickInteraction.attachTo(component);
             clickInteraction.detachFrom(component);
             assert.doesNotThrow(function () {
                 clickInteraction.detachFrom(component);
-            }, "calling detaching a component twice should not throw even when attached to SVG");
+            }, "calling detachFrom() twice should not throw an error even if the Component is anchored");
             svg.remove();
         });
         it("can move interaction from one component to another", function () {


### PR DESCRIPTION
Closes #2012
Calling `detachFrom` twice used to throw an error. Fixed the error and added comprehensive testing for the testcase. Waiting for a merge, then opening this up

Before 1: http://jsfiddle.net/zLerabxg/
After 1:http://jsfiddle.net/zLerabxg/2/

Before 2:http://jsfiddle.net/zLerabxg/1/
After 2: http://jsfiddle.net/zLerabxg/3/