### PR TITLE
[Axis] - Generics!

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1733,7 +1733,7 @@ declare module Plottable {
 
 
 declare module Plottable {
-    class Axis extends Component {
+    class Axis<D> extends Component {
         /**
          * The css class applied to each end tick mark (the line on the end tick).
          */
@@ -1749,7 +1749,7 @@ declare module Plottable {
         protected _tickMarkContainer: D3.Selection;
         protected _tickLabelContainer: D3.Selection;
         protected _baseline: D3.Selection;
-        protected _scale: Scale<any, number>;
+        protected _scale: Scale<D, number>;
         protected _computedWidth: number;
         protected _computedHeight: number;
         /**
@@ -1763,7 +1763,7 @@ declare module Plottable {
          * @param {Formatter} Data is passed through this formatter before being
          * displayed.
          */
-        constructor(scale: Scale<any, number>, orientation: string, formatter?: (d: any) => string);
+        constructor(scale: Scale<D, number>, orientation: string, formatter?: (d: any) => string);
         destroy(): void;
         protected _isHorizontal(): boolean;
         protected _computeWidth(): number;
@@ -1772,9 +1772,9 @@ declare module Plottable {
         fixedHeight(): boolean;
         fixedWidth(): boolean;
         protected _rescale(): void;
-        computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Axis;
+        computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Axis<D>;
         protected _setup(): void;
-        protected _getTickValues(): any[];
+        protected _getTickValues(): D[];
         protected _render(): void;
         protected _generateBaselineAttrHash(): {
             x1: number;
@@ -1805,7 +1805,7 @@ declare module Plottable {
          * @param {Formatter} formatter If provided, data will be passed though `formatter(data)`.
          * @returns {Axis} The calling Axis.
          */
-        formatter(formatter: Formatter): Axis;
+        formatter(formatter: Formatter): Axis<D>;
         /**
          * Gets the current tick mark length.
          *
@@ -1818,7 +1818,7 @@ declare module Plottable {
          * @param {number} length If provided, length of each tick.
          * @returns {Axis} The calling Axis.
          */
-        tickLength(length: number): Axis;
+        tickLength(length: number): Axis<D>;
         /**
          * Gets the current end tick mark length.
          *
@@ -1831,7 +1831,7 @@ declare module Plottable {
          * @param {number} length If provided, the length of the end ticks.
          * @returns {BaseAxis} The calling Axis.
          */
-        endTickLength(length: number): Axis;
+        endTickLength(length: number): Axis<D>;
         protected _maxLabelTickLength(): number;
         /**
          * Gets the padding between each tick mark and its associated label.
@@ -1846,7 +1846,7 @@ declare module Plottable {
          * @param {number} padding If provided, the desired padding.
          * @returns {Axis} The calling Axis.
          */
-        tickLabelPadding(padding: number): Axis;
+        tickLabelPadding(padding: number): Axis<D>;
         /**
          * Gets the size of the gutter (the extra space between the tick
          * labels and the outer edge of the axis).
@@ -1862,7 +1862,7 @@ declare module Plottable {
          * @param {number} size If provided, the desired gutter.
          * @returns {Axis} The calling Axis.
          */
-        gutter(size: number): Axis;
+        gutter(size: number): Axis<D>;
         /**
          * Gets the orientation of the Axis.
          *
@@ -1876,7 +1876,7 @@ declare module Plottable {
          * (top/bottom/left/right).
          * @returns {Axis} The calling Axis.
          */
-        orientation(orientation: string): Axis;
+        orientation(orientation: string): Axis<D>;
         /**
          * Gets whether the Axis is currently set to show the first and last
          * tick labels.
@@ -1893,7 +1893,7 @@ declare module Plottable {
          * labels.
          * @returns {Axis} The calling Axis.
          */
-        showEndTickLabels(show: boolean): Axis;
+        showEndTickLabels(show: boolean): Axis<D>;
     }
 }
 
@@ -1927,7 +1927,7 @@ declare module Plottable {
          * Currently, up to two tiers are supported.
          */
         type TimeAxisConfiguration = TimeAxisTierConfiguration[];
-        class Time extends Axis {
+        class Time extends Axis<Date> {
             /**
              * The css class applied to each time axis tier
              */
@@ -1976,7 +1976,7 @@ declare module Plottable {
 
 declare module Plottable {
     module Axes {
-        class Numeric extends Axis {
+        class Numeric extends Axis<number> {
             /**
              * Constructs a NumericAxis.
              *
@@ -1992,7 +1992,7 @@ declare module Plottable {
             protected _setup(): void;
             protected _computeWidth(): number;
             protected _computeHeight(): number;
-            protected _getTickValues(): any[];
+            protected _getTickValues(): number[];
             protected _rescale(): void;
             protected _render(): void;
             /**
@@ -2042,7 +2042,7 @@ declare module Plottable {
 
 declare module Plottable {
     module Axes {
-        class Category extends Axis {
+        class Category extends Axis<string> {
             /**
              * Constructs a CategoryAxis.
              *
@@ -2075,7 +2075,7 @@ declare module Plottable {
              */
             tickLabelAngle(angle: number): Category;
             protected _render(): Category;
-            computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Axis;
+            computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Axis<string>;
         }
     }
 }

--- a/src/components/axes/axis.ts
+++ b/src/components/axes/axis.ts
@@ -1,7 +1,7 @@
 ///<reference path="../../reference.ts" />
 
 module Plottable {
-  export class Axis extends Component {
+  export class Axis<D> extends Component {
     /**
      * The css class applied to each end tick mark (the line on the end tick).
      */
@@ -17,7 +17,7 @@ module Plottable {
     protected _tickMarkContainer: D3.Selection;
     protected _tickLabelContainer: D3.Selection;
     protected _baseline: D3.Selection;
-    protected _scale: Scale<any, number>;
+    protected _scale: Scale<D, number>;
     private _formatter: Formatter;
     private _orientation: string;
     protected _computedWidth: number;
@@ -27,7 +27,7 @@ module Plottable {
     private _tickLabelPadding = 10;
     private _gutter = 15;
     private _showEndTickLabels = false;
-    private _rescaleCallback: ScaleCallback<Scale<any, number>>;
+    private _rescaleCallback: ScaleCallback<Scale<D, number>>;
 
     /**
      * Constructs an axis. An axis is a wrapper around a scale for rendering.
@@ -40,7 +40,7 @@ module Plottable {
      * @param {Formatter} Data is passed through this formatter before being
      * displayed.
      */
-    constructor(scale: Scale<any, number>, orientation: string, formatter = Formatters.identity()) {
+    constructor(scale: Scale<D, number>, orientation: string, formatter = Formatters.identity()) {
       super();
       if (scale == null || orientation == null) { throw new Error("Axis requires a scale and orientation"); }
       this._scale = scale;
@@ -138,7 +138,7 @@ module Plottable {
      * Function for generating tick values in data-space (as opposed to pixel values).
      * To be implemented by subclasses.
      */
-    protected _getTickValues(): any[] {
+    protected _getTickValues(): D[] {
       return [];
     }
 
@@ -271,7 +271,7 @@ module Plottable {
      * @param {Formatter} formatter If provided, data will be passed though `formatter(data)`.
      * @returns {Axis} The calling Axis.
      */
-    public formatter(formatter: Formatter): Axis;
+    public formatter(formatter: Formatter): Axis<D>;
     public formatter(formatter?: Formatter): any {
       if (formatter === undefined) {
         return this._formatter;
@@ -293,7 +293,7 @@ module Plottable {
      * @param {number} length If provided, length of each tick.
      * @returns {Axis} The calling Axis.
      */
-    public tickLength(length: number): Axis;
+    public tickLength(length: number): Axis<D>;
     public tickLength(length?: number): any {
       if (length == null) {
         return this._tickLength;
@@ -319,7 +319,7 @@ module Plottable {
      * @param {number} length If provided, the length of the end ticks.
      * @returns {BaseAxis} The calling Axis.
      */
-    public endTickLength(length: number): Axis;
+    public endTickLength(length: number): Axis<D>;
     public endTickLength(length?: number): any {
       if (length == null) {
         return this._endTickLength;
@@ -354,7 +354,7 @@ module Plottable {
      * @param {number} padding If provided, the desired padding.
      * @returns {Axis} The calling Axis.
      */
-    public tickLabelPadding(padding: number): Axis;
+    public tickLabelPadding(padding: number): Axis<D>;
     public tickLabelPadding(padding?: number): any {
       if (padding == null) {
         return this._tickLabelPadding;
@@ -383,7 +383,7 @@ module Plottable {
      * @param {number} size If provided, the desired gutter.
      * @returns {Axis} The calling Axis.
      */
-    public gutter(size: number): Axis;
+    public gutter(size: number): Axis<D>;
     public gutter(size?: number): any {
       if (size == null) {
         return this._gutter;
@@ -410,7 +410,7 @@ module Plottable {
      * (top/bottom/left/right).
      * @returns {Axis} The calling Axis.
      */
-    public orientation(orientation: string): Axis;
+    public orientation(orientation: string): Axis<D>;
     public orientation(orientation?: string): any {
       if (orientation == null) {
         return this._orientation;
@@ -444,7 +444,7 @@ module Plottable {
      * labels.
      * @returns {Axis} The calling Axis.
      */
-    public showEndTickLabels(show: boolean): Axis;
+    public showEndTickLabels(show: boolean): Axis<D>;
     public showEndTickLabels(show?: boolean): any {
       if (show == null) {
         return this._showEndTickLabels;

--- a/src/components/axes/categoryAxis.ts
+++ b/src/components/axes/categoryAxis.ts
@@ -2,7 +2,7 @@
 
 module Plottable {
 export module Axes {
-  export class Category extends Axis {
+  export class Category extends Axis<string> {
     private _tickLabelAngle = 0;
     private _measurer: SVGTypewriter.Measurers.CacheCharacterMeasurer;
     private _wrapper: SVGTypewriter.Wrappers.SingleLineWrapper;
@@ -62,7 +62,7 @@ export module Axes {
       };
     }
 
-    protected _getTickValues(): string[] {
+    protected _getTickValues() {
       return this._scale.domain();
     }
 

--- a/src/components/axes/numericAxis.ts
+++ b/src/components/axes/numericAxis.ts
@@ -2,7 +2,7 @@
 
 module Plottable {
 export module Axes {
-  export class Numeric extends Axis {
+  export class Numeric extends Axis<number> {
 
     private _tickLabelPositioning = "center";
     // Whether or not first/last tick label will still be displayed even if
@@ -63,7 +63,7 @@ export module Axes {
       return this._computedHeight;
     }
 
-    protected _getTickValues(): any[] {
+    protected _getTickValues() {
       var scale = (<QuantitativeScale<number>> this._scale);
       var domain = scale.domain();
       var min = domain[0] <= domain[1] ? domain[0] : domain[1];

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -33,7 +33,7 @@ export module Axes {
    */
   export type TimeAxisConfiguration = TimeAxisTierConfiguration[];
 
-  export class Time extends Axis {
+  export class Time extends Axis<Date> {
     /**
      * The css class applied to each time axis tier
      */
@@ -340,7 +340,7 @@ export module Axes {
       return (<Scales.Time> this._scale).tickInterval(config.interval, config.step);
     }
 
-    protected _getTickValues(): any[] {
+    protected _getTickValues() {
       return this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex].reduce(
           (ticks: any[], config: TimeAxisTierConfiguration) => ticks.concat(this._getTickIntervalValues(config)),
           []


### PR DESCRIPTION
Axes now have a generic type that reflects the domain type of the input scale.  This should not affect anyone who's using `Axis.Category` or `Axis.Numeric` and it helps us reason about our own code.