### PR TITLE
[Plot] - Default keys

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2606,7 +2606,6 @@ declare module Plottable {
             constructor();
             computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Pie;
             addDataset(dataset: Dataset): Pie;
-            protected _generateAttrToProjector(): AttributeToProjector;
             protected _getDrawer(key: string): Drawers.AbstractDrawer;
             getAllPlotData(datasets?: Dataset[]): Plots.PlotData;
             sectorValue<S>(): AccessorScaleBinding<S, number>;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2946,9 +2946,6 @@ declare module Plottable {
             protected _updateYDomainer(): void;
             protected _getResetYFunction(): (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
             protected _wholeDatumAttributes(): string[];
-            protected _generateAttrToProjector(): {
-                [attrToSet: string]: (datum: any, index: number, dataset: Dataset, plotMetadata: PlotMetadata) => any;
-            };
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -6927,6 +6927,7 @@ var Plottable;
                 _super.call(this, xScale, yScale);
                 this._defaultFillColor = new Plottable.Scales.Color().range()[0];
                 this.classed("rectangle-plot", true);
+                this.attr("fill", this._defaultFillColor);
             }
             Rectangle.prototype._getDrawer = function (key) {
                 return new Plottable.Drawers.Rect(key, true);
@@ -6951,7 +6952,6 @@ var Plottable;
                 delete attrToProjector["y1"];
                 delete attrToProjector["x2"];
                 delete attrToProjector["y2"];
-                attrToProjector["fill"] = attrToProjector["fill"] || d3.functor(this._defaultFillColor);
                 return attrToProjector;
             };
             Rectangle.prototype._generateDrawSteps = function () {
@@ -7025,6 +7025,8 @@ var Plottable;
                 this._defaultFillColor = new Plottable.Scales.Color().range()[0];
                 this.animator("symbols-reset", new Plottable.Animators.Null());
                 this.animator("symbols", new Plottable.Animators.Base().duration(250).delay(5));
+                this.attr("opacity", 0.6);
+                this.attr("fill", this._defaultFillColor);
             }
             Scatter.prototype._getDrawer = function (key) {
                 return new Plottable.Drawers.Symbol(key);
@@ -7032,8 +7034,6 @@ var Plottable;
             Scatter.prototype._generateAttrToProjector = function () {
                 var attrToProjector = _super.prototype._generateAttrToProjector.call(this);
                 attrToProjector["size"] = attrToProjector["size"] || d3.functor(6);
-                attrToProjector["opacity"] = attrToProjector["opacity"] || d3.functor(0.6);
-                attrToProjector["fill"] = attrToProjector["fill"] || d3.functor(this._defaultFillColor);
                 attrToProjector["symbol"] = attrToProjector["symbol"] || (function () { return Plottable.SymbolFactories.circle(); });
                 return attrToProjector;
             };
@@ -7218,6 +7218,7 @@ var Plottable;
                 this.animator("baseline", new Plottable.Animators.Null());
                 this._isVertical = isVertical;
                 this.baseline(0);
+                this.attr("fill", this._defaultFillColor);
             }
             Bar.prototype._getDrawer = function (key) {
                 return new Plottable.Drawers.Rect(key, this._isVertical);
@@ -7497,7 +7498,6 @@ var Plottable;
                     };
                     attrToProjector["positive"] = function (d, i, dataset, m) { return originalPositionFn(d, i, dataset, m) <= scaledBaseline; };
                 }
-                attrToProjector["fill"] = attrToProjector["fill"] || d3.functor(this._defaultFillColor);
                 return attrToProjector;
             };
             /**
@@ -7759,6 +7759,9 @@ var Plottable;
                 this.animator("reset", new Plottable.Animators.Null());
                 this.animator("main", new Plottable.Animators.Base().duration(600).easing("exp-in-out"));
                 this._defaultFillColor = new Plottable.Scales.Color().range()[0];
+                this.attr("fill-opacity", 0.25);
+                this.attr("fill", this._defaultFillColor);
+                this.attr("stroke", this._defaultFillColor);
             }
             Area.prototype.y0 = function (y0, y0Scale) {
                 if (y0 == null) {
@@ -7802,13 +7805,6 @@ var Plottable;
                 var wholeDatumAttributes = _super.prototype._wholeDatumAttributes.call(this);
                 wholeDatumAttributes.push("y0");
                 return wholeDatumAttributes;
-            };
-            Area.prototype._generateAttrToProjector = function () {
-                var attrToProjector = _super.prototype._generateAttrToProjector.call(this);
-                attrToProjector["fill-opacity"] = attrToProjector["fill-opacity"] || d3.functor(0.25);
-                attrToProjector["fill"] = attrToProjector["fill"] || d3.functor(this._defaultFillColor);
-                attrToProjector["stroke"] = attrToProjector["stroke"] || d3.functor(this._defaultFillColor);
-                return attrToProjector;
             };
             Area._Y0_KEY = "y0";
             return Area;
@@ -8132,6 +8128,7 @@ var Plottable;
                 this._baselineValue = 0;
                 this.classed("area-plot", true);
                 this._isVertical = true;
+                this.attr("fill-opacity", 1);
             }
             StackedArea.prototype._getDrawer = function (key) {
                 return new Plottable.Drawers.Area(key).drawLine(false);
@@ -8198,9 +8195,6 @@ var Plottable;
             StackedArea.prototype._generateAttrToProjector = function () {
                 var _this = this;
                 var attrToProjector = _super.prototype._generateAttrToProjector.call(this);
-                if (this._attrBindings.get("fill-opacity") == null) {
-                    attrToProjector["fill-opacity"] = d3.functor(1);
-                }
                 var yAccessor = this.y().accessor;
                 var xAccessor = this.x().accessor;
                 attrToProjector["y"] = function (d, i, dataset, m) { return _this.y().scale.scale(+yAccessor(d, i, dataset, m) + m.offsets.get(xAccessor(d, i, dataset, m))); };

--- a/plottable.js
+++ b/plottable.js
@@ -6598,6 +6598,7 @@ var Plottable;
                 this.innerRadius(0);
                 this.outerRadius(function () { return Math.min(_this.width(), _this.height()) / 2; });
                 this.classed("pie-plot", true);
+                this.attr("fill", function (d, i) { return String(i); }, new Plottable.Scales.Color());
             }
             Pie.prototype.computeLayout = function (origin, availableWidth, availableHeight) {
                 _super.prototype.computeLayout.call(this, origin, availableWidth, availableHeight);
@@ -6618,13 +6619,6 @@ var Plottable;
                 }
                 _super.prototype.addDataset.call(this, dataset);
                 return this;
-            };
-            Pie.prototype._generateAttrToProjector = function () {
-                var _this = this;
-                var attrToProjector = _super.prototype._generateAttrToProjector.call(this);
-                var defaultFillFunction = function (d, i) { return _this._colorScale.scale(String(i)); };
-                attrToProjector["fill"] = attrToProjector["fill"] || defaultFillFunction;
-                return attrToProjector;
             };
             Pie.prototype._getDrawer = function (key) {
                 return new Plottable.Drawers.Arc(key).setClass("arc");

--- a/plottable.js
+++ b/plottable.js
@@ -6925,9 +6925,8 @@ var Plottable;
              */
             function Rectangle(xScale, yScale) {
                 _super.call(this, xScale, yScale);
-                this._defaultFillColor = new Plottable.Scales.Color().range()[0];
                 this.classed("rectangle-plot", true);
-                this.attr("fill", this._defaultFillColor);
+                this.attr("fill", new Plottable.Scales.Color().range()[0]);
             }
             Rectangle.prototype._getDrawer = function (key) {
                 return new Plottable.Drawers.Rect(key, true);
@@ -7022,11 +7021,10 @@ var Plottable;
             function Scatter(xScale, yScale) {
                 _super.call(this, xScale, yScale);
                 this.classed("scatter-plot", true);
-                this._defaultFillColor = new Plottable.Scales.Color().range()[0];
                 this.animator("symbols-reset", new Plottable.Animators.Null());
                 this.animator("symbols", new Plottable.Animators.Base().duration(250).delay(5));
                 this.attr("opacity", 0.6);
-                this.attr("fill", this._defaultFillColor);
+                this.attr("fill", new Plottable.Scales.Color().range()[0]);
             }
             Scatter.prototype._getDrawer = function (key) {
                 return new Plottable.Drawers.Symbol(key);
@@ -7212,13 +7210,12 @@ var Plottable;
                 this._labelsEnabled = false;
                 this._hideBarsIfAnyAreTooWide = true;
                 this.classed("bar-plot", true);
-                this._defaultFillColor = new Plottable.Scales.Color().range()[0];
                 this.animator("bars-reset", new Plottable.Animators.Null());
                 this.animator("bars", new Plottable.Animators.Base());
                 this.animator("baseline", new Plottable.Animators.Null());
                 this._isVertical = isVertical;
                 this.baseline(0);
-                this.attr("fill", this._defaultFillColor);
+                this.attr("fill", new Plottable.Scales.Color().range()[0]);
             }
             Bar.prototype._getDrawer = function (key) {
                 return new Plottable.Drawers.Rect(key, this._isVertical);
@@ -7601,8 +7598,7 @@ var Plottable;
                 this.classed("line-plot", true);
                 this.animator("reset", new Plottable.Animators.Null());
                 this.animator("main", new Plottable.Animators.Base().duration(600).easing("exp-in-out"));
-                this._defaultStrokeColor = new Plottable.Scales.Color().range()[0];
-                this.attr("stroke", this._defaultStrokeColor);
+                this.attr("stroke", new Plottable.Scales.Color().range()[0]);
                 this.attr("stroke-width", "2px");
             }
             Line.prototype._getDrawer = function (key) {
@@ -7758,10 +7754,10 @@ var Plottable;
                 this.y0(0, yScale); // default
                 this.animator("reset", new Plottable.Animators.Null());
                 this.animator("main", new Plottable.Animators.Base().duration(600).easing("exp-in-out"));
-                this._defaultFillColor = new Plottable.Scales.Color().range()[0];
+                var defaultColor = new Plottable.Scales.Color().range()[0];
                 this.attr("fill-opacity", 0.25);
-                this.attr("fill", this._defaultFillColor);
-                this.attr("stroke", this._defaultFillColor);
+                this.attr("fill", defaultColor);
+                this.attr("stroke", defaultColor);
             }
             Area.prototype.y0 = function (y0, y0Scale) {
                 if (y0 == null) {

--- a/plottable.js
+++ b/plottable.js
@@ -6595,9 +6595,8 @@ var Plottable;
                 var _this = this;
                 _super.call(this);
                 this._colorScale = new Plottable.Scales.Color();
-                this._propertyBindings.set(Pie._INNER_RADIUS_KEY, { accessor: function () { return 0; } });
-                this._propertyBindings.set(Pie._OUTER_RADIUS_KEY, { accessor: function () { return Math.min(_this.width(), _this.height()) / 2; } });
-                this._propertyBindings.set(Pie._SECTOR_VALUE_KEY, { accessor: function () { return null; } });
+                this.innerRadius(0);
+                this.outerRadius(function () { return Math.min(_this.width(), _this.height()) / 2; });
                 this.classed("pie-plot", true);
             }
             Pie.prototype.computeLayout = function (origin, availableWidth, availableHeight) {

--- a/plottable.js
+++ b/plottable.js
@@ -7602,6 +7602,8 @@ var Plottable;
                 this.animator("reset", new Plottable.Animators.Null());
                 this.animator("main", new Plottable.Animators.Base().duration(600).easing("exp-in-out"));
                 this._defaultStrokeColor = new Plottable.Scales.Color().range()[0];
+                this.attr("stroke", this._defaultStrokeColor);
+                this.attr("stroke-width", "2px");
             }
             Line.prototype._getDrawer = function (key) {
                 return new Plottable.Drawers.Line(key);
@@ -7643,8 +7645,6 @@ var Plottable;
                     var yValue = yFunction(d, i, dataset, m);
                     return xValue != null && xValue === xValue && yValue != null && yValue === yValue;
                 };
-                attrToProjector["stroke"] = attrToProjector["stroke"] || d3.functor(this._defaultStrokeColor);
-                attrToProjector["stroke-width"] = attrToProjector["stroke-width"] || d3.functor("2px");
                 return attrToProjector;
             };
             Line.prototype._wholeDatumAttributes = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -6594,7 +6594,6 @@ var Plottable;
             function Pie() {
                 var _this = this;
                 _super.call(this);
-                this._colorScale = new Plottable.Scales.Color();
                 this.innerRadius(0);
                 this.outerRadius(function () { return Math.min(_this.width(), _this.height()) / 2; });
                 this.classed("pie-plot", true);
@@ -7197,6 +7196,7 @@ var Plottable;
              * @param {boolean} isVertical if the plot if vertical.
              */
             function Bar(xScale, yScale, isVertical) {
+                var _this = this;
                 if (isVertical === void 0) { isVertical = true; }
                 _super.call(this, xScale, yScale);
                 this._barAlignmentFactor = 0.5;
@@ -7210,6 +7210,7 @@ var Plottable;
                 this._isVertical = isVertical;
                 this.baseline(0);
                 this.attr("fill", new Plottable.Scales.Color().range()[0]);
+                this.attr("width", function () { return _this._getBarPixelWidth(); });
             }
             Bar.prototype._getDrawer = function (key) {
                 return new Plottable.Drawers.Rect(key, this._isVertical);
@@ -7460,9 +7461,6 @@ var Plottable;
                 var scaledBaseline = primaryScale.scale(this._baselineValue);
                 var positionF = attrToProjector[secondaryAttr];
                 var widthF = attrToProjector["width"];
-                if (widthF == null) {
-                    widthF = function () { return _this._getBarPixelWidth(); };
-                }
                 var originalPositionFn = attrToProjector[primaryAttr];
                 var heightF = function (d, i, dataset, m) {
                     return Math.abs(scaledBaseline - originalPositionFn(d, i, dataset, m));
@@ -7501,6 +7499,9 @@ var Plottable;
              */
             Bar.prototype._getBarPixelWidth = function () {
                 var _this = this;
+                if (!this._projectorsReady()) {
+                    return 0;
+                }
                 var barPixelWidth;
                 var barScale = this._isVertical ? this.x().scale : this.y().scale;
                 if (barScale instanceof Plottable.Scales.Category) {

--- a/src/components/plots/areaPlot.ts
+++ b/src/components/plots/areaPlot.ts
@@ -26,6 +26,9 @@ export module Plots {
                                         .duration(600)
                                         .easing("exp-in-out"));
       this._defaultFillColor = new Scales.Color().range()[0];
+      this.attr("fill-opacity", 0.25);
+      this.attr("fill", this._defaultFillColor);
+      this.attr("stroke", this._defaultFillColor);
     }
 
     public y0(): Plots.AccessorScaleBinding<number, number>;
@@ -79,14 +82,6 @@ export module Plots {
       var wholeDatumAttributes = super._wholeDatumAttributes();
       wholeDatumAttributes.push("y0");
       return wholeDatumAttributes;
-    }
-
-    protected _generateAttrToProjector() {
-      var attrToProjector = super._generateAttrToProjector();
-      attrToProjector["fill-opacity"] = attrToProjector["fill-opacity"] || d3.functor(0.25);
-      attrToProjector["fill"] = attrToProjector["fill"] || d3.functor(this._defaultFillColor);
-      attrToProjector["stroke"] = attrToProjector["stroke"] || d3.functor(this._defaultFillColor);
-      return attrToProjector;
     }
   }
 }

--- a/src/components/plots/areaPlot.ts
+++ b/src/components/plots/areaPlot.ts
@@ -7,7 +7,6 @@ export module Plots {
    */
   export class Area<X> extends Line<X> {
     private static _Y0_KEY = "y0";
-    private _defaultFillColor: string;
 
     /**
      * Constructs an AreaPlot.
@@ -25,10 +24,10 @@ export module Plots {
       this.animator("main", new Animators.Base()
                                         .duration(600)
                                         .easing("exp-in-out"));
-      this._defaultFillColor = new Scales.Color().range()[0];
+      var defaultColor = new Scales.Color().range()[0];
       this.attr("fill-opacity", 0.25);
-      this.attr("fill", this._defaultFillColor);
-      this.attr("stroke", this._defaultFillColor);
+      this.attr("fill", defaultColor);
+      this.attr("stroke", defaultColor);
     }
 
     public y0(): Plots.AccessorScaleBinding<number, number>;

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -14,7 +14,6 @@ export module Plots {
     private _labelFormatter: Formatter = Formatters.identity();
     private _labelsEnabled = false;
     private _hideBarsIfAnyAreTooWide = true;
-    private _defaultFillColor: string;
 
     /**
      * Constructs a BarPlot.
@@ -27,13 +26,12 @@ export module Plots {
     constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, isVertical = true) {
       super(xScale, yScale);
       this.classed("bar-plot", true);
-      this._defaultFillColor = new Scales.Color().range()[0];
       this.animator("bars-reset", new Animators.Null());
       this.animator("bars", new Animators.Base());
       this.animator("baseline", new Animators.Null());
       this._isVertical = isVertical;
       this.baseline(0);
-      this.attr("fill", this._defaultFillColor);
+      this.attr("fill", new Scales.Color().range()[0]);
     }
 
     protected _getDrawer(key: string) {

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -32,6 +32,7 @@ export module Plots {
       this._isVertical = isVertical;
       this.baseline(0);
       this.attr("fill", new Scales.Color().range()[0]);
+      this.attr("width", () => this._getBarPixelWidth());
     }
 
     protected _getDrawer(key: string) {
@@ -364,7 +365,6 @@ export module Plots {
 
       var positionF = attrToProjector[secondaryAttr];
       var widthF = attrToProjector["width"];
-      if (widthF == null) { widthF = () => this._getBarPixelWidth(); }
       var originalPositionFn = attrToProjector[primaryAttr];
       var heightF = (d: any, i: number, dataset: Dataset, m: PlotMetadata) => {
         return Math.abs(scaledBaseline - originalPositionFn(d, i, dataset, m));
@@ -410,6 +410,7 @@ export module Plots {
      * If the position scale of the plot is a QuantitativeScale, then _getMinimumDataWidth is scaled to compute the barPixelWidth
      */
     protected _getBarPixelWidth(): number {
+      if (!this._projectorsReady()) { return 0; }
       var barPixelWidth: number;
       var barScale: Scale<any, number>  = this._isVertical ? this.x().scale : this.y().scale;
       if (barScale instanceof Plottable.Scales.Category) {

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -33,6 +33,7 @@ export module Plots {
       this.animator("baseline", new Animators.Null());
       this._isVertical = isVertical;
       this.baseline(0);
+      this.attr("fill", this._defaultFillColor);
     }
 
     protected _getDrawer(key: string) {
@@ -398,8 +399,6 @@ export module Plots {
         attrToProjector["positive"] = (d: any, i: number, dataset: Dataset, m: PlotMetadata) =>
           originalPositionFn(d, i, dataset, m) <= scaledBaseline;
       }
-
-      attrToProjector["fill"] = attrToProjector["fill"] || d3.functor(this._defaultFillColor);
 
       return attrToProjector;
     }

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -20,8 +20,7 @@ export module Plots {
                                          .duration(600)
                                          .easing("exp-in-out"));
 
-      this._defaultStrokeColor = new Scales.Color().range()[0];
-      this.attr("stroke", this._defaultStrokeColor);
+      this.attr("stroke", new Scales.Color().range()[0]);
       this.attr("stroke-width", "2px");
     }
 

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -3,7 +3,6 @@
 module Plottable {
 export module Plots {
   export class Line<X> extends XYPlot<X, number> {
-    private _defaultStrokeColor: string;
 
     /**
      * Constructs a LinePlot.

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -21,6 +21,8 @@ export module Plots {
                                          .easing("exp-in-out"));
 
       this._defaultStrokeColor = new Scales.Color().range()[0];
+      this.attr("stroke", this._defaultStrokeColor);
+      this.attr("stroke-width", "2px");
     }
 
     protected _getDrawer(key: string) {
@@ -71,9 +73,6 @@ export module Plots {
         var yValue = yFunction(d, i, dataset, m);
         return xValue != null && xValue === xValue && yValue != null && yValue === yValue;
       };
-
-      attrToProjector["stroke"] = attrToProjector["stroke"] || d3.functor(this._defaultStrokeColor);
-      attrToProjector["stroke-width"] = attrToProjector["stroke-width"] || d3.functor("2px");
 
       return attrToProjector;
     }

--- a/src/components/plots/piePlot.ts
+++ b/src/components/plots/piePlot.ts
@@ -21,10 +21,8 @@ export module Plots {
     constructor() {
       super();
       this._colorScale = new Scales.Color();
-
-      this._propertyBindings.set(Pie._INNER_RADIUS_KEY, { accessor: () => 0 });
-      this._propertyBindings.set(Pie._OUTER_RADIUS_KEY, { accessor: () => Math.min(this.width(), this.height()) / 2 });
-      this._propertyBindings.set(Pie._SECTOR_VALUE_KEY, { accessor: () => null });
+      this.innerRadius(0);
+      this.outerRadius(() => Math.min(this.width(), this.height()) / 2);
       this.classed("pie-plot", true);
     }
 

--- a/src/components/plots/piePlot.ts
+++ b/src/components/plots/piePlot.ts
@@ -24,6 +24,7 @@ export module Plots {
       this.innerRadius(0);
       this.outerRadius(() => Math.min(this.width(), this.height()) / 2);
       this.classed("pie-plot", true);
+      this.attr("fill", (d, i) => String(i), new Scales.Color());
     }
 
     public computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number) {
@@ -46,15 +47,6 @@ export module Plots {
       }
       super.addDataset(dataset);
       return this;
-    }
-
-    protected _generateAttrToProjector(): AttributeToProjector {
-      var attrToProjector = super._generateAttrToProjector();
-
-      var defaultFillFunction = (d: any, i: number) => this._colorScale.scale(String(i));
-      attrToProjector["fill"] = attrToProjector["fill"] || defaultFillFunction;
-
-      return attrToProjector;
     }
 
     protected _getDrawer(key: string) {

--- a/src/components/plots/piePlot.ts
+++ b/src/components/plots/piePlot.ts
@@ -8,7 +8,6 @@ export module Plots {
    */
   export class Pie extends Plot {
 
-    private _colorScale: Scales.Color;
     private static _INNER_RADIUS_KEY = "inner-radius";
     private static _OUTER_RADIUS_KEY = "outer-radius";
     private static _SECTOR_VALUE_KEY = "sector-value";
@@ -20,7 +19,6 @@ export module Plots {
      */
     constructor() {
       super();
-      this._colorScale = new Scales.Color();
       this.innerRadius(0);
       this.outerRadius(() => Math.min(this.width(), this.height()) / 2);
       this.classed("pie-plot", true);

--- a/src/components/plots/rectanglePlot.ts
+++ b/src/components/plots/rectanglePlot.ts
@@ -7,7 +7,6 @@ export module Plots {
     private static _X2_KEY = "x2";
     private static _Y1_KEY = "y1";
     private static _Y2_KEY = "y2";
-    private _defaultFillColor: string;
 
     /**
      * Constructs a RectanglePlot.
@@ -22,9 +21,8 @@ export module Plots {
      */
     constructor(xScale: Scale<X, any>, yScale: Scale<Y, any>) {
       super(xScale, yScale);
-      this._defaultFillColor = new Scales.Color().range()[0];
       this.classed("rectangle-plot", true);
-      this.attr("fill", this._defaultFillColor);
+      this.attr("fill", new Scales.Color().range()[0]);
     }
 
     protected _getDrawer(key: string) {

--- a/src/components/plots/rectanglePlot.ts
+++ b/src/components/plots/rectanglePlot.ts
@@ -24,6 +24,7 @@ export module Plots {
       super(xScale, yScale);
       this._defaultFillColor = new Scales.Color().range()[0];
       this.classed("rectangle-plot", true);
+      this.attr("fill", this._defaultFillColor);
     }
 
     protected _getDrawer(key: string) {
@@ -55,7 +56,6 @@ export module Plots {
       delete attrToProjector["x2"];
       delete attrToProjector["y2"];
 
-      attrToProjector["fill"] = attrToProjector["fill"] || d3.functor(this._defaultFillColor);
       return attrToProjector;
     }
 

--- a/src/components/plots/scatterPlot.ts
+++ b/src/components/plots/scatterPlot.ts
@@ -23,6 +23,8 @@ export module Plots {
       this.animator("symbols", new Animators.Base()
                                            .duration(250)
                                            .delay(5));
+      this.attr("opacity", 0.6);
+      this.attr("fill", this._defaultFillColor);
     }
 
     protected _getDrawer(key: string) {
@@ -32,8 +34,6 @@ export module Plots {
     protected _generateAttrToProjector() {
       var attrToProjector = super._generateAttrToProjector();
       attrToProjector["size"] = attrToProjector["size"] || d3.functor(6);
-      attrToProjector["opacity"] = attrToProjector["opacity"] || d3.functor(0.6);
-      attrToProjector["fill"] = attrToProjector["fill"] || d3.functor(this._defaultFillColor);
       attrToProjector["symbol"] = attrToProjector["symbol"] || (() => SymbolFactories.circle());
 
       return attrToProjector;

--- a/src/components/plots/scatterPlot.ts
+++ b/src/components/plots/scatterPlot.ts
@@ -3,7 +3,6 @@
 module Plottable {
 export module Plots {
   export class Scatter<X, Y> extends XYPlot<X, Y> {
-    private _defaultFillColor: string;
     private static _SIZE_KEY = "size";
     private static _SYMBOL_KEY = "symbol";
 
@@ -17,14 +16,13 @@ export module Plots {
     constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>) {
       super(xScale, yScale);
       this.classed("scatter-plot", true);
-      this._defaultFillColor = new Scales.Color().range()[0];
 
       this.animator("symbols-reset", new Animators.Null());
       this.animator("symbols", new Animators.Base()
                                            .duration(250)
                                            .delay(5));
       this.attr("opacity", 0.6);
-      this.attr("fill", this._defaultFillColor);
+      this.attr("fill", new Scales.Color().range()[0]);
     }
 
     protected _getDrawer(key: string) {

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -19,6 +19,7 @@ export module Plots {
       super(xScale, yScale);
       this.classed("area-plot", true);
       this._isVertical = true;
+      this.attr("fill-opacity", 1);
     }
 
     protected _getDrawer(key: string) {
@@ -93,10 +94,6 @@ export module Plots {
 
     protected _generateAttrToProjector() {
       var attrToProjector = super._generateAttrToProjector();
-
-      if (this._attrBindings.get("fill-opacity") == null) {
-        attrToProjector["fill-opacity"] = d3.functor(1);
-      }
 
       var yAccessor = this.y().accessor;
       var xAccessor = this.x().accessor;


### PR DESCRIPTION
Moving appropriate defaults from `generateAttrToProjector()` to the constructor so that appropriate getter calls to those attirbutes can be called safely.