### PR TITLE
Repaired renderer

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -949,8 +949,7 @@ var Plottable;
                 case Plottable.TimeInterval.year:
                     return d3.time.year;
                 default:
-                    Plottable.Utils.Methods.warn("TimeInterval specified does not exist: " + timeInterval);
-                    return d3.time.year;
+                    throw Error("TimeInterval specified does not exist: " + timeInterval);
             }
         }
         Formatters.timeIntervalToD3Time = timeIntervalToD3Time;
@@ -1324,9 +1323,7 @@ var Plottable;
                 // Layout
                 _componentsNeedingComputeLayout.values().forEach(function (component) { return component.computeLayout(); });
                 _componentsNeedingComputeLayout = new Plottable.Utils.Set();
-                var toRender = _componentsNeedingRender;
-                _componentsNeedingRender = new Plottable.Utils.Set();
-                toRender.values().forEach(function (component) {
+                _componentsNeedingRender.values().forEach(function (component) {
                     try {
                         component.render(true);
                     }
@@ -1335,9 +1332,9 @@ var Plottable;
                         window.setTimeout(function () {
                             throw err;
                         }, 0);
-                        registerToRender(component); // try again later
                     }
                 });
+                _componentsNeedingRender = new Plottable.Utils.Set();
                 _animationRequested = false;
             }
             if (_componentsNeedingRender.values().length !== 0) {

--- a/src/core/renderController.ts
+++ b/src/core/renderController.ts
@@ -87,17 +87,15 @@ module Plottable {
         _componentsNeedingComputeLayout.values().forEach((component) => component.computeLayout());
         _componentsNeedingComputeLayout = new Utils.Set<Component>();
 
-        var toRender = _componentsNeedingRender;
-        _componentsNeedingRender = new Utils.Set<Component>();
-        toRender.values().forEach((component) => {
+        _componentsNeedingRender.values().forEach((component) => {
           try {
             component.render(true);
           } catch (err) {
             // throw error with timeout to avoid interrupting further renders
             window.setTimeout(() => { throw err; }, 0);
-            registerToRender(component); // try again later
           }
         });
+        _componentsNeedingRender = new Utils.Set<Component>();
         _animationRequested = false;
       }
       if (_componentsNeedingRender.values().length !== 0) {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -210,8 +210,7 @@ module Plottable {
       case TimeInterval.year:
         return d3.time.year;
       default:
-        Utils.Methods.warn("TimeInterval specified does not exist: " + timeInterval);
-        return d3.time.year;
+        throw Error("TimeInterval specified does not exist: " + timeInterval);
       }
     }
 


### PR DESCRIPTION
Issue:  The try, catch block inside the `rendererController.flush()`. If anything inside here (and there's a lot in her) fails and throws an exception, the exception is going to be caught by https://github.com/palantir/plottable/blob/timeD3/src/core/renderController.ts#L95 and not thrown immediately. Also, the renderer is going to loop infinitely, as it keeps rescheduling the component to a render. Removed the rescheduling bit. 

Reasoning behind it: From a discussion with @jtlan , the render should be (and I hope is) a pure function (no side effect), hence it should not modify the model. Since it does not modify the model, nothing changes. Since nothing changes, the component render will fail forever. 