### PR TITLE
[timeAxis & timeScale] TimeAxis configurations no longer expose d3.time

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -382,10 +382,10 @@ declare module Plottable {
          */
         function time(specifier: string): Formatter;
         /**
-         * Transforms the Plottable TimeInterval into a d3 time interval equivalent.
+         * Transforms the Plottable TimeInterval string into a d3 time interval equivalent.
          * If the provided TimeInterval is incorrect, the default is d3.time.year
          */
-        function timeIntervalToD3Time(timeInterval: TimeInterval): D3.Time.Interval;
+        function timeIntervalToD3Time(timeInterval: string): D3.Time.Interval;
         /**
          * Creates a formatter for relative dates.
          *
@@ -1174,7 +1174,15 @@ declare module Plottable {
              */
             constructor();
             constructor(scale: D3.Scale.LinearScale);
-            tickInterval(interval: TimeInterval, step?: number): Date[];
+            /**
+             * Specifies the interval between ticks
+             *
+             * @param {string} interval TimeInterval string specifying the interval unit measure
+             * @param {number?} step? The distance between adjacent ticks (using the interval unit measure)
+             *
+             * @return {Date[]}
+             */
+            tickInterval(interval: string, step?: number): Date[];
             protected _setDomain(values: Date[]): void;
             copy(): Time;
             _defaultExtent(): Date[];
@@ -1925,14 +1933,14 @@ declare module Plottable {
 
 
 declare module Plottable {
-    enum TimeInterval {
-        second = 0,
-        minute = 1,
-        hour = 2,
-        day = 3,
-        week = 4,
-        month = 5,
-        year = 6,
+    module TimeInterval {
+        var second: string;
+        var minute: string;
+        var hour: string;
+        var day: string;
+        var week: string;
+        var month: string;
+        var year: string;
     }
     module Axes {
         /**
@@ -1943,7 +1951,7 @@ declare module Plottable {
          * formatter - formatter used to format tick labels.
          */
         type TimeAxisTierConfiguration = {
-            interval: TimeInterval;
+            interval: string;
             step: number;
             formatter: Formatter;
         };

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1169,7 +1169,7 @@ declare module Plottable {
              */
             constructor();
             constructor(scale: D3.Scale.LinearScale);
-            tickInterval(interval: D3.Time.Interval, step?: number): Date[];
+            tickInterval(interval: TimeInterval, step?: number): Date[];
             protected _setDomain(values: Date[]): void;
             copy(): Time;
             _defaultExtent(): Date[];
@@ -1920,15 +1920,15 @@ declare module Plottable {
 
 
 declare module Plottable {
+    enum TimeInterval {
+        second = 0,
+        minute = 1,
+        hour = 2,
+        day = 3,
+        month = 4,
+        year = 5,
+    }
     module Axes {
-        enum TimeInterval {
-            second = 0,
-            minute = 1,
-            hour = 2,
-            day = 3,
-            month = 4,
-            year = 5,
-        }
         /**
          * Defines a configuration for a time axis tier.
          * For details on how ticks are generated see: https://github.com/mbostock/d3/wiki/Time-Scales#ticks
@@ -1937,7 +1937,7 @@ declare module Plottable {
          * formatter - formatter used to format tick labels.
          */
         type TimeAxisTierConfiguration = {
-            interval: D3.Time.Interval;
+            interval: TimeInterval;
             step: number;
             formatter: Formatter;
         };

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1929,8 +1929,9 @@ declare module Plottable {
         minute = 1,
         hour = 2,
         day = 3,
-        month = 4,
-        year = 5,
+        week = 4,
+        month = 5,
+        year = 6,
     }
     module Axes {
         /**

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -382,7 +382,8 @@ declare module Plottable {
          */
         function time(specifier: string): Formatter;
         /**
-         * Transforms the Plottable TimeInterval into a d3 time interval equivalent
+         * Transforms the Plottable TimeInterval into a d3 time interval equivalent.
+         * If the provided TimeInterval is incorrect, the default is d3.time.year
          */
         function timeIntervalToD3Time(timeInterval: TimeInterval): D3.Time.Interval;
         /**

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1921,6 +1921,14 @@ declare module Plottable {
 
 declare module Plottable {
     module Axes {
+        enum TimeInterval {
+            second = 0,
+            minute = 1,
+            hour = 2,
+            day = 3,
+            month = 4,
+            year = 5,
+        }
         /**
          * Defines a configuration for a time axis tier.
          * For details on how ticks are generated see: https://github.com/mbostock/d3/wiki/Time-Scales#ticks

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -382,6 +382,10 @@ declare module Plottable {
          */
         function time(specifier: string): Formatter;
         /**
+         * Transforms the Plottable TimeInterval into a d3 time interval equivalent
+         */
+        function timeIntervalToD3Time(timeInterval: TimeInterval): D3.Time.Interval;
+        /**
          * Creates a formatter for relative dates.
          *
          * @param {number} baseValue The start date (as epoch time) used in computing relative dates (default 0)

--- a/plottable.js
+++ b/plottable.js
@@ -2245,6 +2245,10 @@ var Plottable;
                         return d3.time.day;
                     case 4 /* month */:
                         return d3.time.month;
+                    case 5 /* year */:
+                        return d3.time.year;
+                    default:
+                        throw Error("TimeInterval specified does not exist");
                 }
             };
             return Time;
@@ -4408,6 +4412,10 @@ var Plottable;
                         return d3.time.day;
                     case 4 /* month */:
                         return d3.time.month;
+                    case 5 /* year */:
+                        return d3.time.year;
+                    default:
+                        throw Error("TimeInterval specified does not exist");
                 }
             };
             /**

--- a/plottable.js
+++ b/plottable.js
@@ -2214,9 +2214,10 @@ var Plottable;
             Time.prototype.tickInterval = function (interval, step) {
                 // temporarily creats a time scale from our linear scale into a time scale so we can get access to its api
                 var tempScale = d3.time.scale();
+                var d3Interval = this._getD3TimeInterval(interval);
                 tempScale.domain(this.domain());
                 tempScale.range(this.range());
-                return tempScale.ticks(interval.range, step);
+                return tempScale.ticks(d3Interval.range, step);
             };
             Time.prototype._setDomain = function (values) {
                 if (values[1] < values[0]) {
@@ -2231,6 +2232,20 @@ var Plottable;
                 var endTimeValue = new Date().valueOf();
                 var startTimeValue = endTimeValue - Plottable.MILLISECONDS_IN_ONE_DAY;
                 return [new Date(startTimeValue), new Date(endTimeValue)];
+            };
+            Time.prototype._getD3TimeInterval = function (timeInterval) {
+                switch (timeInterval) {
+                    case 0 /* second */:
+                        return d3.time.second;
+                    case 1 /* minute */:
+                        return d3.time.minute;
+                    case 2 /* hour */:
+                        return d3.time.hour;
+                    case 3 /* day */:
+                        return d3.time.day;
+                    case 4 /* month */:
+                        return d3.time.month;
+                }
             };
             return Time;
         })(Plottable.QuantitativeScale);
@@ -4072,18 +4087,18 @@ var __extends = this.__extends || function (d, b) {
 };
 var Plottable;
 (function (Plottable) {
+    (function (TimeInterval) {
+        TimeInterval[TimeInterval["second"] = 0] = "second";
+        TimeInterval[TimeInterval["minute"] = 1] = "minute";
+        TimeInterval[TimeInterval["hour"] = 2] = "hour";
+        TimeInterval[TimeInterval["day"] = 3] = "day";
+        TimeInterval[TimeInterval["month"] = 4] = "month";
+        TimeInterval[TimeInterval["year"] = 5] = "year";
+    })(Plottable.TimeInterval || (Plottable.TimeInterval = {}));
+    var TimeInterval = Plottable.TimeInterval;
+    ;
     var Axes;
     (function (Axes) {
-        (function (TimeInterval) {
-            TimeInterval[TimeInterval["second"] = 0] = "second";
-            TimeInterval[TimeInterval["minute"] = 1] = "minute";
-            TimeInterval[TimeInterval["hour"] = 2] = "hour";
-            TimeInterval[TimeInterval["day"] = 3] = "day";
-            TimeInterval[TimeInterval["month"] = 4] = "month";
-            TimeInterval[TimeInterval["year"] = 5] = "year";
-        })(Axes.TimeInterval || (Axes.TimeInterval = {}));
-        var TimeInterval = Axes.TimeInterval;
-        ;
         var Time = (function (_super) {
             __extends(Time, _super);
             /**
@@ -4167,7 +4182,8 @@ var Plottable;
             };
             Time.prototype._getIntervalLength = function (config) {
                 var startDate = this._scale.domain()[0];
-                var endDate = config.interval.offset(startDate, config.step);
+                var d3Interval = this._getD3TimeInterval(config.interval);
+                var endDate = d3Interval.offset(startDate, config.step);
                 if (endDate > this._scale.domain()[1]) {
                     // this offset is too large, so just return available width
                     return this.width();
@@ -4403,111 +4419,111 @@ var Plottable;
              */
             Time._DEFAULT_TIME_AXIS_CONFIGURATIONS = [
                 [
-                    { interval: d3.time.second, step: 1, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: 0 /* second */, step: 1, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: d3.time.second, step: 5, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: 0 /* second */, step: 5, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: d3.time.second, step: 10, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: 0 /* second */, step: 10, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: d3.time.second, step: 15, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: 0 /* second */, step: 15, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: d3.time.second, step: 30, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: 0 /* second */, step: 30, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: d3.time.minute, step: 1, formatter: Plottable.Formatters.time("%I:%M %p") },
-                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: 1 /* minute */, step: 1, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: d3.time.minute, step: 5, formatter: Plottable.Formatters.time("%I:%M %p") },
-                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: 1 /* minute */, step: 5, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: d3.time.minute, step: 10, formatter: Plottable.Formatters.time("%I:%M %p") },
-                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: 1 /* minute */, step: 10, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: d3.time.minute, step: 15, formatter: Plottable.Formatters.time("%I:%M %p") },
-                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: 1 /* minute */, step: 15, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: d3.time.minute, step: 30, formatter: Plottable.Formatters.time("%I:%M %p") },
-                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: 1 /* minute */, step: 30, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: d3.time.hour, step: 1, formatter: Plottable.Formatters.time("%I %p") },
-                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: 2 /* hour */, step: 1, formatter: Plottable.Formatters.time("%I %p") },
+                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: d3.time.hour, step: 3, formatter: Plottable.Formatters.time("%I %p") },
-                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: 2 /* hour */, step: 3, formatter: Plottable.Formatters.time("%I %p") },
+                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: d3.time.hour, step: 6, formatter: Plottable.Formatters.time("%I %p") },
-                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: 2 /* hour */, step: 6, formatter: Plottable.Formatters.time("%I %p") },
+                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: d3.time.hour, step: 12, formatter: Plottable.Formatters.time("%I %p") },
-                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: 2 /* hour */, step: 12, formatter: Plottable.Formatters.time("%I %p") },
+                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%a %e") },
-                    { interval: d3.time.month, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
+                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%a %e") },
+                    { interval: 4 /* month */, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
                 ],
                 [
-                    { interval: d3.time.day, step: 1, formatter: Plottable.Formatters.time("%e") },
-                    { interval: d3.time.month, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
+                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%e") },
+                    { interval: 4 /* month */, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
                 ],
                 [
-                    { interval: d3.time.month, step: 1, formatter: Plottable.Formatters.time("%B") },
-                    { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 4 /* month */, step: 1, formatter: Plottable.Formatters.time("%B") },
+                    { interval: 5 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: d3.time.month, step: 1, formatter: Plottable.Formatters.time("%b") },
-                    { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 4 /* month */, step: 1, formatter: Plottable.Formatters.time("%b") },
+                    { interval: 5 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: d3.time.month, step: 3, formatter: Plottable.Formatters.time("%b") },
-                    { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 4 /* month */, step: 3, formatter: Plottable.Formatters.time("%b") },
+                    { interval: 5 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: d3.time.month, step: 6, formatter: Plottable.Formatters.time("%b") },
-                    { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 4 /* month */, step: 6, formatter: Plottable.Formatters.time("%b") },
+                    { interval: 5 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 5 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: d3.time.year, step: 1, formatter: Plottable.Formatters.time("%y") }
+                    { interval: 5 /* year */, step: 1, formatter: Plottable.Formatters.time("%y") }
                 ],
                 [
-                    { interval: d3.time.year, step: 5, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 5 /* year */, step: 5, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: d3.time.year, step: 25, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 5 /* year */, step: 25, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: d3.time.year, step: 50, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 5 /* year */, step: 50, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: d3.time.year, step: 100, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 5 /* year */, step: 100, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: d3.time.year, step: 200, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 5 /* year */, step: 200, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: d3.time.year, step: 500, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 5 /* year */, step: 500, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: d3.time.year, step: 1000, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 5 /* year */, step: 1000, formatter: Plottable.Formatters.time("%Y") }
                 ]
             ];
             Time._LONG_DATE = new Date(9999, 8, 29, 12, 59, 9999);

--- a/plottable.js
+++ b/plottable.js
@@ -929,6 +929,28 @@ var Plottable;
         }
         Formatters.time = time;
         /**
+         * Transforms the Plottable TimeInterval into a d3 time interval equivalent
+         */
+        function timeIntervalToD3Time(timeInterval) {
+            switch (timeInterval) {
+                case 0 /* second */:
+                    return d3.time.second;
+                case 1 /* minute */:
+                    return d3.time.minute;
+                case 2 /* hour */:
+                    return d3.time.hour;
+                case 3 /* day */:
+                    return d3.time.day;
+                case 4 /* month */:
+                    return d3.time.month;
+                case 5 /* year */:
+                    return d3.time.year;
+                default:
+                    throw Error("TimeInterval specified does not exist");
+            }
+        }
+        Formatters.timeIntervalToD3Time = timeIntervalToD3Time;
+        /**
          * Creates a formatter for relative dates.
          *
          * @param {number} baseValue The start date (as epoch time) used in computing relative dates (default 0)
@@ -2214,7 +2236,7 @@ var Plottable;
             Time.prototype.tickInterval = function (interval, step) {
                 // temporarily creats a time scale from our linear scale into a time scale so we can get access to its api
                 var tempScale = d3.time.scale();
-                var d3Interval = this._getD3TimeInterval(interval);
+                var d3Interval = Plottable.Formatters.timeIntervalToD3Time(interval);
                 tempScale.domain(this.domain());
                 tempScale.range(this.range());
                 return tempScale.ticks(d3Interval.range, step);
@@ -2232,24 +2254,6 @@ var Plottable;
                 var endTimeValue = new Date().valueOf();
                 var startTimeValue = endTimeValue - Plottable.MILLISECONDS_IN_ONE_DAY;
                 return [new Date(startTimeValue), new Date(endTimeValue)];
-            };
-            Time.prototype._getD3TimeInterval = function (timeInterval) {
-                switch (timeInterval) {
-                    case 0 /* second */:
-                        return d3.time.second;
-                    case 1 /* minute */:
-                        return d3.time.minute;
-                    case 2 /* hour */:
-                        return d3.time.hour;
-                    case 3 /* day */:
-                        return d3.time.day;
-                    case 4 /* month */:
-                        return d3.time.month;
-                    case 5 /* year */:
-                        return d3.time.year;
-                    default:
-                        throw Error("TimeInterval specified does not exist");
-                }
             };
             return Time;
         })(Plottable.QuantitativeScale);
@@ -4186,7 +4190,7 @@ var Plottable;
             };
             Time.prototype._getIntervalLength = function (config) {
                 var startDate = this._scale.domain()[0];
-                var d3Interval = this._getD3TimeInterval(config.interval);
+                var d3Interval = Plottable.Formatters.timeIntervalToD3Time(config.interval);
                 var endDate = d3Interval.offset(startDate, config.step);
                 if (endDate > this._scale.domain()[1]) {
                     // this offset is too large, so just return available width
@@ -4399,24 +4403,6 @@ var Plottable;
                         tickLabel.style("visibility", "inherit");
                     }
                 });
-            };
-            Time.prototype._getD3TimeInterval = function (timeInterval) {
-                switch (timeInterval) {
-                    case 0 /* second */:
-                        return d3.time.second;
-                    case 1 /* minute */:
-                        return d3.time.minute;
-                    case 2 /* hour */:
-                        return d3.time.hour;
-                    case 3 /* day */:
-                        return d3.time.day;
-                    case 4 /* month */:
-                        return d3.time.month;
-                    case 5 /* year */:
-                        return d3.time.year;
-                    default:
-                        throw Error("TimeInterval specified does not exist");
-                }
             };
             /**
              * The css class applied to each time axis tier

--- a/plottable.js
+++ b/plottable.js
@@ -948,7 +948,8 @@ var Plottable;
                 case 6 /* year */:
                     return d3.time.year;
                 default:
-                    throw Error("TimeInterval specified does not exist");
+                    Plottable.Utils.Methods.warn("TimeInterval specified does not exist");
+                    return d3.time.year;
             }
         }
         Formatters.timeIntervalToD3Time = timeIntervalToD3Time;

--- a/plottable.js
+++ b/plottable.js
@@ -929,7 +929,8 @@ var Plottable;
         }
         Formatters.time = time;
         /**
-         * Transforms the Plottable TimeInterval into a d3 time interval equivalent
+         * Transforms the Plottable TimeInterval into a d3 time interval equivalent.
+         * If the provided TimeInterval is incorrect, the default is d3.time.year
          */
         function timeIntervalToD3Time(timeInterval) {
             switch (timeInterval) {

--- a/plottable.js
+++ b/plottable.js
@@ -929,24 +929,24 @@ var Plottable;
         }
         Formatters.time = time;
         /**
-         * Transforms the Plottable TimeInterval into a d3 time interval equivalent.
+         * Transforms the Plottable TimeInterval string into a d3 time interval equivalent.
          * If the provided TimeInterval is incorrect, the default is d3.time.year
          */
         function timeIntervalToD3Time(timeInterval) {
             switch (timeInterval) {
-                case 0 /* second */:
+                case Plottable.TimeInterval.second:
                     return d3.time.second;
-                case 1 /* minute */:
+                case Plottable.TimeInterval.minute:
                     return d3.time.minute;
-                case 2 /* hour */:
+                case Plottable.TimeInterval.hour:
                     return d3.time.hour;
-                case 3 /* day */:
+                case Plottable.TimeInterval.day:
                     return d3.time.day;
-                case 4 /* week */:
+                case Plottable.TimeInterval.week:
                     return d3.time.week;
-                case 5 /* month */:
+                case Plottable.TimeInterval.month:
                     return d3.time.month;
-                case 6 /* year */:
+                case Plottable.TimeInterval.year:
                     return d3.time.year;
                 default:
                     Plottable.Utils.Methods.warn("TimeInterval specified does not exist");
@@ -2237,6 +2237,14 @@ var Plottable;
                 // need to cast since d3 time scales do not descend from QuantitativeScale scales
                 _super.call(this, scale == null ? d3.time.scale() : scale);
             }
+            /**
+             * Specifies the interval between ticks
+             *
+             * @param {string} interval TimeInterval string specifying the interval unit measure
+             * @param {number?} step? The distance between adjacent ticks (using the interval unit measure)
+             *
+             * @return {Date[]}
+             */
             Time.prototype.tickInterval = function (interval, step) {
                 // temporarily creats a time scale from our linear scale into a time scale so we can get access to its api
                 var tempScale = d3.time.scale();
@@ -4099,16 +4107,16 @@ var __extends = this.__extends || function (d, b) {
 };
 var Plottable;
 (function (Plottable) {
+    var TimeInterval;
     (function (TimeInterval) {
-        TimeInterval[TimeInterval["second"] = 0] = "second";
-        TimeInterval[TimeInterval["minute"] = 1] = "minute";
-        TimeInterval[TimeInterval["hour"] = 2] = "hour";
-        TimeInterval[TimeInterval["day"] = 3] = "day";
-        TimeInterval[TimeInterval["week"] = 4] = "week";
-        TimeInterval[TimeInterval["month"] = 5] = "month";
-        TimeInterval[TimeInterval["year"] = 6] = "year";
-    })(Plottable.TimeInterval || (Plottable.TimeInterval = {}));
-    var TimeInterval = Plottable.TimeInterval;
+        TimeInterval.second = "second";
+        TimeInterval.minute = "minute";
+        TimeInterval.hour = "hour";
+        TimeInterval.day = "day";
+        TimeInterval.week = "week";
+        TimeInterval.month = "month";
+        TimeInterval.year = "year";
+    })(TimeInterval = Plottable.TimeInterval || (Plottable.TimeInterval = {}));
     ;
     var Axes;
     (function (Axes) {
@@ -4418,111 +4426,111 @@ var Plottable;
              */
             Time._DEFAULT_TIME_AXIS_CONFIGURATIONS = [
                 [
-                    { interval: 0 /* second */, step: 1, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: TimeInterval.second, step: 1, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: 0 /* second */, step: 5, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: TimeInterval.second, step: 5, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: 0 /* second */, step: 10, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: TimeInterval.second, step: 10, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: 0 /* second */, step: 15, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: TimeInterval.second, step: 15, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: 0 /* second */, step: 30, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: TimeInterval.second, step: 30, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: 1 /* minute */, step: 1, formatter: Plottable.Formatters.time("%I:%M %p") },
-                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: TimeInterval.minute, step: 1, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: 1 /* minute */, step: 5, formatter: Plottable.Formatters.time("%I:%M %p") },
-                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: TimeInterval.minute, step: 5, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: 1 /* minute */, step: 10, formatter: Plottable.Formatters.time("%I:%M %p") },
-                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: TimeInterval.minute, step: 10, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: 1 /* minute */, step: 15, formatter: Plottable.Formatters.time("%I:%M %p") },
-                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: TimeInterval.minute, step: 15, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: 1 /* minute */, step: 30, formatter: Plottable.Formatters.time("%I:%M %p") },
-                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: TimeInterval.minute, step: 30, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: 2 /* hour */, step: 1, formatter: Plottable.Formatters.time("%I %p") },
-                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: TimeInterval.hour, step: 1, formatter: Plottable.Formatters.time("%I %p") },
+                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: 2 /* hour */, step: 3, formatter: Plottable.Formatters.time("%I %p") },
-                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: TimeInterval.hour, step: 3, formatter: Plottable.Formatters.time("%I %p") },
+                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: 2 /* hour */, step: 6, formatter: Plottable.Formatters.time("%I %p") },
-                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: TimeInterval.hour, step: 6, formatter: Plottable.Formatters.time("%I %p") },
+                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: 2 /* hour */, step: 12, formatter: Plottable.Formatters.time("%I %p") },
-                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: TimeInterval.hour, step: 12, formatter: Plottable.Formatters.time("%I %p") },
+                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%a %e") },
-                    { interval: 5 /* month */, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
+                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%a %e") },
+                    { interval: TimeInterval.month, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
                 ],
                 [
-                    { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%e") },
-                    { interval: 5 /* month */, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
+                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%e") },
+                    { interval: TimeInterval.month, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
                 ],
                 [
-                    { interval: 5 /* month */, step: 1, formatter: Plottable.Formatters.time("%B") },
-                    { interval: 6 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: TimeInterval.month, step: 1, formatter: Plottable.Formatters.time("%B") },
+                    { interval: TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 5 /* month */, step: 1, formatter: Plottable.Formatters.time("%b") },
-                    { interval: 6 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: TimeInterval.month, step: 1, formatter: Plottable.Formatters.time("%b") },
+                    { interval: TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 5 /* month */, step: 3, formatter: Plottable.Formatters.time("%b") },
-                    { interval: 6 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: TimeInterval.month, step: 3, formatter: Plottable.Formatters.time("%b") },
+                    { interval: TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 5 /* month */, step: 6, formatter: Plottable.Formatters.time("%b") },
-                    { interval: 6 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: TimeInterval.month, step: 6, formatter: Plottable.Formatters.time("%b") },
+                    { interval: TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 6 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 6 /* year */, step: 1, formatter: Plottable.Formatters.time("%y") }
+                    { interval: TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%y") }
                 ],
                 [
-                    { interval: 6 /* year */, step: 5, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: TimeInterval.year, step: 5, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 6 /* year */, step: 25, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: TimeInterval.year, step: 25, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 6 /* year */, step: 50, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: TimeInterval.year, step: 50, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 6 /* year */, step: 100, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: TimeInterval.year, step: 100, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 6 /* year */, step: 200, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: TimeInterval.year, step: 200, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 6 /* year */, step: 500, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: TimeInterval.year, step: 500, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 6 /* year */, step: 1000, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: TimeInterval.year, step: 1000, formatter: Plottable.Formatters.time("%Y") }
                 ]
             ];
             Time._LONG_DATE = new Date(9999, 8, 29, 12, 59, 9999);

--- a/plottable.js
+++ b/plottable.js
@@ -949,7 +949,7 @@ var Plottable;
                 case Plottable.TimeInterval.year:
                     return d3.time.year;
                 default:
-                    Plottable.Utils.Methods.warn("TimeInterval specified does not exist");
+                    Plottable.Utils.Methods.warn("TimeInterval specified does not exist: " + timeInterval);
                     return d3.time.year;
             }
         }

--- a/plottable.js
+++ b/plottable.js
@@ -4074,6 +4074,16 @@ var Plottable;
 (function (Plottable) {
     var Axes;
     (function (Axes) {
+        (function (TimeInterval) {
+            TimeInterval[TimeInterval["second"] = 0] = "second";
+            TimeInterval[TimeInterval["minute"] = 1] = "minute";
+            TimeInterval[TimeInterval["hour"] = 2] = "hour";
+            TimeInterval[TimeInterval["day"] = 3] = "day";
+            TimeInterval[TimeInterval["month"] = 4] = "month";
+            TimeInterval[TimeInterval["year"] = 5] = "year";
+        })(Axes.TimeInterval || (Axes.TimeInterval = {}));
+        var TimeInterval = Axes.TimeInterval;
+        ;
         var Time = (function (_super) {
             __extends(Time, _super);
             /**
@@ -4369,6 +4379,20 @@ var Plottable;
                         tickLabel.style("visibility", "inherit");
                     }
                 });
+            };
+            Time.prototype._getD3TimeInterval = function (timeInterval) {
+                switch (timeInterval) {
+                    case 0 /* second */:
+                        return d3.time.second;
+                    case 1 /* minute */:
+                        return d3.time.minute;
+                    case 2 /* hour */:
+                        return d3.time.hour;
+                    case 3 /* day */:
+                        return d3.time.day;
+                    case 4 /* month */:
+                        return d3.time.month;
+                }
             };
             /**
              * The css class applied to each time axis tier

--- a/plottable.js
+++ b/plottable.js
@@ -941,9 +941,11 @@ var Plottable;
                     return d3.time.hour;
                 case 3 /* day */:
                     return d3.time.day;
-                case 4 /* month */:
+                case 4 /* week */:
+                    return d3.time.week;
+                case 5 /* month */:
                     return d3.time.month;
-                case 5 /* year */:
+                case 6 /* year */:
                     return d3.time.year;
                 default:
                     throw Error("TimeInterval specified does not exist");
@@ -4100,8 +4102,9 @@ var Plottable;
         TimeInterval[TimeInterval["minute"] = 1] = "minute";
         TimeInterval[TimeInterval["hour"] = 2] = "hour";
         TimeInterval[TimeInterval["day"] = 3] = "day";
-        TimeInterval[TimeInterval["month"] = 4] = "month";
-        TimeInterval[TimeInterval["year"] = 5] = "year";
+        TimeInterval[TimeInterval["week"] = 4] = "week";
+        TimeInterval[TimeInterval["month"] = 5] = "month";
+        TimeInterval[TimeInterval["year"] = 6] = "year";
     })(Plottable.TimeInterval || (Plottable.TimeInterval = {}));
     var TimeInterval = Plottable.TimeInterval;
     ;
@@ -4470,54 +4473,54 @@ var Plottable;
                 ],
                 [
                     { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%a %e") },
-                    { interval: 4 /* month */, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
+                    { interval: 5 /* month */, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
                 ],
                 [
                     { interval: 3 /* day */, step: 1, formatter: Plottable.Formatters.time("%e") },
-                    { interval: 4 /* month */, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
+                    { interval: 5 /* month */, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
                 ],
                 [
-                    { interval: 4 /* month */, step: 1, formatter: Plottable.Formatters.time("%B") },
-                    { interval: 5 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 5 /* month */, step: 1, formatter: Plottable.Formatters.time("%B") },
+                    { interval: 6 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 4 /* month */, step: 1, formatter: Plottable.Formatters.time("%b") },
-                    { interval: 5 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 5 /* month */, step: 1, formatter: Plottable.Formatters.time("%b") },
+                    { interval: 6 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 4 /* month */, step: 3, formatter: Plottable.Formatters.time("%b") },
-                    { interval: 5 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 5 /* month */, step: 3, formatter: Plottable.Formatters.time("%b") },
+                    { interval: 6 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 4 /* month */, step: 6, formatter: Plottable.Formatters.time("%b") },
-                    { interval: 5 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 5 /* month */, step: 6, formatter: Plottable.Formatters.time("%b") },
+                    { interval: 6 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 5 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 6 /* year */, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 5 /* year */, step: 1, formatter: Plottable.Formatters.time("%y") }
+                    { interval: 6 /* year */, step: 1, formatter: Plottable.Formatters.time("%y") }
                 ],
                 [
-                    { interval: 5 /* year */, step: 5, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 6 /* year */, step: 5, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 5 /* year */, step: 25, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 6 /* year */, step: 25, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 5 /* year */, step: 50, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 6 /* year */, step: 50, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 5 /* year */, step: 100, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 6 /* year */, step: 100, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 5 /* year */, step: 200, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 6 /* year */, step: 200, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 5 /* year */, step: 500, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 6 /* year */, step: 500, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: 5 /* year */, step: 1000, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: 6 /* year */, step: 1000, formatter: Plottable.Formatters.time("%Y") }
                 ]
             ];
             Time._LONG_DATE = new Date(9999, 8, 29, 12, 59, 9999);

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -2,6 +2,11 @@
 
 module Plottable {
 export module Axes {
+
+  export enum TimeInterval {
+    second, minute, hour, day, month, year
+  };
+
   /**
    * Defines a configuration for a time axis tier.
    * For details on how ticks are generated see: https://github.com/mbostock/d3/wiki/Time-Scales#ticks
@@ -531,6 +536,22 @@ export module Axes {
         }
       });
     }
+
+    private _getD3TimeInterval(timeInterval: TimeInterval) {
+      switch(timeInterval) {
+        case TimeInterval.second:
+          return d3.time.second;
+        case TimeInterval.minute:
+          return d3.time.minute;
+        case TimeInterval.hour:
+          return d3.time.hour;
+        case TimeInterval.day:
+          return d3.time.day;
+        case TimeInterval.month:
+          return d3.time.month;
+      }
+    }
+
   }
 }
 }

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -1,12 +1,12 @@
 ///<reference path="../../reference.ts" />
 
 module Plottable {
+
+export enum TimeInterval {
+  second, minute, hour, day, month, year
+};
+
 export module Axes {
-
-  export enum TimeInterval {
-    second, minute, hour, day, month, year
-  };
-
   /**
    * Defines a configuration for a time axis tier.
    * For details on how ticks are generated see: https://github.com/mbostock/d3/wiki/Time-Scales#ticks
@@ -15,7 +15,7 @@ export module Axes {
    * formatter - formatter used to format tick labels.
    */
   export type TimeAxisTierConfiguration = {
-    interval: D3.Time.Interval;
+    interval: TimeInterval;
     step: number;
     formatter: Formatter;
   };
@@ -38,111 +38,111 @@ export module Axes {
      */
     private static _DEFAULT_TIME_AXIS_CONFIGURATIONS: TimeAxisConfiguration[] = [
       [
-        {interval: d3.time.second, step: 1, formatter: Formatters.time("%I:%M:%S %p")},
-        {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
+        {interval: TimeInterval.second, step: 1, formatter: Formatters.time("%I:%M:%S %p")},
+        {interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
       ],
       [
-        {interval: d3.time.second, step: 5, formatter: Formatters.time("%I:%M:%S %p")},
-        {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
+        {interval: TimeInterval.second, step: 5, formatter: Formatters.time("%I:%M:%S %p")},
+        {interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
       ],
       [
-        {interval: d3.time.second, step: 10, formatter: Formatters.time("%I:%M:%S %p")},
-        {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
+        {interval: TimeInterval.second, step: 10, formatter: Formatters.time("%I:%M:%S %p")},
+        {interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
       ],
       [
-        {interval: d3.time.second, step: 15, formatter: Formatters.time("%I:%M:%S %p")},
-        {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
+        {interval: TimeInterval.second, step: 15, formatter: Formatters.time("%I:%M:%S %p")},
+        {interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
       ],
       [
-        {interval: d3.time.second, step: 30, formatter: Formatters.time("%I:%M:%S %p")},
-        {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
+        {interval: TimeInterval.second, step: 30, formatter: Formatters.time("%I:%M:%S %p")},
+        {interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
       ],
       [
-        {interval: d3.time.minute, step: 1, formatter: Formatters.time("%I:%M %p")},
-        {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
+        {interval: TimeInterval.minute, step: 1, formatter: Formatters.time("%I:%M %p")},
+        {interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
       ],
       [
-        {interval: d3.time.minute, step: 5, formatter: Formatters.time("%I:%M %p")},
-        {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
+        {interval: TimeInterval.minute, step: 5, formatter: Formatters.time("%I:%M %p")},
+        {interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
       ],
       [
-        {interval: d3.time.minute, step: 10, formatter: Formatters.time("%I:%M %p")},
-        {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
+        {interval: TimeInterval.minute, step: 10, formatter: Formatters.time("%I:%M %p")},
+        {interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
       ],
       [
-        {interval: d3.time.minute, step: 15, formatter: Formatters.time("%I:%M %p")},
-        {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
+        {interval: TimeInterval.minute, step: 15, formatter: Formatters.time("%I:%M %p")},
+        {interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
       ],
       [
-        {interval: d3.time.minute, step: 30, formatter: Formatters.time("%I:%M %p")},
-        {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
+        {interval: TimeInterval.minute, step: 30, formatter: Formatters.time("%I:%M %p")},
+        {interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
       ],
       [
-        {interval: d3.time.hour, step: 1, formatter: Formatters.time("%I %p")},
-        {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
+        {interval: TimeInterval.hour, step: 1, formatter: Formatters.time("%I %p")},
+        {interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
       ],
       [
-        {interval: d3.time.hour, step: 3, formatter: Formatters.time("%I %p")},
-        {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
+        {interval: TimeInterval.hour, step: 3, formatter: Formatters.time("%I %p")},
+        {interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
       ],
       [
-        {interval: d3.time.hour, step: 6, formatter: Formatters.time("%I %p")},
-        {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
+        {interval: TimeInterval.hour, step: 6, formatter: Formatters.time("%I %p")},
+        {interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
       ],
       [
-        {interval: d3.time.hour, step: 12, formatter: Formatters.time("%I %p")},
-        {interval: d3.time.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
+        {interval: TimeInterval.hour, step: 12, formatter: Formatters.time("%I %p")},
+        {interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y")}
       ],
       [
-        {interval: d3.time.day, step: 1, formatter: Formatters.time("%a %e")},
-        {interval: d3.time.month, step: 1, formatter: Formatters.time("%B %Y")}
+        {interval: TimeInterval.day, step: 1, formatter: Formatters.time("%a %e")},
+        {interval: TimeInterval.month, step: 1, formatter: Formatters.time("%B %Y")}
       ],
       [
-        {interval: d3.time.day, step: 1, formatter: Formatters.time("%e")},
-        {interval: d3.time.month, step: 1, formatter: Formatters.time("%B %Y")}
+        {interval: TimeInterval.day, step: 1, formatter: Formatters.time("%e")},
+        {interval: TimeInterval.month, step: 1, formatter: Formatters.time("%B %Y")}
       ],
       [
-        {interval: d3.time.month, step: 1, formatter: Formatters.time("%B")},
-        {interval: d3.time.year, step: 1, formatter: Formatters.time("%Y")}
+        {interval: TimeInterval.month, step: 1, formatter: Formatters.time("%B")},
+        {interval: TimeInterval.year, step: 1, formatter: Formatters.time("%Y")}
       ],
       [
-        {interval: d3.time.month, step: 1, formatter: Formatters.time("%b")},
-        {interval: d3.time.year, step: 1, formatter: Formatters.time("%Y")}
+        {interval: TimeInterval.month, step: 1, formatter: Formatters.time("%b")},
+        {interval: TimeInterval.year, step: 1, formatter: Formatters.time("%Y")}
       ],
       [
-        {interval: d3.time.month, step: 3, formatter: Formatters.time("%b")},
-        {interval: d3.time.year, step: 1, formatter: Formatters.time("%Y")}
+        {interval: TimeInterval.month, step: 3, formatter: Formatters.time("%b")},
+        {interval: TimeInterval.year, step: 1, formatter: Formatters.time("%Y")}
       ],
       [
-        {interval: d3.time.month, step: 6, formatter: Formatters.time("%b")},
-        {interval: d3.time.year, step: 1, formatter: Formatters.time("%Y")}
+        {interval: TimeInterval.month, step: 6, formatter: Formatters.time("%b")},
+        {interval: TimeInterval.year, step: 1, formatter: Formatters.time("%Y")}
       ],
       [
-        {interval: d3.time.year, step: 1, formatter: Formatters.time("%Y")}
+        {interval: TimeInterval.year, step: 1, formatter: Formatters.time("%Y")}
       ],
       [
-        {interval: d3.time.year, step: 1, formatter: Formatters.time("%y")}
+        {interval: TimeInterval.year, step: 1, formatter: Formatters.time("%y")}
       ],
       [
-        {interval: d3.time.year, step: 5, formatter: Formatters.time("%Y")}
+        {interval: TimeInterval.year, step: 5, formatter: Formatters.time("%Y")}
       ],
       [
-        {interval: d3.time.year, step: 25, formatter: Formatters.time("%Y")}
+        {interval: TimeInterval.year, step: 25, formatter: Formatters.time("%Y")}
       ],
       [
-        {interval: d3.time.year, step: 50, formatter: Formatters.time("%Y")}
+        {interval: TimeInterval.year, step: 50, formatter: Formatters.time("%Y")}
       ],
       [
-        {interval: d3.time.year, step: 100, formatter: Formatters.time("%Y")}
+        {interval: TimeInterval.year, step: 100, formatter: Formatters.time("%Y")}
       ],
       [
-        {interval: d3.time.year, step: 200, formatter: Formatters.time("%Y")}
+        {interval: TimeInterval.year, step: 200, formatter: Formatters.time("%Y")}
       ],
       [
-        {interval: d3.time.year, step: 500, formatter: Formatters.time("%Y")}
+        {interval: TimeInterval.year, step: 500, formatter: Formatters.time("%Y")}
       ],
       [
-        {interval: d3.time.year, step: 1000, formatter: Formatters.time("%Y")}
+        {interval: TimeInterval.year, step: 1000, formatter: Formatters.time("%Y")}
       ]
     ];
 
@@ -272,7 +272,8 @@ export module Axes {
 
     private _getIntervalLength(config: TimeAxisTierConfiguration) {
       var startDate = this._scale.domain()[0];
-      var endDate = config.interval.offset(startDate, config.step);
+      var d3Interval = this._getD3TimeInterval(config.interval);
+      var endDate = d3Interval.offset(startDate, config.step);
       if (endDate > this._scale.domain()[1]) {
         // this offset is too large, so just return available width
         return this.width();
@@ -538,7 +539,7 @@ export module Axes {
     }
 
     private _getD3TimeInterval(timeInterval: TimeInterval) {
-      switch(timeInterval) {
+      switch (timeInterval) {
         case TimeInterval.second:
           return d3.time.second;
         case TimeInterval.minute:
@@ -551,7 +552,6 @@ export module Axes {
           return d3.time.month;
       }
     }
-
   }
 }
 }

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -2,8 +2,14 @@
 
 module Plottable {
 
-export enum TimeInterval {
-  second, minute, hour, day, week, month, year
+export module TimeInterval {
+  export var second = "second";
+  export var minute = "minute";
+  export var hour = "hour";
+  export var day = "day";
+  export var week = "week";
+  export var month = "month";
+  export var year = "year";
 };
 
 export module Axes {
@@ -15,7 +21,7 @@ export module Axes {
    * formatter - formatter used to format tick labels.
    */
   export type TimeAxisTierConfiguration = {
-    interval: TimeInterval;
+    interval: string;
     step: number;
     formatter: Formatter;
   };

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -550,6 +550,10 @@ export module Axes {
           return d3.time.day;
         case TimeInterval.month:
           return d3.time.month;
+        case TimeInterval.year:
+          return d3.time.year;
+        default:
+          throw Error("TimeInterval specified does not exist");
       }
     }
   }

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -272,7 +272,7 @@ export module Axes {
 
     private _getIntervalLength(config: TimeAxisTierConfiguration) {
       var startDate = this._scale.domain()[0];
-      var d3Interval = this._getD3TimeInterval(config.interval);
+      var d3Interval = Formatters.timeIntervalToD3Time(config.interval);
       var endDate = d3Interval.offset(startDate, config.step);
       if (endDate > this._scale.domain()[1]) {
         // this offset is too large, so just return available width
@@ -536,25 +536,6 @@ export module Axes {
           tickLabel.style("visibility", "inherit");
         }
       });
-    }
-
-    private _getD3TimeInterval(timeInterval: TimeInterval) {
-      switch (timeInterval) {
-        case TimeInterval.second:
-          return d3.time.second;
-        case TimeInterval.minute:
-          return d3.time.minute;
-        case TimeInterval.hour:
-          return d3.time.hour;
-        case TimeInterval.day:
-          return d3.time.day;
-        case TimeInterval.month:
-          return d3.time.month;
-        case TimeInterval.year:
-          return d3.time.year;
-        default:
-          throw Error("TimeInterval specified does not exist");
-      }
     }
   }
 }

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -3,7 +3,7 @@
 module Plottable {
 
 export enum TimeInterval {
-  second, minute, hour, day, month, year
+  second, minute, hour, day, week, month, year
 };
 
 export module Axes {

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -56,6 +56,11 @@ export module Scales {
           return d3.time.day;
         case TimeInterval.month:
           return d3.time.month;
+        case TimeInterval.year:
+          return d3.time.year;
+        default:
+          throw Error("TimeInterval specified does not exist");
+
       }
     }
 

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -18,7 +18,15 @@ export module Scales {
       super(scale == null ? (<any>d3.time.scale()) : scale);
     }
 
-    public tickInterval(interval: TimeInterval, step?: number): Date[] {
+    /**
+     * Specifies the interval between ticks
+     *
+     * @param {string} interval TimeInterval string specifying the interval unit measure
+     * @param {number?} step? The distance between adjacent ticks (using the interval unit measure)
+     *
+     * @return {Date[]}
+     */
+    public tickInterval(interval: string, step?: number): Date[] {
       // temporarily creats a time scale from our linear scale into a time scale so we can get access to its api
       var tempScale = d3.time.scale();
       var d3Interval = Formatters.timeIntervalToD3Time(interval);

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -18,12 +18,13 @@ export module Scales {
       super(scale == null ? (<any>d3.time.scale()) : scale);
     }
 
-    public tickInterval(interval: D3.Time.Interval, step?: number): Date[] {
+    public tickInterval(interval: TimeInterval, step?: number): Date[] {
       // temporarily creats a time scale from our linear scale into a time scale so we can get access to its api
       var tempScale = d3.time.scale();
+      var d3Interval = this._getD3TimeInterval(interval);
       tempScale.domain(this.domain());
       tempScale.range(this.range());
-      return tempScale.ticks(interval.range, step);
+      return tempScale.ticks(d3Interval.range, step);
     }
 
     protected _setDomain(values: Date[]) {
@@ -42,6 +43,22 @@ export module Scales {
       var startTimeValue = endTimeValue - Plottable.MILLISECONDS_IN_ONE_DAY;
       return [new Date(startTimeValue), new Date(endTimeValue)];
     }
+
+    private _getD3TimeInterval(timeInterval: TimeInterval) {
+      switch (timeInterval) {
+        case TimeInterval.second:
+          return d3.time.second;
+        case TimeInterval.minute:
+          return d3.time.minute;
+        case TimeInterval.hour:
+          return d3.time.hour;
+        case TimeInterval.day:
+          return d3.time.day;
+        case TimeInterval.month:
+          return d3.time.month;
+      }
+    }
+
   }
 }
 }

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -21,7 +21,7 @@ export module Scales {
     public tickInterval(interval: TimeInterval, step?: number): Date[] {
       // temporarily creats a time scale from our linear scale into a time scale so we can get access to its api
       var tempScale = d3.time.scale();
-      var d3Interval = this._getD3TimeInterval(interval);
+      var d3Interval = Formatters.timeIntervalToD3Time(interval);
       tempScale.domain(this.domain());
       tempScale.range(this.range());
       return tempScale.ticks(d3Interval.range, step);
@@ -43,27 +43,6 @@ export module Scales {
       var startTimeValue = endTimeValue - Plottable.MILLISECONDS_IN_ONE_DAY;
       return [new Date(startTimeValue), new Date(endTimeValue)];
     }
-
-    private _getD3TimeInterval(timeInterval: TimeInterval) {
-      switch (timeInterval) {
-        case TimeInterval.second:
-          return d3.time.second;
-        case TimeInterval.minute:
-          return d3.time.minute;
-        case TimeInterval.hour:
-          return d3.time.hour;
-        case TimeInterval.day:
-          return d3.time.day;
-        case TimeInterval.month:
-          return d3.time.month;
-        case TimeInterval.year:
-          return d3.time.year;
-        default:
-          throw Error("TimeInterval specified does not exist");
-
-      }
-    }
-
   }
 }
 }

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -209,7 +209,8 @@ module Plottable {
       case TimeInterval.year:
         return d3.time.year;
       default:
-        throw Error("TimeInterval specified does not exist");
+        Utils.Methods.warn("TimeInterval specified does not exist");
+        return d3.time.year;
       }
     }
 

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -190,7 +190,8 @@ module Plottable {
     }
 
     /**
-     * Transforms the Plottable TimeInterval into a d3 time interval equivalent
+     * Transforms the Plottable TimeInterval into a d3 time interval equivalent.
+     * If the provided TimeInterval is incorrect, the default is d3.time.year
      */
     export function timeIntervalToD3Time(timeInterval: TimeInterval) {
       switch (timeInterval) {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -190,6 +190,28 @@ module Plottable {
     }
 
     /**
+     * Transforms the Plottable TimeInterval into a d3 time interval equivalent
+     */
+    export function timeIntervalToD3Time(timeInterval: TimeInterval) {
+      switch (timeInterval) {
+      case TimeInterval.second:
+        return d3.time.second;
+      case TimeInterval.minute:
+        return d3.time.minute;
+      case TimeInterval.hour:
+        return d3.time.hour;
+      case TimeInterval.day:
+        return d3.time.day;
+      case TimeInterval.month:
+        return d3.time.month;
+      case TimeInterval.year:
+        return d3.time.year;
+      default:
+        throw Error("TimeInterval specified does not exist");
+      }
+    }
+
+    /**
      * Creates a formatter for relative dates.
      *
      * @param {number} baseValue The start date (as epoch time) used in computing relative dates (default 0)

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -190,10 +190,10 @@ module Plottable {
     }
 
     /**
-     * Transforms the Plottable TimeInterval into a d3 time interval equivalent.
+     * Transforms the Plottable TimeInterval string into a d3 time interval equivalent.
      * If the provided TimeInterval is incorrect, the default is d3.time.year
      */
-    export function timeIntervalToD3Time(timeInterval: TimeInterval) {
+    export function timeIntervalToD3Time(timeInterval: string) {
       switch (timeInterval) {
       case TimeInterval.second:
         return d3.time.second;

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -210,7 +210,7 @@ module Plottable {
       case TimeInterval.year:
         return d3.time.year;
       default:
-        Utils.Methods.warn("TimeInterval specified does not exist");
+        Utils.Methods.warn("TimeInterval specified does not exist: " + timeInterval);
         return d3.time.year;
       }
     }

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -202,6 +202,8 @@ module Plottable {
         return d3.time.hour;
       case TimeInterval.day:
         return d3.time.day;
+      case TimeInterval.week:
+        return d3.time.week;
       case TimeInterval.month:
         return d3.time.month;
       case TimeInterval.year:

--- a/test/components/timeAxisTests.ts
+++ b/test/components/timeAxisTests.ts
@@ -90,7 +90,7 @@ describe("TimeAxis", () => {
     var configurations = axis.axisConfigurations();
     var newPossibleConfigurations = configurations.slice(0, 3);
     newPossibleConfigurations.forEach(axisConfig => axisConfig.forEach(tierConfig => {
-      tierConfig.interval = d3.time.minute;
+      tierConfig.interval = Plottable.TimeInterval.minute;
       tierConfig.step += 3;
     }));
     axis.axisConfigurations(newPossibleConfigurations);
@@ -101,7 +101,7 @@ describe("TimeAxis", () => {
     scale.range([0, 800]);
     axis.renderTo(svg);
     var configs = newPossibleConfigurations[(<any> axis)._mostPreciseConfigIndex];
-    assert.deepEqual(configs[0].interval, d3.time.minute, "axis used new time unit");
+    assert.deepEqual(configs[0].interval, Plottable.TimeInterval.minute, "axis used new time unit");
     assert.deepEqual(configs[0].step, 4, "axis used new step");
     svg.remove();
   });
@@ -160,7 +160,7 @@ describe("TimeAxis", () => {
 
     xAxis.axisConfigurations([
         [
-           {interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e")}
+           {interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e")}
         ],
     ]);
 
@@ -170,8 +170,8 @@ describe("TimeAxis", () => {
 
     xAxis.axisConfigurations([
         [
-           {interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e")},
-           {interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e")}
+           {interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e")},
+           {interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e")}
         ],
     ]);
 
@@ -181,7 +181,7 @@ describe("TimeAxis", () => {
 
     xAxis.axisConfigurations([
         [
-           {interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e")}
+           {interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e")}
         ],
     ]);
 
@@ -204,8 +204,8 @@ describe("TimeAxis", () => {
 
     xAxis.axisConfigurations([
         [
-           {interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e")},
-           {interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e")},
+           {interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e")},
+           {interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e")},
         ],
     ]);
 
@@ -213,9 +213,9 @@ describe("TimeAxis", () => {
 
     xAxis.axisConfigurations([
         [
-           {interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e")},
-           {interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e")},
-           {interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e")},
+           {interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e")},
+           {interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e")},
+           {interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e")},
         ],
     ]);
 
@@ -236,7 +236,7 @@ describe("TimeAxis", () => {
 
     var tiersToCreate = 15;
     var configuration = Array.apply(null, Array(tiersToCreate)).map(() => {
-      return {interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e") };
+      return {interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e") };
     });
     xAxis.axisConfigurations([configuration]);
 

--- a/test/scales/timeScaleTests.ts
+++ b/test/scales/timeScaleTests.ts
@@ -12,31 +12,31 @@ describe("TimeScale tests", () => {
     var scale = new Plottable.Scales.Time();
     // 100 year span
     scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2100, 0, 1, 0, 0, 0, 0)]);
-    var ticks = scale.tickInterval(d3.time.year);
+    var ticks = scale.tickInterval(Plottable.TimeInterval.year);
     assert.strictEqual(ticks.length, 101, "generated correct number of ticks");
     // 1 year span
     scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 11, 31, 0, 0, 0, 0)]);
-    ticks = scale.tickInterval(d3.time.month);
+    ticks = scale.tickInterval(Plottable.TimeInterval.month);
     assert.strictEqual(ticks.length, 12, "generated correct number of ticks");
-    ticks = scale.tickInterval(d3.time.month, 3);
+    ticks = scale.tickInterval(Plottable.TimeInterval.month, 3);
     assert.strictEqual(ticks.length, 4, "generated correct number of ticks");
     // 1 month span
     scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 1, 1, 0, 0, 0, 0)]);
-    ticks = scale.tickInterval(d3.time.day);
+    ticks = scale.tickInterval(Plottable.TimeInterval.day);
     assert.strictEqual(ticks.length, 32, "generated correct number of ticks");
     // 1 day span
     scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 0, 1, 23, 0, 0, 0)]);
-    ticks = scale.tickInterval(d3.time.hour);
+    ticks = scale.tickInterval(Plottable.TimeInterval.hour);
     assert.strictEqual(ticks.length, 24, "generated correct number of ticks");
     // 1 hour span
     scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 0, 1, 1, 0, 0, 0)]);
-    ticks = scale.tickInterval(d3.time.minute);
+    ticks = scale.tickInterval(Plottable.TimeInterval.minute);
     assert.strictEqual(ticks.length, 61, "generated correct number of ticks");
-    ticks = scale.tickInterval(d3.time.minute, 10);
+    ticks = scale.tickInterval(Plottable.TimeInterval.minute, 10);
     assert.strictEqual(ticks.length, 7, "generated correct number of ticks");
     // 1 minute span
     scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 0, 1, 0, 1, 0, 0)]);
-    ticks = scale.tickInterval(d3.time.second);
+    ticks = scale.tickInterval(Plottable.TimeInterval.second);
     assert.strictEqual(ticks.length, 61, "generated correct number of ticks");
   });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -745,7 +745,7 @@ describe("TimeAxis", function () {
         var configurations = axis.axisConfigurations();
         var newPossibleConfigurations = configurations.slice(0, 3);
         newPossibleConfigurations.forEach(function (axisConfig) { return axisConfig.forEach(function (tierConfig) {
-            tierConfig.interval = d3.time.minute;
+            tierConfig.interval = 1 /* minute */;
             tierConfig.step += 3;
         }); });
         axis.axisConfigurations(newPossibleConfigurations);
@@ -756,7 +756,7 @@ describe("TimeAxis", function () {
         scale.range([0, 800]);
         axis.renderTo(svg);
         var configs = newPossibleConfigurations[axis._mostPreciseConfigIndex];
-        assert.deepEqual(configs[0].interval, d3.time.minute, "axis used new time unit");
+        assert.deepEqual(configs[0].interval, 1 /* minute */, "axis used new time unit");
         assert.deepEqual(configs[0].step, 4, "axis used new step");
         svg.remove();
     });
@@ -809,22 +809,22 @@ describe("TimeAxis", function () {
         xAxis.gutter(0);
         xAxis.axisConfigurations([
             [
-                { interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e") }
+                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") }
             ],
         ]);
         xAxis.renderTo(svg);
         var oneTierSize = xAxis.height();
         xAxis.axisConfigurations([
             [
-                { interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e") },
-                { interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e") }
+                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") },
+                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") }
             ],
         ]);
         var twoTierSize = xAxis.height();
         assert.strictEqual(twoTierSize, oneTierSize * 2, "two-tier axis is twice as tall as one-tier axis");
         xAxis.axisConfigurations([
             [
-                { interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e") }
+                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") }
             ],
         ]);
         var initialTierSize = xAxis.height();
@@ -840,16 +840,16 @@ describe("TimeAxis", function () {
         xAxis.renderTo(svg);
         xAxis.axisConfigurations([
             [
-                { interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e") },
-                { interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e") },
+                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") },
+                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") },
             ],
         ]);
         var twoTierAxisHeight = xAxis.height();
         xAxis.axisConfigurations([
             [
-                { interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e") },
-                { interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e") },
-                { interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e") },
+                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") },
+                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") },
+                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") },
             ],
         ]);
         var threeTierAxisHeight = xAxis.height();
@@ -863,7 +863,7 @@ describe("TimeAxis", function () {
         var xAxis = new Plottable.Axes.Time(xScale, "bottom");
         var tiersToCreate = 15;
         var configuration = Array.apply(null, Array(tiersToCreate)).map(function () {
-            return { interval: d3.time.day, step: 2, formatter: Plottable.Formatters.time("%a %e") };
+            return { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") };
         });
         xAxis.axisConfigurations([configuration]);
         xAxis.renderTo(svg);
@@ -7450,31 +7450,31 @@ describe("TimeScale tests", function () {
         var scale = new Plottable.Scales.Time();
         // 100 year span
         scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2100, 0, 1, 0, 0, 0, 0)]);
-        var ticks = scale.tickInterval(d3.time.year);
+        var ticks = scale.tickInterval(5 /* year */);
         assert.strictEqual(ticks.length, 101, "generated correct number of ticks");
         // 1 year span
         scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 11, 31, 0, 0, 0, 0)]);
-        ticks = scale.tickInterval(d3.time.month);
+        ticks = scale.tickInterval(4 /* month */);
         assert.strictEqual(ticks.length, 12, "generated correct number of ticks");
-        ticks = scale.tickInterval(d3.time.month, 3);
+        ticks = scale.tickInterval(4 /* month */, 3);
         assert.strictEqual(ticks.length, 4, "generated correct number of ticks");
         // 1 month span
         scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 1, 1, 0, 0, 0, 0)]);
-        ticks = scale.tickInterval(d3.time.day);
+        ticks = scale.tickInterval(3 /* day */);
         assert.strictEqual(ticks.length, 32, "generated correct number of ticks");
         // 1 day span
         scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 0, 1, 23, 0, 0, 0)]);
-        ticks = scale.tickInterval(d3.time.hour);
+        ticks = scale.tickInterval(2 /* hour */);
         assert.strictEqual(ticks.length, 24, "generated correct number of ticks");
         // 1 hour span
         scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 0, 1, 1, 0, 0, 0)]);
-        ticks = scale.tickInterval(d3.time.minute);
+        ticks = scale.tickInterval(1 /* minute */);
         assert.strictEqual(ticks.length, 61, "generated correct number of ticks");
-        ticks = scale.tickInterval(d3.time.minute, 10);
+        ticks = scale.tickInterval(1 /* minute */, 10);
         assert.strictEqual(ticks.length, 7, "generated correct number of ticks");
         // 1 minute span
         scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 0, 1, 0, 1, 0, 0)]);
-        ticks = scale.tickInterval(d3.time.second);
+        ticks = scale.tickInterval(0 /* second */);
         assert.strictEqual(ticks.length, 61, "generated correct number of ticks");
     });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -745,7 +745,7 @@ describe("TimeAxis", function () {
         var configurations = axis.axisConfigurations();
         var newPossibleConfigurations = configurations.slice(0, 3);
         newPossibleConfigurations.forEach(function (axisConfig) { return axisConfig.forEach(function (tierConfig) {
-            tierConfig.interval = 1 /* minute */;
+            tierConfig.interval = Plottable.TimeInterval.minute;
             tierConfig.step += 3;
         }); });
         axis.axisConfigurations(newPossibleConfigurations);
@@ -756,7 +756,7 @@ describe("TimeAxis", function () {
         scale.range([0, 800]);
         axis.renderTo(svg);
         var configs = newPossibleConfigurations[axis._mostPreciseConfigIndex];
-        assert.deepEqual(configs[0].interval, 1 /* minute */, "axis used new time unit");
+        assert.deepEqual(configs[0].interval, Plottable.TimeInterval.minute, "axis used new time unit");
         assert.deepEqual(configs[0].step, 4, "axis used new step");
         svg.remove();
     });
@@ -809,22 +809,22 @@ describe("TimeAxis", function () {
         xAxis.gutter(0);
         xAxis.axisConfigurations([
             [
-                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") }
+                { interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e") }
             ],
         ]);
         xAxis.renderTo(svg);
         var oneTierSize = xAxis.height();
         xAxis.axisConfigurations([
             [
-                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") },
-                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") }
+                { interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e") },
+                { interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e") }
             ],
         ]);
         var twoTierSize = xAxis.height();
         assert.strictEqual(twoTierSize, oneTierSize * 2, "two-tier axis is twice as tall as one-tier axis");
         xAxis.axisConfigurations([
             [
-                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") }
+                { interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e") }
             ],
         ]);
         var initialTierSize = xAxis.height();
@@ -840,16 +840,16 @@ describe("TimeAxis", function () {
         xAxis.renderTo(svg);
         xAxis.axisConfigurations([
             [
-                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") },
-                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") },
+                { interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e") },
+                { interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e") },
             ],
         ]);
         var twoTierAxisHeight = xAxis.height();
         xAxis.axisConfigurations([
             [
-                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") },
-                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") },
-                { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") },
+                { interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e") },
+                { interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e") },
+                { interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e") },
             ],
         ]);
         var threeTierAxisHeight = xAxis.height();
@@ -863,7 +863,7 @@ describe("TimeAxis", function () {
         var xAxis = new Plottable.Axes.Time(xScale, "bottom");
         var tiersToCreate = 15;
         var configuration = Array.apply(null, Array(tiersToCreate)).map(function () {
-            return { interval: 3 /* day */, step: 2, formatter: Plottable.Formatters.time("%a %e") };
+            return { interval: Plottable.TimeInterval.day, step: 2, formatter: Plottable.Formatters.time("%a %e") };
         });
         xAxis.axisConfigurations([configuration]);
         xAxis.renderTo(svg);
@@ -7450,31 +7450,31 @@ describe("TimeScale tests", function () {
         var scale = new Plottable.Scales.Time();
         // 100 year span
         scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2100, 0, 1, 0, 0, 0, 0)]);
-        var ticks = scale.tickInterval(6 /* year */);
+        var ticks = scale.tickInterval(Plottable.TimeInterval.year);
         assert.strictEqual(ticks.length, 101, "generated correct number of ticks");
         // 1 year span
         scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 11, 31, 0, 0, 0, 0)]);
-        ticks = scale.tickInterval(5 /* month */);
+        ticks = scale.tickInterval(Plottable.TimeInterval.month);
         assert.strictEqual(ticks.length, 12, "generated correct number of ticks");
-        ticks = scale.tickInterval(5 /* month */, 3);
+        ticks = scale.tickInterval(Plottable.TimeInterval.month, 3);
         assert.strictEqual(ticks.length, 4, "generated correct number of ticks");
         // 1 month span
         scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 1, 1, 0, 0, 0, 0)]);
-        ticks = scale.tickInterval(3 /* day */);
+        ticks = scale.tickInterval(Plottable.TimeInterval.day);
         assert.strictEqual(ticks.length, 32, "generated correct number of ticks");
         // 1 day span
         scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 0, 1, 23, 0, 0, 0)]);
-        ticks = scale.tickInterval(2 /* hour */);
+        ticks = scale.tickInterval(Plottable.TimeInterval.hour);
         assert.strictEqual(ticks.length, 24, "generated correct number of ticks");
         // 1 hour span
         scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 0, 1, 1, 0, 0, 0)]);
-        ticks = scale.tickInterval(1 /* minute */);
+        ticks = scale.tickInterval(Plottable.TimeInterval.minute);
         assert.strictEqual(ticks.length, 61, "generated correct number of ticks");
-        ticks = scale.tickInterval(1 /* minute */, 10);
+        ticks = scale.tickInterval(Plottable.TimeInterval.minute, 10);
         assert.strictEqual(ticks.length, 7, "generated correct number of ticks");
         // 1 minute span
         scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 0, 1, 0, 1, 0, 0)]);
-        ticks = scale.tickInterval(0 /* second */);
+        ticks = scale.tickInterval(Plottable.TimeInterval.second);
         assert.strictEqual(ticks.length, 61, "generated correct number of ticks");
     });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -7450,13 +7450,13 @@ describe("TimeScale tests", function () {
         var scale = new Plottable.Scales.Time();
         // 100 year span
         scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2100, 0, 1, 0, 0, 0, 0)]);
-        var ticks = scale.tickInterval(5 /* year */);
+        var ticks = scale.tickInterval(6 /* year */);
         assert.strictEqual(ticks.length, 101, "generated correct number of ticks");
         // 1 year span
         scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 11, 31, 0, 0, 0, 0)]);
-        ticks = scale.tickInterval(4 /* month */);
+        ticks = scale.tickInterval(5 /* month */);
         assert.strictEqual(ticks.length, 12, "generated correct number of ticks");
-        ticks = scale.tickInterval(4 /* month */, 3);
+        ticks = scale.tickInterval(5 /* month */, 3);
         assert.strictEqual(ticks.length, 4, "generated correct number of ticks");
         // 1 month span
         scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 1, 1, 0, 0, 0, 0)]);


### PR DESCRIPTION
Instead we defined our own enum called TimeInterval, which we expose to the public API.
The reasoning behind this change is that we do not want d3 implementation details (internals) to leak out to the user.