### PR TITLE
Generic accessor

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2708,7 +2708,7 @@ declare module Plottable {
             protected _generateDrawSteps(): Drawers.DrawStep[];
             x1<X1>(): AccessorScaleBinding<X1, number>;
             x1(x1: number | Accessor<number>): Plots.Rectangle<X, Y>;
-            x1<X1>(x1: X | Accessor<X>, scale: Scale<X1, number>): Plots.Rectangle<X, Y>;
+            x1<X1>(x1: X1 | Accessor<X1>, scale: Scale<X1, number>): Plots.Rectangle<X, Y>;
             x2<X2>(): AccessorScaleBinding<X2, number>;
             x2(x2: number | Accessor<number>): Plots.Rectangle<X, Y>;
             x2<X2>(x2: X2 | Accessor<X2>, scale: Scale<X2, number>): Plots.Rectangle<X, Y>;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2706,18 +2706,18 @@ declare module Plottable {
                 [attrToSet: string]: (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
             };
             protected _generateDrawSteps(): Drawers.DrawStep[];
-            x1(): AccessorScaleBinding<X, number>;
+            x1<X1>(): AccessorScaleBinding<X1, number>;
             x1(x1: number | Accessor<number>): Plots.Rectangle<X, Y>;
-            x1(x1: X | Accessor<X>, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
-            x2(): AccessorScaleBinding<X, number>;
+            x1<X1>(x1: X | Accessor<X>, scale: Scale<X1, number>): Plots.Rectangle<X, Y>;
+            x2<X2>(): AccessorScaleBinding<X2, number>;
             x2(x2: number | Accessor<number>): Plots.Rectangle<X, Y>;
-            x2(x2: X | Accessor<X>, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
-            y1(): AccessorScaleBinding<Y, number>;
+            x2<X2>(x2: X2 | Accessor<X2>, scale: Scale<X2, number>): Plots.Rectangle<X, Y>;
+            y1<Y1>(): AccessorScaleBinding<Y1, number>;
             y1(y1: number | Accessor<number>): Plots.Rectangle<X, Y>;
-            y1(y1: Y | Accessor<Y>, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
-            y2(): AccessorScaleBinding<Y, number>;
+            y1<Y1>(y1: Y1 | Accessor<Y1>, scale: Scale<Y1, number>): Plots.Rectangle<X, Y>;
+            y2<Y2>(): AccessorScaleBinding<Y2, number>;
             y2(y2: number | Accessor<number>): Plots.Rectangle<X, Y>;
-            y2(y2: Y | Accessor<Y>, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
+            y2<Y2>(y2: Y2 | Accessor<Y>, scale: Scale<Y2, number>): Plots.Rectangle<X, Y>;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2525,7 +2525,7 @@ declare module Plottable {
          */
         protected _updateExtents(): void;
         protected _updateExtentsForProperty(property: string): void;
-        protected _filterForProperty(property: string): Accessor<any>;
+        protected _filterForProperty(property: string): Accessor<boolean>;
         /**
          * Override in subclass to add special extents, such as included values
          */

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2497,9 +2497,9 @@ declare module Plottable {
         protected _getDrawer(key: string): Drawers.AbstractDrawer;
         protected _getAnimator(key: string): Animators.PlotAnimator;
         protected _onDatasetUpdate(): void;
-        attr<D>(attr: string): Plots.AccessorScaleBinding<D, number | string>;
+        attr<A>(attr: string): Plots.AccessorScaleBinding<A, number | string>;
         attr(attr: string, attrValue: number | string | Accessor<number> | Accessor<string>): Plot;
-        attr<D>(attr: string, attrValue: D | Accessor<D>, scale: Scale<D, number | string>): Plot;
+        attr<A>(attr: string, attrValue: A | Accessor<A>, scale: Scale<A, number | string>): Plot;
         protected _bindProperty(property: string, value: any, scale: Scale<any, any>): void;
         protected _generateAttrToProjector(): AttributeToProjector;
         /**

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -596,7 +596,7 @@ declare module Plottable {
     /**
      * Access specific datum property.
      */
-    type _Accessor = (datum: any, index?: number, dataset?: Dataset, plotMetadata?: Plots.PlotMetadata) => any;
+    type Accessor = (datum: any, index?: number, dataset?: Dataset, plotMetadata?: Plots.PlotMetadata) => any;
     /**
      * Retrieves scaled datum property.
      */
@@ -609,7 +609,7 @@ declare module Plottable {
      * Defines a way how specific attribute needs be retrieved before rendering.
      */
     type _Projection = {
-        accessor: _Accessor;
+        accessor: Accessor;
         scale?: Scale<any, any>;
         attribute: string;
     };
@@ -2457,7 +2457,7 @@ declare module Plottable {
             selection: D3.Selection;
         };
         interface AccessorScaleBinding<D, R> {
-            accessor: _Accessor;
+            accessor: Accessor;
             scale?: Scale<D, R>;
         }
     }
@@ -2496,8 +2496,8 @@ declare module Plottable {
         protected _getAnimator(key: string): Animators.PlotAnimator;
         protected _onDatasetUpdate(): void;
         attr<D>(attr: string): Plots.AccessorScaleBinding<D, number | string>;
-        attr(attr: string, attrValue: number | string | _Accessor): Plot;
-        attr<D>(attr: string, attrValue: D | _Accessor, scale: Scale<D, number | string>): Plot;
+        attr(attr: string, attrValue: number | string | Accessor): Plot;
+        attr<D>(attr: string, attrValue: D | Accessor, scale: Scale<D, number | string>): Plot;
         protected _bindProperty(property: string, value: any, scale: Scale<any, any>): void;
         protected _generateAttrToProjector(): AttributeToProjector;
         /**
@@ -2523,7 +2523,7 @@ declare module Plottable {
          */
         protected _updateExtents(): void;
         protected _updateExtentsForProperty(property: string): void;
-        protected _filterForProperty(property: string): _Accessor;
+        protected _filterForProperty(property: string): Accessor;
         /**
          * Override in subclass to add special extents, such as included values
          */
@@ -2614,14 +2614,14 @@ declare module Plottable {
             protected _getDrawer(key: string): Drawers.AbstractDrawer;
             getAllPlotData(datasets?: Dataset[]): Plots.PlotData;
             sectorValue(): AccessorScaleBinding<D, number>;
-            sectorValue(sectorValue: number | _Accessor): Plots.Pie<D>;
-            sectorValue(sectorValue: D | _Accessor, scale: Scale<D, number>): Plots.Pie<D>;
+            sectorValue(sectorValue: number | Accessor): Plots.Pie<D>;
+            sectorValue(sectorValue: D | Accessor, scale: Scale<D, number>): Plots.Pie<D>;
             innerRadius(): AccessorScaleBinding<D, number>;
-            innerRadius(innerRadius: number | _Accessor): Plots.Pie<D>;
-            innerRadius(innerRadius: D | _Accessor, scale: Scale<D, number>): Plots.Pie<D>;
+            innerRadius(innerRadius: number | Accessor): Plots.Pie<D>;
+            innerRadius(innerRadius: D | Accessor, scale: Scale<D, number>): Plots.Pie<D>;
             outerRadius(): AccessorScaleBinding<D, number>;
-            outerRadius(outerRadius: number | _Accessor): Plots.Pie<D>;
-            outerRadius(outerRadius: D | _Accessor, scale: Scale<D, number>): Plots.Pie<D>;
+            outerRadius(outerRadius: number | Accessor): Plots.Pie<D>;
+            outerRadius(outerRadius: D | Accessor, scale: Scale<D, number>): Plots.Pie<D>;
         }
     }
 }
@@ -2642,11 +2642,11 @@ declare module Plottable {
          */
         constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>);
         x(): Plots.AccessorScaleBinding<X, number>;
-        x(x: number | _Accessor): XYPlot<X, Y>;
-        x(x: X | _Accessor, xScale: Scale<X, number>): XYPlot<X, Y>;
+        x(x: number | Accessor): XYPlot<X, Y>;
+        x(x: X | Accessor, xScale: Scale<X, number>): XYPlot<X, Y>;
         y(): Plots.AccessorScaleBinding<Y, number>;
-        y(y: number | _Accessor): XYPlot<X, Y>;
-        y(y: Y | _Accessor, yScale: Scale<Y, number>): XYPlot<X, Y>;
+        y(y: number | Accessor): XYPlot<X, Y>;
+        y(y: Y | Accessor, yScale: Scale<Y, number>): XYPlot<X, Y>;
         protected _filterForProperty(property: string): (datum: any, index: number, dataset: Dataset, plotMetadata: Plots.PlotMetadata) => boolean;
         protected _uninstallScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _installScaleForKey(scale: Scale<any, any>, key: string): void;
@@ -2705,17 +2705,17 @@ declare module Plottable {
             };
             protected _generateDrawSteps(): Drawers.DrawStep[];
             x1(): AccessorScaleBinding<X, number>;
-            x1(x1: number | _Accessor): Plots.Rectangle<X, Y>;
-            x1(x1: X | _Accessor, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
+            x1(x1: number | Accessor): Plots.Rectangle<X, Y>;
+            x1(x1: X | Accessor, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
             x2(): AccessorScaleBinding<X, number>;
-            x2(x2: number | _Accessor): Plots.Rectangle<X, Y>;
-            x2(x2: X | _Accessor, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
+            x2(x2: number | Accessor): Plots.Rectangle<X, Y>;
+            x2(x2: X | Accessor, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
             y1(): AccessorScaleBinding<X, number>;
-            y1(y1: number | _Accessor): Plots.Rectangle<X, Y>;
-            y1(y1: Y | _Accessor, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
+            y1(y1: number | Accessor): Plots.Rectangle<X, Y>;
+            y1(y1: Y | Accessor, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
             y2(): AccessorScaleBinding<X, number>;
-            y2(y2: number | _Accessor): Plots.Rectangle<X, Y>;
-            y2(y2: Y | _Accessor, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
+            y2(y2: number | Accessor): Plots.Rectangle<X, Y>;
+            y2(y2: Y | Accessor, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
         }
     }
 }
@@ -2737,10 +2737,10 @@ declare module Plottable {
                 [attrToSet: string]: (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
             };
             size(): AccessorScaleBinding<X, number>;
-            size(size: number | _Accessor): Plots.Scatter<X, Y>;
-            size(size: any | _Accessor, scale: Scale<any, number>): Plots.Scatter<X, Y>;
+            size(size: number | Accessor): Plots.Scatter<X, Y>;
+            size(size: any | Accessor, scale: Scale<any, number>): Plots.Scatter<X, Y>;
             symbol(): AccessorScaleBinding<any, any>;
-            symbol(symbol: _Accessor): Plots.Scatter<X, Y>;
+            symbol(symbol: Accessor): Plots.Scatter<X, Y>;
             protected _generateDrawSteps(): Drawers.DrawStep[];
             protected _isVisibleOnPlot(datum: any, pixelPoint: Point, selection: D3.Selection): boolean;
         }
@@ -2768,11 +2768,11 @@ declare module Plottable {
             protected _getDrawer(key: string): Drawers.Rect;
             protected _generateDrawSteps(): Drawers.DrawStep[];
             x(): Plots.AccessorScaleBinding<any, number>;
-            x(x: number | _Accessor): Grid;
-            x(x: any | _Accessor, scale: Scale<any, number>): Grid;
+            x(x: number | Accessor): Grid;
+            x(x: any | Accessor, scale: Scale<any, number>): Grid;
             y(): Plots.AccessorScaleBinding<any, number>;
-            y(y: number | _Accessor): Grid;
-            y(y: any | _Accessor, scale: Scale<any, number>): Grid;
+            y(y: number | Accessor): Grid;
+            y(y: any | Accessor, scale: Scale<any, number>): Grid;
         }
     }
 }
@@ -2908,7 +2908,7 @@ declare module Plottable {
              * @param {QuantitativeScale} yScale The y scale to use.
              */
             constructor(xScale: QuantitativeScale<X>, yScale: QuantitativeScale<number>);
-            protected _rejectNullsAndNaNs(d: any, i: number, dataset: Dataset, plotMetadata: any, accessor: _Accessor): boolean;
+            protected _rejectNullsAndNaNs(d: any, i: number, dataset: Dataset, plotMetadata: any, accessor: Accessor): boolean;
             protected _getDrawer(key: string): Drawers.Line;
             protected _getResetYFunction(): (d: any, i: number, dataset: Dataset, m: PlotMetadata) => number;
             protected _generateDrawSteps(): Drawers.DrawStep[];
@@ -2948,8 +2948,8 @@ declare module Plottable {
              */
             constructor(xScale: QuantitativeScale<X>, yScale: QuantitativeScale<number>);
             y0(): Plots.AccessorScaleBinding<number, number>;
-            y0(y0: number | _Accessor): Area<X>;
-            y0(y0: number | _Accessor, y0Scale: Scale<number, number>): Area<X>;
+            y0(y0: number | Accessor): Area<X>;
+            y0(y0: number | Accessor, y0Scale: Scale<number, number>): Area<X>;
             protected _onDatasetUpdate(): void;
             protected _getDrawer(key: string): Drawers.Area;
             protected _updateYDomainer(): void;
@@ -3007,11 +3007,11 @@ declare module Plottable {
         protected _isVertical: boolean;
         _getPlotMetadataForDataset(key: string): Plots.StackedPlotMetadata;
         x(): Plots.AccessorScaleBinding<X, number>;
-        x(x: number | _Accessor): XYPlot<X, Y>;
-        x(x: X | _Accessor, scale: Scale<X, number>): XYPlot<X, Y>;
+        x(x: number | Accessor): XYPlot<X, Y>;
+        x(x: X | Accessor, scale: Scale<X, number>): XYPlot<X, Y>;
         y(): Plots.AccessorScaleBinding<Y, number>;
-        y(y: number | _Accessor): XYPlot<X, Y>;
-        y(y: Y | _Accessor, scale: Scale<Y, number>): XYPlot<X, Y>;
+        y(y: number | Accessor): XYPlot<X, Y>;
+        y(y: Y | Accessor, scale: Scale<Y, number>): XYPlot<X, Y>;
         _onDatasetUpdate(): void;
         _updateStackOffsets(): void;
         _updateStackExtents(): void;
@@ -3029,8 +3029,8 @@ declare module Plottable {
         _generateDefaultMapArray(): D3.Map<Plots.StackedDatum>[];
         protected _updateExtentsForProperty(property: string): void;
         protected _extentsForProperty(attr: string): any[];
-        _keyAccessor(): _Accessor;
-        _valueAccessor(): _Accessor;
+        _keyAccessor(): Accessor;
+        _valueAccessor(): Accessor;
     }
 }
 
@@ -3050,11 +3050,11 @@ declare module Plottable {
             _getAnimator(key: string): Animators.PlotAnimator;
             protected _setup(): void;
             x(): Plots.AccessorScaleBinding<X, number>;
-            x(x: number | _Accessor): StackedArea<X>;
-            x(x: X | _Accessor, xScale: Scale<X, number>): Area<X>;
+            x(x: number | Accessor): StackedArea<X>;
+            x(x: X | Accessor, xScale: Scale<X, number>): Area<X>;
             y(): Plots.AccessorScaleBinding<number, number>;
-            y(y: number | _Accessor): StackedArea<X>;
-            y(y: number | _Accessor, yScale: Scale<number, number>): Area<X>;
+            y(y: number | Accessor): StackedArea<X>;
+            y(y: number | Accessor, yScale: Scale<number, number>): Area<X>;
             protected _additionalPaint(): void;
             protected _updateYDomainer(): void;
             protected _onDatasetUpdate(): StackedArea<X>;
@@ -3069,8 +3069,8 @@ declare module Plottable {
             _getDomainKeys(): any;
             _generateDefaultMapArray(): D3.Map<StackedDatum>[];
             protected _extentsForProperty(attr: string): any;
-            _keyAccessor(): _Accessor;
-            _valueAccessor(): _Accessor;
+            _keyAccessor(): Accessor;
+            _valueAccessor(): Accessor;
             _getPlotMetadataForDataset(key: string): StackedPlotMetadata;
             protected _updateExtentsForProperty(property: string): void;
         }
@@ -3093,11 +3093,11 @@ declare module Plottable {
             constructor(xScale?: Scale<X, number>, yScale?: Scale<Y, number>, isVertical?: boolean);
             protected _getAnimator(key: string): Animators.PlotAnimator;
             x(): Plots.AccessorScaleBinding<X, number>;
-            x(x: number | _Accessor): StackedBar<X, Y>;
-            x(x: X | _Accessor, xScale: Scale<X, number>): StackedBar<X, Y>;
+            x(x: number | Accessor): StackedBar<X, Y>;
+            x(x: X | Accessor, xScale: Scale<X, number>): StackedBar<X, Y>;
             y(): Plots.AccessorScaleBinding<Y, number>;
-            y(y: number | _Accessor): StackedBar<X, Y>;
-            y(y: Y | _Accessor, yScale: Scale<Y, number>): StackedBar<X, Y>;
+            y(y: number | Accessor): StackedBar<X, Y>;
+            y(y: Y | Accessor, yScale: Scale<Y, number>): StackedBar<X, Y>;
             protected _generateAttrToProjector(): {
                 [attrToSet: string]: (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
             };
@@ -3112,8 +3112,8 @@ declare module Plottable {
             _getDomainKeys(): any;
             _generateDefaultMapArray(): D3.Map<StackedDatum>[];
             protected _extentsForProperty(attr: string): any;
-            _keyAccessor(): _Accessor;
-            _valueAccessor(): _Accessor;
+            _keyAccessor(): Accessor;
+            _valueAccessor(): Accessor;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3097,7 +3097,7 @@ declare module Plottable {
             _getDomainKeys(): any;
             _generateDefaultMapArray(): D3.Map<StackedDatum>[];
             protected _extentsForProperty(attr: string): any;
-            _keyAccessor(): Accessor<any>;
+            _keyAccessor(): Accessor<X> | Accessor<Y>;
             _valueAccessor(): Accessor<number>;
         }
     }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3023,7 +3023,7 @@ declare module Plottable {
         _generateDefaultMapArray(): D3.Map<Plots.StackedDatum>[];
         protected _updateExtentsForProperty(property: string): void;
         protected _extentsForProperty(attr: string): any[];
-        _keyAccessor(): Accessor<any>;
+        _keyAccessor(): Accessor<X> | Accessor<Y>;
         _valueAccessor(): Accessor<number>;
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2752,7 +2752,7 @@ declare module Plottable {
 
 declare module Plottable {
     module Plots {
-        class Grid extends Rectangle<any, any> {
+        class Grid<X, Y> extends Rectangle<any, any> {
             /**
              * Constructs a GridPlot.
              *
@@ -2765,12 +2765,12 @@ declare module Plottable {
              * @param {Scale.Color|Scale.InterpolatedColor} colorScale The color scale
              * to use for each grid cell.
              */
-            constructor(xScale: Scale<any, any>, yScale: Scale<any, any>);
-            addDataset(dataset: Dataset): Grid;
+            constructor(xScale: Scale<X, any>, yScale: Scale<Y, any>);
+            addDataset(dataset: Dataset): Grid<X, Y>;
             protected _getDrawer(key: string): Drawers.Rect;
             protected _generateDrawSteps(): Drawers.DrawStep[];
-            x(x?: number | Accessor<number> | any | Accessor<any>, scale?: Scale<any, number>): any;
-            y(y?: number | Accessor<number> | any, scale?: Scale<any, number>): any;
+            x(x?: number | Accessor<number> | X | Accessor<X>, scale?: Scale<X, number>): any;
+            y(y?: number | Accessor<number> | Y | Accessor<Y>, scale?: Scale<Y, number>): any;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2906,7 +2906,6 @@ declare module Plottable {
              * @param {QuantitativeScale} yScale The y scale to use.
              */
             constructor(xScale: QuantitativeScale<X>, yScale: QuantitativeScale<number>);
-            protected _rejectNullsAndNaNs(d: any, i: number, dataset: Dataset, plotMetadata: any, accessor: Accessor<X> | Accessor<number>): boolean;
             protected _getDrawer(key: string): Drawers.Line;
             protected _getResetYFunction(): (d: any, i: number, dataset: Dataset, m: PlotMetadata) => number;
             protected _generateDrawSteps(): Drawers.DrawStep[];

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2618,12 +2618,12 @@ declare module Plottable {
             sectorValue<S>(): AccessorScaleBinding<S, number>;
             sectorValue(sectorValue: number | Accessor<number>): Plots.Pie;
             sectorValue<S>(sectorValue: S | Accessor<S>, scale: Scale<S, number>): Plots.Pie;
-            innerRadius<I>(): AccessorScaleBinding<I, number>;
+            innerRadius<R>(): AccessorScaleBinding<R, number>;
             innerRadius(innerRadius: number | Accessor<number>): Plots.Pie;
-            innerRadius<I>(innerRadius: I | Accessor<I>, scale: Scale<I, number>): Plots.Pie;
-            outerRadius<O>(): AccessorScaleBinding<O, number>;
+            innerRadius<R>(innerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Pie;
+            outerRadius<R>(): AccessorScaleBinding<R, number>;
             outerRadius(outerRadius: number | Accessor<number>): Plots.Pie;
-            outerRadius<O>(outerRadius: O | Accessor<O>, scale: Scale<O, number>): Plots.Pie;
+            outerRadius<R>(outerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Pie;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2906,7 +2906,7 @@ declare module Plottable {
              * @param {QuantitativeScale} yScale The y scale to use.
              */
             constructor(xScale: QuantitativeScale<X>, yScale: QuantitativeScale<number>);
-            protected _rejectNullsAndNaNs(d: any, i: number, dataset: Dataset, plotMetadata: any, accessor: Accessor<any>): boolean;
+            protected _rejectNullsAndNaNs(d: any, i: number, dataset: Dataset, plotMetadata: any, accessor: Accessor<X> | Accessor<number>): boolean;
             protected _getDrawer(key: string): Drawers.Line;
             protected _getResetYFunction(): (d: any, i: number, dataset: Dataset, m: PlotMetadata) => number;
             protected _generateDrawSteps(): Drawers.DrawStep[];

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -596,7 +596,9 @@ declare module Plottable {
     /**
      * Access specific datum property.
      */
-    type Accessor = (datum: any, index?: number, dataset?: Dataset, plotMetadata?: Plots.PlotMetadata) => any;
+    interface Accessor<T> {
+        (datum: any, index: number, dataset: Dataset, plotMetadata: Plots.PlotMetadata): T;
+    }
     /**
      * Retrieves scaled datum property.
      */
@@ -609,7 +611,7 @@ declare module Plottable {
      * Defines a way how specific attribute needs be retrieved before rendering.
      */
     type _Projection = {
-        accessor: Accessor;
+        accessor: Accessor<any>;
         scale?: Scale<any, any>;
         attribute: string;
     };
@@ -2457,7 +2459,7 @@ declare module Plottable {
             selection: D3.Selection;
         };
         interface AccessorScaleBinding<D, R> {
-            accessor: Accessor;
+            accessor: Accessor<any>;
             scale?: Scale<D, R>;
         }
     }
@@ -2496,8 +2498,8 @@ declare module Plottable {
         protected _getAnimator(key: string): Animators.PlotAnimator;
         protected _onDatasetUpdate(): void;
         attr<D>(attr: string): Plots.AccessorScaleBinding<D, number | string>;
-        attr(attr: string, attrValue: number | string | Accessor): Plot;
-        attr<D>(attr: string, attrValue: D | Accessor, scale: Scale<D, number | string>): Plot;
+        attr(attr: string, attrValue: number | string | Accessor<number> | Accessor<string>): Plot;
+        attr<D>(attr: string, attrValue: D | Accessor<D>, scale: Scale<D, number | string>): Plot;
         protected _bindProperty(property: string, value: any, scale: Scale<any, any>): void;
         protected _generateAttrToProjector(): AttributeToProjector;
         /**
@@ -2523,7 +2525,7 @@ declare module Plottable {
          */
         protected _updateExtents(): void;
         protected _updateExtentsForProperty(property: string): void;
-        protected _filterForProperty(property: string): Accessor;
+        protected _filterForProperty(property: string): Accessor<any>;
         /**
          * Override in subclass to add special extents, such as included values
          */
@@ -2601,27 +2603,27 @@ declare module Plottable {
 
 declare module Plottable {
     module Plots {
-        class Pie<D> extends Plot {
+        class Pie extends Plot {
             /**
              * Constructs a PiePlot.
              *
              * @constructor
              */
             constructor();
-            computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Pie<D>;
-            addDataset(dataset: Dataset): Pie<D>;
+            computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Pie;
+            addDataset(dataset: Dataset): Pie;
             protected _generateAttrToProjector(): AttributeToProjector;
             protected _getDrawer(key: string): Drawers.AbstractDrawer;
             getAllPlotData(datasets?: Dataset[]): Plots.PlotData;
-            sectorValue(): AccessorScaleBinding<D, number>;
-            sectorValue(sectorValue: number | Accessor): Plots.Pie<D>;
-            sectorValue(sectorValue: D | Accessor, scale: Scale<D, number>): Plots.Pie<D>;
-            innerRadius(): AccessorScaleBinding<D, number>;
-            innerRadius(innerRadius: number | Accessor): Plots.Pie<D>;
-            innerRadius(innerRadius: D | Accessor, scale: Scale<D, number>): Plots.Pie<D>;
-            outerRadius(): AccessorScaleBinding<D, number>;
-            outerRadius(outerRadius: number | Accessor): Plots.Pie<D>;
-            outerRadius(outerRadius: D | Accessor, scale: Scale<D, number>): Plots.Pie<D>;
+            sectorValue<S>(): AccessorScaleBinding<S, number>;
+            sectorValue(sectorValue: number | Accessor<number>): Plots.Pie;
+            sectorValue<S>(sectorValue: S | Accessor<S>, scale: Scale<S, number>): Plots.Pie;
+            innerRadius<I>(): AccessorScaleBinding<I, number>;
+            innerRadius(innerRadius: number | Accessor<number>): Plots.Pie;
+            innerRadius<I>(innerRadius: I | Accessor<I>, scale: Scale<I, number>): Plots.Pie;
+            outerRadius<O>(): AccessorScaleBinding<O, number>;
+            outerRadius(outerRadius: number | Accessor<number>): Plots.Pie;
+            outerRadius<O>(outerRadius: O | Accessor<O>, scale: Scale<O, number>): Plots.Pie;
         }
     }
 }
@@ -2642,11 +2644,11 @@ declare module Plottable {
          */
         constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>);
         x(): Plots.AccessorScaleBinding<X, number>;
-        x(x: number | Accessor): XYPlot<X, Y>;
-        x(x: X | Accessor, xScale: Scale<X, number>): XYPlot<X, Y>;
+        x(x: number | Accessor<number>): XYPlot<X, Y>;
+        x(x: X | Accessor<X>, xScale: Scale<X, number>): XYPlot<X, Y>;
         y(): Plots.AccessorScaleBinding<Y, number>;
-        y(y: number | Accessor): XYPlot<X, Y>;
-        y(y: Y | Accessor, yScale: Scale<Y, number>): XYPlot<X, Y>;
+        y(y: number | Accessor<number>): XYPlot<X, Y>;
+        y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): XYPlot<X, Y>;
         protected _filterForProperty(property: string): (datum: any, index: number, dataset: Dataset, plotMetadata: Plots.PlotMetadata) => boolean;
         protected _uninstallScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _installScaleForKey(scale: Scale<any, any>, key: string): void;
@@ -2705,17 +2707,17 @@ declare module Plottable {
             };
             protected _generateDrawSteps(): Drawers.DrawStep[];
             x1(): AccessorScaleBinding<X, number>;
-            x1(x1: number | Accessor): Plots.Rectangle<X, Y>;
-            x1(x1: X | Accessor, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
+            x1(x1: number | Accessor<number>): Plots.Rectangle<X, Y>;
+            x1(x1: X | Accessor<X>, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
             x2(): AccessorScaleBinding<X, number>;
-            x2(x2: number | Accessor): Plots.Rectangle<X, Y>;
-            x2(x2: X | Accessor, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
-            y1(): AccessorScaleBinding<X, number>;
-            y1(y1: number | Accessor): Plots.Rectangle<X, Y>;
-            y1(y1: Y | Accessor, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
-            y2(): AccessorScaleBinding<X, number>;
-            y2(y2: number | Accessor): Plots.Rectangle<X, Y>;
-            y2(y2: Y | Accessor, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
+            x2(x2: number | Accessor<number>): Plots.Rectangle<X, Y>;
+            x2(x2: X | Accessor<X>, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
+            y1(): AccessorScaleBinding<Y, number>;
+            y1(y1: number | Accessor<number>): Plots.Rectangle<X, Y>;
+            y1(y1: Y | Accessor<Y>, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
+            y2(): AccessorScaleBinding<Y, number>;
+            y2(y2: number | Accessor<number>): Plots.Rectangle<X, Y>;
+            y2(y2: Y | Accessor<Y>, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
         }
     }
 }
@@ -2736,11 +2738,11 @@ declare module Plottable {
             protected _generateAttrToProjector(): {
                 [attrToSet: string]: (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
             };
-            size(): AccessorScaleBinding<X, number>;
-            size(size: number | Accessor): Plots.Scatter<X, Y>;
-            size(size: any | Accessor, scale: Scale<any, number>): Plots.Scatter<X, Y>;
+            size<S>(): AccessorScaleBinding<S, number>;
+            size(size: number | Accessor<number>): Plots.Scatter<X, Y>;
+            size<S>(size: S | Accessor<S>, scale: Scale<S, number>): Plots.Scatter<X, Y>;
             symbol(): AccessorScaleBinding<any, any>;
-            symbol(symbol: Accessor): Plots.Scatter<X, Y>;
+            symbol(symbol: Accessor<SymbolFactory>): Plots.Scatter<X, Y>;
             protected _generateDrawSteps(): Drawers.DrawStep[];
             protected _isVisibleOnPlot(datum: any, pixelPoint: Point, selection: D3.Selection): boolean;
         }
@@ -2767,12 +2769,8 @@ declare module Plottable {
             addDataset(dataset: Dataset): Grid;
             protected _getDrawer(key: string): Drawers.Rect;
             protected _generateDrawSteps(): Drawers.DrawStep[];
-            x(): Plots.AccessorScaleBinding<any, number>;
-            x(x: number | Accessor): Grid;
-            x(x: any | Accessor, scale: Scale<any, number>): Grid;
-            y(): Plots.AccessorScaleBinding<any, number>;
-            y(y: number | Accessor): Grid;
-            y(y: any | Accessor, scale: Scale<any, number>): Grid;
+            x(x?: number | Accessor<number> | any | Accessor<any>, scale?: Scale<any, number>): any;
+            y(y?: number | Accessor<number> | any, scale?: Scale<any, number>): any;
         }
     }
 }
@@ -2908,7 +2906,7 @@ declare module Plottable {
              * @param {QuantitativeScale} yScale The y scale to use.
              */
             constructor(xScale: QuantitativeScale<X>, yScale: QuantitativeScale<number>);
-            protected _rejectNullsAndNaNs(d: any, i: number, dataset: Dataset, plotMetadata: any, accessor: Accessor): boolean;
+            protected _rejectNullsAndNaNs(d: any, i: number, dataset: Dataset, plotMetadata: any, accessor: Accessor<any>): boolean;
             protected _getDrawer(key: string): Drawers.Line;
             protected _getResetYFunction(): (d: any, i: number, dataset: Dataset, m: PlotMetadata) => number;
             protected _generateDrawSteps(): Drawers.DrawStep[];
@@ -2948,8 +2946,8 @@ declare module Plottable {
              */
             constructor(xScale: QuantitativeScale<X>, yScale: QuantitativeScale<number>);
             y0(): Plots.AccessorScaleBinding<number, number>;
-            y0(y0: number | Accessor): Area<X>;
-            y0(y0: number | Accessor, y0Scale: Scale<number, number>): Area<X>;
+            y0(y0: number | Accessor<number>): Area<X>;
+            y0(y0: number | Accessor<number>, y0Scale: Scale<number, number>): Area<X>;
             protected _onDatasetUpdate(): void;
             protected _getDrawer(key: string): Drawers.Area;
             protected _updateYDomainer(): void;
@@ -3006,12 +3004,8 @@ declare module Plottable {
     class Stacked<X, Y> extends XYPlot<X, Y> {
         protected _isVertical: boolean;
         _getPlotMetadataForDataset(key: string): Plots.StackedPlotMetadata;
-        x(): Plots.AccessorScaleBinding<X, number>;
-        x(x: number | Accessor): XYPlot<X, Y>;
-        x(x: X | Accessor, scale: Scale<X, number>): XYPlot<X, Y>;
-        y(): Plots.AccessorScaleBinding<Y, number>;
-        y(y: number | Accessor): XYPlot<X, Y>;
-        y(y: Y | Accessor, scale: Scale<Y, number>): XYPlot<X, Y>;
+        x(x?: number | Accessor<number> | X | Accessor<X>, scale?: Scale<X, number>): any;
+        y(y?: number | Accessor<number> | Y | Accessor<Y>, scale?: Scale<Y, number>): any;
         _onDatasetUpdate(): void;
         _updateStackOffsets(): void;
         _updateStackExtents(): void;
@@ -3029,8 +3023,8 @@ declare module Plottable {
         _generateDefaultMapArray(): D3.Map<Plots.StackedDatum>[];
         protected _updateExtentsForProperty(property: string): void;
         protected _extentsForProperty(attr: string): any[];
-        _keyAccessor(): Accessor;
-        _valueAccessor(): Accessor;
+        _keyAccessor(): Accessor<any>;
+        _valueAccessor(): Accessor<number>;
     }
 }
 
@@ -3049,12 +3043,8 @@ declare module Plottable {
             protected _getDrawer(key: string): Drawers.Area;
             _getAnimator(key: string): Animators.PlotAnimator;
             protected _setup(): void;
-            x(): Plots.AccessorScaleBinding<X, number>;
-            x(x: number | Accessor): StackedArea<X>;
-            x(x: X | Accessor, xScale: Scale<X, number>): Area<X>;
-            y(): Plots.AccessorScaleBinding<number, number>;
-            y(y: number | Accessor): StackedArea<X>;
-            y(y: number | Accessor, yScale: Scale<number, number>): Area<X>;
+            x(x?: number | Accessor<number> | X | Accessor<X>, xScale?: Scale<X, number>): any;
+            y(y?: number | Accessor<number>, yScale?: Scale<number, number>): any;
             protected _additionalPaint(): void;
             protected _updateYDomainer(): void;
             protected _onDatasetUpdate(): StackedArea<X>;
@@ -3069,8 +3059,8 @@ declare module Plottable {
             _getDomainKeys(): any;
             _generateDefaultMapArray(): D3.Map<StackedDatum>[];
             protected _extentsForProperty(attr: string): any;
-            _keyAccessor(): Accessor;
-            _valueAccessor(): Accessor;
+            _keyAccessor(): Accessor<X>;
+            _valueAccessor(): Accessor<number>;
             _getPlotMetadataForDataset(key: string): StackedPlotMetadata;
             protected _updateExtentsForProperty(property: string): void;
         }
@@ -3092,12 +3082,8 @@ declare module Plottable {
              */
             constructor(xScale?: Scale<X, number>, yScale?: Scale<Y, number>, isVertical?: boolean);
             protected _getAnimator(key: string): Animators.PlotAnimator;
-            x(): Plots.AccessorScaleBinding<X, number>;
-            x(x: number | Accessor): StackedBar<X, Y>;
-            x(x: X | Accessor, xScale: Scale<X, number>): StackedBar<X, Y>;
-            y(): Plots.AccessorScaleBinding<Y, number>;
-            y(y: number | Accessor): StackedBar<X, Y>;
-            y(y: Y | Accessor, yScale: Scale<Y, number>): StackedBar<X, Y>;
+            x(x?: number | Accessor<number> | X | Accessor<X>, xScale?: Scale<X, number>): any;
+            y(y?: number | Accessor<number> | Y | Accessor<Y>, yScale?: Scale<Y, number>): any;
             protected _generateAttrToProjector(): {
                 [attrToSet: string]: (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
             };
@@ -3112,8 +3098,8 @@ declare module Plottable {
             _getDomainKeys(): any;
             _generateDefaultMapArray(): D3.Map<StackedDatum>[];
             protected _extentsForProperty(attr: string): any;
-            _keyAccessor(): Accessor;
-            _valueAccessor(): Accessor;
+            _keyAccessor(): Accessor<any>;
+            _valueAccessor(): Accessor<number>;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2706,18 +2706,18 @@ declare module Plottable {
                 [attrToSet: string]: (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
             };
             protected _generateDrawSteps(): Drawers.DrawStep[];
-            x1<X1>(): AccessorScaleBinding<X1, number>;
+            x1(): AccessorScaleBinding<X, number>;
             x1(x1: number | Accessor<number>): Plots.Rectangle<X, Y>;
-            x1<X1>(x1: X1 | Accessor<X1>, scale: Scale<X1, number>): Plots.Rectangle<X, Y>;
-            x2<X2>(): AccessorScaleBinding<X2, number>;
+            x1(x1: X | Accessor<X>, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
+            x2(): AccessorScaleBinding<X, number>;
             x2(x2: number | Accessor<number>): Plots.Rectangle<X, Y>;
-            x2<X2>(x2: X2 | Accessor<X2>, scale: Scale<X2, number>): Plots.Rectangle<X, Y>;
-            y1<Y1>(): AccessorScaleBinding<Y1, number>;
+            x2(x2: X | Accessor<X>, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
+            y1(): AccessorScaleBinding<Y, number>;
             y1(y1: number | Accessor<number>): Plots.Rectangle<X, Y>;
-            y1<Y1>(y1: Y1 | Accessor<Y1>, scale: Scale<Y1, number>): Plots.Rectangle<X, Y>;
-            y2<Y2>(): AccessorScaleBinding<Y2, number>;
+            y1(y1: Y | Accessor<Y>, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
+            y2(): AccessorScaleBinding<Y, number>;
             y2(y2: number | Accessor<number>): Plots.Rectangle<X, Y>;
-            y2<Y2>(y2: Y2 | Accessor<Y>, scale: Scale<Y2, number>): Plots.Rectangle<X, Y>;
+            y2(y2: Y | Accessor<Y>, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -7198,8 +7198,9 @@ var Plottable;
                 else {
                     _super.prototype.x.call(this, x, scale);
                     if (scale instanceof Plottable.Scales.Category) {
-                        this.x1(function (d, i, dataset, m) { return scale.scale(_this.x().accessor(d, i, dataset, m)) - scale.rangeBand() / 2; });
-                        this.x2(function (d, i, dataset, m) { return scale.scale(_this.x().accessor(d, i, dataset, m)) + scale.rangeBand() / 2; });
+                        var xCatScale = scale;
+                        this.x1(function (d, i, dataset, m) { return scale.scale(_this.x().accessor(d, i, dataset, m)) - xCatScale.rangeBand() / 2; });
+                        this.x2(function (d, i, dataset, m) { return scale.scale(_this.x().accessor(d, i, dataset, m)) + xCatScale.rangeBand() / 2; });
                     }
                     else if (scale instanceof Plottable.QuantitativeScale) {
                         this.x1(function (d, i, dataset, m) { return scale.scale(_this.x().accessor(d, i, dataset, m)); });
@@ -7218,8 +7219,9 @@ var Plottable;
                 else {
                     _super.prototype.y.call(this, y, scale);
                     if (scale instanceof Plottable.Scales.Category) {
-                        this.y1(function (d, i, dataset, m) { return scale.scale(_this.y().accessor(d, i, dataset, m)) - scale.rangeBand() / 2; });
-                        this.y2(function (d, i, dataset, m) { return scale.scale(_this.y().accessor(d, i, dataset, m)) + scale.rangeBand() / 2; });
+                        var yCatScale = scale;
+                        this.y1(function (d, i, dataset, m) { return scale.scale(_this.y().accessor(d, i, dataset, m)) - yCatScale.rangeBand() / 2; });
+                        this.y2(function (d, i, dataset, m) { return scale.scale(_this.y().accessor(d, i, dataset, m)) + yCatScale.rangeBand() / 2; });
                     }
                     else if (scale instanceof Plottable.QuantitativeScale) {
                         this.y1(function (d, i, dataset, m) { return scale.scale(_this.y().accessor(d, i, dataset, m)); });

--- a/plottable.js
+++ b/plottable.js
@@ -7653,10 +7653,6 @@ var Plottable;
                 this.animator("main", new Plottable.Animators.Base().duration(600).easing("exp-in-out"));
                 this._defaultStrokeColor = new Plottable.Scales.Color().range()[0];
             }
-            Line.prototype._rejectNullsAndNaNs = function (d, i, dataset, plotMetadata, accessor) {
-                var value = accessor(d, i, dataset, plotMetadata);
-                return value != null && value === value;
-            };
             Line.prototype._getDrawer = function (key) {
                 return new Plottable.Drawers.Line(key);
             };
@@ -7682,7 +7678,6 @@ var Plottable;
                 return drawSteps;
             };
             Line.prototype._generateAttrToProjector = function () {
-                var _this = this;
                 var attrToProjector = _super.prototype._generateAttrToProjector.call(this);
                 var wholeDatumAttributes = this._wholeDatumAttributes();
                 var isSingleDatumAttr = function (attr) { return wholeDatumAttributes.indexOf(attr) === -1; };
@@ -7693,7 +7688,11 @@ var Plottable;
                 });
                 var xFunction = attrToProjector["x"];
                 var yFunction = attrToProjector["y"];
-                attrToProjector["defined"] = function (d, i, dataset, m) { return _this._rejectNullsAndNaNs(d, i, dataset, m, xFunction) && _this._rejectNullsAndNaNs(d, i, dataset, m, yFunction); };
+                attrToProjector["defined"] = function (d, i, dataset, m) {
+                    var xValue = xFunction(d, i, dataset, m);
+                    var yValue = yFunction(d, i, dataset, m);
+                    return xValue != null && xValue === xValue && yValue != null && yValue === yValue;
+                };
                 attrToProjector["stroke"] = attrToProjector["stroke"] || d3.functor(this._defaultStrokeColor);
                 attrToProjector["stroke-width"] = attrToProjector["stroke-width"] || d3.functor("2px");
                 return attrToProjector;

--- a/plottable.js
+++ b/plottable.js
@@ -8037,7 +8037,7 @@ var Plottable;
                     data = data.filter(function (d, i) { return filter(d, i, dataset, plotMetadata); });
                 }
                 return Plottable.Utils.Methods.max(data, function (datum, i) {
-                    return +valueAccessor(datum, i, dataset, plotMetadata) + plotMetadata.offsets.get(keyAccessor(datum, i, dataset, plotMetadata));
+                    return +valueAccessor(datum, i, dataset, plotMetadata) + plotMetadata.offsets.get(String(keyAccessor(datum, i, dataset, plotMetadata)));
                 }, 0);
             }, 0);
             var minStackExtent = Plottable.Utils.Methods.min(this._datasetKeysInOrder, function (k) {
@@ -8048,7 +8048,7 @@ var Plottable;
                     data = data.filter(function (d, i) { return filter(d, i, dataset, plotMetadata); });
                 }
                 return Plottable.Utils.Methods.min(data, function (datum, i) {
-                    return +valueAccessor(datum, i, dataset, plotMetadata) + plotMetadata.offsets.get(keyAccessor(datum, i, dataset, plotMetadata));
+                    return +valueAccessor(datum, i, dataset, plotMetadata) + plotMetadata.offsets.get(String(keyAccessor(datum, i, dataset, plotMetadata)));
                 }, 0);
             }, 0);
             this._stackedExtent = [Math.min(minStackExtent, 0), Math.max(0, maxStackExtent)];
@@ -8080,7 +8080,7 @@ var Plottable;
                 var negativeDataMap = negativeDataMapArray[index];
                 var isAllNegativeValues = dataset.data().every(function (datum, i) { return valueAccessor(datum, i, dataset, plotMetadata) <= 0; });
                 dataset.data().forEach(function (datum, datumIndex) {
-                    var key = keyAccessor(datum, datumIndex, dataset, plotMetadata);
+                    var key = String(keyAccessor(datum, datumIndex, dataset, plotMetadata));
                     var positiveOffset = positiveDataMap.get(key).offset;
                     var negativeOffset = negativeDataMap.get(key).offset;
                     var value = valueAccessor(datum, datumIndex, dataset, plotMetadata);
@@ -8122,7 +8122,7 @@ var Plottable;
                 var dataset = _this._key2PlotDatasetKey.get(k).dataset;
                 var plotMetadata = _this._key2PlotDatasetKey.get(k).plotMetadata;
                 dataset.data().forEach(function (datum, index) {
-                    var key = keyAccessor(datum, index, dataset, plotMetadata);
+                    var key = String(keyAccessor(datum, index, dataset, plotMetadata));
                     var value = valueAccessor(datum, index, dataset, plotMetadata);
                     dataMapArray[datasetIndex].set(key, { key: key, value: value });
                 });

--- a/src/components/plots/areaPlot.ts
+++ b/src/components/plots/areaPlot.ts
@@ -29,9 +29,9 @@ export module Plots {
     }
 
     public y0(): Plots.AccessorScaleBinding<number, number>;
-    public y0(y0: number | _Accessor): Area<X>;
-    public y0(y0: number | _Accessor, y0Scale: Scale<number, number>): Area<X>;
-    public y0(y0?: number | _Accessor, y0Scale?: Scale<number, number>): any {
+    public y0(y0: number | Accessor): Area<X>;
+    public y0(y0: number | Accessor, y0Scale: Scale<number, number>): Area<X>;
+    public y0(y0?: number | Accessor, y0Scale?: Scale<number, number>): any {
       if (y0 == null) {
         return this._propertyBindings.get(Area._Y0_KEY);
       }

--- a/src/components/plots/areaPlot.ts
+++ b/src/components/plots/areaPlot.ts
@@ -29,9 +29,9 @@ export module Plots {
     }
 
     public y0(): Plots.AccessorScaleBinding<number, number>;
-    public y0(y0: number | Accessor): Area<X>;
-    public y0(y0: number | Accessor, y0Scale: Scale<number, number>): Area<X>;
-    public y0(y0?: number | Accessor, y0Scale?: Scale<number, number>): any {
+    public y0(y0: number | Accessor<number>): Area<X>;
+    public y0(y0: number | Accessor<number>, y0Scale: Scale<number, number>): Area<X>;
+    public y0(y0?: number | Accessor<number>, y0Scale?: Scale<number, number>): any {
       if (y0 == null) {
         return this._propertyBindings.get(Area._Y0_KEY);
       }

--- a/src/components/plots/gridPlot.ts
+++ b/src/components/plots/gridPlot.ts
@@ -48,17 +48,14 @@ export module Plots {
       return [{attrToProjector: this._generateAttrToProjector(), animator: this._getAnimator("cells")}];
     }
 
-    public x(): Plots.AccessorScaleBinding<any, number>;
-    public x(x: number | Accessor): Grid;
-    public x(x: any | Accessor, scale: Scale<any, number>): Grid;
-    public x(x?: number | Accessor | any, scale?: Scale<any, number>): any {
+    public x(x?: number | Accessor<number> | any | Accessor<any>, scale?: Scale<any, number>): any {
       if (x == null) {
         return super.x();
       }
       if (scale == null) {
-        super.x(<number | Accessor> x);
+        super.x(<number | Accessor<number>> x);
       } else {
-        super.x(<any | Accessor> x, scale);
+        super.x(<any | Accessor<any>> x, scale);
         if (scale instanceof Scales.Category) {
           this.x1((d, i, dataset, m) => scale.scale(this.x().accessor(d, i, dataset, m)) - scale.rangeBand() / 2);
           this.x2((d, i, dataset, m) => scale.scale(this.x().accessor(d, i, dataset, m)) + scale.rangeBand() / 2);
@@ -69,17 +66,14 @@ export module Plots {
       return this;
     }
 
-    public y(): Plots.AccessorScaleBinding<any, number>;
-    public y(y: number | Accessor): Grid;
-    public y(y: any | Accessor, scale: Scale<any, number>): Grid;
-    public y(y?: number | Accessor | any, scale?: Scale<any, number>): any {
+    public y(y?: number | Accessor<number> | any, scale?: Scale<any, number>): any {
       if (y == null) {
         return super.y();
       }
       if (scale == null) {
-        super.y(<number | Accessor> y);
+        super.y(<number | Accessor<number>> y);
       } else {
-        super.y(<any | Accessor> y, scale);
+        super.y(<any | Accessor<any>> y, scale);
         if (scale instanceof Scales.Category) {
           this.y1((d, i, dataset, m) => scale.scale(this.y().accessor(d, i, dataset, m)) - scale.rangeBand() / 2);
           this.y2((d, i, dataset, m) => scale.scale(this.y().accessor(d, i, dataset, m)) + scale.rangeBand() / 2);

--- a/src/components/plots/gridPlot.ts
+++ b/src/components/plots/gridPlot.ts
@@ -49,16 +49,16 @@ export module Plots {
     }
 
     public x(): Plots.AccessorScaleBinding<any, number>;
-    public x(x: number | _Accessor): Grid;
-    public x(x: any | _Accessor, scale: Scale<any, number>): Grid;
-    public x(x?: number | _Accessor | any, scale?: Scale<any, number>): any {
+    public x(x: number | Accessor): Grid;
+    public x(x: any | Accessor, scale: Scale<any, number>): Grid;
+    public x(x?: number | Accessor | any, scale?: Scale<any, number>): any {
       if (x == null) {
         return super.x();
       }
       if (scale == null) {
-        super.x(<number | _Accessor> x);
+        super.x(<number | Accessor> x);
       } else {
-        super.x(<any | _Accessor> x, scale);
+        super.x(<any | Accessor> x, scale);
         if (scale instanceof Scales.Category) {
           this.x1((d, i, dataset, m) => scale.scale(this.x().accessor(d, i, dataset, m)) - scale.rangeBand() / 2);
           this.x2((d, i, dataset, m) => scale.scale(this.x().accessor(d, i, dataset, m)) + scale.rangeBand() / 2);
@@ -70,16 +70,16 @@ export module Plots {
     }
 
     public y(): Plots.AccessorScaleBinding<any, number>;
-    public y(y: number | _Accessor): Grid;
-    public y(y: any | _Accessor, scale: Scale<any, number>): Grid;
-    public y(y?: number | _Accessor | any, scale?: Scale<any, number>): any {
+    public y(y: number | Accessor): Grid;
+    public y(y: any | Accessor, scale: Scale<any, number>): Grid;
+    public y(y?: number | Accessor | any, scale?: Scale<any, number>): any {
       if (y == null) {
         return super.y();
       }
       if (scale == null) {
-        super.y(<number | _Accessor> y);
+        super.y(<number | Accessor> y);
       } else {
-        super.y(<any | _Accessor> y, scale);
+        super.y(<any | Accessor> y, scale);
         if (scale instanceof Scales.Category) {
           this.y1((d, i, dataset, m) => scale.scale(this.y().accessor(d, i, dataset, m)) - scale.rangeBand() / 2);
           this.y2((d, i, dataset, m) => scale.scale(this.y().accessor(d, i, dataset, m)) + scale.rangeBand() / 2);

--- a/src/components/plots/gridPlot.ts
+++ b/src/components/plots/gridPlot.ts
@@ -2,7 +2,7 @@
 
 module Plottable {
 export module Plots {
-  export class Grid extends Rectangle<any, any> {
+  export class Grid<X, Y> extends Rectangle<any, any> {
 
     /**
      * Constructs a GridPlot.
@@ -16,16 +16,16 @@ export module Plots {
      * @param {Scale.Color|Scale.InterpolatedColor} colorScale The color scale
      * to use for each grid cell.
      */
-    constructor(xScale: Scale<any, any>, yScale: Scale<any, any>) {
+    constructor(xScale: Scale<X, any>, yScale: Scale<Y, any>) {
       super(xScale, yScale);
       this.classed("grid-plot", true);
 
       // The x and y scales should render in bands with no padding for category scales
       if (xScale instanceof Scales.Category) {
-        xScale.innerPadding(0).outerPadding(0);
+        (<Scales.Category> <any> xScale).innerPadding(0).outerPadding(0);
       }
       if (yScale instanceof Scales.Category) {
-        yScale.innerPadding(0).outerPadding(0);
+        (<Scales.Category> <any> yScale).innerPadding(0).outerPadding(0);
       }
 
       this.animator("cells", new Animators.Null());
@@ -48,17 +48,18 @@ export module Plots {
       return [{attrToProjector: this._generateAttrToProjector(), animator: this._getAnimator("cells")}];
     }
 
-    public x(x?: number | Accessor<number> | any | Accessor<any>, scale?: Scale<any, number>): any {
+    public x(x?: number | Accessor<number> | X | Accessor<X>, scale?: Scale<X, number>): any {
       if (x == null) {
         return super.x();
       }
       if (scale == null) {
         super.x(<number | Accessor<number>> x);
       } else {
-        super.x(<any | Accessor<any>> x, scale);
+        super.x(<X | Accessor<X>> x, scale);
         if (scale instanceof Scales.Category) {
-          this.x1((d, i, dataset, m) => scale.scale(this.x().accessor(d, i, dataset, m)) - scale.rangeBand() / 2);
-          this.x2((d, i, dataset, m) => scale.scale(this.x().accessor(d, i, dataset, m)) + scale.rangeBand() / 2);
+          var xCatScale = (<Scales.Category> <any> scale);
+          this.x1((d, i, dataset, m) => scale.scale(this.x().accessor(d, i, dataset, m)) - xCatScale.rangeBand() / 2);
+          this.x2((d, i, dataset, m) => scale.scale(this.x().accessor(d, i, dataset, m)) + xCatScale.rangeBand() / 2);
         } else if (scale instanceof QuantitativeScale) {
           this.x1((d, i, dataset, m) => scale.scale(this.x().accessor(d, i, dataset, m)));
         }
@@ -66,17 +67,18 @@ export module Plots {
       return this;
     }
 
-    public y(y?: number | Accessor<number> | any, scale?: Scale<any, number>): any {
+    public y(y?: number | Accessor<number> | Y | Accessor<Y>, scale?: Scale<Y, number>): any {
       if (y == null) {
         return super.y();
       }
       if (scale == null) {
         super.y(<number | Accessor<number>> y);
       } else {
-        super.y(<any | Accessor<any>> y, scale);
+        super.y(<Y | Accessor<Y>> y, scale);
         if (scale instanceof Scales.Category) {
-          this.y1((d, i, dataset, m) => scale.scale(this.y().accessor(d, i, dataset, m)) - scale.rangeBand() / 2);
-          this.y2((d, i, dataset, m) => scale.scale(this.y().accessor(d, i, dataset, m)) + scale.rangeBand() / 2);
+          var yCatScale = (<Scales.Category> <any> scale);
+          this.y1((d, i, dataset, m) => scale.scale(this.y().accessor(d, i, dataset, m)) - yCatScale.rangeBand() / 2);
+          this.y2((d, i, dataset, m) => scale.scale(this.y().accessor(d, i, dataset, m)) + yCatScale.rangeBand() / 2);
         } else if (scale instanceof QuantitativeScale) {
           this.y1((d, i, dataset, m) => scale.scale(this.y().accessor(d, i, dataset, m)));
         }

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -23,7 +23,7 @@ export module Plots {
       this._defaultStrokeColor = new Scales.Color().range()[0];
     }
 
-    protected _rejectNullsAndNaNs(d: any, i: number, dataset: Dataset, plotMetadata: any, accessor: Accessor) {
+    protected _rejectNullsAndNaNs(d: any, i: number, dataset: Dataset, plotMetadata: any, accessor: Accessor<any>) {
       var value = accessor(d, i, dataset, plotMetadata);
       return value != null && value === value;
     }

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -23,11 +23,6 @@ export module Plots {
       this._defaultStrokeColor = new Scales.Color().range()[0];
     }
 
-    protected _rejectNullsAndNaNs(d: any, i: number, dataset: Dataset, plotMetadata: any, accessor: Accessor<X> | Accessor<number>) {
-      var value = accessor(d, i, dataset, plotMetadata);
-      return value != null && value === value;
-    }
-
     protected _getDrawer(key: string) {
       return new Plottable.Drawers.Line(key);
     }
@@ -71,8 +66,11 @@ export module Plots {
       var xFunction = attrToProjector["x"];
       var yFunction = attrToProjector["y"];
 
-      attrToProjector["defined"] = (d: any, i: number, dataset: Dataset, m: any) =>
-          this._rejectNullsAndNaNs(d, i, dataset, m, xFunction) && this._rejectNullsAndNaNs(d, i, dataset, m, yFunction);
+      attrToProjector["defined"] = (d: any, i: number, dataset: Dataset, m: any) => {
+        var xValue = xFunction(d, i, dataset, m);
+        var yValue = yFunction(d, i, dataset, m);
+        return xValue != null && xValue === xValue && yValue != null && yValue === yValue;
+      };
 
       attrToProjector["stroke"] = attrToProjector["stroke"] || d3.functor(this._defaultStrokeColor);
       attrToProjector["stroke-width"] = attrToProjector["stroke-width"] || d3.functor("2px");

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -23,7 +23,7 @@ export module Plots {
       this._defaultStrokeColor = new Scales.Color().range()[0];
     }
 
-    protected _rejectNullsAndNaNs(d: any, i: number, dataset: Dataset, plotMetadata: any, accessor: Accessor<any>) {
+    protected _rejectNullsAndNaNs(d: any, i: number, dataset: Dataset, plotMetadata: any, accessor: Accessor<X> | Accessor<number>) {
       var value = accessor(d, i, dataset, plotMetadata);
       return value != null && value === value;
     }

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -23,7 +23,7 @@ export module Plots {
       this._defaultStrokeColor = new Scales.Color().range()[0];
     }
 
-    protected _rejectNullsAndNaNs(d: any, i: number, dataset: Dataset, plotMetadata: any, accessor: _Accessor) {
+    protected _rejectNullsAndNaNs(d: any, i: number, dataset: Dataset, plotMetadata: any, accessor: Accessor) {
       var value = accessor(d, i, dataset, plotMetadata);
       return value != null && value === value;
     }

--- a/src/components/plots/piePlot.ts
+++ b/src/components/plots/piePlot.ts
@@ -86,10 +86,10 @@ export module Plots {
       return this;
     }
 
-    public innerRadius<I>(): AccessorScaleBinding<I, number>;
+    public innerRadius<R>(): AccessorScaleBinding<R, number>;
     public innerRadius(innerRadius: number | Accessor<number>): Plots.Pie;
-    public innerRadius<I>(innerRadius: I | Accessor<I>, scale: Scale<I, number>): Plots.Pie;
-    public innerRadius<I>(innerRadius?: number | Accessor<number> | I | Accessor<I>, scale?: Scale<I, number>): any {
+    public innerRadius<R>(innerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Pie;
+    public innerRadius<R>(innerRadius?: number | Accessor<number> | R | Accessor<R>, scale?: Scale<R, number>): any {
       if (innerRadius == null) {
         return this._propertyBindings.get(Pie._INNER_RADIUS_KEY);
       }
@@ -98,10 +98,10 @@ export module Plots {
       return this;
     }
 
-    public outerRadius<O>(): AccessorScaleBinding<O, number>;
+    public outerRadius<R>(): AccessorScaleBinding<R, number>;
     public outerRadius(outerRadius: number | Accessor<number>): Plots.Pie;
-    public outerRadius<O>(outerRadius: O | Accessor<O>, scale: Scale<O, number>): Plots.Pie;
-    public outerRadius<O>(outerRadius?: number | Accessor<number> | O | Accessor<O>, scale?: Scale<O, number>): any {
+    public outerRadius<R>(outerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Pie;
+    public outerRadius<R>(outerRadius?: number | Accessor<number> | R | Accessor<R>, scale?: Scale<R, number>): any {
       if (outerRadius == null) {
         return this._propertyBindings.get(Pie._OUTER_RADIUS_KEY);
       }

--- a/src/components/plots/piePlot.ts
+++ b/src/components/plots/piePlot.ts
@@ -75,9 +75,9 @@ export module Plots {
     }
 
     public sectorValue(): AccessorScaleBinding<D, number>;
-    public sectorValue(sectorValue: number | _Accessor): Plots.Pie<D>;
-    public sectorValue(sectorValue: D | _Accessor, scale: Scale<D, number>): Plots.Pie<D>;
-    public sectorValue(sectorValue?: number | _Accessor | D, scale?: Scale<D, number>): any {
+    public sectorValue(sectorValue: number | Accessor): Plots.Pie<D>;
+    public sectorValue(sectorValue: D | Accessor, scale: Scale<D, number>): Plots.Pie<D>;
+    public sectorValue(sectorValue?: number | Accessor | D, scale?: Scale<D, number>): any {
       if (sectorValue == null) {
         return this._propertyBindings.get(Pie._SECTOR_VALUE_KEY);
       }
@@ -87,9 +87,9 @@ export module Plots {
     }
 
     public innerRadius(): AccessorScaleBinding<D, number>;
-    public innerRadius(innerRadius: number | _Accessor): Plots.Pie<D>;
-    public innerRadius(innerRadius: D | _Accessor, scale: Scale<D, number>): Plots.Pie<D>;
-    public innerRadius(innerRadius?: number | _Accessor | D, scale?: Scale<D, number>): any {
+    public innerRadius(innerRadius: number | Accessor): Plots.Pie<D>;
+    public innerRadius(innerRadius: D | Accessor, scale: Scale<D, number>): Plots.Pie<D>;
+    public innerRadius(innerRadius?: number | Accessor | D, scale?: Scale<D, number>): any {
       if (innerRadius == null) {
         return this._propertyBindings.get(Pie._INNER_RADIUS_KEY);
       }
@@ -99,9 +99,9 @@ export module Plots {
     }
 
     public outerRadius(): AccessorScaleBinding<D, number>;
-    public outerRadius(outerRadius: number | _Accessor): Plots.Pie<D>;
-    public outerRadius(outerRadius: D | _Accessor, scale: Scale<D, number>): Plots.Pie<D>;
-    public outerRadius(outerRadius?: number | _Accessor | D, scale?: Scale<D, number>): any {
+    public outerRadius(outerRadius: number | Accessor): Plots.Pie<D>;
+    public outerRadius(outerRadius: D | Accessor, scale: Scale<D, number>): Plots.Pie<D>;
+    public outerRadius(outerRadius?: number | Accessor | D, scale?: Scale<D, number>): any {
       if (outerRadius == null) {
         return this._propertyBindings.get(Pie._OUTER_RADIUS_KEY);
       }

--- a/src/components/plots/piePlot.ts
+++ b/src/components/plots/piePlot.ts
@@ -6,7 +6,7 @@ export module Plots {
    * A PiePlot is a plot meant to show how much out of a total an attribute's value is.
    * One usecase is to show how much funding departments are given out of a total budget.
    */
-  export class Pie<D> extends Plot {
+  export class Pie extends Plot {
 
     private _colorScale: Scales.Color;
     private static _INNER_RADIUS_KEY = "inner-radius";
@@ -74,10 +74,10 @@ export module Plots {
       return allPlotData;
     }
 
-    public sectorValue(): AccessorScaleBinding<D, number>;
-    public sectorValue(sectorValue: number | Accessor): Plots.Pie<D>;
-    public sectorValue(sectorValue: D | Accessor, scale: Scale<D, number>): Plots.Pie<D>;
-    public sectorValue(sectorValue?: number | Accessor | D, scale?: Scale<D, number>): any {
+    public sectorValue<S>(): AccessorScaleBinding<S, number>;
+    public sectorValue(sectorValue: number | Accessor<number>): Plots.Pie;
+    public sectorValue<S>(sectorValue: S | Accessor<S>, scale: Scale<S, number>): Plots.Pie;
+    public sectorValue<S>(sectorValue?: number | Accessor<number> | S | Accessor<S>, scale?: Scale<S, number>): any {
       if (sectorValue == null) {
         return this._propertyBindings.get(Pie._SECTOR_VALUE_KEY);
       }
@@ -86,10 +86,10 @@ export module Plots {
       return this;
     }
 
-    public innerRadius(): AccessorScaleBinding<D, number>;
-    public innerRadius(innerRadius: number | Accessor): Plots.Pie<D>;
-    public innerRadius(innerRadius: D | Accessor, scale: Scale<D, number>): Plots.Pie<D>;
-    public innerRadius(innerRadius?: number | Accessor | D, scale?: Scale<D, number>): any {
+    public innerRadius<I>(): AccessorScaleBinding<I, number>;
+    public innerRadius(innerRadius: number | Accessor<number>): Plots.Pie;
+    public innerRadius<I>(innerRadius: I | Accessor<I>, scale: Scale<I, number>): Plots.Pie;
+    public innerRadius<I>(innerRadius?: number | Accessor<number> | I | Accessor<I>, scale?: Scale<I, number>): any {
       if (innerRadius == null) {
         return this._propertyBindings.get(Pie._INNER_RADIUS_KEY);
       }
@@ -98,10 +98,10 @@ export module Plots {
       return this;
     }
 
-    public outerRadius(): AccessorScaleBinding<D, number>;
-    public outerRadius(outerRadius: number | Accessor): Plots.Pie<D>;
-    public outerRadius(outerRadius: D | Accessor, scale: Scale<D, number>): Plots.Pie<D>;
-    public outerRadius(outerRadius?: number | Accessor | D, scale?: Scale<D, number>): any {
+    public outerRadius<O>(): AccessorScaleBinding<O, number>;
+    public outerRadius(outerRadius: number | Accessor<number>): Plots.Pie;
+    public outerRadius<O>(outerRadius: O | Accessor<O>, scale: Scale<O, number>): Plots.Pie;
+    public outerRadius<O>(outerRadius?: number | Accessor<number> | O | Accessor<O>, scale?: Scale<O, number>): any {
       if (outerRadius == null) {
         return this._propertyBindings.get(Pie._OUTER_RADIUS_KEY);
       }

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -141,11 +141,11 @@ module Plottable {
       this.render();
     }
 
-    public attr<D>(attr: string): Plots.AccessorScaleBinding<D, number | string>;
+    public attr<A>(attr: string): Plots.AccessorScaleBinding<A, number | string>;
     public attr(attr: string, attrValue: number | string | Accessor<number> | Accessor<string>): Plot;
-    public attr<D>(attr: string, attrValue: D | Accessor<D>, scale: Scale<D, number | string>): Plot;
-    public attr<D>(attr: string, attrValue?: number | string | Accessor<number> | Accessor<string> | D | Accessor<D>,
-                   scale?: Scale<D, number | string>): any {
+    public attr<A>(attr: string, attrValue: A | Accessor<A>, scale: Scale<A, number | string>): Plot;
+    public attr<A>(attr: string, attrValue?: number | string | Accessor<number> | Accessor<string> | A | Accessor<A>,
+                   scale?: Scale<A, number | string>): any {
       if (attrValue == null) {
         return this._attrBindings.get(attr);
       }

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -25,7 +25,7 @@ module Plottable {
     }
 
     export interface AccessorScaleBinding<D, R> {
-      accessor: Accessor;
+      accessor: Accessor<any>;
       scale?: Scale<D, R>;
     }
   }
@@ -142,9 +142,10 @@ module Plottable {
     }
 
     public attr<D>(attr: string): Plots.AccessorScaleBinding<D, number | string>;
-    public attr(attr: string, attrValue: number | string | Accessor): Plot;
-    public attr<D>(attr: string, attrValue: D | Accessor, scale: Scale<D, number | string>): Plot;
-    public attr<D>(attr: string, attrValue?: number | string | Accessor | D, scale?: Scale<D, number | string>): any {
+    public attr(attr: string, attrValue: number | string | Accessor<number> | Accessor<string>): Plot;
+    public attr<D>(attr: string, attrValue: D | Accessor<D>, scale: Scale<D, number | string>): Plot;
+    public attr<D>(attr: string, attrValue?: number | string | Accessor<number> | Accessor<string> | D | Accessor<D>,
+                   scale?: Scale<D, number | string>): any {
       if (attrValue == null) {
         return this._attrBindings.get(attr);
       }
@@ -283,12 +284,12 @@ module Plottable {
       this._updateExtentsForKey(property, this._propertyBindings, this._propertyExtents, this._filterForProperty(property));
     }
 
-    protected _filterForProperty(property: string): Accessor {
+    protected _filterForProperty(property: string): Accessor<any> {
       return null;
     }
 
     private _updateExtentsForKey(key: string, bindings: D3.Map<Plots.AccessorScaleBinding<any, any>>,
-        extents: D3.Map<any[]>, filter: Accessor) {
+        extents: D3.Map<any[]>, filter: Accessor<any>) {
       var accScaleBinding = bindings.get(key);
       if (accScaleBinding.accessor == null) { return; }
       extents.set(key, this._datasetKeysInOrder.map((key) => {
@@ -299,7 +300,7 @@ module Plottable {
       }));
     }
 
-    private _computeExtent(dataset: Dataset, accessor: Accessor, plotMetadata: any, filter: Accessor): any[] {
+    private _computeExtent(dataset: Dataset, accessor: Accessor<any>, plotMetadata: any, filter: Accessor<any>): any[] {
       var data = dataset.data();
       if (filter != null) {
         data = data.filter((d, i) => filter(d, i, dataset, plotMetadata));

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -25,7 +25,7 @@ module Plottable {
     }
 
     export interface AccessorScaleBinding<D, R> {
-      accessor: _Accessor;
+      accessor: Accessor;
       scale?: Scale<D, R>;
     }
   }
@@ -142,9 +142,9 @@ module Plottable {
     }
 
     public attr<D>(attr: string): Plots.AccessorScaleBinding<D, number | string>;
-    public attr(attr: string, attrValue: number | string | _Accessor): Plot;
-    public attr<D>(attr: string, attrValue: D | _Accessor, scale: Scale<D, number | string>): Plot;
-    public attr<D>(attr: string, attrValue?: number | string | _Accessor | D, scale?: Scale<D, number | string>): any {
+    public attr(attr: string, attrValue: number | string | Accessor): Plot;
+    public attr<D>(attr: string, attrValue: D | Accessor, scale: Scale<D, number | string>): Plot;
+    public attr<D>(attr: string, attrValue?: number | string | Accessor | D, scale?: Scale<D, number | string>): any {
       if (attrValue == null) {
         return this._attrBindings.get(attr);
       }
@@ -283,12 +283,12 @@ module Plottable {
       this._updateExtentsForKey(property, this._propertyBindings, this._propertyExtents, this._filterForProperty(property));
     }
 
-    protected _filterForProperty(property: string): _Accessor {
+    protected _filterForProperty(property: string): Accessor {
       return null;
     }
 
     private _updateExtentsForKey(key: string, bindings: D3.Map<Plots.AccessorScaleBinding<any, any>>,
-        extents: D3.Map<any[]>, filter: _Accessor) {
+        extents: D3.Map<any[]>, filter: Accessor) {
       var accScaleBinding = bindings.get(key);
       if (accScaleBinding.accessor == null) { return; }
       extents.set(key, this._datasetKeysInOrder.map((key) => {
@@ -299,7 +299,7 @@ module Plottable {
       }));
     }
 
-    private _computeExtent(dataset: Dataset, accessor: _Accessor, plotMetadata: any, filter: _Accessor): any[] {
+    private _computeExtent(dataset: Dataset, accessor: Accessor, plotMetadata: any, filter: Accessor): any[] {
       var data = dataset.data();
       if (filter != null) {
         data = data.filter((d, i) => filter(d, i, dataset, plotMetadata));

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -284,12 +284,12 @@ module Plottable {
       this._updateExtentsForKey(property, this._propertyBindings, this._propertyExtents, this._filterForProperty(property));
     }
 
-    protected _filterForProperty(property: string): Accessor<any> {
+    protected _filterForProperty(property: string): Accessor<boolean> {
       return null;
     }
 
     private _updateExtentsForKey(key: string, bindings: D3.Map<Plots.AccessorScaleBinding<any, any>>,
-        extents: D3.Map<any[]>, filter: Accessor<any>) {
+        extents: D3.Map<any[]>, filter: Accessor<boolean>) {
       var accScaleBinding = bindings.get(key);
       if (accScaleBinding.accessor == null) { return; }
       extents.set(key, this._datasetKeysInOrder.map((key) => {
@@ -300,7 +300,7 @@ module Plottable {
       }));
     }
 
-    private _computeExtent(dataset: Dataset, accessor: Accessor<any>, plotMetadata: any, filter: Accessor<any>): any[] {
+    private _computeExtent(dataset: Dataset, accessor: Accessor<any>, plotMetadata: any, filter: Accessor<boolean>): any[] {
       var data = dataset.data();
       if (filter != null) {
         data = data.filter((d, i) => filter(d, i, dataset, plotMetadata));

--- a/src/components/plots/rectanglePlot.ts
+++ b/src/components/plots/rectanglePlot.ts
@@ -63,10 +63,10 @@ export module Plots {
       return [{attrToProjector: this._generateAttrToProjector(), animator: this._getAnimator("rectangles")}];
     }
 
-    public x1(): AccessorScaleBinding<X, number>;
+    public x1<X1>(): AccessorScaleBinding<X1, number>;
     public x1(x1: number | Accessor<number>): Plots.Rectangle<X, Y>;
-    public x1(x1: X | Accessor<X>, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
-    public x1(x1?: number | Accessor<number> | X | Accessor<X>, scale?: Scale<X, number>): any {
+    public x1<X1>(x1: X | Accessor<X>, scale: Scale<X1, number>): Plots.Rectangle<X, Y>;
+    public x1<X1>(x1?: number | Accessor<number> | X1 | Accessor<X1>, scale?: Scale<X1, number>): any {
       if (x1 == null) {
         return this._propertyBindings.get(Rectangle._X1_KEY);
       }
@@ -75,10 +75,10 @@ export module Plots {
       return this;
     }
 
-    public x2(): AccessorScaleBinding<X, number>;
+    public x2<X2>(): AccessorScaleBinding<X2, number>;
     public x2(x2: number | Accessor<number>): Plots.Rectangle<X, Y>;
-    public x2(x2: X | Accessor<X>, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
-    public x2(x2?: number | Accessor<number> | X | Accessor<X>, scale?: Scale<X, number>): any {
+    public x2<X2>(x2: X2 | Accessor<X2>, scale: Scale<X2, number>): Plots.Rectangle<X, Y>;
+    public x2<X2>(x2?: number | Accessor<number> | X2 | Accessor<X2>, scale?: Scale<X2, number>): any {
       if (x2 == null) {
         return this._propertyBindings.get(Rectangle._X2_KEY);
       }
@@ -87,10 +87,10 @@ export module Plots {
       return this;
     }
 
-    public y1(): AccessorScaleBinding<Y, number>;
+    public y1<Y1>(): AccessorScaleBinding<Y1, number>;
     public y1(y1: number | Accessor<number>): Plots.Rectangle<X, Y>;
-    public y1(y1: Y | Accessor<Y>, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
-    public y1(y1?: number | Accessor<number> | Y | Accessor<Y>, scale?: Scale<Y, number>): any {
+    public y1<Y1>(y1: Y1 | Accessor<Y1>, scale: Scale<Y1, number>): Plots.Rectangle<X, Y>;
+    public y1<Y1>(y1?: number | Accessor<number> | Y1 | Accessor<Y1>, scale?: Scale<Y1, number>): any {
       if (y1 == null) {
         return this._propertyBindings.get(Rectangle._Y1_KEY);
       }
@@ -99,10 +99,10 @@ export module Plots {
       return this;
     }
 
-    public y2(): AccessorScaleBinding<Y, number>;
+    public y2<Y2>(): AccessorScaleBinding<Y2, number>;
     public y2(y2: number | Accessor<number>): Plots.Rectangle<X, Y>;
-    public y2(y2: Y | Accessor<Y>, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
-    public y2(y2?: number | Accessor<number> | Y | Accessor<Y>, scale?: Scale<Y, number>): any {
+    public y2<Y2>(y2: Y2 | Accessor<Y>, scale: Scale<Y2, number>): Plots.Rectangle<X, Y>;
+    public y2<Y2>(y2?: number | Accessor<number> | Y2 | Accessor<Y2>, scale?: Scale<Y2, number>): any {
       if (y2 == null) {
         return this._propertyBindings.get(Rectangle._Y2_KEY);
       }

--- a/src/components/plots/rectanglePlot.ts
+++ b/src/components/plots/rectanglePlot.ts
@@ -63,10 +63,10 @@ export module Plots {
       return [{attrToProjector: this._generateAttrToProjector(), animator: this._getAnimator("rectangles")}];
     }
 
-    public x1<X1>(): AccessorScaleBinding<X1, number>;
+    public x1(): AccessorScaleBinding<X, number>;
     public x1(x1: number | Accessor<number>): Plots.Rectangle<X, Y>;
-    public x1<X1>(x1: X1 | Accessor<X1>, scale: Scale<X1, number>): Plots.Rectangle<X, Y>;
-    public x1<X1>(x1?: number | Accessor<number> | X1 | Accessor<X1>, scale?: Scale<X1, number>): any {
+    public x1(x1: X | Accessor<X>, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
+    public x1(x1?: number | Accessor<number> | X | Accessor<X>, scale?: Scale<X, number>): any {
       if (x1 == null) {
         return this._propertyBindings.get(Rectangle._X1_KEY);
       }
@@ -75,10 +75,10 @@ export module Plots {
       return this;
     }
 
-    public x2<X2>(): AccessorScaleBinding<X2, number>;
+    public x2(): AccessorScaleBinding<X, number>;
     public x2(x2: number | Accessor<number>): Plots.Rectangle<X, Y>;
-    public x2<X2>(x2: X2 | Accessor<X2>, scale: Scale<X2, number>): Plots.Rectangle<X, Y>;
-    public x2<X2>(x2?: number | Accessor<number> | X2 | Accessor<X2>, scale?: Scale<X2, number>): any {
+    public x2(x2: X | Accessor<X>, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
+    public x2(x2?: number | Accessor<number> | X | Accessor<X>, scale?: Scale<X, number>): any {
       if (x2 == null) {
         return this._propertyBindings.get(Rectangle._X2_KEY);
       }
@@ -87,10 +87,10 @@ export module Plots {
       return this;
     }
 
-    public y1<Y1>(): AccessorScaleBinding<Y1, number>;
+    public y1(): AccessorScaleBinding<Y, number>;
     public y1(y1: number | Accessor<number>): Plots.Rectangle<X, Y>;
-    public y1<Y1>(y1: Y1 | Accessor<Y1>, scale: Scale<Y1, number>): Plots.Rectangle<X, Y>;
-    public y1<Y1>(y1?: number | Accessor<number> | Y1 | Accessor<Y1>, scale?: Scale<Y1, number>): any {
+    public y1(y1: Y | Accessor<Y>, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
+    public y1(y1?: number | Accessor<number> | Y | Accessor<Y>, scale?: Scale<Y, number>): any {
       if (y1 == null) {
         return this._propertyBindings.get(Rectangle._Y1_KEY);
       }
@@ -99,10 +99,10 @@ export module Plots {
       return this;
     }
 
-    public y2<Y2>(): AccessorScaleBinding<Y2, number>;
+    public y2(): AccessorScaleBinding<Y, number>;
     public y2(y2: number | Accessor<number>): Plots.Rectangle<X, Y>;
-    public y2<Y2>(y2: Y2 | Accessor<Y>, scale: Scale<Y2, number>): Plots.Rectangle<X, Y>;
-    public y2<Y2>(y2?: number | Accessor<number> | Y2 | Accessor<Y2>, scale?: Scale<Y2, number>): any {
+    public y2(y2: Y | Accessor<Y>, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
+    public y2(y2?: number | Accessor<number> | Y | Accessor<Y>, scale?: Scale<Y, number>): any {
       if (y2 == null) {
         return this._propertyBindings.get(Rectangle._Y2_KEY);
       }

--- a/src/components/plots/rectanglePlot.ts
+++ b/src/components/plots/rectanglePlot.ts
@@ -64,9 +64,9 @@ export module Plots {
     }
 
     public x1(): AccessorScaleBinding<X, number>;
-    public x1(x1: number | Accessor): Plots.Rectangle<X, Y>;
-    public x1(x1: X | Accessor, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
-    public x1(x1?: number | Accessor | X, scale?: Scale<X, number>): any {
+    public x1(x1: number | Accessor<number>): Plots.Rectangle<X, Y>;
+    public x1(x1: X | Accessor<X>, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
+    public x1(x1?: number | Accessor<number> | X | Accessor<X>, scale?: Scale<X, number>): any {
       if (x1 == null) {
         return this._propertyBindings.get(Rectangle._X1_KEY);
       }
@@ -76,9 +76,9 @@ export module Plots {
     }
 
     public x2(): AccessorScaleBinding<X, number>;
-    public x2(x2: number | Accessor): Plots.Rectangle<X, Y>;
-    public x2(x2: X | Accessor, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
-    public x2(x2?: number | Accessor | X, scale?: Scale<X, number>): any {
+    public x2(x2: number | Accessor<number>): Plots.Rectangle<X, Y>;
+    public x2(x2: X | Accessor<X>, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
+    public x2(x2?: number | Accessor<number> | X | Accessor<X>, scale?: Scale<X, number>): any {
       if (x2 == null) {
         return this._propertyBindings.get(Rectangle._X2_KEY);
       }
@@ -87,10 +87,10 @@ export module Plots {
       return this;
     }
 
-    public y1(): AccessorScaleBinding<X, number>;
-    public y1(y1: number | Accessor): Plots.Rectangle<X, Y>;
-    public y1(y1: Y | Accessor, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
-    public y1(y1?: number | Accessor | Y, scale?: Scale<Y, number>): any {
+    public y1(): AccessorScaleBinding<Y, number>;
+    public y1(y1: number | Accessor<number>): Plots.Rectangle<X, Y>;
+    public y1(y1: Y | Accessor<Y>, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
+    public y1(y1?: number | Accessor<number> | Y | Accessor<Y>, scale?: Scale<Y, number>): any {
       if (y1 == null) {
         return this._propertyBindings.get(Rectangle._Y1_KEY);
       }
@@ -99,10 +99,10 @@ export module Plots {
       return this;
     }
 
-    public y2(): AccessorScaleBinding<X, number>;
-    public y2(y2: number | Accessor): Plots.Rectangle<X, Y>;
-    public y2(y2: Y | Accessor, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
-    public y2(y2?: number | Accessor | Y, scale?: Scale<Y, number>): any {
+    public y2(): AccessorScaleBinding<Y, number>;
+    public y2(y2: number | Accessor<number>): Plots.Rectangle<X, Y>;
+    public y2(y2: Y | Accessor<Y>, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
+    public y2(y2?: number | Accessor<number> | Y | Accessor<Y>, scale?: Scale<Y, number>): any {
       if (y2 == null) {
         return this._propertyBindings.get(Rectangle._Y2_KEY);
       }

--- a/src/components/plots/rectanglePlot.ts
+++ b/src/components/plots/rectanglePlot.ts
@@ -64,9 +64,9 @@ export module Plots {
     }
 
     public x1(): AccessorScaleBinding<X, number>;
-    public x1(x1: number | _Accessor): Plots.Rectangle<X, Y>;
-    public x1(x1: X | _Accessor, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
-    public x1(x1?: number | _Accessor | X, scale?: Scale<X, number>): any {
+    public x1(x1: number | Accessor): Plots.Rectangle<X, Y>;
+    public x1(x1: X | Accessor, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
+    public x1(x1?: number | Accessor | X, scale?: Scale<X, number>): any {
       if (x1 == null) {
         return this._propertyBindings.get(Rectangle._X1_KEY);
       }
@@ -76,9 +76,9 @@ export module Plots {
     }
 
     public x2(): AccessorScaleBinding<X, number>;
-    public x2(x2: number | _Accessor): Plots.Rectangle<X, Y>;
-    public x2(x2: X | _Accessor, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
-    public x2(x2?: number | _Accessor | X, scale?: Scale<X, number>): any {
+    public x2(x2: number | Accessor): Plots.Rectangle<X, Y>;
+    public x2(x2: X | Accessor, scale: Scale<X, number>): Plots.Rectangle<X, Y>;
+    public x2(x2?: number | Accessor | X, scale?: Scale<X, number>): any {
       if (x2 == null) {
         return this._propertyBindings.get(Rectangle._X2_KEY);
       }
@@ -88,9 +88,9 @@ export module Plots {
     }
 
     public y1(): AccessorScaleBinding<X, number>;
-    public y1(y1: number | _Accessor): Plots.Rectangle<X, Y>;
-    public y1(y1: Y | _Accessor, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
-    public y1(y1?: number | _Accessor | Y, scale?: Scale<Y, number>): any {
+    public y1(y1: number | Accessor): Plots.Rectangle<X, Y>;
+    public y1(y1: Y | Accessor, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
+    public y1(y1?: number | Accessor | Y, scale?: Scale<Y, number>): any {
       if (y1 == null) {
         return this._propertyBindings.get(Rectangle._Y1_KEY);
       }
@@ -100,9 +100,9 @@ export module Plots {
     }
 
     public y2(): AccessorScaleBinding<X, number>;
-    public y2(y2: number | _Accessor): Plots.Rectangle<X, Y>;
-    public y2(y2: Y | _Accessor, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
-    public y2(y2?: number | _Accessor | Y, scale?: Scale<Y, number>): any {
+    public y2(y2: number | Accessor): Plots.Rectangle<X, Y>;
+    public y2(y2: Y | Accessor, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
+    public y2(y2?: number | Accessor | Y, scale?: Scale<Y, number>): any {
       if (y2 == null) {
         return this._propertyBindings.get(Rectangle._Y2_KEY);
       }

--- a/src/components/plots/rectanglePlot.ts
+++ b/src/components/plots/rectanglePlot.ts
@@ -65,7 +65,7 @@ export module Plots {
 
     public x1<X1>(): AccessorScaleBinding<X1, number>;
     public x1(x1: number | Accessor<number>): Plots.Rectangle<X, Y>;
-    public x1<X1>(x1: X | Accessor<X>, scale: Scale<X1, number>): Plots.Rectangle<X, Y>;
+    public x1<X1>(x1: X1 | Accessor<X1>, scale: Scale<X1, number>): Plots.Rectangle<X, Y>;
     public x1<X1>(x1?: number | Accessor<number> | X1 | Accessor<X1>, scale?: Scale<X1, number>): any {
       if (x1 == null) {
         return this._propertyBindings.get(Rectangle._X1_KEY);

--- a/src/components/plots/scatterPlot.ts
+++ b/src/components/plots/scatterPlot.ts
@@ -39,10 +39,10 @@ export module Plots {
       return attrToProjector;
     }
 
-    public size(): AccessorScaleBinding<X, number>;
-    public size(size: number | Accessor): Plots.Scatter<X, Y>;
-    public size(size: any | Accessor, scale: Scale<any, number>): Plots.Scatter<X, Y>;
-    public size(size?: number | Accessor | any, scale?: Scale<any, number>): any {
+    public size<S>(): AccessorScaleBinding<S, number>;
+    public size(size: number | Accessor<number>): Plots.Scatter<X, Y>;
+    public size<S>(size: S | Accessor<S>, scale: Scale<S, number>): Plots.Scatter<X, Y>;
+    public size<S>(size?: number | Accessor<number> | S | Accessor<S>, scale?: Scale<S, number>): any {
       if (size == null) {
         return this._propertyBindings.get(Scatter._SIZE_KEY);
       }
@@ -52,8 +52,8 @@ export module Plots {
     }
 
     public symbol(): AccessorScaleBinding<any, any>;
-    public symbol(symbol: Accessor): Plots.Scatter<X, Y>;
-    public symbol(symbol?: Accessor): any {
+    public symbol(symbol: Accessor<SymbolFactory>): Plots.Scatter<X, Y>;
+    public symbol(symbol?: Accessor<SymbolFactory>): any {
       if (symbol == null) {
         return this._propertyBindings.get(Scatter._SYMBOL_KEY);
       }

--- a/src/components/plots/scatterPlot.ts
+++ b/src/components/plots/scatterPlot.ts
@@ -40,9 +40,9 @@ export module Plots {
     }
 
     public size(): AccessorScaleBinding<X, number>;
-    public size(size: number | _Accessor): Plots.Scatter<X, Y>;
-    public size(size: any | _Accessor, scale: Scale<any, number>): Plots.Scatter<X, Y>;
-    public size(size?: number | _Accessor | any, scale?: Scale<any, number>): any {
+    public size(size: number | Accessor): Plots.Scatter<X, Y>;
+    public size(size: any | Accessor, scale: Scale<any, number>): Plots.Scatter<X, Y>;
+    public size(size?: number | Accessor | any, scale?: Scale<any, number>): any {
       if (size == null) {
         return this._propertyBindings.get(Scatter._SIZE_KEY);
       }
@@ -52,8 +52,8 @@ export module Plots {
     }
 
     public symbol(): AccessorScaleBinding<any, any>;
-    public symbol(symbol: _Accessor): Plots.Scatter<X, Y>;
-    public symbol(symbol?: _Accessor): any {
+    public symbol(symbol: Accessor): Plots.Scatter<X, Y>;
+    public symbol(symbol?: Accessor): any {
       if (symbol == null) {
         return this._propertyBindings.get(Scatter._SYMBOL_KEY);
       }

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -34,35 +34,29 @@ export module Plots {
       this._baseline = this._renderArea.append("line").classed("baseline", true);
     }
 
-    public x(): Plots.AccessorScaleBinding<X, number>;
-    public x(x: number | Accessor): StackedArea<X>;
-    public x(x: X | Accessor, xScale: Scale<X, number>): Area<X>;
-    public x(x?: number | Accessor | X, xScale?: Scale<X, number>): any {
+    public x(x?: number | Accessor<number> | X | Accessor<X>, xScale?: Scale<X, number>): any {
       if (x == null) {
         return super.x();
       }
       if (xScale == null) {
-        super.x(<number | Accessor> x);
+        super.x(<number | Accessor<number>> x);
         Stacked.prototype.x.apply(this, [x]);
       } else {
-        super.x(<X | Accessor> x, xScale);
+        super.x(<X | Accessor<X>> x, xScale);
         Stacked.prototype.x.apply(this, [x, xScale]);
       }
       return this;
     }
 
-    public y(): Plots.AccessorScaleBinding<number, number>;
-    public y(y: number | Accessor): StackedArea<X>;
-    public y(y: number | Accessor, yScale: Scale<number, number>): Area<X>;
-    public y(y?: number | Accessor | number, yScale?: Scale<number, number>): any {
+    public y(y?: number | Accessor<number>, yScale?: Scale<number, number>): any {
       if (y == null) {
         return super.y();
       }
       if (yScale == null) {
-        super.y(<number | Accessor> y);
+        super.y(<number | Accessor<number>> y);
         Stacked.prototype.y.apply(this, [y]);
       } else {
-        super.y(<number | Accessor> y, yScale);
+        super.y(<number | Accessor<number>> y, yScale);
         Stacked.prototype.y.apply(this, [y, yScale]);
       }
       return this;
@@ -159,11 +153,11 @@ export module Plots {
       return (<any> Stacked.prototype)._extentsForProperty.call(this, attr);
     }
 
-    public _keyAccessor(): Accessor {
+    public _keyAccessor(): Accessor<X> {
       return Stacked.prototype._keyAccessor.call(this);
     }
 
-    public _valueAccessor(): Accessor {
+    public _valueAccessor(): Accessor<number> {
       return Stacked.prototype._valueAccessor.call(this);
     }
 

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -35,34 +35,34 @@ export module Plots {
     }
 
     public x(): Plots.AccessorScaleBinding<X, number>;
-    public x(x: number | _Accessor): StackedArea<X>;
-    public x(x: X | _Accessor, xScale: Scale<X, number>): Area<X>;
-    public x(x?: number | _Accessor | X, xScale?: Scale<X, number>): any {
+    public x(x: number | Accessor): StackedArea<X>;
+    public x(x: X | Accessor, xScale: Scale<X, number>): Area<X>;
+    public x(x?: number | Accessor | X, xScale?: Scale<X, number>): any {
       if (x == null) {
         return super.x();
       }
       if (xScale == null) {
-        super.x(<number | _Accessor> x);
+        super.x(<number | Accessor> x);
         Stacked.prototype.x.apply(this, [x]);
       } else {
-        super.x(<X | _Accessor> x, xScale);
+        super.x(<X | Accessor> x, xScale);
         Stacked.prototype.x.apply(this, [x, xScale]);
       }
       return this;
     }
 
     public y(): Plots.AccessorScaleBinding<number, number>;
-    public y(y: number | _Accessor): StackedArea<X>;
-    public y(y: number | _Accessor, yScale: Scale<number, number>): Area<X>;
-    public y(y?: number | _Accessor | number, yScale?: Scale<number, number>): any {
+    public y(y: number | Accessor): StackedArea<X>;
+    public y(y: number | Accessor, yScale: Scale<number, number>): Area<X>;
+    public y(y?: number | Accessor | number, yScale?: Scale<number, number>): any {
       if (y == null) {
         return super.y();
       }
       if (yScale == null) {
-        super.y(<number | _Accessor> y);
+        super.y(<number | Accessor> y);
         Stacked.prototype.y.apply(this, [y]);
       } else {
-        super.y(<number | _Accessor> y, yScale);
+        super.y(<number | Accessor> y, yScale);
         Stacked.prototype.y.apply(this, [y, yScale]);
       }
       return this;
@@ -159,11 +159,11 @@ export module Plots {
       return (<any> Stacked.prototype)._extentsForProperty.call(this, attr);
     }
 
-    public _keyAccessor(): _Accessor {
+    public _keyAccessor(): Accessor {
       return Stacked.prototype._keyAccessor.call(this);
     }
 
-    public _valueAccessor(): _Accessor {
+    public _valueAccessor(): Accessor {
       return Stacked.prototype._valueAccessor.call(this);
     }
 

--- a/src/components/plots/stackedBarPlot.ts
+++ b/src/components/plots/stackedBarPlot.ts
@@ -32,34 +32,34 @@ export module Plots {
     }
 
     public x(): Plots.AccessorScaleBinding<X, number>;
-    public x(x: number | _Accessor): StackedBar<X, Y>;
-    public x(x: X | _Accessor, xScale: Scale<X, number>): StackedBar<X, Y>;
-    public x(x?: number | _Accessor | X, xScale?: Scale<X, number>): any {
+    public x(x: number | Accessor): StackedBar<X, Y>;
+    public x(x: X | Accessor, xScale: Scale<X, number>): StackedBar<X, Y>;
+    public x(x?: number | Accessor | X, xScale?: Scale<X, number>): any {
       if (x == null) {
         return super.x();
       }
       if (xScale == null) {
-        super.x(<number | _Accessor> x);
+        super.x(<number | Accessor> x);
         Stacked.prototype.x.apply(this, [x]);
       } else {
-        super.x(<X | _Accessor> x, xScale);
+        super.x(<X | Accessor> x, xScale);
         Stacked.prototype.x.apply(this, [x, xScale]);
       }
       return this;
     }
 
     public y(): Plots.AccessorScaleBinding<Y, number>;
-    public y(y: number | _Accessor): StackedBar<X, Y>;
-    public y(y: Y | _Accessor, yScale: Scale<Y, number>): StackedBar<X, Y>;
-    public y(y?: number | _Accessor | Y, yScale?: Scale<Y, number>): any {
+    public y(y: number | Accessor): StackedBar<X, Y>;
+    public y(y: Y | Accessor, yScale: Scale<Y, number>): StackedBar<X, Y>;
+    public y(y?: number | Accessor | Y, yScale?: Scale<Y, number>): any {
       if (y == null) {
         return super.y();
       }
       if (yScale == null) {
-        super.y(<number | _Accessor> y);
+        super.y(<number | Accessor> y);
         Stacked.prototype.y.apply(this, [y]);
       } else {
-        super.y(<Y | _Accessor> y, yScale);
+        super.y(<Y | Accessor> y, yScale);
         Stacked.prototype.y.apply(this, [y, yScale]);
       }
       return this;
@@ -137,11 +137,11 @@ export module Plots {
       return (<any> Stacked.prototype)._extentsForProperty.call(this, attr);
     }
 
-    public _keyAccessor(): _Accessor {
+    public _keyAccessor(): Accessor {
       return Stacked.prototype._keyAccessor.call(this);
     }
 
-    public _valueAccessor(): _Accessor {
+    public _valueAccessor(): Accessor {
       return Stacked.prototype._valueAccessor.call(this);
     }
     // ===== /Stack logic =====

--- a/src/components/plots/stackedBarPlot.ts
+++ b/src/components/plots/stackedBarPlot.ts
@@ -131,7 +131,7 @@ export module Plots {
       return (<any> Stacked.prototype)._extentsForProperty.call(this, attr);
     }
 
-    public _keyAccessor(): Accessor<any> {
+    public _keyAccessor(): Accessor<X> | Accessor<Y> {
       return Stacked.prototype._keyAccessor.call(this);
     }
 

--- a/src/components/plots/stackedBarPlot.ts
+++ b/src/components/plots/stackedBarPlot.ts
@@ -31,35 +31,29 @@ export module Plots {
       return new Animators.Null();
     }
 
-    public x(): Plots.AccessorScaleBinding<X, number>;
-    public x(x: number | Accessor): StackedBar<X, Y>;
-    public x(x: X | Accessor, xScale: Scale<X, number>): StackedBar<X, Y>;
-    public x(x?: number | Accessor | X, xScale?: Scale<X, number>): any {
+    public x(x?: number | Accessor<number> | X | Accessor<X>, xScale?: Scale<X, number>): any {
       if (x == null) {
         return super.x();
       }
       if (xScale == null) {
-        super.x(<number | Accessor> x);
+        super.x(<number | Accessor<number>> x);
         Stacked.prototype.x.apply(this, [x]);
       } else {
-        super.x(<X | Accessor> x, xScale);
+        super.x(<X | Accessor<X>> x, xScale);
         Stacked.prototype.x.apply(this, [x, xScale]);
       }
       return this;
     }
 
-    public y(): Plots.AccessorScaleBinding<Y, number>;
-    public y(y: number | Accessor): StackedBar<X, Y>;
-    public y(y: Y | Accessor, yScale: Scale<Y, number>): StackedBar<X, Y>;
-    public y(y?: number | Accessor | Y, yScale?: Scale<Y, number>): any {
+    public y(y?: number | Accessor<number> | Y | Accessor<Y>, yScale?: Scale<Y, number>): any {
       if (y == null) {
         return super.y();
       }
       if (yScale == null) {
-        super.y(<number | Accessor> y);
+        super.y(<number | Accessor<number>> y);
         Stacked.prototype.y.apply(this, [y]);
       } else {
-        super.y(<Y | Accessor> y, yScale);
+        super.y(<Y | Accessor<Y>> y, yScale);
         Stacked.prototype.y.apply(this, [y, yScale]);
       }
       return this;
@@ -137,11 +131,11 @@ export module Plots {
       return (<any> Stacked.prototype)._extentsForProperty.call(this, attr);
     }
 
-    public _keyAccessor(): Accessor {
+    public _keyAccessor(): Accessor<any> {
       return Stacked.prototype._keyAccessor.call(this);
     }
 
-    public _valueAccessor(): Accessor {
+    public _valueAccessor(): Accessor<number> {
       return Stacked.prototype._valueAccessor.call(this);
     }
     // ===== /Stack logic =====

--- a/src/components/plots/stackedPlot.ts
+++ b/src/components/plots/stackedPlot.ts
@@ -25,16 +25,16 @@ module Plottable {
     }
 
     public x(): Plots.AccessorScaleBinding<X, number>;
-    public x(x: number | _Accessor): XYPlot<X, Y>;
-    public x(x: X | _Accessor, scale: Scale<X, number>): XYPlot<X, Y>;
-    public x(x?: number | _Accessor | X, scale?: Scale<X, number>): any {
+    public x(x: number | Accessor): XYPlot<X, Y>;
+    public x(x: X | Accessor, scale: Scale<X, number>): XYPlot<X, Y>;
+    public x(x?: number | Accessor | X, scale?: Scale<X, number>): any {
       if (x == null) {
         return super.x();
       }
       if (scale == null) {
-        super.x(<number | _Accessor> x);
+        super.x(<number | Accessor> x);
       } else {
-        super.x(<X | _Accessor> x, scale);
+        super.x(<X | Accessor> x, scale);
       }
       if (this.x().accessor != null && this.y().accessor != null) {
         this._updateStackOffsets();
@@ -43,16 +43,16 @@ module Plottable {
     }
 
     public y(): Plots.AccessorScaleBinding<Y, number>;
-    public y(y: number | _Accessor): XYPlot<X, Y>;
-    public y(y: Y | _Accessor, scale: Scale<Y, number>): XYPlot<X, Y>;
-    public y(y?: number | _Accessor | Y, scale?: Scale<Y, number>): any {
+    public y(y: number | Accessor): XYPlot<X, Y>;
+    public y(y: Y | Accessor, scale: Scale<Y, number>): XYPlot<X, Y>;
+    public y(y?: number | Accessor | Y, scale?: Scale<Y, number>): any {
       if (y == null) {
         return super.y();
       }
       if (scale == null) {
-        super.y(<number | _Accessor> y);
+        super.y(<number | Accessor> y);
       } else {
-        super.y(<Y | _Accessor> y, scale);
+        super.y(<Y | Accessor> y, scale);
       }
       if (this.x().accessor != null && this.y().accessor != null) {
         this._updateStackOffsets();
@@ -228,11 +228,11 @@ module Plottable {
       }
     }
 
-    public _keyAccessor(): _Accessor {
+    public _keyAccessor(): Accessor {
        return this._isVertical ? this.x().accessor : this.y().accessor;
     }
 
-    public _valueAccessor(): _Accessor {
+    public _valueAccessor(): Accessor {
        return this._isVertical ? this.y().accessor : this.x().accessor;
     }
   }

--- a/src/components/plots/stackedPlot.ts
+++ b/src/components/plots/stackedPlot.ts
@@ -94,7 +94,7 @@ module Plottable {
         }
         return Utils.Methods.max<any, number>(data, (datum: any, i: number) => {
           return +valueAccessor(datum, i, dataset, plotMetadata) +
-            plotMetadata.offsets.get(keyAccessor(datum, i, dataset, plotMetadata));
+            plotMetadata.offsets.get(String(keyAccessor(datum, i, dataset, plotMetadata)));
         }, 0);
       }, 0);
 
@@ -107,7 +107,7 @@ module Plottable {
         }
         return Utils.Methods.min<any, number>(data, (datum: any, i: number) => {
           return +valueAccessor(datum, i, dataset, plotMetadata) +
-            plotMetadata.offsets.get(keyAccessor(datum, i, dataset, plotMetadata));
+            plotMetadata.offsets.get(String(keyAccessor(datum, i, dataset, plotMetadata)));
         }, 0);
       }, 0);
 
@@ -148,7 +148,7 @@ module Plottable {
         var isAllNegativeValues = dataset.data().every((datum, i) => valueAccessor(datum, i, dataset, plotMetadata) <= 0);
 
         dataset.data().forEach((datum: any, datumIndex: number) => {
-          var key = keyAccessor(datum, datumIndex, dataset, plotMetadata);
+          var key = String(keyAccessor(datum, datumIndex, dataset, plotMetadata));
           var positiveOffset = positiveDataMap.get(key).offset;
           var negativeOffset = negativeDataMap.get(key).offset;
 
@@ -194,7 +194,7 @@ module Plottable {
         var dataset = this._key2PlotDatasetKey.get(k).dataset;
         var plotMetadata = this._key2PlotDatasetKey.get(k).plotMetadata;
         dataset.data().forEach((datum, index) => {
-          var key = keyAccessor(datum, index, dataset, plotMetadata);
+          var key = String(keyAccessor(datum, index, dataset, plotMetadata));
           var value = valueAccessor(datum, index, dataset, plotMetadata);
           dataMapArray[datasetIndex].set(key, {key: key, value: value});
         });
@@ -222,7 +222,7 @@ module Plottable {
       }
     }
 
-    public _keyAccessor(): Accessor<any> {
+    public _keyAccessor(): Accessor<X> | Accessor<Y> {
        return this._isVertical ? this.x().accessor : this.y().accessor;
     }
 

--- a/src/components/plots/stackedPlot.ts
+++ b/src/components/plots/stackedPlot.ts
@@ -24,17 +24,14 @@ module Plottable {
       return metadata;
     }
 
-    public x(): Plots.AccessorScaleBinding<X, number>;
-    public x(x: number | Accessor): XYPlot<X, Y>;
-    public x(x: X | Accessor, scale: Scale<X, number>): XYPlot<X, Y>;
-    public x(x?: number | Accessor | X, scale?: Scale<X, number>): any {
+    public x(x?: number | Accessor<number> | X | Accessor<X>, scale?: Scale<X, number>): any {
       if (x == null) {
         return super.x();
       }
       if (scale == null) {
-        super.x(<number | Accessor> x);
+        super.x(<number | Accessor<number>> x);
       } else {
-        super.x(<X | Accessor> x, scale);
+        super.x(<X | Accessor<X>> x, scale);
       }
       if (this.x().accessor != null && this.y().accessor != null) {
         this._updateStackOffsets();
@@ -42,17 +39,14 @@ module Plottable {
       return this;
     }
 
-    public y(): Plots.AccessorScaleBinding<Y, number>;
-    public y(y: number | Accessor): XYPlot<X, Y>;
-    public y(y: Y | Accessor, scale: Scale<Y, number>): XYPlot<X, Y>;
-    public y(y?: number | Accessor | Y, scale?: Scale<Y, number>): any {
+    public y(y?: number | Accessor<number> | Y | Accessor<Y>, scale?: Scale<Y, number>): any {
       if (y == null) {
         return super.y();
       }
       if (scale == null) {
-        super.y(<number | Accessor> y);
+        super.y(<number | Accessor<number>> y);
       } else {
-        super.y(<Y | Accessor> y, scale);
+        super.y(<Y | Accessor<Y>> y, scale);
       }
       if (this.x().accessor != null && this.y().accessor != null) {
         this._updateStackOffsets();
@@ -228,11 +222,11 @@ module Plottable {
       }
     }
 
-    public _keyAccessor(): Accessor {
+    public _keyAccessor(): Accessor<any> {
        return this._isVertical ? this.x().accessor : this.y().accessor;
     }
 
-    public _valueAccessor(): Accessor {
+    public _valueAccessor(): Accessor<number> {
        return this._isVertical ? this.y().accessor : this.x().accessor;
     }
   }

--- a/src/components/plots/xyPlot.ts
+++ b/src/components/plots/xyPlot.ts
@@ -41,9 +41,9 @@ module Plottable {
     }
 
     public x(): Plots.AccessorScaleBinding<X, number>;
-    public x(x: number | Accessor): XYPlot<X, Y>;
-    public x(x: X | Accessor, xScale: Scale<X, number>): XYPlot<X, Y>;
-    public x(x?: number | Accessor | X, xScale?: Scale<X, number>): any {
+    public x(x: number | Accessor<number>): XYPlot<X, Y>;
+    public x(x: X | Accessor<X>, xScale: Scale<X, number>): XYPlot<X, Y>;
+    public x(x?: number | Accessor<number> | X | Accessor<X>, xScale?: Scale<X, number>): any {
       if (x == null) {
         return this._propertyBindings.get(XYPlot._X_KEY);
       }
@@ -58,9 +58,9 @@ module Plottable {
     }
 
     public y(): Plots.AccessorScaleBinding<Y, number>;
-    public y(y: number | Accessor): XYPlot<X, Y>;
-    public y(y: Y | Accessor, yScale: Scale<Y, number>): XYPlot<X, Y>;
-    public y(y?: number | Accessor | Y, yScale?: Scale<Y, number>): any {
+    public y(y: number | Accessor<number>): XYPlot<X, Y>;
+    public y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): XYPlot<X, Y>;
+    public y(y?: number | Accessor<number> | Y | Accessor<Y>, yScale?: Scale<Y, number>): any {
       if (y == null) {
         return this._propertyBindings.get(XYPlot._Y_KEY);
       }

--- a/src/components/plots/xyPlot.ts
+++ b/src/components/plots/xyPlot.ts
@@ -41,9 +41,9 @@ module Plottable {
     }
 
     public x(): Plots.AccessorScaleBinding<X, number>;
-    public x(x: number | _Accessor): XYPlot<X, Y>;
-    public x(x: X | _Accessor, xScale: Scale<X, number>): XYPlot<X, Y>;
-    public x(x?: number | _Accessor | X, xScale?: Scale<X, number>): any {
+    public x(x: number | Accessor): XYPlot<X, Y>;
+    public x(x: X | Accessor, xScale: Scale<X, number>): XYPlot<X, Y>;
+    public x(x?: number | Accessor | X, xScale?: Scale<X, number>): any {
       if (x == null) {
         return this._propertyBindings.get(XYPlot._X_KEY);
       }
@@ -58,9 +58,9 @@ module Plottable {
     }
 
     public y(): Plots.AccessorScaleBinding<Y, number>;
-    public y(y: number | _Accessor): XYPlot<X, Y>;
-    public y(y: Y | _Accessor, yScale: Scale<Y, number>): XYPlot<X, Y>;
-    public y(y?: number | _Accessor | Y, yScale?: Scale<Y, number>): any {
+    public y(y: number | Accessor): XYPlot<X, Y>;
+    public y(y: Y | Accessor, yScale: Scale<Y, number>): XYPlot<X, Y>;
+    public y(y?: number | Accessor | Y, yScale?: Scale<Y, number>): any {
       if (y == null) {
         return this._propertyBindings.get(XYPlot._Y_KEY);
       }

--- a/src/core/dataset.ts
+++ b/src/core/dataset.ts
@@ -4,10 +4,6 @@ module Plottable {
 
   export type DatasetCallback = (dataset: Dataset) => any;
 
-  type CachedExtent = {
-    accessor: Accessor;
-    extent: any[];
-  }
   export class Dataset {
     private _data: any[];
     private _metadata: any;

--- a/src/core/dataset.ts
+++ b/src/core/dataset.ts
@@ -5,7 +5,7 @@ module Plottable {
   export type DatasetCallback = (dataset: Dataset) => any;
 
   type CachedExtent = {
-    accessor: _Accessor;
+    accessor: Accessor;
     extent: any[];
   }
   export class Dataset {

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -2,7 +2,9 @@ module Plottable {
   /**
    * Access specific datum property.
    */
-  export type Accessor = (datum: any, index?: number, dataset?: Dataset, plotMetadata?: Plots.PlotMetadata) => any;
+  export interface Accessor<T> {
+    (datum: any, index: number, dataset: Dataset, plotMetadata: Plots.PlotMetadata): T;
+  }
 
   /**
    * Retrieves scaled datum property.
@@ -18,7 +20,7 @@ module Plottable {
    * Defines a way how specific attribute needs be retrieved before rendering.
    */
   export type _Projection = {
-    accessor: Accessor;
+    accessor: Accessor<any>;
     scale?: Scale<any, any>;
     attribute: string;
   }

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -2,7 +2,7 @@ module Plottable {
   /**
    * Access specific datum property.
    */
-  export type _Accessor = (datum: any, index?: number, dataset?: Dataset, plotMetadata?: Plots.PlotMetadata) => any;
+  export type Accessor = (datum: any, index?: number, dataset?: Dataset, plotMetadata?: Plots.PlotMetadata) => any;
 
   /**
    * Retrieves scaled datum property.
@@ -18,7 +18,7 @@ module Plottable {
    * Defines a way how specific attribute needs be retrieved before rendering.
    */
   export type _Projection = {
-    accessor: _Accessor;
+    accessor: Accessor;
     scale?: Scale<any, any>;
     attribute: string;
   }

--- a/test/components/plots/gridPlotTests.ts
+++ b/test/components/plots/gridPlotTests.ts
@@ -67,7 +67,7 @@ describe("Plots", () => {
       var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var dataset = new Plottable.Dataset();
-      var gridPlot: Plottable.Plots.Grid = new Plottable.Plots.Grid(xScale, yScale);
+      var gridPlot = new Plottable.Plots.Grid(xScale, yScale);
       gridPlot.addDataset(dataset)
               .attr("fill", (d) => d.magnitude, colorScale);
       gridPlot.x((d: any) => d.x, xScale)
@@ -86,7 +86,7 @@ describe("Plots", () => {
       var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var dataset = new Plottable.Dataset();
-      var gridPlot: Plottable.Plots.Grid = new Plottable.Plots.Grid(xScale, yScale);
+      var gridPlot = new Plottable.Plots.Grid(xScale, yScale);
       gridPlot.addDataset(dataset)
               .attr("fill", (d) => d.magnitude, colorScale);
       gridPlot.x((d: any) => d.x, xScale)

--- a/test/components/plots/piePlotTests.ts
+++ b/test/components/plots/piePlotTests.ts
@@ -7,7 +7,7 @@ describe("Plots", () => {
     // HACKHACK #1798: beforeEach being used below
     it("renders correctly with no data", () => {
       var svg = TestMethods.generateSVG(400, 400);
-      var plot = new Plottable.Plots.Pie<number>();
+      var plot = new Plottable.Plots.Pie();
       plot.sectorValue((d) => d.value);
       assert.doesNotThrow(() => plot.renderTo(svg), Error);
       assert.strictEqual(plot.width(), 400, "was allocated width");
@@ -20,14 +20,14 @@ describe("Plots", () => {
     var svg: D3.Selection;
     var simpleDataset: Plottable.Dataset;
     var simpleData: any[];
-    var piePlot: Plottable.Plots.Pie<number>;
+    var piePlot: Plottable.Plots.Pie;
     var renderArea: D3.Selection;
 
     beforeEach(() => {
       svg = TestMethods.generateSVG(500, 500);
       simpleData = [{value: 5, value2: 10, type: "A"}, {value: 15, value2: 10, type: "B"}];
       simpleDataset = new Plottable.Dataset(simpleData);
-      piePlot = new Plottable.Plots.Pie<number>();
+      piePlot = new Plottable.Plots.Pie();
       piePlot.addDataset(simpleDataset);
       piePlot.sectorValue((d) => d.value);
       piePlot.renderTo(svg);
@@ -233,7 +233,7 @@ describe("Plots", () => {
         { v: 1 },
       ];
 
-      var plot = new Plottable.Plots.Pie<number>();
+      var plot = new Plottable.Plots.Pie();
       plot.addDataset(new Plottable.Dataset(data1));
       plot.sectorValue((d) => d.v);
 
@@ -258,7 +258,7 @@ describe("Plots", () => {
         { v: 1 },
       ];
 
-      var plot = new Plottable.Plots.Pie<number>();
+      var plot = new Plottable.Plots.Pie();
       plot.addDataset(new Plottable.Dataset(data1));
       plot.sectorValue((d) => d.v);
 

--- a/test/components/plots/stackedAreaPlotTests.ts
+++ b/test/components/plots/stackedAreaPlotTests.ts
@@ -406,7 +406,7 @@ describe("Plots", () => {
       var dataset2 = new Plottable.Dataset(data2);
       plot.addDataset(dataset2);
       plot.attr("fill", "fill");
-      plot.x((d) => d.x, xScale).y((d) => d.y, yScale);
+      plot.x((d: any) => d.x, xScale).y((d: any) => d.y, yScale);
 
       var ds0Point2Offset = (<any> plot)._key2PlotDatasetKey.get("_0").plotMetadata.offsets.get(2);
       var ds1Point2Offset = (<any> plot)._key2PlotDatasetKey.get("_1").plotMetadata.offsets.get(2);
@@ -447,7 +447,7 @@ describe("Plots", () => {
       var dataset2 = new Plottable.Dataset(data2);
       plot.addDataset(dataset2);
       plot.attr("fill", "fill");
-      plot.x((d) => d.x, xScale).y((d) => d.y, yScale);
+      plot.x((d: any) => d.x, xScale).y((d: any) => d.y, yScale);
 
       var ds0Point2Offset = (<any> plot)._key2PlotDatasetKey.get("_0").plotMetadata.offsets.get(2);
       var ds1Point2Offset = (<any> plot)._key2PlotDatasetKey.get("_1").plotMetadata.offsets.get(2);

--- a/test/components/plots/stackedBarPlotTests.ts
+++ b/test/components/plots/stackedBarPlotTests.ts
@@ -421,7 +421,7 @@ describe("Plots", () => {
       plot.addDataset(new Plottable.Dataset(data1));
       plot.addDataset(new Plottable.Dataset(data2));
       plot.attr("fill", "fill");
-      plot.x((d) => d.x, xScale).y((d) => d.y, yScale);
+      plot.x((d: any) => d.x, xScale).y((d: any) => d.y, yScale);
 
       var ds1FirstColumnOffset = (<any> plot)._key2PlotDatasetKey.get("_0").plotMetadata.offsets.get("A");
       var ds2FirstColumnOffset = (<any> plot)._key2PlotDatasetKey.get("_1").plotMetadata.offsets.get("A");
@@ -460,7 +460,7 @@ describe("Plots", () => {
       plot.addDataset(new Plottable.Dataset(data4));
       plot.addDataset(new Plottable.Dataset(data5));
       plot.attr("fill", "fill");
-      plot.x((d) => d.x, xScale).y((d) => d.y, yScale);
+      plot.x((d: any) => d.x, xScale).y((d: any) => d.y, yScale);
 
       var keys = (<any> plot)._key2PlotDatasetKey.keys();
       var offset0 = (<any> plot)._key2PlotDatasetKey.get(keys[0]).plotMetadata.offsets.get("A");

--- a/test/components/plots/stackedPlotTests.ts
+++ b/test/components/plots/stackedPlotTests.ts
@@ -197,7 +197,7 @@ describe("Plots", () => {
       plot.addDataset(dataset1)
           .addDataset(dataset2);
       plot.x((d) => d.x, xScale)
-          .y((d) => d.y, yScale);
+          .y((d: any) => d.y, yScale);
       (<any>plot).automaticallyAdjustYScaleOverVisiblePoints(true);
       plot.renderTo(svg);
       assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
@@ -209,7 +209,7 @@ describe("Plots", () => {
       plot.addDataset(dataset1)
           .addDataset(dataset2);
       plot.x((d) => d.x, xScale)
-          .y((d) => d.y, yScale);
+          .y((d: any) => d.y, yScale);
       (<any>plot).automaticallyAdjustYScaleOverVisiblePoints(true);
       plot.renderTo(svg);
       assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
@@ -250,7 +250,7 @@ describe("Plots", () => {
       plot.addDataset(dataset1)
           .addDataset(dataset2);
       plot.x((d) => d.x, yScale)
-          .y((d) => d.y, yScale);
+          .y((d: any) => d.y, yScale);
       (<any>plot).automaticallyAdjustYScaleOverVisiblePoints(true);
       plot.renderTo(svg);
       assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
@@ -262,7 +262,7 @@ describe("Plots", () => {
       plot.addDataset(dataset1)
           .addDataset(dataset2);
       plot.x((d) => d.x, xScale)
-          .y((d) => d.y, yScale);
+          .y((d: any) => d.y, yScale);
       (<any>plot).automaticallyAdjustYScaleOverVisiblePoints(true);
       plot.renderTo(svg);
       assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");

--- a/test/core/metadataTests.ts
+++ b/test/core/metadataTests.ts
@@ -212,7 +212,7 @@ describe("Metadata", () => {
       plot.destroy();
     };
 
-    var checkPiePlot = (plot: Plottable.Plots.Pie<number>) => {
+    var checkPiePlot = (plot: Plottable.Plots.Pie) => {
       plot.sectorValue((d) => d.x).addDataset(dataset1);
 
       // This should not crash. If some metadata is not passed, undefined property error will be raised during accessor call.
@@ -228,7 +228,7 @@ describe("Metadata", () => {
     checkXYPlot(new Plottable.Plots.ClusteredBar(xScale, yScale));
     checkXYPlot(new Plottable.Plots.Bar(xScale, yScale, false));
     checkXYPlot(new Plottable.Plots.Scatter(xScale, yScale));
-    checkPiePlot(new Plottable.Plots.Pie<number>());
+    checkPiePlot(new Plottable.Plots.Pie());
     svg.remove();
   });
 });


### PR DESCRIPTION
* `_Accessor` is now exposed as `Accessor` and will be referred to as such
* `Accessor` now takes in a generic type param to signify the return type of the Accessor function
* `Plots.Pie` no longer requires a generic type as the types are applied to the specific property functions