### PR TITLE
[Plot] - `project()` has now been named to `attr()`.  Completely reworked.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2569,10 +2569,6 @@ declare module Plottable {
          * @returns {Plot} The calling Plot.
          */
         attr(attrToSet: string, accessor: any, scale?: Scale<any, any>): Plot;
-        /**
-         * Identical to plot.attr
-         */
-        project(attrToSet: string, accessor: any, scale?: Scale<any, any>): Plot;
         protected _bindProperty(property: string, value: any, scale: Scale<any, any>): void;
         protected _generateAttrToProjector(): AttributeToProjector;
         /**
@@ -2846,7 +2842,7 @@ declare module Plottable {
              * @param {string} attrToSet One of ["x", "y", "x2", "y2", "fill"]. If "fill" is used,
              * the data should return a valid CSS color.
              */
-            project(attrToSet: string, accessor: any, scale?: Scale<any, any>): Grid;
+            attr(attrToSet: string, accessor: any, scale?: Scale<any, any>): Grid;
             protected _generateDrawSteps(): Drawers.DrawStep[];
             x(): Plots.AccessorScaleBinding<any, number>;
             x(x: number | _Accessor): Grid;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -44,11 +44,6 @@ declare module Plottable {
              */
             function intersection<T>(set1: D3.Set<T>, set2: D3.Set<T>): D3.Set<string>;
             /**
-             * Take an accessor object (may be a string to be made into a key, or a value, or a color code)
-             * and "activate" it by turning it into a function in (datum, index,  dataset)
-             */
-            function accessorize(accessor: any): _Accessor;
-            /**
              * Takes two sets and returns the union
              *
              * Due to the fact that D3.Sets store strings internally, return type is always a string set
@@ -2545,30 +2540,9 @@ declare module Plottable {
         protected _getDrawer(key: string): Drawers.AbstractDrawer;
         protected _getAnimator(key: string): Animators.PlotAnimator;
         protected _onDatasetUpdate(): void;
-        /**
-         * Sets an attribute of every data point.
-         *
-         * Here's a common use case:
-         * ```typescript
-         * plot.attr("x", function(d) { return d.foo; }, xScale);
-         * ```
-         * This will set the x accessor of each datum `d` to be `d.foo`,
-         * scaled in accordance with `xScale`
-         *
-         * @param {string} attrToSet The attribute to set across each data
-         * point. Popular examples include "x", "y".
-         *
-         * @param {Function|string|any} accessor Function to apply to each element
-         * of the dataSource. If a Function, use `accessor(d, i)`. If a string,
-         * `d[accessor]` is used. If anything else, use `accessor` as a constant
-         * across all data points.
-         *
-         * @param {Scale.Scale} scale If provided, the result of the accessor
-         * is passed through the scale, such as `scale.scale(accessor(d, i))`.
-         *
-         * @returns {Plot} The calling Plot.
-         */
-        attr(attrToSet: string, accessor: any, scale?: Scale<any, any>): Plot;
+        attr<D>(attr: string): Plots.AccessorScaleBinding<D, number | string>;
+        attr(attr: string, attrValue: number | string | _Accessor): Plot;
+        attr<D>(attr: string, attrValue: D | _Accessor, scale: Scale<D, number | string>): Plot;
         protected _bindProperty(property: string, value: any, scale: Scale<any, any>): void;
         protected _generateAttrToProjector(): AttributeToProjector;
         /**
@@ -2835,14 +2809,9 @@ declare module Plottable {
              * @param {Scale.Color|Scale.InterpolatedColor} colorScale The color scale
              * to use for each grid cell.
              */
-            constructor(xScale: Scale<any, any>, yScale: Scale<any, any>, colorScale: Scale<any, string>);
+            constructor(xScale: Scale<any, any>, yScale: Scale<any, any>);
             addDataset(dataset: Dataset): Grid;
             protected _getDrawer(key: string): Drawers.Rect;
-            /**
-             * @param {string} attrToSet One of ["x", "y", "x2", "y2", "fill"]. If "fill" is used,
-             * the data should return a valid CSS color.
-             */
-            attr(attrToSet: string, accessor: any, scale?: Scale<any, any>): Grid;
             protected _generateDrawSteps(): Drawers.DrawStep[];
             x(): Plots.AccessorScaleBinding<any, number>;
             x(x: number | _Accessor): Grid;

--- a/plottable.js
+++ b/plottable.js
@@ -89,23 +89,6 @@ var Plottable;
             }
             Methods.intersection = intersection;
             /**
-             * Take an accessor object (may be a string to be made into a key, or a value, or a color code)
-             * and "activate" it by turning it into a function in (datum, index,  dataset)
-             */
-            function accessorize(accessor) {
-                if (typeof (accessor) === "function") {
-                    return accessor;
-                }
-                else if (typeof (accessor) === "string" && accessor[0] !== "#") {
-                    return function (datum, index, dataset) { return datum[accessor]; };
-                }
-                else {
-                    return function (datum, index, dataset) { return accessor; };
-                }
-                ;
-            }
-            Methods.accessorize = accessorize;
-            /**
              * Takes two sets and returns the union
              *
              * Due to the fact that D3.Sets store strings internally, return type is always a string set
@@ -6288,33 +6271,11 @@ var Plottable;
             this._dataChanged = true;
             this.render();
         };
-        /**
-         * Sets an attribute of every data point.
-         *
-         * Here's a common use case:
-         * ```typescript
-         * plot.attr("x", function(d) { return d.foo; }, xScale);
-         * ```
-         * This will set the x accessor of each datum `d` to be `d.foo`,
-         * scaled in accordance with `xScale`
-         *
-         * @param {string} attrToSet The attribute to set across each data
-         * point. Popular examples include "x", "y".
-         *
-         * @param {Function|string|any} accessor Function to apply to each element
-         * of the dataSource. If a Function, use `accessor(d, i)`. If a string,
-         * `d[accessor]` is used. If anything else, use `accessor` as a constant
-         * across all data points.
-         *
-         * @param {Scale.Scale} scale If provided, the result of the accessor
-         * is passed through the scale, such as `scale.scale(accessor(d, i))`.
-         *
-         * @returns {Plot} The calling Plot.
-         */
-        Plot.prototype.attr = function (attrToSet, accessor, scale) {
-            attrToSet = attrToSet.toLowerCase();
-            accessor = Plottable.Utils.Methods.accessorize(accessor);
-            this._bindAttr(attrToSet, accessor, scale);
+        Plot.prototype.attr = function (attr, attrValue, scale) {
+            if (attrValue == null) {
+                return this._attrBindings.get(attr);
+            }
+            this._bindAttr(attr, attrValue, scale);
             this.render(); // queue a re-render upon changing projector
             return this;
         };
@@ -7233,7 +7194,7 @@ var Plottable;
              * @param {Scale.Color|Scale.InterpolatedColor} colorScale The color scale
              * to use for each grid cell.
              */
-            function Grid(xScale, yScale, colorScale) {
+            function Grid(xScale, yScale) {
                 _super.call(this, xScale, yScale);
                 this.classed("grid-plot", true);
                 // The x and y scales should render in bands with no padding for category scales
@@ -7243,7 +7204,6 @@ var Plottable;
                 if (yScale instanceof Plottable.Scales.Category) {
                     yScale.innerPadding(0).outerPadding(0);
                 }
-                this._colorScale = colorScale;
                 this.animator("cells", new Plottable.Animators.Null());
             }
             Grid.prototype.addDataset = function (dataset) {
@@ -7256,17 +7216,6 @@ var Plottable;
             };
             Grid.prototype._getDrawer = function (key) {
                 return new Plottable.Drawers.Rect(key, true);
-            };
-            /**
-             * @param {string} attrToSet One of ["x", "y", "x2", "y2", "fill"]. If "fill" is used,
-             * the data should return a valid CSS color.
-             */
-            Grid.prototype.attr = function (attrToSet, accessor, scale) {
-                _super.prototype.attr.call(this, attrToSet, accessor, scale);
-                if (attrToSet === "fill") {
-                    this._colorScale = this._attrBindings.get("fill").scale;
-                }
-                return this;
             };
             Grid.prototype._generateDrawSteps = function () {
                 return [{ attrToProjector: this._generateAttrToProjector(), animator: this._getAnimator("cells") }];

--- a/plottable.js
+++ b/plottable.js
@@ -6312,12 +6312,6 @@ var Plottable;
          * @returns {Plot} The calling Plot.
          */
         Plot.prototype.attr = function (attrToSet, accessor, scale) {
-            return this.project(attrToSet, accessor, scale);
-        };
-        /**
-         * Identical to plot.attr
-         */
-        Plot.prototype.project = function (attrToSet, accessor, scale) {
             attrToSet = attrToSet.toLowerCase();
             accessor = Plottable.Utils.Methods.accessorize(accessor);
             this._bindAttr(attrToSet, accessor, scale);
@@ -7267,8 +7261,8 @@ var Plottable;
              * @param {string} attrToSet One of ["x", "y", "x2", "y2", "fill"]. If "fill" is used,
              * the data should return a valid CSS color.
              */
-            Grid.prototype.project = function (attrToSet, accessor, scale) {
-                _super.prototype.project.call(this, attrToSet, accessor, scale);
+            Grid.prototype.attr = function (attrToSet, accessor, scale) {
+                _super.prototype.attr.call(this, attrToSet, accessor, scale);
                 if (attrToSet === "fill") {
                     this._colorScale = this._attrBindings.get("fill").scale;
                 }

--- a/src/components/plots/gridPlot.ts
+++ b/src/components/plots/gridPlot.ts
@@ -51,8 +51,8 @@ export module Plots {
      * @param {string} attrToSet One of ["x", "y", "x2", "y2", "fill"]. If "fill" is used,
      * the data should return a valid CSS color.
      */
-    public project(attrToSet: string, accessor: any, scale?: Scale<any, any>) {
-      super.project(attrToSet, accessor, scale);
+    public attr(attrToSet: string, accessor: any, scale?: Scale<any, any>) {
+      super.attr(attrToSet, accessor, scale);
 
       if (attrToSet === "fill") {
         this._colorScale = this._attrBindings.get("fill").scale;

--- a/src/components/plots/gridPlot.ts
+++ b/src/components/plots/gridPlot.ts
@@ -3,7 +3,6 @@
 module Plottable {
 export module Plots {
   export class Grid extends Rectangle<any, any> {
-    private _colorScale: Scale<any, string>;
 
     /**
      * Constructs a GridPlot.
@@ -17,8 +16,7 @@ export module Plots {
      * @param {Scale.Color|Scale.InterpolatedColor} colorScale The color scale
      * to use for each grid cell.
      */
-    constructor(xScale: Scale<any, any>, yScale: Scale<any, any>,
-      colorScale: Scale<any, string>) {
+    constructor(xScale: Scale<any, any>, yScale: Scale<any, any>) {
       super(xScale, yScale);
       this.classed("grid-plot", true);
 
@@ -30,7 +28,6 @@ export module Plots {
         yScale.innerPadding(0).outerPadding(0);
       }
 
-      this._colorScale = colorScale;
       this.animator("cells", new Animators.Null());
     }
 
@@ -45,20 +42,6 @@ export module Plots {
 
     protected _getDrawer(key: string) {
       return new Drawers.Rect(key, true);
-    }
-
-    /**
-     * @param {string} attrToSet One of ["x", "y", "x2", "y2", "fill"]. If "fill" is used,
-     * the data should return a valid CSS color.
-     */
-    public attr(attrToSet: string, accessor: any, scale?: Scale<any, any>) {
-      super.attr(attrToSet, accessor, scale);
-
-      if (attrToSet === "fill") {
-        this._colorScale = this._attrBindings.get("fill").scale;
-      }
-
-      return this;
     }
 
     protected _generateDrawSteps(): Drawers.DrawStep[] {

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -141,33 +141,14 @@ module Plottable {
       this.render();
     }
 
-    /**
-     * Sets an attribute of every data point.
-     *
-     * Here's a common use case:
-     * ```typescript
-     * plot.attr("x", function(d) { return d.foo; }, xScale);
-     * ```
-     * This will set the x accessor of each datum `d` to be `d.foo`,
-     * scaled in accordance with `xScale`
-     *
-     * @param {string} attrToSet The attribute to set across each data
-     * point. Popular examples include "x", "y".
-     *
-     * @param {Function|string|any} accessor Function to apply to each element
-     * of the dataSource. If a Function, use `accessor(d, i)`. If a string,
-     * `d[accessor]` is used. If anything else, use `accessor` as a constant
-     * across all data points.
-     *
-     * @param {Scale.Scale} scale If provided, the result of the accessor
-     * is passed through the scale, such as `scale.scale(accessor(d, i))`.
-     *
-     * @returns {Plot} The calling Plot.
-     */
-    public attr(attrToSet: string, accessor: any, scale?: Scale<any, any>) {
-      attrToSet = attrToSet.toLowerCase();
-      accessor = Utils.Methods.accessorize(accessor);
-      this._bindAttr(attrToSet, accessor, scale);
+    public attr<D>(attr: string): Plots.AccessorScaleBinding<D, number | string>;
+    public attr(attr: string, attrValue: number | string | _Accessor): Plot;
+    public attr<D>(attr: string, attrValue: D | _Accessor, scale: Scale<D, number | string>): Plot;
+    public attr<D>(attr: string, attrValue?: number | string | _Accessor | D, scale?: Scale<D, number | string>): any {
+      if (attrValue == null) {
+        return this._attrBindings.get(attr);
+      }
+      this._bindAttr(attr, attrValue, scale);
       this.render(); // queue a re-render upon changing projector
       return this;
     }

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -165,13 +165,6 @@ module Plottable {
      * @returns {Plot} The calling Plot.
      */
     public attr(attrToSet: string, accessor: any, scale?: Scale<any, any>) {
-      return this.project(attrToSet, accessor, scale);
-    }
-
-    /**
-     * Identical to plot.attr
-     */
-    public project(attrToSet: string, accessor: any, scale?: Scale<any, any>) {
       attrToSet = attrToSet.toLowerCase();
       accessor = Utils.Methods.accessorize(accessor);
       this._bindAttr(attrToSet, accessor, scale);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -81,20 +81,6 @@ export module Utils {
     }
 
     /**
-     * Take an accessor object (may be a string to be made into a key, or a value, or a color code)
-     * and "activate" it by turning it into a function in (datum, index,  dataset)
-     */
-    export function accessorize(accessor: any): _Accessor {
-      if (typeof(accessor) === "function") {
-        return (<_Accessor> accessor);
-      } else if (typeof(accessor) === "string" && accessor[0] !== "#") {
-        return (datum: any, index: number, dataset: Dataset) => datum[accessor];
-      } else {
-        return (datum: any, index: number, dataset: Dataset) => accessor;
-      };
-    }
-
-    /**
      * Takes two sets and returns the union
      *
      * Due to the fact that D3.Sets store strings internally, return type is always a string set

--- a/test/components/plots/areaPlotTests.ts
+++ b/test/components/plots/areaPlotTests.ts
@@ -51,8 +51,8 @@ describe("Plots", () => {
       areaPlot.x(xAccessor, xScale)
               .y(yAccessor, yScale);
       areaPlot.y0(y0Accessor, yScale)
-              .project("fill", fillAccessor)
-              .project("stroke", colorAccessor)
+              .attr("fill", fillAccessor)
+              .attr("stroke", colorAccessor)
               .renderTo(svg);
       renderArea = (<any> areaPlot)._renderArea;
     });
@@ -167,7 +167,7 @@ describe("Plots", () => {
 
     it("retains original classes when class is projected", () => {
       var newClassProjector = () => "pink";
-      areaPlot.project("class", newClassProjector);
+      areaPlot.attr("class", newClassProjector);
       areaPlot.renderTo(svg);
       var areaPath = renderArea.select("." + Plottable.Drawers.Area.AREA_CLASS);
       assert.isTrue(areaPath.classed("pink"));

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -501,7 +501,7 @@ describe("Plots", () => {
         var bar1 = d3.select(bars[0][1]);
         var bar0y = bar0.data()[0].y;
         var bar1y = bar1.data()[0].y;
-        barPlot.project("width", 10);
+        barPlot.attr("width", 10);
         assert.closeTo(TestMethods.numAttr(bar0, "height"), 10, 0.01, "bar0 height");
         assert.closeTo(TestMethods.numAttr(bar1, "height"), 10, 0.01, "bar1 height");
         assert.closeTo(TestMethods.numAttr(bar0, "width"), 100, 0.01, "bar0 width");

--- a/test/components/plots/gridPlotTests.ts
+++ b/test/components/plots/gridPlotTests.ts
@@ -53,7 +53,7 @@ describe("Plots", () => {
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
       gridPlot.addDataset(new Plottable.Dataset(DATA))
-              .project("fill", "magnitude", colorScale);
+              .attr("fill", "magnitude", colorScale);
       gridPlot.x((d: any) => d.x, xScale)
               .y((d: any) => d.y, yScale);
       gridPlot.renderTo(svg);
@@ -69,7 +69,7 @@ describe("Plots", () => {
       var dataset = new Plottable.Dataset();
       var gridPlot: Plottable.Plots.Grid = new Plottable.Plots.Grid(xScale, yScale, colorScale);
       gridPlot.addDataset(dataset)
-              .project("fill", "magnitude", colorScale);
+              .attr("fill", "magnitude", colorScale);
       gridPlot.x((d: any) => d.x, xScale)
               .y((d: any) => d.y, yScale)
               .renderTo(svg);
@@ -88,7 +88,7 @@ describe("Plots", () => {
       var dataset = new Plottable.Dataset();
       var gridPlot: Plottable.Plots.Grid = new Plottable.Plots.Grid(xScale, yScale, colorScale);
       gridPlot.addDataset(dataset)
-              .project("fill", "magnitude", colorScale);
+              .attr("fill", "magnitude", colorScale);
       gridPlot.x((d: any) => d.x, xScale)
               .y((d: any) => d.y, yScale)
               .renderTo(svg);
@@ -118,7 +118,7 @@ describe("Plots", () => {
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
       gridPlot.addDataset(new Plottable.Dataset(DATA))
-              .project("fill", "magnitude")
+              .attr("fill", "magnitude")
               .x((d: any) => d.x, xScale)
               .y((d: any) => d.y, yScale)
               .renderTo(svg);
@@ -161,7 +161,7 @@ describe("Plots", () => {
         var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
         var dataset = new Plottable.Dataset(DATA);
         gridPlot.addDataset(dataset)
-                .project("fill", "magnitude", colorScale)
+                .attr("fill", "magnitude", colorScale)
                 .x((d: any) => d.x, xScale)
                 .y((d: any) => d.y, yScale);
         gridPlot.renderTo(svg);
@@ -180,7 +180,7 @@ describe("Plots", () => {
         var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
         var dataset = new Plottable.Dataset(DATA);
         gridPlot.addDataset(dataset)
-                .project("fill", "magnitude", colorScale);
+                .attr("fill", "magnitude", colorScale);
         gridPlot.x((d: any) => d.x, xScale)
                 .y((d: any) => d.y, yScale);
         gridPlot.renderTo(svg);
@@ -201,7 +201,7 @@ describe("Plots", () => {
         var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
         var dataset = new Plottable.Dataset(DATA);
         gridPlot.addDataset(dataset)
-          .project("fill", "magnitude", colorScale);
+          .attr("fill", "magnitude", colorScale);
          gridPlot.x((d: any) => d.x, xScale)
           .y((d: any) => d.y, yScale);
         gridPlot.renderTo(svg);

--- a/test/components/plots/gridPlotTests.ts
+++ b/test/components/plots/gridPlotTests.ts
@@ -51,9 +51,9 @@ describe("Plots", () => {
       var yScale = new Plottable.Scales.Category();
       var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
+      var gridPlot = new Plottable.Plots.Grid(xScale, yScale);
       gridPlot.addDataset(new Plottable.Dataset(DATA))
-              .attr("fill", "magnitude", colorScale);
+              .attr("fill", (d) => d.magnitude, colorScale);
       gridPlot.x((d: any) => d.x, xScale)
               .y((d: any) => d.y, yScale);
       gridPlot.renderTo(svg);
@@ -67,9 +67,9 @@ describe("Plots", () => {
       var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var dataset = new Plottable.Dataset();
-      var gridPlot: Plottable.Plots.Grid = new Plottable.Plots.Grid(xScale, yScale, colorScale);
+      var gridPlot: Plottable.Plots.Grid = new Plottable.Plots.Grid(xScale, yScale);
       gridPlot.addDataset(dataset)
-              .attr("fill", "magnitude", colorScale);
+              .attr("fill", (d) => d.magnitude, colorScale);
       gridPlot.x((d: any) => d.x, xScale)
               .y((d: any) => d.y, yScale)
               .renderTo(svg);
@@ -86,9 +86,9 @@ describe("Plots", () => {
       var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var dataset = new Plottable.Dataset();
-      var gridPlot: Plottable.Plots.Grid = new Plottable.Plots.Grid(xScale, yScale, colorScale);
+      var gridPlot: Plottable.Plots.Grid = new Plottable.Plots.Grid(xScale, yScale);
       gridPlot.addDataset(dataset)
-              .attr("fill", "magnitude", colorScale);
+              .attr("fill", (d) => d.magnitude, colorScale);
       gridPlot.x((d: any) => d.x, xScale)
               .y((d: any) => d.y, yScale)
               .renderTo(svg);
@@ -116,10 +116,10 @@ describe("Plots", () => {
       var yScale = new Plottable.Scales.Category();
       var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
+      var gridPlot = new Plottable.Plots.Grid(xScale, yScale);
       gridPlot.addDataset(new Plottable.Dataset(DATA))
-              .attr("fill", "magnitude")
-              .x((d: any) => d.x, xScale)
+              .attr("fill", (d) => d.magnitude, colorScale);
+      gridPlot.x((d: any) => d.x, xScale)
               .y((d: any) => d.y, yScale)
               .renderTo(svg);
 
@@ -158,11 +158,11 @@ describe("Plots", () => {
         var yScale = new Plottable.Scales.Category();
         var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
         var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
+        var gridPlot = new Plottable.Plots.Grid(xScale, yScale);
         var dataset = new Plottable.Dataset(DATA);
         gridPlot.addDataset(dataset)
-                .attr("fill", "magnitude", colorScale)
-                .x((d: any) => d.x, xScale)
+                .attr("fill", (d) => d.magnitude, colorScale);
+        gridPlot.x((d: any) => d.x, xScale)
                 .y((d: any) => d.y, yScale);
         gridPlot.renderTo(svg);
 
@@ -177,10 +177,10 @@ describe("Plots", () => {
         var yScale = new Plottable.Scales.Category();
         var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
         var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
+        var gridPlot = new Plottable.Plots.Grid(xScale, yScale);
         var dataset = new Plottable.Dataset(DATA);
         gridPlot.addDataset(dataset)
-                .attr("fill", "magnitude", colorScale);
+                .attr("fill", (d) => d.magnitude, colorScale);
         gridPlot.x((d: any) => d.x, xScale)
                 .y((d: any) => d.y, yScale);
         gridPlot.renderTo(svg);
@@ -198,10 +198,10 @@ describe("Plots", () => {
         var yScale = new Plottable.Scales.Category();
         var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
         var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
+        var gridPlot = new Plottable.Plots.Grid(xScale, yScale);
         var dataset = new Plottable.Dataset(DATA);
         gridPlot.addDataset(dataset)
-          .attr("fill", "magnitude", colorScale);
+          .attr("fill", (d) => d.magnitude, colorScale);
          gridPlot.x((d: any) => d.x, xScale)
           .y((d: any) => d.y, yScale);
         gridPlot.renderTo(svg);

--- a/test/components/plots/linePlotTests.ts
+++ b/test/components/plots/linePlotTests.ts
@@ -77,7 +77,7 @@ describe("Plots", () => {
       linePlot.addDataset(simpleDataset);
       linePlot.x(xAccessor, xScale)
               .y(yAccessor, yScale)
-              .project("stroke", colorAccessor)
+              .attr("stroke", colorAccessor)
               .renderTo(svg);
       renderArea = (<any> linePlot)._renderArea;
     });
@@ -98,7 +98,7 @@ describe("Plots", () => {
 
     it("attributes can be changed by projecting new accessor and re-render appropriately", () => {
       var newColorAccessor = () => "pink";
-      linePlot.project("stroke", newColorAccessor);
+      linePlot.attr("stroke", newColorAccessor);
       linePlot.renderTo(svg);
       var linePath = renderArea.select(".line");
       assert.strictEqual(linePath.attr("stroke"), "pink", "stroke changed correctly");
@@ -109,7 +109,7 @@ describe("Plots", () => {
       var data = JSON.parse(JSON.stringify(twoPointData)); // deep copy to not affect other tests
       data.forEach(function(d: any) { d.stroke = "pink"; });
       simpleDataset.data(data);
-      linePlot.project("stroke", "stroke");
+      linePlot.attr("stroke", "stroke");
       var areaPath = renderArea.select(".line");
       assert.strictEqual(areaPath.attr("stroke"), "pink", "stroke set to uniform stroke color");
 
@@ -317,7 +317,7 @@ describe("Plots", () => {
 
     it("retains original classes when class is projected", () => {
       var newClassProjector = () => "pink";
-      linePlot.project("class", newClassProjector);
+      linePlot.attr("class", newClassProjector);
       linePlot.renderTo(svg);
       var linePath = renderArea.select("." + Plottable.Drawers.Line.LINE_CLASS);
       assert.isTrue(linePath.classed("pink"));

--- a/test/components/plots/linePlotTests.ts
+++ b/test/components/plots/linePlotTests.ts
@@ -109,7 +109,7 @@ describe("Plots", () => {
       var data = JSON.parse(JSON.stringify(twoPointData)); // deep copy to not affect other tests
       data.forEach(function(d: any) { d.stroke = "pink"; });
       simpleDataset.data(data);
-      linePlot.attr("stroke", "stroke");
+      linePlot.attr("stroke", (d) => d.stroke);
       var areaPath = renderArea.select(".line");
       assert.strictEqual(areaPath.attr("stroke"), "pink", "stroke set to uniform stroke color");
 

--- a/test/components/plots/piePlotTests.ts
+++ b/test/components/plots/piePlotTests.ts
@@ -182,7 +182,7 @@ describe("Plots", () => {
       });
 
       it("project fill", () => {
-        piePlot.project("fill", (d: any, i: number) => String(i), new Plottable.Scales.Color("10"));
+        piePlot.attr("fill", (d: any, i: number) => String(i), new Plottable.Scales.Color("10"));
 
         var arcPaths = renderArea.selectAll(".arc");
 
@@ -192,7 +192,7 @@ describe("Plots", () => {
         var arcPath1 = d3.select(arcPaths[0][1]);
         assert.strictEqual(arcPath1.attr("fill"), "#ff7f0e", "second sector filled appropriately");
 
-        piePlot.project("fill", "type", new Plottable.Scales.Color("20"));
+        piePlot.attr("fill", "type", new Plottable.Scales.Color("20"));
 
         arcPaths = renderArea.selectAll(".arc");
 

--- a/test/components/plots/piePlotTests.ts
+++ b/test/components/plots/piePlotTests.ts
@@ -192,7 +192,7 @@ describe("Plots", () => {
         var arcPath1 = d3.select(arcPaths[0][1]);
         assert.strictEqual(arcPath1.attr("fill"), "#ff7f0e", "second sector filled appropriately");
 
-        piePlot.attr("fill", "type", new Plottable.Scales.Color("20"));
+        piePlot.attr("fill", (d) => d.type, new Plottable.Scales.Color("20"));
 
         arcPaths = renderArea.selectAll(".arc");
 

--- a/test/components/plots/plotTests.ts
+++ b/test/components/plots/plotTests.ts
@@ -83,8 +83,8 @@ describe("Plots", () => {
       var xScale = new Plottable.Scales.Linear();
       var yScale = new Plottable.Scales.Linear();
       var metadataProjector = (d: any, i: number, m: any) => m.cssClass;
-      r.attr("x", "x", xScale);
-      r.attr("y", "y", yScale);
+      r.attr("x", (d) => d.x, xScale);
+      r.attr("y", (d) => d.y, yScale);
       r.attr("meta", metadataProjector);
       xScale.onUpdate((listenable: Plottable.Scales.Linear) => {
         assert.strictEqual(listenable, xScale, "Callback received the calling scale as the first argument");
@@ -121,7 +121,7 @@ describe("Plots", () => {
     it("Plot.project works as intended", () => {
       var r = new Plottable.Plot();
       var s = new Plottable.Scales.Linear().domain([0, 1]).range([0, 10]);
-      r.attr("attr", "a", s);
+      r.attr("attr", (d) => d.a, s);
       var attrToProjector = (<any> r)._generateAttrToProjector();
       var projector = attrToProjector["attr"];
       assert.strictEqual(projector({"a": 0.5}, 0, null, null), 5, "projector works as intended");
@@ -386,7 +386,7 @@ describe("Plots", () => {
     it("destroy() disconnects plots from its scales", () => {
       var plot2 = new Plottable.Plot();
       var scale = new Plottable.Scales.Linear();
-      plot2.attr("attr", "a", scale);
+      plot2.attr("attr", (d) => d.a, scale);
       plot2.destroy();
       var scaleCallbacks = (<any> scale)._callbacks.values();
       assert.strictEqual(scaleCallbacks.length, 0, "the plot is no longer attached to the scale");
@@ -460,7 +460,7 @@ describe("Plots", () => {
       var plot = new Plottable.Plot();
       plot.addDataset(dataset2);
       plot.addDataset(dataset1);
-      plot.attr("key", "key", categoryScale);
+      plot.attr("key", (d) => d.key, categoryScale);
 
       var svg = TestMethods.generateSVG();
       plot.renderTo(svg);

--- a/test/components/plots/plotTests.ts
+++ b/test/components/plots/plotTests.ts
@@ -83,9 +83,9 @@ describe("Plots", () => {
       var xScale = new Plottable.Scales.Linear();
       var yScale = new Plottable.Scales.Linear();
       var metadataProjector = (d: any, i: number, m: any) => m.cssClass;
-      r.project("x", "x", xScale);
-      r.project("y", "y", yScale);
-      r.project("meta", metadataProjector);
+      r.attr("x", "x", xScale);
+      r.attr("y", "y", yScale);
+      r.attr("meta", metadataProjector);
       xScale.onUpdate((listenable: Plottable.Scales.Linear) => {
         assert.strictEqual(listenable, xScale, "Callback received the calling scale as the first argument");
         ++xScaleCalls;
@@ -121,7 +121,7 @@ describe("Plots", () => {
     it("Plot.project works as intended", () => {
       var r = new Plottable.Plot();
       var s = new Plottable.Scales.Linear().domain([0, 1]).range([0, 10]);
-      r.project("attr", "a", s);
+      r.attr("attr", "a", s);
       var attrToProjector = (<any> r)._generateAttrToProjector();
       var projector = attrToProjector["attr"];
       assert.strictEqual(projector({"a": 0.5}, 0, null, null), 5, "projector works as intended");
@@ -135,11 +135,11 @@ describe("Plots", () => {
       var svg2 = TestMethods.generateSVG(100, 100);
       new Plottable.Plot()
         .addDataset(ds1)
-        .project("x", (x: number) => x, s)
+        .attr("x", (x: number) => x, s)
         .renderTo(svg1);
       new Plottable.Plot()
         .addDataset(ds2)
-        .project("x", (x: number) => x, s)
+        .attr("x", (x: number) => x, s)
         .renderTo(svg2);
       assert.deepEqual(s.domain(), [0, 3], "Simple domain combining");
       ds1.data([]);
@@ -386,7 +386,7 @@ describe("Plots", () => {
     it("destroy() disconnects plots from its scales", () => {
       var plot2 = new Plottable.Plot();
       var scale = new Plottable.Scales.Linear();
-      plot2.project("attr", "a", scale);
+      plot2.attr("attr", "a", scale);
       plot2.destroy();
       var scaleCallbacks = (<any> scale)._callbacks.values();
       assert.strictEqual(scaleCallbacks.length, 0, "the plot is no longer attached to the scale");
@@ -460,7 +460,7 @@ describe("Plots", () => {
       var plot = new Plottable.Plot();
       plot.addDataset(dataset2);
       plot.addDataset(dataset1);
-      plot.project("key", "key", categoryScale);
+      plot.attr("key", "key", categoryScale);
 
       var svg = TestMethods.generateSVG();
       plot.renderTo(svg);

--- a/test/components/plots/rectanglePlotTests.ts
+++ b/test/components/plots/rectanglePlotTests.ts
@@ -58,9 +58,8 @@ describe("Plots", () => {
 
       var xScale = new Plottable.Scales.Category();
       var yScale = new Plottable.Scales.Linear();
-      var cScale = new Plottable.Scales.Color();
 
-      var plot = new Plottable.Plots.Grid(xScale, yScale, cScale);
+      var plot = new Plottable.Plots.Grid(xScale, yScale);
       plot
         .x((d: any) => d.x, xScale)
         .y((d: any) => d.y1, yScale)

--- a/test/components/plots/scatterPlotTests.ts
+++ b/test/components/plots/scatterPlotTests.ts
@@ -221,7 +221,7 @@ describe("Plots", () => {
         yScale = new Plottable.Scales.Linear().domain([0, 81]);
         circlePlot = new Plottable.Plots.Scatter(xScale, yScale);
         circlePlot.addDataset(quadraticDataset);
-        circlePlot.project("fill", colorAccessor);
+        circlePlot.attr("fill", colorAccessor);
         circlePlot.x((d) => d.x, xScale);
         circlePlot.y((d) => d.y, yScale);
         circlePlot.renderTo(svg);

--- a/test/components/plots/stackedAreaPlotTests.ts
+++ b/test/components/plots/stackedAreaPlotTests.ts
@@ -35,7 +35,7 @@ describe("Plots", () => {
       renderer.addDataset(dataset2);
       renderer.x((d) => d.x, xScale);
       renderer.y((d) => d.y, yScale);
-      renderer.project("fill", "type", colorScale);
+      renderer.attr("fill", "type", colorScale);
       var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
       new Plottable.Components.Table([[renderer], [xAxis]]).renderTo(svg);
     });
@@ -82,7 +82,7 @@ describe("Plots", () => {
       renderer = new Plottable.Plots.StackedArea(xScale, yScale);
       renderer.addDataset(new Plottable.Dataset(data1));
       renderer.addDataset(new Plottable.Dataset(data2));
-      renderer.project("fill", "type", colorScale);
+      renderer.attr("fill", "type", colorScale);
       renderer.x((d) => d.x, xScale);
       renderer.y((d) => d.y, yScale);
       new Plottable.Components.Table([[renderer]]).renderTo(svg);
@@ -128,7 +128,7 @@ describe("Plots", () => {
       renderer = new Plottable.Plots.StackedArea(xScale, yScale);
       renderer.addDataset(new Plottable.Dataset(data1));
       renderer.addDataset(new Plottable.Dataset(data2));
-      renderer.project("fill", "type", colorScale);
+      renderer.attr("fill", "type", colorScale);
       renderer.x((d) => d.x, xScale);
       renderer.y((d) => d.y, yScale);
       renderer.renderTo(svg);
@@ -342,7 +342,7 @@ describe("Plots", () => {
       renderer.x((d) => d.x, xScale);
       renderer.addDataset(new Plottable.Dataset(data1));
       renderer.addDataset(new Plottable.Dataset(data2));
-      renderer.project("fill", "type", colorScale);
+      renderer.attr("fill", "type", colorScale);
       var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
       new Plottable.Components.Table([[renderer], [xAxis]]).renderTo(svg);
     });
@@ -366,7 +366,7 @@ describe("Plots", () => {
     });
 
     it("project works correctly", () => {
-      renderer.project("check", "type");
+      renderer.attr("check", "type");
       var areas = (<any> renderer)._renderArea.selectAll(".area");
       var area0 = d3.select(areas[0][0]);
       assert.strictEqual(area0.attr("check"), "a", "projector has been applied to first area");
@@ -405,7 +405,7 @@ describe("Plots", () => {
       plot.addDataset(dataset1);
       var dataset2 = new Plottable.Dataset(data2);
       plot.addDataset(dataset2);
-      plot.project("fill", "fill");
+      plot.attr("fill", "fill");
       plot.x((d) => d.x, xScale).y((d) => d.y, yScale);
 
       var ds0Point2Offset = (<any> plot)._key2PlotDatasetKey.get("_0").plotMetadata.offsets.get(2);
@@ -446,7 +446,7 @@ describe("Plots", () => {
       plot.addDataset(dataset1);
       var dataset2 = new Plottable.Dataset(data2);
       plot.addDataset(dataset2);
-      plot.project("fill", "fill");
+      plot.attr("fill", "fill");
       plot.x((d) => d.x, xScale).y((d) => d.y, yScale);
 
       var ds0Point2Offset = (<any> plot)._key2PlotDatasetKey.get("_0").plotMetadata.offsets.get(2);

--- a/test/components/plots/stackedAreaPlotTests.ts
+++ b/test/components/plots/stackedAreaPlotTests.ts
@@ -342,7 +342,7 @@ describe("Plots", () => {
       renderer.x((d) => d.x, xScale);
       renderer.addDataset(new Plottable.Dataset(data1));
       renderer.addDataset(new Plottable.Dataset(data2));
-      renderer.attr("fill", "type", colorScale);
+      renderer.attr("fill", (d) => d.type, colorScale);
       var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
       new Plottable.Components.Table([[renderer], [xAxis]]).renderTo(svg);
     });
@@ -366,7 +366,7 @@ describe("Plots", () => {
     });
 
     it("project works correctly", () => {
-      renderer.attr("check", "type");
+      renderer.attr("check", (d) => d.type);
       var areas = (<any> renderer)._renderArea.selectAll(".area");
       var area0 = d3.select(areas[0][0]);
       assert.strictEqual(area0.attr("check"), "a", "projector has been applied to first area");

--- a/test/components/plots/stackedBarPlotTests.ts
+++ b/test/components/plots/stackedBarPlotTests.ts
@@ -420,7 +420,7 @@ describe("Plots", () => {
       var plot = new Plottable.Plots.StackedBar(xScale, yScale);
       plot.addDataset(new Plottable.Dataset(data1));
       plot.addDataset(new Plottable.Dataset(data2));
-      plot.project("fill", "fill");
+      plot.attr("fill", "fill");
       plot.x((d) => d.x, xScale).y((d) => d.y, yScale);
 
       var ds1FirstColumnOffset = (<any> plot)._key2PlotDatasetKey.get("_0").plotMetadata.offsets.get("A");
@@ -459,7 +459,7 @@ describe("Plots", () => {
       plot.addDataset(new Plottable.Dataset(data3));
       plot.addDataset(new Plottable.Dataset(data4));
       plot.addDataset(new Plottable.Dataset(data5));
-      plot.project("fill", "fill");
+      plot.attr("fill", "fill");
       plot.x((d) => d.x, xScale).y((d) => d.y, yScale);
 
       var keys = (<any> plot)._key2PlotDatasetKey.keys();

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -73,7 +73,7 @@ describe("Scales", () => {
       var svg = TestMethods.generateSVG(100, 100);
       new Plottable.Plot()
         .addDataset(dataset)
-        .attr("x", "foo", scale)
+        .attr("x", (d) => d.foo, scale)
         .renderTo(svg);
       assert.deepEqual(scale.domain(), [0, 5], "scale domain was autoranged properly");
       data.push({foo: 100, bar: 200});
@@ -87,17 +87,17 @@ describe("Scales", () => {
       var svg2 = TestMethods.generateSVG(100, 100);
       var renderer1 = new Plottable.Plot()
                           .addDataset(dataset)
-                          .attr("x", "foo", scale);
+                          .attr("x", (d) => d.foo, scale);
       renderer1.renderTo(svg1);
       var renderer2 = new Plottable.Plot()
                           .addDataset(dataset)
-                          .attr("x", "foo", scale);
+                          .attr("x", (d) => d.foo, scale);
       renderer2.renderTo(svg2);
       var otherScale = new Plottable.Scales.Linear();
-      renderer1.attr("x", "foo", otherScale);
+      renderer1.attr("x", (d) => d.foo, otherScale);
       dataset.data([{foo: 10}, {foo: 11}]);
       assert.deepEqual(scale.domain(), [10, 11], "scale was still listening to dataset after one perspective deregistered");
-      renderer2.attr("x", "foo", otherScale);
+      renderer2.attr("x", (d) => d.foo, otherScale);
       // "scale not listening to the dataset after all perspectives removed"
       dataset.data([{foo: 99}, {foo: 100}]);
       assert.deepEqual(scale.domain(), [0, 1], "scale shows default values when all perspectives removed");

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -73,7 +73,7 @@ describe("Scales", () => {
       var svg = TestMethods.generateSVG(100, 100);
       new Plottable.Plot()
         .addDataset(dataset)
-        .project("x", "foo", scale)
+        .attr("x", "foo", scale)
         .renderTo(svg);
       assert.deepEqual(scale.domain(), [0, 5], "scale domain was autoranged properly");
       data.push({foo: 100, bar: 200});
@@ -87,17 +87,17 @@ describe("Scales", () => {
       var svg2 = TestMethods.generateSVG(100, 100);
       var renderer1 = new Plottable.Plot()
                           .addDataset(dataset)
-                          .project("x", "foo", scale);
+                          .attr("x", "foo", scale);
       renderer1.renderTo(svg1);
       var renderer2 = new Plottable.Plot()
                           .addDataset(dataset)
-                          .project("x", "foo", scale);
+                          .attr("x", "foo", scale);
       renderer2.renderTo(svg2);
       var otherScale = new Plottable.Scales.Linear();
-      renderer1.project("x", "foo", otherScale);
+      renderer1.attr("x", "foo", otherScale);
       dataset.data([{foo: 10}, {foo: 11}]);
       assert.deepEqual(scale.domain(), [10, 11], "scale was still listening to dataset after one perspective deregistered");
-      renderer2.project("x", "foo", otherScale);
+      renderer2.attr("x", "foo", otherScale);
       // "scale not listening to the dataset after all perspectives removed"
       dataset.data([{foo: 99}, {foo: 100}]);
       assert.deepEqual(scale.domain(), [0, 1], "scale shows default values when all perspectives removed");

--- a/test/tests.js
+++ b/test/tests.js
@@ -2152,9 +2152,9 @@ describe("Plots", function () {
             var xScale = new Plottable.Scales.Linear();
             var yScale = new Plottable.Scales.Linear();
             var metadataProjector = function (d, i, m) { return m.cssClass; };
-            r.project("x", "x", xScale);
-            r.project("y", "y", yScale);
-            r.project("meta", metadataProjector);
+            r.attr("x", "x", xScale);
+            r.attr("y", "y", yScale);
+            r.attr("meta", metadataProjector);
             xScale.onUpdate(function (listenable) {
                 assert.strictEqual(listenable, xScale, "Callback received the calling scale as the first argument");
                 ++xScaleCalls;
@@ -2183,7 +2183,7 @@ describe("Plots", function () {
         it("Plot.project works as intended", function () {
             var r = new Plottable.Plot();
             var s = new Plottable.Scales.Linear().domain([0, 1]).range([0, 10]);
-            r.project("attr", "a", s);
+            r.attr("attr", "a", s);
             var attrToProjector = r._generateAttrToProjector();
             var projector = attrToProjector["attr"];
             assert.strictEqual(projector({ "a": 0.5 }, 0, null, null), 5, "projector works as intended");
@@ -2194,8 +2194,8 @@ describe("Plots", function () {
             var s = new Plottable.Scales.Linear();
             var svg1 = TestMethods.generateSVG(100, 100);
             var svg2 = TestMethods.generateSVG(100, 100);
-            new Plottable.Plot().addDataset(ds1).project("x", function (x) { return x; }, s).renderTo(svg1);
-            new Plottable.Plot().addDataset(ds2).project("x", function (x) { return x; }, s).renderTo(svg2);
+            new Plottable.Plot().addDataset(ds1).attr("x", function (x) { return x; }, s).renderTo(svg1);
+            new Plottable.Plot().addDataset(ds2).attr("x", function (x) { return x; }, s).renderTo(svg2);
             assert.deepEqual(s.domain(), [0, 3], "Simple domain combining");
             ds1.data([]);
             assert.deepEqual(s.domain(), [1, 3], "Contracting domain due to projection becoming empty");
@@ -2410,7 +2410,7 @@ describe("Plots", function () {
         it("destroy() disconnects plots from its scales", function () {
             var plot2 = new Plottable.Plot();
             var scale = new Plottable.Scales.Linear();
-            plot2.project("attr", "a", scale);
+            plot2.attr("attr", "a", scale);
             plot2.destroy();
             var scaleCallbacks = scale._callbacks.values();
             assert.strictEqual(scaleCallbacks.length, 0, "the plot is no longer attached to the scale");
@@ -2472,7 +2472,7 @@ describe("Plots", function () {
             var plot = new Plottable.Plot();
             plot.addDataset(dataset2);
             plot.addDataset(dataset1);
-            plot.project("key", "key", categoryScale);
+            plot.attr("key", "key", categoryScale);
             var svg = TestMethods.generateSVG();
             plot.renderTo(svg);
             assert.deepEqual(categoryScale.domain(), ["B", "A"], "extent is in the right order");
@@ -2716,13 +2716,13 @@ describe("Plots", function () {
                 svg.remove();
             });
             it("project fill", function () {
-                piePlot.project("fill", function (d, i) { return String(i); }, new Plottable.Scales.Color("10"));
+                piePlot.attr("fill", function (d, i) { return String(i); }, new Plottable.Scales.Color("10"));
                 var arcPaths = renderArea.selectAll(".arc");
                 var arcPath0 = d3.select(arcPaths[0][0]);
                 assert.strictEqual(arcPath0.attr("fill"), "#1f77b4", "first sector filled appropriately");
                 var arcPath1 = d3.select(arcPaths[0][1]);
                 assert.strictEqual(arcPath1.attr("fill"), "#ff7f0e", "second sector filled appropriately");
-                piePlot.project("fill", "type", new Plottable.Scales.Color("20"));
+                piePlot.attr("fill", "type", new Plottable.Scales.Color("20"));
                 arcPaths = renderArea.selectAll(".arc");
                 arcPath0 = d3.select(arcPaths[0][0]);
                 assert.strictEqual(arcPath0.attr("fill"), "#1f77b4", "first sector filled appropriately");
@@ -2850,7 +2850,7 @@ describe("Plots", function () {
             simpleDataset = new Plottable.Dataset(twoPointData);
             linePlot = new Plottable.Plots.Line(xScale, yScale);
             linePlot.addDataset(simpleDataset);
-            linePlot.x(xAccessor, xScale).y(yAccessor, yScale).project("stroke", colorAccessor).renderTo(svg);
+            linePlot.x(xAccessor, xScale).y(yAccessor, yScale).attr("stroke", colorAccessor).renderTo(svg);
             renderArea = linePlot._renderArea;
         });
         it("draws a line correctly", function () {
@@ -2867,7 +2867,7 @@ describe("Plots", function () {
         });
         it("attributes can be changed by projecting new accessor and re-render appropriately", function () {
             var newColorAccessor = function () { return "pink"; };
-            linePlot.project("stroke", newColorAccessor);
+            linePlot.attr("stroke", newColorAccessor);
             linePlot.renderTo(svg);
             var linePath = renderArea.select(".line");
             assert.strictEqual(linePath.attr("stroke"), "pink", "stroke changed correctly");
@@ -2879,7 +2879,7 @@ describe("Plots", function () {
                 d.stroke = "pink";
             });
             simpleDataset.data(data);
-            linePlot.project("stroke", "stroke");
+            linePlot.attr("stroke", "stroke");
             var areaPath = renderArea.select(".line");
             assert.strictEqual(areaPath.attr("stroke"), "pink", "stroke set to uniform stroke color");
             data[0].stroke = "green";
@@ -3047,7 +3047,7 @@ describe("Plots", function () {
         });
         it("retains original classes when class is projected", function () {
             var newClassProjector = function () { return "pink"; };
-            linePlot.project("class", newClassProjector);
+            linePlot.attr("class", newClassProjector);
             linePlot.renderTo(svg);
             var linePath = renderArea.select("." + Plottable.Drawers.Line.LINE_CLASS);
             assert.isTrue(linePath.classed("pink"));
@@ -3103,7 +3103,7 @@ describe("Plots", function () {
             areaPlot = new Plottable.Plots.Area(xScale, yScale);
             areaPlot.addDataset(simpleDataset);
             areaPlot.x(xAccessor, xScale).y(yAccessor, yScale);
-            areaPlot.y0(y0Accessor, yScale).project("fill", fillAccessor).project("stroke", colorAccessor).renderTo(svg);
+            areaPlot.y0(y0Accessor, yScale).attr("fill", fillAccessor).attr("stroke", colorAccessor).renderTo(svg);
             renderArea = areaPlot._renderArea;
         });
         it("draws area and line correctly", function () {
@@ -3195,7 +3195,7 @@ describe("Plots", function () {
         });
         it("retains original classes when class is projected", function () {
             var newClassProjector = function () { return "pink"; };
-            areaPlot.project("class", newClassProjector);
+            areaPlot.attr("class", newClassProjector);
             areaPlot.renderTo(svg);
             var areaPath = renderArea.select("." + Plottable.Drawers.Area.AREA_CLASS);
             assert.isTrue(areaPath.classed("pink"));
@@ -3629,7 +3629,7 @@ describe("Plots", function () {
                 var bar1 = d3.select(bars[0][1]);
                 var bar0y = bar0.data()[0].y;
                 var bar1y = bar1.data()[0].y;
-                barPlot.project("width", 10);
+                barPlot.attr("width", 10);
                 assert.closeTo(TestMethods.numAttr(bar0, "height"), 10, 0.01, "bar0 height");
                 assert.closeTo(TestMethods.numAttr(bar1, "height"), 10, 0.01, "bar1 height");
                 assert.closeTo(TestMethods.numAttr(bar0, "width"), 100, 0.01, "bar0 width");
@@ -3921,7 +3921,7 @@ describe("Plots", function () {
             var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
-            gridPlot.addDataset(new Plottable.Dataset(DATA)).project("fill", "magnitude", colorScale);
+            gridPlot.addDataset(new Plottable.Dataset(DATA)).attr("fill", "magnitude", colorScale);
             gridPlot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale);
             gridPlot.renderTo(svg);
             VERIFY_CELLS(gridPlot._renderArea.selectAll("rect")[0]);
@@ -3934,7 +3934,7 @@ describe("Plots", function () {
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var dataset = new Plottable.Dataset();
             var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
-            gridPlot.addDataset(dataset).project("fill", "magnitude", colorScale);
+            gridPlot.addDataset(dataset).attr("fill", "magnitude", colorScale);
             gridPlot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).renderTo(svg);
             dataset.data(DATA);
             VERIFY_CELLS(gridPlot._renderArea.selectAll("rect")[0]);
@@ -3949,7 +3949,7 @@ describe("Plots", function () {
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var dataset = new Plottable.Dataset();
             var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
-            gridPlot.addDataset(dataset).project("fill", "magnitude", colorScale);
+            gridPlot.addDataset(dataset).attr("fill", "magnitude", colorScale);
             gridPlot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).renderTo(svg);
             var data = [
                 { x: "A", y: "W", magnitude: 0 },
@@ -3975,7 +3975,7 @@ describe("Plots", function () {
             var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
-            gridPlot.addDataset(new Plottable.Dataset(DATA)).project("fill", "magnitude").x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).renderTo(svg);
+            gridPlot.addDataset(new Plottable.Dataset(DATA)).attr("fill", "magnitude").x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).renderTo(svg);
             yScale.domain(["U", "V"]);
             var cells = gridPlot._renderArea.selectAll("rect")[0];
             var cellAU = d3.select(cells[0]);
@@ -4006,7 +4006,7 @@ describe("Plots", function () {
                 var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
                 var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
                 var dataset = new Plottable.Dataset(DATA);
-                gridPlot.addDataset(dataset).project("fill", "magnitude", colorScale).x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale);
+                gridPlot.addDataset(dataset).attr("fill", "magnitude", colorScale).x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale);
                 gridPlot.renderTo(svg);
                 var allCells = gridPlot.getAllSelections();
                 assert.strictEqual(allCells.size(), 4, "all cells retrieved");
@@ -4019,7 +4019,7 @@ describe("Plots", function () {
                 var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
                 var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
                 var dataset = new Plottable.Dataset(DATA);
-                gridPlot.addDataset(dataset).project("fill", "magnitude", colorScale);
+                gridPlot.addDataset(dataset).attr("fill", "magnitude", colorScale);
                 gridPlot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale);
                 gridPlot.renderTo(svg);
                 var allCells = gridPlot.getAllSelections([dataset]);
@@ -4035,7 +4035,7 @@ describe("Plots", function () {
                 var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
                 var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
                 var dataset = new Plottable.Dataset(DATA);
-                gridPlot.addDataset(dataset).project("fill", "magnitude", colorScale);
+                gridPlot.addDataset(dataset).attr("fill", "magnitude", colorScale);
                 gridPlot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale);
                 gridPlot.renderTo(svg);
                 var dummyDataset = new Plottable.Dataset([]);
@@ -4302,7 +4302,7 @@ describe("Plots", function () {
                 yScale = new Plottable.Scales.Linear().domain([0, 81]);
                 circlePlot = new Plottable.Plots.Scatter(xScale, yScale);
                 circlePlot.addDataset(quadraticDataset);
-                circlePlot.project("fill", colorAccessor);
+                circlePlot.attr("fill", colorAccessor);
                 circlePlot.x(function (d) { return d.x; }, xScale);
                 circlePlot.y(function (d) { return d.y; }, yScale);
                 circlePlot.renderTo(svg);
@@ -4639,7 +4639,7 @@ describe("Plots", function () {
             renderer.addDataset(dataset2);
             renderer.x(function (d) { return d.x; }, xScale);
             renderer.y(function (d) { return d.y; }, yScale);
-            renderer.project("fill", "type", colorScale);
+            renderer.attr("fill", "type", colorScale);
             var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
             new Plottable.Components.Table([[renderer], [xAxis]]).renderTo(svg);
         });
@@ -4678,7 +4678,7 @@ describe("Plots", function () {
             renderer = new Plottable.Plots.StackedArea(xScale, yScale);
             renderer.addDataset(new Plottable.Dataset(data1));
             renderer.addDataset(new Plottable.Dataset(data2));
-            renderer.project("fill", "type", colorScale);
+            renderer.attr("fill", "type", colorScale);
             renderer.x(function (d) { return d.x; }, xScale);
             renderer.y(function (d) { return d.y; }, yScale);
             new Plottable.Components.Table([[renderer]]).renderTo(svg);
@@ -4716,7 +4716,7 @@ describe("Plots", function () {
             renderer = new Plottable.Plots.StackedArea(xScale, yScale);
             renderer.addDataset(new Plottable.Dataset(data1));
             renderer.addDataset(new Plottable.Dataset(data2));
-            renderer.project("fill", "type", colorScale);
+            renderer.attr("fill", "type", colorScale);
             renderer.x(function (d) { return d.x; }, xScale);
             renderer.y(function (d) { return d.y; }, yScale);
             renderer.renderTo(svg);
@@ -4894,7 +4894,7 @@ describe("Plots", function () {
             renderer.x(function (d) { return d.x; }, xScale);
             renderer.addDataset(new Plottable.Dataset(data1));
             renderer.addDataset(new Plottable.Dataset(data2));
-            renderer.project("fill", "type", colorScale);
+            renderer.attr("fill", "type", colorScale);
             var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
             new Plottable.Components.Table([[renderer], [xAxis]]).renderTo(svg);
         });
@@ -4914,7 +4914,7 @@ describe("Plots", function () {
             svg.remove();
         });
         it("project works correctly", function () {
-            renderer.project("check", "type");
+            renderer.attr("check", "type");
             var areas = renderer._renderArea.selectAll(".area");
             var area0 = d3.select(areas[0][0]);
             assert.strictEqual(area0.attr("check"), "a", "projector has been applied to first area");
@@ -4949,7 +4949,7 @@ describe("Plots", function () {
             plot.addDataset(dataset1);
             var dataset2 = new Plottable.Dataset(data2);
             plot.addDataset(dataset2);
-            plot.project("fill", "fill");
+            plot.attr("fill", "fill");
             plot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale);
             var ds0Point2Offset = plot._key2PlotDatasetKey.get("_0").plotMetadata.offsets.get(2);
             var ds1Point2Offset = plot._key2PlotDatasetKey.get("_1").plotMetadata.offsets.get(2);
@@ -4983,7 +4983,7 @@ describe("Plots", function () {
             plot.addDataset(dataset1);
             var dataset2 = new Plottable.Dataset(data2);
             plot.addDataset(dataset2);
-            plot.project("fill", "fill");
+            plot.attr("fill", "fill");
             plot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale);
             var ds0Point2Offset = plot._key2PlotDatasetKey.get("_0").plotMetadata.offsets.get(2);
             var ds1Point2Offset = plot._key2PlotDatasetKey.get("_1").plotMetadata.offsets.get(2);
@@ -5355,7 +5355,7 @@ describe("Plots", function () {
             var plot = new Plottable.Plots.StackedBar(xScale, yScale);
             plot.addDataset(new Plottable.Dataset(data1));
             plot.addDataset(new Plottable.Dataset(data2));
-            plot.project("fill", "fill");
+            plot.attr("fill", "fill");
             plot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale);
             var ds1FirstColumnOffset = plot._key2PlotDatasetKey.get("_0").plotMetadata.offsets.get("A");
             var ds2FirstColumnOffset = plot._key2PlotDatasetKey.get("_1").plotMetadata.offsets.get("A");
@@ -5388,7 +5388,7 @@ describe("Plots", function () {
             plot.addDataset(new Plottable.Dataset(data3));
             plot.addDataset(new Plottable.Dataset(data4));
             plot.addDataset(new Plottable.Dataset(data5));
-            plot.project("fill", "fill");
+            plot.attr("fill", "fill");
             plot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale);
             var keys = plot._key2PlotDatasetKey.keys();
             var offset0 = plot._key2PlotDatasetKey.get(keys[0]).plotMetadata.offsets.get("A");
@@ -7105,7 +7105,7 @@ describe("Scales", function () {
         });
         it("scale autorange works as expected with single dataset", function () {
             var svg = TestMethods.generateSVG(100, 100);
-            new Plottable.Plot().addDataset(dataset).project("x", "foo", scale).renderTo(svg);
+            new Plottable.Plot().addDataset(dataset).attr("x", "foo", scale).renderTo(svg);
             assert.deepEqual(scale.domain(), [0, 5], "scale domain was autoranged properly");
             data.push({ foo: 100, bar: 200 });
             dataset.data(data);
@@ -7115,15 +7115,15 @@ describe("Scales", function () {
         it("scale reference counting works as expected", function () {
             var svg1 = TestMethods.generateSVG(100, 100);
             var svg2 = TestMethods.generateSVG(100, 100);
-            var renderer1 = new Plottable.Plot().addDataset(dataset).project("x", "foo", scale);
+            var renderer1 = new Plottable.Plot().addDataset(dataset).attr("x", "foo", scale);
             renderer1.renderTo(svg1);
-            var renderer2 = new Plottable.Plot().addDataset(dataset).project("x", "foo", scale);
+            var renderer2 = new Plottable.Plot().addDataset(dataset).attr("x", "foo", scale);
             renderer2.renderTo(svg2);
             var otherScale = new Plottable.Scales.Linear();
-            renderer1.project("x", "foo", otherScale);
+            renderer1.attr("x", "foo", otherScale);
             dataset.data([{ foo: 10 }, { foo: 11 }]);
             assert.deepEqual(scale.domain(), [10, 11], "scale was still listening to dataset after one perspective deregistered");
-            renderer2.project("x", "foo", otherScale);
+            renderer2.attr("x", "foo", otherScale);
             // "scale not listening to the dataset after all perspectives removed"
             dataset.data([{ foo: 99 }, { foo: 100 }]);
             assert.deepEqual(scale.domain(), [0, 1], "scale shows default values when all perspectives removed");

--- a/test/tests.js
+++ b/test/tests.js
@@ -2152,8 +2152,8 @@ describe("Plots", function () {
             var xScale = new Plottable.Scales.Linear();
             var yScale = new Plottable.Scales.Linear();
             var metadataProjector = function (d, i, m) { return m.cssClass; };
-            r.attr("x", "x", xScale);
-            r.attr("y", "y", yScale);
+            r.attr("x", function (d) { return d.x; }, xScale);
+            r.attr("y", function (d) { return d.y; }, yScale);
             r.attr("meta", metadataProjector);
             xScale.onUpdate(function (listenable) {
                 assert.strictEqual(listenable, xScale, "Callback received the calling scale as the first argument");
@@ -2183,7 +2183,7 @@ describe("Plots", function () {
         it("Plot.project works as intended", function () {
             var r = new Plottable.Plot();
             var s = new Plottable.Scales.Linear().domain([0, 1]).range([0, 10]);
-            r.attr("attr", "a", s);
+            r.attr("attr", function (d) { return d.a; }, s);
             var attrToProjector = r._generateAttrToProjector();
             var projector = attrToProjector["attr"];
             assert.strictEqual(projector({ "a": 0.5 }, 0, null, null), 5, "projector works as intended");
@@ -2410,7 +2410,7 @@ describe("Plots", function () {
         it("destroy() disconnects plots from its scales", function () {
             var plot2 = new Plottable.Plot();
             var scale = new Plottable.Scales.Linear();
-            plot2.attr("attr", "a", scale);
+            plot2.attr("attr", function (d) { return d.a; }, scale);
             plot2.destroy();
             var scaleCallbacks = scale._callbacks.values();
             assert.strictEqual(scaleCallbacks.length, 0, "the plot is no longer attached to the scale");
@@ -2472,7 +2472,7 @@ describe("Plots", function () {
             var plot = new Plottable.Plot();
             plot.addDataset(dataset2);
             plot.addDataset(dataset1);
-            plot.attr("key", "key", categoryScale);
+            plot.attr("key", function (d) { return d.key; }, categoryScale);
             var svg = TestMethods.generateSVG();
             plot.renderTo(svg);
             assert.deepEqual(categoryScale.domain(), ["B", "A"], "extent is in the right order");
@@ -2722,7 +2722,7 @@ describe("Plots", function () {
                 assert.strictEqual(arcPath0.attr("fill"), "#1f77b4", "first sector filled appropriately");
                 var arcPath1 = d3.select(arcPaths[0][1]);
                 assert.strictEqual(arcPath1.attr("fill"), "#ff7f0e", "second sector filled appropriately");
-                piePlot.attr("fill", "type", new Plottable.Scales.Color("20"));
+                piePlot.attr("fill", function (d) { return d.type; }, new Plottable.Scales.Color("20"));
                 arcPaths = renderArea.selectAll(".arc");
                 arcPath0 = d3.select(arcPaths[0][0]);
                 assert.strictEqual(arcPath0.attr("fill"), "#1f77b4", "first sector filled appropriately");
@@ -2879,7 +2879,7 @@ describe("Plots", function () {
                 d.stroke = "pink";
             });
             simpleDataset.data(data);
-            linePlot.attr("stroke", "stroke");
+            linePlot.attr("stroke", function (d) { return d.stroke; });
             var areaPath = renderArea.select(".line");
             assert.strictEqual(areaPath.attr("stroke"), "pink", "stroke set to uniform stroke color");
             data[0].stroke = "green";
@@ -3920,8 +3920,8 @@ describe("Plots", function () {
             var yScale = new Plottable.Scales.Category();
             var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-            var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
-            gridPlot.addDataset(new Plottable.Dataset(DATA)).attr("fill", "magnitude", colorScale);
+            var gridPlot = new Plottable.Plots.Grid(xScale, yScale);
+            gridPlot.addDataset(new Plottable.Dataset(DATA)).attr("fill", function (d) { return d.magnitude; }, colorScale);
             gridPlot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale);
             gridPlot.renderTo(svg);
             VERIFY_CELLS(gridPlot._renderArea.selectAll("rect")[0]);
@@ -3933,8 +3933,8 @@ describe("Plots", function () {
             var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var dataset = new Plottable.Dataset();
-            var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
-            gridPlot.addDataset(dataset).attr("fill", "magnitude", colorScale);
+            var gridPlot = new Plottable.Plots.Grid(xScale, yScale);
+            gridPlot.addDataset(dataset).attr("fill", function (d) { return d.magnitude; }, colorScale);
             gridPlot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).renderTo(svg);
             dataset.data(DATA);
             VERIFY_CELLS(gridPlot._renderArea.selectAll("rect")[0]);
@@ -3948,8 +3948,8 @@ describe("Plots", function () {
             var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var dataset = new Plottable.Dataset();
-            var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
-            gridPlot.addDataset(dataset).attr("fill", "magnitude", colorScale);
+            var gridPlot = new Plottable.Plots.Grid(xScale, yScale);
+            gridPlot.addDataset(dataset).attr("fill", function (d) { return d.magnitude; }, colorScale);
             gridPlot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).renderTo(svg);
             var data = [
                 { x: "A", y: "W", magnitude: 0 },
@@ -3974,8 +3974,9 @@ describe("Plots", function () {
             var yScale = new Plottable.Scales.Category();
             var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-            var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
-            gridPlot.addDataset(new Plottable.Dataset(DATA)).attr("fill", "magnitude").x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).renderTo(svg);
+            var gridPlot = new Plottable.Plots.Grid(xScale, yScale);
+            gridPlot.addDataset(new Plottable.Dataset(DATA)).attr("fill", function (d) { return d.magnitude; }, colorScale);
+            gridPlot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).renderTo(svg);
             yScale.domain(["U", "V"]);
             var cells = gridPlot._renderArea.selectAll("rect")[0];
             var cellAU = d3.select(cells[0]);
@@ -4004,9 +4005,10 @@ describe("Plots", function () {
                 var yScale = new Plottable.Scales.Category();
                 var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
                 var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-                var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
+                var gridPlot = new Plottable.Plots.Grid(xScale, yScale);
                 var dataset = new Plottable.Dataset(DATA);
-                gridPlot.addDataset(dataset).attr("fill", "magnitude", colorScale).x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale);
+                gridPlot.addDataset(dataset).attr("fill", function (d) { return d.magnitude; }, colorScale);
+                gridPlot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale);
                 gridPlot.renderTo(svg);
                 var allCells = gridPlot.getAllSelections();
                 assert.strictEqual(allCells.size(), 4, "all cells retrieved");
@@ -4017,9 +4019,9 @@ describe("Plots", function () {
                 var yScale = new Plottable.Scales.Category();
                 var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
                 var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-                var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
+                var gridPlot = new Plottable.Plots.Grid(xScale, yScale);
                 var dataset = new Plottable.Dataset(DATA);
-                gridPlot.addDataset(dataset).attr("fill", "magnitude", colorScale);
+                gridPlot.addDataset(dataset).attr("fill", function (d) { return d.magnitude; }, colorScale);
                 gridPlot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale);
                 gridPlot.renderTo(svg);
                 var allCells = gridPlot.getAllSelections([dataset]);
@@ -4033,9 +4035,9 @@ describe("Plots", function () {
                 var yScale = new Plottable.Scales.Category();
                 var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
                 var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-                var gridPlot = new Plottable.Plots.Grid(xScale, yScale, colorScale);
+                var gridPlot = new Plottable.Plots.Grid(xScale, yScale);
                 var dataset = new Plottable.Dataset(DATA);
-                gridPlot.addDataset(dataset).attr("fill", "magnitude", colorScale);
+                gridPlot.addDataset(dataset).attr("fill", function (d) { return d.magnitude; }, colorScale);
                 gridPlot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale);
                 gridPlot.renderTo(svg);
                 var dummyDataset = new Plottable.Dataset([]);
@@ -4097,8 +4099,7 @@ describe("Plots", function () {
             ];
             var xScale = new Plottable.Scales.Category();
             var yScale = new Plottable.Scales.Linear();
-            var cScale = new Plottable.Scales.Color();
-            var plot = new Plottable.Plots.Grid(xScale, yScale, cScale);
+            var plot = new Plottable.Plots.Grid(xScale, yScale);
             plot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y1; }, yScale).y2(function (d) { return d.y2; }, yScale);
             plot.addDataset(new Plottable.Dataset(data1));
             plot.renderTo(svg);
@@ -4894,7 +4895,7 @@ describe("Plots", function () {
             renderer.x(function (d) { return d.x; }, xScale);
             renderer.addDataset(new Plottable.Dataset(data1));
             renderer.addDataset(new Plottable.Dataset(data2));
-            renderer.attr("fill", "type", colorScale);
+            renderer.attr("fill", function (d) { return d.type; }, colorScale);
             var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
             new Plottable.Components.Table([[renderer], [xAxis]]).renderTo(svg);
         });
@@ -4914,7 +4915,7 @@ describe("Plots", function () {
             svg.remove();
         });
         it("project works correctly", function () {
-            renderer.attr("check", "type");
+            renderer.attr("check", function (d) { return d.type; });
             var areas = renderer._renderArea.selectAll(".area");
             var area0 = d3.select(areas[0][0]);
             assert.strictEqual(area0.attr("check"), "a", "projector has been applied to first area");
@@ -7105,7 +7106,7 @@ describe("Scales", function () {
         });
         it("scale autorange works as expected with single dataset", function () {
             var svg = TestMethods.generateSVG(100, 100);
-            new Plottable.Plot().addDataset(dataset).attr("x", "foo", scale).renderTo(svg);
+            new Plottable.Plot().addDataset(dataset).attr("x", function (d) { return d.foo; }, scale).renderTo(svg);
             assert.deepEqual(scale.domain(), [0, 5], "scale domain was autoranged properly");
             data.push({ foo: 100, bar: 200 });
             dataset.data(data);
@@ -7115,15 +7116,15 @@ describe("Scales", function () {
         it("scale reference counting works as expected", function () {
             var svg1 = TestMethods.generateSVG(100, 100);
             var svg2 = TestMethods.generateSVG(100, 100);
-            var renderer1 = new Plottable.Plot().addDataset(dataset).attr("x", "foo", scale);
+            var renderer1 = new Plottable.Plot().addDataset(dataset).attr("x", function (d) { return d.foo; }, scale);
             renderer1.renderTo(svg1);
-            var renderer2 = new Plottable.Plot().addDataset(dataset).attr("x", "foo", scale);
+            var renderer2 = new Plottable.Plot().addDataset(dataset).attr("x", function (d) { return d.foo; }, scale);
             renderer2.renderTo(svg2);
             var otherScale = new Plottable.Scales.Linear();
-            renderer1.attr("x", "foo", otherScale);
+            renderer1.attr("x", function (d) { return d.foo; }, otherScale);
             dataset.data([{ foo: 10 }, { foo: 11 }]);
             assert.deepEqual(scale.domain(), [10, 11], "scale was still listening to dataset after one perspective deregistered");
-            renderer2.attr("x", "foo", otherScale);
+            renderer2.attr("x", function (d) { return d.foo; }, otherScale);
             // "scale not listening to the dataset after all perspectives removed"
             dataset.data([{ foo: 99 }, { foo: 100 }]);
             assert.deepEqual(scale.domain(), [0, 1], "scale shows default values when all perspectives removed");
@@ -8003,20 +8004,6 @@ describe("Utils.Methods", function () {
         assert.isTrue(Plottable.Utils.Methods.inRange(0, -1, 1), "basic functionality works");
         assert.isTrue(Plottable.Utils.Methods.inRange(0, 0, 1), "it is a closed interval");
         assert.isTrue(!Plottable.Utils.Methods.inRange(0, 1, 2), "returns false when false");
-    });
-    it("accessorize works properly", function () {
-        var datum = { "foo": 2, "bar": 3, "key": 4 };
-        var f = function (d, i, m) { return d + i; };
-        var a1 = Plottable.Utils.Methods.accessorize(f);
-        assert.strictEqual(f, a1, "function passes through accessorize unchanged");
-        var a2 = Plottable.Utils.Methods.accessorize("key");
-        assert.strictEqual(a2(datum, 0, null), 4, "key accessor works appropriately");
-        var a3 = Plottable.Utils.Methods.accessorize("#aaaa");
-        assert.strictEqual(a3(datum, 0, null), "#aaaa", "strings beginning with # are returned as final value");
-        var a4 = Plottable.Utils.Methods.accessorize(33);
-        assert.strictEqual(a4(datum, 0, null), 33, "numbers are return as final value");
-        var a5 = Plottable.Utils.Methods.accessorize(datum);
-        assert.strictEqual(a5(datum, 0, null), datum, "objects are return as final value");
     });
     it("uniq works as expected", function () {
         var strings = ["foo", "bar", "foo", "foo", "baz", "bam"];

--- a/test/utils/utilsTests.ts
+++ b/test/utils/utilsTests.ts
@@ -9,26 +9,6 @@ describe("Utils.Methods", () => {
     assert.isTrue(!Plottable.Utils.Methods.inRange(0, 1, 2), "returns false when false");
   });
 
-  it("accessorize works properly", () => {
-    var datum = {"foo": 2, "bar": 3, "key": 4};
-
-    var f = (d: any, i: number, m: any) => d + i;
-    var a1 = Plottable.Utils.Methods.accessorize(f);
-    assert.strictEqual(f, a1, "function passes through accessorize unchanged");
-
-    var a2 = Plottable.Utils.Methods.accessorize("key");
-    assert.strictEqual(a2(datum, 0, null), 4, "key accessor works appropriately");
-
-    var a3 = Plottable.Utils.Methods.accessorize("#aaaa");
-    assert.strictEqual(a3(datum, 0, null), "#aaaa", "strings beginning with # are returned as final value");
-
-    var a4 = Plottable.Utils.Methods.accessorize(33);
-    assert.strictEqual(a4(datum, 0, null), 33, "numbers are return as final value");
-
-    var a5 = Plottable.Utils.Methods.accessorize(datum);
-    assert.strictEqual(a5(datum, 0, null), datum, "objects are return as final value");
-  });
-
   it("uniq works as expected", () => {
     var strings = ["foo", "bar", "foo", "foo", "baz", "bam"];
     assert.deepEqual(Plottable.Utils.Methods.uniq(strings), ["foo", "bar", "baz", "bam"]);


### PR DESCRIPTION
Quite a few things have happened but all has been discussed prior.

* `project()` has been renamed to `attr()` and will be referred as such for the remainder of the PR
* the value parameter to `attr()` will be assumed to be an `_Accessor` or a `number` or a `string` or the "domainType" if a scale is provided.  No more key strings.
* `attr()` has been given a rework similar to how the property endpoints have been reworked and thus has a getter, a setter without a scale, and a setter with a scale

Few things to note:
* `Utils.Methods.accessorize` has been removed
* The `colorScale` argument to `Plots.Grid` has been removed