### PR TITLE
Reduced the build time to 3 minutes on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ node_js:
 - '0.10'
 notifications:
   email: false
-addons:
-  sauce_connect: true
 env:
   global:
   - secure: D/VxpQ0fvxqD75Qgwa0HcxbQYNsIv+D7RJ+khiAwNlsluY9VKH84O0hmCQ1ijHKrUTGbSEqAkbNS+D0hvngmSfLCgsNhZyDVTZ0s2kzjV2v5jXrvppr7TmBsCUcp6+5CEgoL/0UL3w+Me3bq9WioMDD0AkmAwAdR/B2LJojEsEY=


### PR DESCRIPTION
Also removed the possibility of a livelock

Issue: 
By using the sauce connection, we were basically creating a tunnel which we were not using. Sauce Connection, as it is documented [here](https://docs.saucelabs.com/reference/sauce-connect/) , only needs this tunnel if the hosting environment is behind a firewall. Since this is an open source project and Travis is publicly accessible, there is no need for that.
Also, when we were running the tests, due to some misconfiguration (I believe in `Grunt`, we were not reusing the TLS tunnel, but instead creating a new insecure one. This basically meant that we were opening 2 tunnels per commit, one of which we were not using.

Future considerations:
When the push was a code review, it basically spawn 2 tasks (times 2 tunnels), which meant 4 tunnels per push.
Seeing a timeline of previous build pipeline:
0:00 - Task enters queue
1:42 - Git Clone (tasks starts)
1:50 - nvm install
2:55 - npm install
3:53 - Saucelab Connect install
6:11 - Travis creates Saucelab TLS tunnel
6:32 - TypeScript compile
6:54 - Running test coverage
7:03 - Running TSLint
7:33 - Running tests on SauceLabs (creating second tunnel)
8:45 - Cleaning Up
8:51 - Done

As it can be seen, at 6:11 one tunnel is created, and at 7:33 a second one is created. If in this time we reach the cap of 5 tunnels, the second tunnel cannot get created, it fails, travis does not pick up the fail (this is another issue), Travis waits for 10 minutes until it times out, but it keeps the second tunnel open. If 5 such scenarios occur (very easily due to the huge time window), all 5 tunnels are used, system does not advance any further

![screen shot 2015-05-18 at 4 57 22 pm](https://cloud.githubusercontent.com/assets/3248682/7693196/ceb3aaee-fd82-11e4-8c92-3f1cbf5938af.png)
