### PR TITLE
[Plots.Line] - Deleting reapplication of "defined" attribute

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -7639,19 +7639,12 @@ var Plottable;
                     var projector = attrToProjector[attribute];
                     attrToProjector[attribute] = function (data, i, dataset, m) { return data.length > 0 ? projector(data[0], i, dataset, m) : null; };
                 });
-                var xFunction = attrToProjector["x"];
-                var yFunction = attrToProjector["y"];
-                attrToProjector["defined"] = function (d, i, dataset, m) {
-                    var xValue = xFunction(d, i, dataset, m);
-                    var yValue = yFunction(d, i, dataset, m);
-                    return xValue != null && xValue === xValue && yValue != null && yValue === yValue;
-                };
                 attrToProjector["stroke"] = attrToProjector["stroke"] || d3.functor(this._defaultStrokeColor);
                 attrToProjector["stroke-width"] = attrToProjector["stroke-width"] || d3.functor("2px");
                 return attrToProjector;
             };
             Line.prototype._wholeDatumAttributes = function () {
-                return ["x", "y"];
+                return ["x", "y", "defined"];
             };
             Line.prototype.getAllPlotData = function (datasets) {
                 var _this = this;

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -63,15 +63,6 @@ export module Plots {
           data.length > 0 ? projector(data[0], i, dataset, m) : null;
       });
 
-      var xFunction = attrToProjector["x"];
-      var yFunction = attrToProjector["y"];
-
-      attrToProjector["defined"] = (d: any, i: number, dataset: Dataset, m: any) => {
-        var xValue = xFunction(d, i, dataset, m);
-        var yValue = yFunction(d, i, dataset, m);
-        return xValue != null && xValue === xValue && yValue != null && yValue === yValue;
-      };
-
       attrToProjector["stroke"] = attrToProjector["stroke"] || d3.functor(this._defaultStrokeColor);
       attrToProjector["stroke-width"] = attrToProjector["stroke-width"] || d3.functor("2px");
 
@@ -79,7 +70,7 @@ export module Plots {
     }
 
     protected _wholeDatumAttributes() {
-      return ["x", "y"];
+      return ["x", "y", "defined"];
     }
 
     public getAllPlotData(datasets = this.datasets()): Plots.PlotData {


### PR DESCRIPTION
The "defined" attribute is already defined in `XYPlot` meaning that the code in `Plots.Line` here is redundant