### PR TITLE
grunt-bump upgrade

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,7 +44,8 @@ module.exports = function(grunt) {
       updateConfigs: ['pkg'],
       commit: false,
       createTag: false,
-      push: false
+      push: false,
+      prereleaseName: "rc"
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "grunt-sed": "~0.1.1",
     "grunt-git": "~0.2.6",
     "grunt-contrib-clean": "~0.4.0",
-    "grunt-bump": "0.0.13",
+    "grunt-bump": "0.3.1",
     "grunt-contrib-compress": "~0.9.1",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-shell": "0.7.0",


### PR DESCRIPTION
Upgraded [`grunt-bump`](https://github.com/vojtajina/grunt-bump) to have access to prerelease versioning:

* Running `grunt-bump: premajor` when the current version is `0.54.0` will set the version to `1.0.0-rc.0`.
* Running `grunt-bump: prerelease` will then set the version to `1.0.0-rc.1`.

You will still have to run `grunt dist-compile` and `grunt gitcommit:version` to finish creating a release version.