### PR TITLE
Repaired RenderController again

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -1306,7 +1306,9 @@ var Plottable;
                 // Layout
                 _componentsNeedingComputeLayout.values().forEach(function (component) { return component.computeLayout(); });
                 _componentsNeedingComputeLayout = new Plottable.Utils.Set();
-                _componentsNeedingRender.values().forEach(function (component) {
+                var toRender = _componentsNeedingRender;
+                _componentsNeedingRender = new Plottable.Utils.Set(); // new Components might queue while we're looping
+                toRender.values().forEach(function (component) {
                     try {
                         component.render(true);
                     }
@@ -1317,7 +1319,6 @@ var Plottable;
                         }, 0);
                     }
                 });
-                _componentsNeedingRender = new Plottable.Utils.Set();
                 _animationRequested = false;
             }
             if (_componentsNeedingRender.values().length !== 0) {

--- a/src/core/renderController.ts
+++ b/src/core/renderController.ts
@@ -87,7 +87,9 @@ module Plottable {
         _componentsNeedingComputeLayout.values().forEach((component) => component.computeLayout());
         _componentsNeedingComputeLayout = new Utils.Set<Component>();
 
-        _componentsNeedingRender.values().forEach((component) => {
+        var toRender = _componentsNeedingRender;
+        _componentsNeedingRender = new Utils.Set<Component>(); // new Components might queue while we're looping
+        toRender.values().forEach((component) => {
           try {
             component.render(true);
           } catch (err) {
@@ -95,7 +97,6 @@ module Plottable {
             window.setTimeout(() => { throw err; }, 0);
           }
         });
-        _componentsNeedingRender = new Utils.Set<Component>();
         _animationRequested = false;
       }
       if (_componentsNeedingRender.values().length !== 0) {

--- a/test/core/renderControllerTests.ts
+++ b/test/core/renderControllerTests.ts
@@ -1,0 +1,23 @@
+///<reference path="../testReference.ts" />
+
+var assert = chai.assert;
+
+describe("RenderController", () => {
+  it("Components whose render() is triggered by another Component's render() will be drawn", () => {
+    var link1 = new Plottable.Component();
+    var svg1 = TestMethods.generateSVG();
+    var link2 = new Plottable.Component();
+    var svg2 = TestMethods.generateSVG();
+    link2.renderTo(svg2);
+
+    (<any> link1)._render = () => link2.render();
+    var link2Rendered = false;
+    (<any> link2)._render = () => link2Rendered = true;
+
+    link1.renderTo(svg1);
+    assert.isTrue(link2Rendered, "dependent Component was eventually drawn");
+
+    svg1.remove();
+    svg2.remove();
+  });
+});

--- a/test/core/renderControllerTests.ts
+++ b/test/core/renderControllerTests.ts
@@ -16,7 +16,7 @@ describe("RenderController", () => {
     (<any> link2)._render = () => link2Rendered = true;
 
     link1.render();
-    assert.isTrue(link2Rendered, "dependent Component was eventually drawn");
+    assert.isTrue(link2Rendered, "dependent Component was render()-ed");
 
     svg1.remove();
     svg2.remove();

--- a/test/core/renderControllerTests.ts
+++ b/test/core/renderControllerTests.ts
@@ -6,15 +6,16 @@ describe("RenderController", () => {
   it("Components whose render() is triggered by another Component's render() will be drawn", () => {
     var link1 = new Plottable.Component();
     var svg1 = TestMethods.generateSVG();
+    link1.anchor(svg1).computeLayout();
     var link2 = new Plottable.Component();
     var svg2 = TestMethods.generateSVG();
-    link2.renderTo(svg2);
+    link2.anchor(svg2).computeLayout();
 
     (<any> link1)._render = () => link2.render();
     var link2Rendered = false;
     (<any> link2)._render = () => link2Rendered = true;
 
-    link1.renderTo(svg1);
+    link1.render();
     assert.isTrue(link2Rendered, "dependent Component was eventually drawn");
 
     svg1.remove();

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -39,6 +39,7 @@
 ///<reference path="components/plots/clusteredBarPlotTests.ts" />
 
 ///<reference path="core/metadataTests.ts" />
+///<reference path="core/renderControllerTests.ts" />
 ///<reference path="core/componentContainerTests.ts" />
 ///<reference path="core/componentGroupTests.ts" />
 ///<reference path="core/componentTests.ts" />

--- a/test/tests.js
+++ b/test/tests.js
@@ -5844,13 +5844,14 @@ describe("RenderController", function () {
     it("Components whose render() is triggered by another Component's render() will be drawn", function () {
         var link1 = new Plottable.Component();
         var svg1 = TestMethods.generateSVG();
+        link1.anchor(svg1).computeLayout();
         var link2 = new Plottable.Component();
         var svg2 = TestMethods.generateSVG();
-        link2.renderTo(svg2);
+        link2.anchor(svg2).computeLayout();
         link1._render = function () { return link2.render(); };
         var link2Rendered = false;
         link2._render = function () { return link2Rendered = true; };
-        link1.renderTo(svg1);
+        link1.render();
         assert.isTrue(link2Rendered, "dependent Component was eventually drawn");
         svg1.remove();
         svg2.remove();

--- a/test/tests.js
+++ b/test/tests.js
@@ -5840,6 +5840,25 @@ describe("Metadata", function () {
 
 ///<reference path="../testReference.ts" />
 var assert = chai.assert;
+describe("RenderController", function () {
+    it("Components whose render() is triggered by another Component's render() will be drawn", function () {
+        var link1 = new Plottable.Component();
+        var svg1 = TestMethods.generateSVG();
+        var link2 = new Plottable.Component();
+        var svg2 = TestMethods.generateSVG();
+        link2.renderTo(svg2);
+        link1._render = function () { return link2.render(); };
+        var link2Rendered = false;
+        link2._render = function () { return link2Rendered = true; };
+        link1.renderTo(svg1);
+        assert.isTrue(link2Rendered, "dependent Component was eventually drawn");
+        svg1.remove();
+        svg2.remove();
+    });
+});
+
+///<reference path="../testReference.ts" />
+var assert = chai.assert;
 describe("ComponentContainer", function () {
     it("add()", function () {
         var container = new Plottable.ComponentContainer();

--- a/test/tests.js
+++ b/test/tests.js
@@ -5852,7 +5852,7 @@ describe("RenderController", function () {
         var link2Rendered = false;
         link2._render = function () { return link2Rendered = true; };
         link1.render();
-        assert.isTrue(link2Rendered, "dependent Component was eventually drawn");
+        assert.isTrue(link2Rendered, "dependent Component was render()-ed");
         svg1.remove();
         svg2.remove();
     });


### PR DESCRIPTION
b98a94b687de50b87143e2e64a001b4b7e46d4b2 caused a problem by removing the declaration of a new `_componentsToRender` `Set` before the loop where all the `Components` were drawn. That change caused a bug because `Component`s that were enqueued by another `Component`'s `render()` call would never be redrawn.

Added a test to catch this bug.