### PR TITLE
orient -> orientation

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1897,7 +1897,7 @@ declare module Plottable {
          *
          * @returns {number} the current orientation.
          */
-        orient(): string;
+        orientation(): string;
         /**
          * Sets the orientation of the Axis.
          *
@@ -1905,7 +1905,7 @@ declare module Plottable {
          * (top/bottom/left/right).
          * @returns {Axis} The calling Axis.
          */
-        orient(newOrientation: string): Axis;
+        orientation(orientation: string): Axis;
         /**
          * Gets whether the Axis is currently set to show the first and last
          * tick labels.
@@ -1988,8 +1988,8 @@ declare module Plottable {
              * @returns {Axis.Time} The calling Axis.Time.
              */
             axisConfigurations(configurations: TimeAxisConfiguration[]): Time;
-            orient(): string;
-            orient(orientation: string): Time;
+            orientation(): string;
+            orientation(orientation: string): Time;
             protected _computeHeight(): number;
             protected _getSize(availableWidth: number, availableHeight: number): {
                 width: number;
@@ -2144,7 +2144,7 @@ declare module Plottable {
              *
              * @returns {string} the current orientation.
              */
-            orient(): string;
+            orientation(): string;
             /**
              * Sets the orientation of the Label.
              *
@@ -2152,7 +2152,7 @@ declare module Plottable {
              * (horizontal/left/right).
              * @returns {Label} The calling Label.
              */
-            orient(newOrientation: string): Label;
+            orientation(orientation: string): Label;
             /**
              * Gets the amount of padding in pixels around the Label.
              *
@@ -2319,7 +2319,7 @@ declare module Plottable {
              *
              * @returns {string} The current orientation.
              */
-            orient(): string;
+            orientation(): string;
             /**
              * Sets the orientation of the InterpolatedColorLegend.
              *
@@ -2327,7 +2327,7 @@ declare module Plottable {
              *
              * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
              */
-            orient(newOrientation: string): InterpolatedColorLegend;
+            orientation(orientation: string): InterpolatedColorLegend;
             protected _setup(): void;
             requestedSpace(offeredWidth: number, offeredHeight: number): _SpaceRequest;
             protected _render(): void;

--- a/plottable.js
+++ b/plottable.js
@@ -3793,7 +3793,7 @@ var Plottable;
                 throw new Error("Axis requires a scale and orientation");
             }
             this._scale = scale;
-            this.orient(orientation);
+            this.orientation(orientation);
             this._setDefaultAlignment();
             this.classed("axis", true);
             if (this._isHorizontal()) {
@@ -4039,12 +4039,12 @@ var Plottable;
                 return this;
             }
         };
-        Axis.prototype.orient = function (newOrientation) {
-            if (newOrientation == null) {
+        Axis.prototype.orientation = function (orientation) {
+            if (orientation == null) {
                 return this._orientation;
             }
             else {
-                var newOrientationLC = newOrientation.toLowerCase();
+                var newOrientationLC = orientation.toLowerCase();
                 if (newOrientationLC !== "top" && newOrientationLC !== "bottom" && newOrientationLC !== "left" && newOrientationLC !== "right") {
                     throw new Error("unsupported orientation");
                 }
@@ -4166,11 +4166,11 @@ var Plottable;
                 }
                 return mostPreciseIndex;
             };
-            Time.prototype.orient = function (orientation) {
+            Time.prototype.orientation = function (orientation) {
                 if (orientation && (orientation.toLowerCase() === "right" || orientation.toLowerCase() === "left")) {
                     throw new Error(orientation + " is not a supported orientation for TimeAxis - only horizontal orientations are supported");
                 }
-                return _super.prototype.orient.call(this, orientation); // maintains getter-setter functionality
+                return _super.prototype.orientation.call(this, orientation); // maintains getter-setter functionality
             };
             Time.prototype._computeHeight = function () {
                 var textHeight = this._measurer.measure().height;
@@ -4276,7 +4276,7 @@ var Plottable;
                 var tickLabelsEnter = tickLabels.enter().append("g").classed(Plottable.Axis.TICK_LABEL_CLASS, true);
                 tickLabelsEnter.append("text");
                 var xTranslate = (this._tierLabelPositions[index] === "center" || config.step === 1) ? 0 : this.tickLabelPadding();
-                var yTranslate = this.orient() === "bottom" ? d3.sum(this._tierHeights.slice(0, index + 1)) - this.tickLabelPadding() : this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding();
+                var yTranslate = this.orientation() === "bottom" ? d3.sum(this._tierHeights.slice(0, index + 1)) - this.tickLabelPadding() : this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding();
                 var textSelection = tickLabels.selectAll("text");
                 if (textSelection.size() > 0) {
                     Plottable.Utils.DOM.translate(textSelection, xTranslate, yTranslate);
@@ -4291,7 +4291,7 @@ var Plottable;
                 tickMarks.enter().append("line").classed(Plottable.Axis.TICK_MARK_CLASS, true);
                 var attr = this._generateTickMarkAttrHash();
                 var offset = this._tierHeights.slice(0, index).reduce(function (translate, height) { return translate + height; }, 0);
-                if (this.orient() === "bottom") {
+                if (this.orientation() === "bottom") {
                     attr["y1"] = offset;
                     attr["y2"] = offset + (this._tierLabelPositions[index] === "center" ? this.tickLength() : this._tierHeights[index]);
                 }
@@ -4300,7 +4300,7 @@ var Plottable;
                     attr["y2"] = this.height() - (offset + (this._tierLabelPositions[index] === "center" ? this.tickLength() : this._tierHeights[index]));
                 }
                 tickMarks.attr(attr);
-                if (this.orient() === "bottom") {
+                if (this.orientation() === "bottom") {
                     attr["y1"] = offset;
                     attr["y2"] = offset + this._tierHeights[index];
                 }
@@ -4318,7 +4318,7 @@ var Plottable;
                 var tickMarks = this._tickMarkContainer.selectAll("." + Plottable.Axis.TICK_MARK_CLASS).data(tickValues);
                 tickMarks.enter().append("line").classed(Plottable.Axis.TICK_MARK_CLASS, true);
                 var attr = this._generateTickMarkAttrHash();
-                attr["y2"] = (this.orient() === "bottom") ? this.tickLabelPadding() : this.height() - this.tickLabelPadding();
+                attr["y2"] = (this.orientation() === "bottom") ? this.tickLabelPadding() : this.height() - this.tickLabelPadding();
                 tickMarks.attr(attr);
                 tickMarks.exit().remove();
             };
@@ -4338,7 +4338,7 @@ var Plottable;
                 var baselineOffset = 0;
                 for (var i = 0; i < Math.max(tierConfigs.length, 1); ++i) {
                     var attr = this._generateBaselineAttrHash();
-                    attr["y1"] += (this.orient() === "bottom") ? baselineOffset : -baselineOffset;
+                    attr["y1"] += (this.orientation() === "bottom") ? baselineOffset : -baselineOffset;
                     attr["y2"] = attr["y1"];
                     this._tierBaselines[i].attr(attr).style("visibility", "inherit");
                     baselineOffset += this._tierHeights[i];
@@ -4660,7 +4660,7 @@ var Plottable;
                     }
                 }
                 var tickMarkAttrHash = this._generateTickMarkAttrHash();
-                switch (this.orient()) {
+                switch (this.orientation()) {
                     case "bottom":
                         tickLabelAttrHash["x"] = tickMarkAttrHash["x1"];
                         tickLabelAttrHash["dy"] = "0.95em";
@@ -4963,8 +4963,8 @@ var Plottable;
                     var height = self._isHorizontal() ? axisHeight - self._maxLabelTickLength() - self.tickLabelPadding() : bandWidth;
                     var writeOptions = {
                         selection: d3.select(this),
-                        xAlign: xAlign[self.orient()],
-                        yAlign: yAlign[self.orient()],
+                        xAlign: xAlign[self.orientation()],
+                        yAlign: yAlign[self.orientation()],
                         textRotation: self.tickLabelAngle()
                     };
                     self._writer.write(self.formatter()(d), width, height, writeOptions);
@@ -5039,8 +5039,8 @@ var Plottable;
                 // erase all text first, then rewrite
                 tickLabels.text("");
                 this._drawTicks(this.width(), this.height(), catScale, tickLabels);
-                var xTranslate = this.orient() === "right" ? this._maxLabelTickLength() + this.tickLabelPadding() : 0;
-                var yTranslate = this.orient() === "bottom" ? this._maxLabelTickLength() + this.tickLabelPadding() : 0;
+                var xTranslate = this.orientation() === "right" ? this._maxLabelTickLength() + this.tickLabelPadding() : 0;
+                var yTranslate = this.orientation() === "bottom" ? this._maxLabelTickLength() + this.tickLabelPadding() : 0;
                 Plottable.Utils.DOM.translate(this._tickLabelContainer, xTranslate, yTranslate);
                 return this;
             };
@@ -5086,7 +5086,7 @@ var Plottable;
                 _super.call(this);
                 this.classed("label", true);
                 this.text(displayText);
-                this.orient(orientation);
+                this.orientation(orientation);
                 this.xAlign("center").yAlign("center");
                 this._fixedHeightFlag = true;
                 this._fixedWidthFlag = true;
@@ -5094,8 +5094,8 @@ var Plottable;
             }
             Label.prototype.requestedSpace = function (offeredWidth, offeredHeight) {
                 var desiredWH = this._measurer.measure(this._text);
-                var desiredWidth = (this.orient() === "horizontal" ? desiredWH.width : desiredWH.height) + 2 * this.padding();
-                var desiredHeight = (this.orient() === "horizontal" ? desiredWH.height : desiredWH.width) + 2 * this.padding();
+                var desiredWidth = (this.orientation() === "horizontal" ? desiredWH.width : desiredWH.height) + 2 * this.padding();
+                var desiredHeight = (this.orientation() === "horizontal" ? desiredWH.height : desiredWH.width) + 2 * this.padding();
                 return {
                     minWidth: desiredWidth,
                     minHeight: desiredHeight
@@ -5119,17 +5119,17 @@ var Plottable;
                     return this;
                 }
             };
-            Label.prototype.orient = function (newOrientation) {
-                if (newOrientation == null) {
+            Label.prototype.orientation = function (orientation) {
+                if (orientation == null) {
                     return this._orientation;
                 }
                 else {
-                    newOrientation = newOrientation.toLowerCase();
-                    if (newOrientation === "horizontal" || newOrientation === "left" || newOrientation === "right") {
-                        this._orientation = newOrientation;
+                    orientation = orientation.toLowerCase();
+                    if (orientation === "horizontal" || orientation === "left" || orientation === "right") {
+                        this._orientation = orientation;
                     }
                     else {
-                        throw new Error(newOrientation + " is not a valid orientation for LabelComponent");
+                        throw new Error(orientation + " is not a valid orientation for LabelComponent");
                     }
                     this.redraw();
                     return this;
@@ -5164,7 +5164,7 @@ var Plottable;
                     selection: this._textContainer,
                     xAlign: this.xAlign(),
                     yAlign: this.yAlign(),
-                    textRotation: textRotation[this.orient()]
+                    textRotation: textRotation[this.orientation()]
                 };
                 this._writer.write(this._text, writeWidth, writeHeight, writeOptions);
             };
@@ -5508,12 +5508,12 @@ var Plottable;
                     throw new Error("\"" + orientation + "\" is not a valid orientation for InterpolatedColorLegend");
                 }
             };
-            InterpolatedColorLegend.prototype.orient = function (newOrientation) {
-                if (newOrientation == null) {
+            InterpolatedColorLegend.prototype.orientation = function (orientation) {
+                if (orientation == null) {
                     return this._orientation;
                 }
                 else {
-                    this._orientation = InterpolatedColorLegend._ensureOrientation(newOrientation);
+                    this._orientation = InterpolatedColorLegend._ensureOrientation(orientation);
                     this.redraw();
                     return this;
                 }

--- a/src/components/axes/axis.ts
+++ b/src/components/axes/axis.ts
@@ -44,7 +44,7 @@ module Plottable {
       super();
       if (scale == null || orientation == null) { throw new Error("Axis requires a scale and orientation"); }
       this._scale = scale;
-      this.orient(orientation);
+      this.orientation(orientation);
       this._setDefaultAlignment();
       this.classed("axis", true);
       if (this._isHorizontal()) {
@@ -402,7 +402,7 @@ module Plottable {
      *
      * @returns {number} the current orientation.
      */
-    public orient(): string;
+    public orientation(): string;
     /**
      * Sets the orientation of the Axis.
      *
@@ -410,12 +410,12 @@ module Plottable {
      * (top/bottom/left/right).
      * @returns {Axis} The calling Axis.
      */
-    public orient(newOrientation: string): Axis;
-    public orient(newOrientation?: string): any {
-      if (newOrientation == null) {
+    public orientation(orientation: string): Axis;
+    public orientation(orientation?: string): any {
+      if (orientation == null) {
         return this._orientation;
       } else {
-        var newOrientationLC = newOrientation.toLowerCase();
+        var newOrientationLC = orientation.toLowerCase();
         if (newOrientationLC !== "top" &&
             newOrientationLC !== "bottom" &&
             newOrientationLC !== "left" &&

--- a/src/components/axes/categoryAxis.ts
+++ b/src/components/axes/categoryAxis.ts
@@ -120,8 +120,8 @@ export module Axes {
         var height = self._isHorizontal() ? axisHeight - self._maxLabelTickLength() - self.tickLabelPadding() : bandWidth;
         var writeOptions = {
           selection: d3.select(this),
-          xAlign: xAlign[self.orient()],
-          yAlign: yAlign[self.orient()],
+          xAlign: xAlign[self.orientation()],
+          yAlign: yAlign[self.orientation()],
           textRotation: self.tickLabelAngle()
         };
         self._writer.write(self.formatter()(d), width, height, writeOptions);
@@ -208,8 +208,8 @@ export module Axes {
       tickLabels.text("");
       this._drawTicks(this.width(), this.height(), catScale, tickLabels);
 
-      var xTranslate = this.orient() === "right" ? this._maxLabelTickLength() + this.tickLabelPadding() : 0;
-      var yTranslate = this.orient() === "bottom" ? this._maxLabelTickLength() + this.tickLabelPadding() : 0;
+      var xTranslate = this.orientation() === "right" ? this._maxLabelTickLength() + this.tickLabelPadding() : 0;
+      var yTranslate = this.orientation() === "bottom" ? this._maxLabelTickLength() + this.tickLabelPadding() : 0;
       Utils.DOM.translate(this._tickLabelContainer, xTranslate, yTranslate);
       return this;
     }

--- a/src/components/axes/numericAxis.ts
+++ b/src/components/axes/numericAxis.ts
@@ -145,7 +145,7 @@ export module Axes {
       }
 
       var tickMarkAttrHash = this._generateTickMarkAttrHash();
-      switch (this.orient()) {
+      switch (this.orientation()) {
         case "bottom":
           tickLabelAttrHash["x"] = tickMarkAttrHash["x1"];
           tickLabelAttrHash["dy"] = "0.95em";

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -254,13 +254,13 @@ export module Axes {
       return mostPreciseIndex;
     }
 
-    public orient(): string;
-    public orient(orientation: string): Time;
-    public orient(orientation?: string): any {
+    public orientation(): string;
+    public orientation(orientation: string): Time;
+    public orientation(orientation?: string): any {
       if (orientation && (orientation.toLowerCase() === "right" || orientation.toLowerCase() === "left")) {
         throw new Error(orientation + " is not a supported orientation for TimeAxis - only horizontal orientations are supported");
       }
-      return super.orient(orientation); // maintains getter-setter functionality
+      return super.orientation(orientation); // maintains getter-setter functionality
     }
 
     protected _computeHeight() {
@@ -386,7 +386,7 @@ export module Axes {
       var tickLabelsEnter = tickLabels.enter().append("g").classed(Axis.TICK_LABEL_CLASS, true);
       tickLabelsEnter.append("text");
       var xTranslate = (this._tierLabelPositions[index] === "center" || config.step === 1) ? 0 : this.tickLabelPadding();
-      var yTranslate = this.orient() === "bottom" ?
+      var yTranslate = this.orientation() === "bottom" ?
           d3.sum(this._tierHeights.slice(0, index + 1)) - this.tickLabelPadding() :
           this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding();
 
@@ -405,7 +405,7 @@ export module Axes {
       tickMarks.enter().append("line").classed(Axis.TICK_MARK_CLASS, true);
       var attr = this._generateTickMarkAttrHash();
       var offset = this._tierHeights.slice(0, index).reduce((translate: number, height: number) => translate + height, 0);
-      if (this.orient() === "bottom") {
+      if (this.orientation() === "bottom") {
         attr["y1"] = offset;
         attr["y2"] = offset + (this._tierLabelPositions[index] === "center" ? this.tickLength() : this._tierHeights[index]);
       } else {
@@ -414,7 +414,7 @@ export module Axes {
                                                   this.tickLength() : this._tierHeights[index]));
       }
       tickMarks.attr(attr);
-      if (this.orient() === "bottom") {
+      if (this.orientation() === "bottom") {
         attr["y1"] = offset;
         attr["y2"] = offset + this._tierHeights[index];
       } else {
@@ -434,7 +434,7 @@ export module Axes {
       var tickMarks = this._tickMarkContainer.selectAll("." + Axis.TICK_MARK_CLASS).data(tickValues);
       tickMarks.enter().append("line").classed(Axis.TICK_MARK_CLASS, true);
       var attr = this._generateTickMarkAttrHash();
-      attr["y2"] = (this.orient() === "bottom") ? this.tickLabelPadding() : this.height() - this.tickLabelPadding();
+      attr["y2"] = (this.orientation() === "bottom") ? this.tickLabelPadding() : this.height() - this.tickLabelPadding();
       tickMarks.attr(attr);
       tickMarks.exit().remove();
     }
@@ -463,7 +463,7 @@ export module Axes {
       var baselineOffset = 0;
       for (var i = 0; i < Math.max(tierConfigs.length, 1); ++i) {
         var attr = this._generateBaselineAttrHash();
-        attr["y1"] += (this.orient() === "bottom") ? baselineOffset : -baselineOffset;
+        attr["y1"] += (this.orientation() === "bottom") ? baselineOffset : -baselineOffset;
         attr["y2"] = attr["y1"];
         this._tierBaselines[i].attr(attr).style("visibility", "inherit");
         baselineOffset += this._tierHeights[i];

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -92,7 +92,7 @@ export module Components {
      *
      * @returns {string} The current orientation.
      */
-    public orient(): string;
+    public orientation(): string;
     /**
      * Sets the orientation of the InterpolatedColorLegend.
      *
@@ -100,12 +100,12 @@ export module Components {
      *
      * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
      */
-    public orient(newOrientation: string): InterpolatedColorLegend;
-    public orient(newOrientation?: string): any {
-      if (newOrientation == null) {
+    public orientation(orientation: string): InterpolatedColorLegend;
+    public orientation(orientation?: string): any {
+      if (orientation == null) {
         return this._orientation;
       } else {
-        this._orientation = InterpolatedColorLegend._ensureOrientation(newOrientation);
+        this._orientation = InterpolatedColorLegend._ensureOrientation(orientation);
         this.redraw();
         return this;
       }

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -25,7 +25,7 @@ export module Components {
       super();
       this.classed("label", true);
       this.text(displayText);
-      this.orient(orientation);
+      this.orientation(orientation);
       this.xAlign("center").yAlign("center");
       this._fixedHeightFlag = true;
       this._fixedWidthFlag = true;
@@ -34,8 +34,8 @@ export module Components {
 
     public requestedSpace(offeredWidth: number, offeredHeight: number): _SpaceRequest {
       var desiredWH = this._measurer.measure(this._text);
-      var desiredWidth  = (this.orient() === "horizontal" ? desiredWH.width : desiredWH.height) + 2 * this.padding();
-      var desiredHeight = (this.orient() === "horizontal" ? desiredWH.height : desiredWH.width) + 2 * this.padding();
+      var desiredWidth  = (this.orientation() === "horizontal" ? desiredWH.width : desiredWH.height) + 2 * this.padding();
+      var desiredHeight = (this.orientation() === "horizontal" ? desiredWH.height : desiredWH.width) + 2 * this.padding();
 
       return {
         minWidth: desiredWidth,
@@ -80,7 +80,7 @@ export module Components {
      *
      * @returns {string} the current orientation.
      */
-    public orient(): string;
+    public orientation(): string;
     /**
      * Sets the orientation of the Label.
      *
@@ -88,16 +88,16 @@ export module Components {
      * (horizontal/left/right).
      * @returns {Label} The calling Label.
      */
-    public orient(newOrientation: string): Label;
-    public orient(newOrientation?: string): any {
-      if (newOrientation == null) {
+    public orientation(orientation: string): Label;
+    public orientation(orientation?: string): any {
+      if (orientation == null) {
         return this._orientation;
       } else {
-        newOrientation = newOrientation.toLowerCase();
-        if (newOrientation === "horizontal" || newOrientation === "left" || newOrientation === "right") {
-          this._orientation = newOrientation;
+        orientation = orientation.toLowerCase();
+        if (orientation === "horizontal" || orientation === "left" || orientation === "right") {
+          this._orientation = orientation;
         } else {
-          throw new Error(newOrientation + " is not a valid orientation for LabelComponent");
+          throw new Error(orientation + " is not a valid orientation for LabelComponent");
         }
         this.redraw();
         return this;
@@ -146,7 +146,7 @@ export module Components {
                         selection: this._textContainer,
                         xAlign: this.xAlign(),
                         yAlign: this.yAlign(),
-                        textRotation: textRotation[this.orient()]
+                        textRotation: textRotation[this.orientation()]
                     };
       this._writer.write(this._text, writeWidth, writeHeight, writeOptions);
     }

--- a/test/components/baseAxisTests.ts
+++ b/test/components/baseAxisTests.ts
@@ -79,7 +79,7 @@ describe("BaseAxis", () => {
     assert.strictEqual(baseline.attr("y1"), "0");
     assert.strictEqual(baseline.attr("y2"), "0");
 
-    baseAxis.orient("top");
+    baseAxis.orientation("top");
     assert.isNotNull(baseline.node(), "baseline was drawn");
     assert.strictEqual(baseline.attr("x1"), "0");
     assert.strictEqual(baseline.attr("x2"), String(SVG_WIDTH));
@@ -111,7 +111,7 @@ describe("BaseAxis", () => {
     assert.strictEqual(baseline.attr("y1"), "0");
     assert.strictEqual(baseline.attr("y2"), String(SVG_HEIGHT));
 
-    baseAxis.orient("right");
+    baseAxis.orientation("right");
     assert.isNotNull(baseline.node(), "baseline was drawn");
     assert.strictEqual(baseline.attr("x1"), "0");
     assert.strictEqual(baseline.attr("x2"), "0");

--- a/test/components/categoryAxisTests.ts
+++ b/test/components/categoryAxisTests.ts
@@ -132,7 +132,7 @@ describe("Category Axes", () => {
     var smallDimension = 10;
     var spaceRequest = axis.requestedSpace(300, smallDimension);
     assert.operator(spaceRequest.minHeight, ">", smallDimension, "horizontal axis requested more height if constrained");
-    axis.orient("left");
+    axis.orientation("left");
     spaceRequest = axis.requestedSpace(smallDimension, 300);
     assert.operator(spaceRequest.minWidth, ">", smallDimension, "vertical axis requested more width if constrained");
     svg.remove();
@@ -157,7 +157,7 @@ describe("Category Axes", () => {
     var tickLabels = (<any> axis)._content.selectAll(".tick-label");
     var tickMarks = (<any> axis)._content.selectAll(".tick-mark");
     verifyTickLabelOverlaps(tickLabels, tickMarks);
-    axis.orient("right");
+    axis.orientation("right");
     verifyTickLabelOverlaps(tickLabels, tickMarks);
     svg.remove();
   });

--- a/test/components/interpolatedColorLegendTests.ts
+++ b/test/components/interpolatedColorLegendTests.ts
@@ -109,14 +109,14 @@ describe("InterpolatedColorLegend", () => {
     svg.remove();
   });
 
-  it("orient() input-checking", () => {
+  it("orientation() input-checking", () => {
     var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "horizontal");
 
-    legend.orient("horizontal"); // should work
-    legend.orient("right"); // should work
-    legend.orient("left"); // should work
+    legend.orientation("horizontal"); // should work
+    legend.orientation("right"); // should work
+    legend.orientation("left"); // should work
 
-    assert.throws(() => legend.orient("blargh"), "not a valid orientation");
+    assert.throws(() => legend.orientation("blargh"), "not a valid orientation");
     svg.remove();
   });
 
@@ -127,7 +127,7 @@ describe("InterpolatedColorLegend", () => {
     var widthBefore = legend.width();
     var heightBefore = legend.height();
 
-    legend.orient("right");
+    legend.orientation("right");
     assert.notEqual(legend.width(), widthBefore, "proportions changed (width)");
     assert.notEqual(legend.height(), heightBefore, "proportions changed (height)");
     svg.remove();

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -121,7 +121,7 @@ describe("Labels", () => {
     var bbox = Plottable.Utils.DOM.getBBox(text);
     assert.closeTo(bbox.height, label.height(), 1, "label is in horizontal position");
 
-    label.orient("right");
+    label.orientation("right");
     text = content.select("text");
     bbox = Plottable.Utils.DOM.getBBox(text);
     TestMethods.assertBBoxInclusion((<any> label)._element.select(".bounding-box"), text);

--- a/test/components/numericAxisTests.ts
+++ b/test/components/numericAxisTests.ts
@@ -200,7 +200,7 @@ describe("NumericAxis", () => {
       }
     }
 
-    numericAxis.orient("bottom");
+    numericAxis.orientation("bottom");
     visibleTickLabels = (<any> numericAxis)._element
                           .selectAll("." + Plottable.Axis.TICK_LABEL_CLASS)
                           .filter(function(d: any, i: number) {

--- a/test/components/timeAxisTests.ts
+++ b/test/components/timeAxisTests.ts
@@ -16,9 +16,9 @@ describe("TimeAxis", () => {
   });
 
   it("cannot change time axis orientation to vertical", () => {
-      assert.throws(() => axis.orient("left"), "horizontal");
-      assert.throws(() => axis.orient("right"), "horizontal");
-      assert.strictEqual(axis.orient(), "bottom", "orientation unchanged");
+      assert.throws(() => axis.orientation("left"), "horizontal");
+      assert.throws(() => axis.orientation("right"), "horizontal");
+      assert.strictEqual(axis.orientation(), "bottom", "orientation unchanged");
   });
 
   it("Computing the default ticks doesn't error out for edge cases", () => {

--- a/test/tests.js
+++ b/test/tests.js
@@ -558,7 +558,7 @@ describe("BaseAxis", function () {
         assert.strictEqual(baseline.attr("x2"), String(SVG_WIDTH));
         assert.strictEqual(baseline.attr("y1"), "0");
         assert.strictEqual(baseline.attr("y2"), "0");
-        baseAxis.orient("top");
+        baseAxis.orientation("top");
         assert.isNotNull(baseline.node(), "baseline was drawn");
         assert.strictEqual(baseline.attr("x1"), "0");
         assert.strictEqual(baseline.attr("x2"), String(SVG_WIDTH));
@@ -587,7 +587,7 @@ describe("BaseAxis", function () {
         assert.strictEqual(baseline.attr("x2"), String(baseAxis.width()));
         assert.strictEqual(baseline.attr("y1"), "0");
         assert.strictEqual(baseline.attr("y2"), String(SVG_HEIGHT));
-        baseAxis.orient("right");
+        baseAxis.orientation("right");
         assert.isNotNull(baseline.node(), "baseline was drawn");
         assert.strictEqual(baseline.attr("x1"), "0");
         assert.strictEqual(baseline.attr("x2"), "0");
@@ -684,9 +684,9 @@ describe("TimeAxis", function () {
         assert.throws(function () { return new Plottable.Axes.Time(scale, "right"); }, "horizontal");
     });
     it("cannot change time axis orientation to vertical", function () {
-        assert.throws(function () { return axis.orient("left"); }, "horizontal");
-        assert.throws(function () { return axis.orient("right"); }, "horizontal");
-        assert.strictEqual(axis.orient(), "bottom", "orientation unchanged");
+        assert.throws(function () { return axis.orientation("left"); }, "horizontal");
+        assert.throws(function () { return axis.orientation("right"); }, "horizontal");
+        assert.strictEqual(axis.orientation(), "bottom", "orientation unchanged");
     });
     it("Computing the default ticks doesn't error out for edge cases", function () {
         var svg = TestMethods.generateSVG(400, 100);
@@ -1079,7 +1079,7 @@ describe("NumericAxis", function () {
                 assert.isFalse(Plottable.Utils.DOM.boxesOverlap(box1, box2), "tick labels don't overlap");
             }
         }
-        numericAxis.orient("bottom");
+        numericAxis.orientation("bottom");
         visibleTickLabels = numericAxis._element.selectAll("." + Plottable.Axis.TICK_LABEL_CLASS).filter(function (d, i) {
             return d3.select(this).style("visibility") === "visible";
         });
@@ -1391,7 +1391,7 @@ describe("Category Axes", function () {
         var smallDimension = 10;
         var spaceRequest = axis.requestedSpace(300, smallDimension);
         assert.operator(spaceRequest.minHeight, ">", smallDimension, "horizontal axis requested more height if constrained");
-        axis.orient("left");
+        axis.orientation("left");
         spaceRequest = axis.requestedSpace(smallDimension, 300);
         assert.operator(spaceRequest.minWidth, ">", smallDimension, "vertical axis requested more width if constrained");
         svg.remove();
@@ -1412,7 +1412,7 @@ describe("Category Axes", function () {
         var tickLabels = axis._content.selectAll(".tick-label");
         var tickMarks = axis._content.selectAll(".tick-mark");
         verifyTickLabelOverlaps(tickLabels, tickMarks);
-        axis.orient("right");
+        axis.orientation("right");
         verifyTickLabelOverlaps(tickLabels, tickMarks);
         svg.remove();
     });
@@ -1575,7 +1575,7 @@ describe("Labels", function () {
         var text = content.select("text");
         var bbox = Plottable.Utils.DOM.getBBox(text);
         assert.closeTo(bbox.height, label.height(), 1, "label is in horizontal position");
-        label.orient("right");
+        label.orientation("right");
         text = content.select("text");
         bbox = Plottable.Utils.DOM.getBBox(text);
         TestMethods.assertBBoxInclusion(label._element.select(".bounding-box"), text);
@@ -1947,12 +1947,12 @@ describe("InterpolatedColorLegend", function () {
         assertBasicRendering(legend);
         svg.remove();
     });
-    it("orient() input-checking", function () {
+    it("orientation() input-checking", function () {
         var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "horizontal");
-        legend.orient("horizontal"); // should work
-        legend.orient("right"); // should work
-        legend.orient("left"); // should work
-        assert.throws(function () { return legend.orient("blargh"); }, "not a valid orientation");
+        legend.orientation("horizontal"); // should work
+        legend.orientation("right"); // should work
+        legend.orientation("left"); // should work
+        assert.throws(function () { return legend.orientation("blargh"); }, "not a valid orientation");
         svg.remove();
     });
     it("orient() triggers layout computation", function () {
@@ -1960,7 +1960,7 @@ describe("InterpolatedColorLegend", function () {
         legend.renderTo(svg);
         var widthBefore = legend.width();
         var heightBefore = legend.height();
-        legend.orient("right");
+        legend.orientation("right");
         assert.notEqual(legend.width(), widthBefore, "proportions changed (width)");
         assert.notEqual(legend.height(), heightBefore, "proportions changed (height)");
         svg.remove();


### PR DESCRIPTION
The name `orient` sounds like it should be affecting state even though it falls under our convention of getters/setters with a noun name.  It should be renamed to `orientation`.