### PR TITLE
[Table] - Hiding _IterateLayoutResult type

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2357,14 +2357,6 @@ declare module Plottable {
 
 declare module Plottable {
     module Components {
-        type _IterateLayoutResult = {
-            colProportionalSpace: number[];
-            rowProportionalSpace: number[];
-            guaranteedWidths: number[];
-            guaranteedHeights: number[];
-            wantsWidth: boolean;
-            wantsHeight: boolean;
-        };
         class Table extends ComponentContainer {
             /**
              * Constructs a Table.

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -9,7 +9,7 @@ export module Components {
     wantsHeightArr: boolean[];
   }
 
-  export type _IterateLayoutResult = {
+  type _IterateLayoutResult = {
     colProportionalSpace: number[];
     rowProportionalSpace: number[];
     guaranteedWidths: number[];

--- a/test/core/tableTests.ts
+++ b/test/core/tableTests.ts
@@ -245,7 +245,7 @@ describe("Tables", () => {
 
   describe("table._iterateLayout works properly", () => {
     // This test battery would have caught #405
-    function verifyLayoutResult(result: Plottable.Components._IterateLayoutResult,
+    function verifyLayoutResult(result: any,
                                 cPS: number[], rPS: number[], gW: number[], gH: number[],
                                 wW: boolean, wH: boolean, id: string) {
       assert.deepEqual(result.colProportionalSpace, cPS, "colProportionalSpace:" + id);


### PR DESCRIPTION
Note the underscore in front.  We should probably not expose this type