### PR TITLE
Improve typing on the map shim.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -168,18 +168,13 @@ declare module Plottable {
 
 declare module Plottable {
     module Utils {
-        /**
-         * An associative array that can be keyed by anything (inc objects).
-         * Uses pointer equality checks which is why this works.
-         * This power has a price: everything is linear time since it is actually backed by an array...
-         */
         class Map<K, V> {
             /**
-             * Set a new key/value pair in the store.
+             * Set a new key/value pair in the Map.
              *
-             * @param {K} key Key to set in the store
-             * @param {V} value Value to set in the store
-             * @return {boolean} True if key already in store, false otherwise
+             * @param {K} key Key to set in the Map
+             * @param {V} value Value to set in the Map
+             * @return {boolean} True if key already in Map, false otherwise
              */
             set(key: K, value: V): boolean;
             /**
@@ -200,26 +195,19 @@ declare module Plottable {
              */
             has(key: K): boolean;
             /**
-             * Return an array of the values in the key-value store
+             * Return an array of the values in the Map
              *
              * @return {V[]} The values in the store
              */
             values(): V[];
             /**
-             * Return an array of keys in the key-value store
+             * Return an array of keys in the Map.
              *
              * @return {K[]} The keys in the store
              */
             keys(): K[];
             /**
-             * Execute a callback for each entry in the array.
-             *
-             * @param {(key: K, val?: V, index?: number) => void} callback The callback to execute
-             * @return {any[]} The results of mapping the callback over the entries
-             */
-            map(cb: (key?: K, value?: V, index?: number) => void): void[];
-            /**
-             * Delete a key from the key-value store. Return whether the key was present.
+             * Delete a key from the Map. Return whether the key was present.
              *
              * @param {K} The key to remove
              * @return {boolean} Whether a matching entry was found and removed

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -188,7 +188,7 @@ declare module Plottable {
              * @param {K} key Key associated with value to retrieve
              * @return {V} Value if found, undefined otherwise
              */
-            get(key: K): any;
+            get(key: K): V;
             /**
              * Test whether store has a value associated with given key.
              *
@@ -204,20 +204,20 @@ declare module Plottable {
              *
              * @return {V[]} The values in the store
              */
-            values(): any[];
+            values(): V[];
             /**
              * Return an array of keys in the key-value store
              *
              * @return {K[]} The keys in the store
              */
-            keys(): any[];
+            keys(): K[];
             /**
              * Execute a callback for each entry in the array.
              *
-             * @param {(key: K, val?: V, index?: number) => any} callback The callback to execute
+             * @param {(key: K, val?: V, index?: number) => void} callback The callback to execute
              * @return {any[]} The results of mapping the callback over the entries
              */
-            map(cb: (key?: K, val?: V, index?: number) => any): any[];
+            map(cb: (key?: K, value?: V, index?: number) => void): void[];
             /**
              * Delete a key from the key-value store. Return whether the key was present.
              *

--- a/plottable.js
+++ b/plottable.js
@@ -384,12 +384,12 @@ var Plottable;
                     throw new Error("NaN may not be used as a key to the Map");
                 }
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
-                    if (this._keyValuePairs[i][0] === key) {
-                        this._keyValuePairs[i][1] = value;
+                    if (this._keyValuePairs[i].key === key) {
+                        this._keyValuePairs[i].value = value;
                         return true;
                     }
                 }
-                this._keyValuePairs.push([key, value]);
+                this._keyValuePairs.push({ key: key, value: value });
                 return false;
             };
             /**
@@ -400,8 +400,8 @@ var Plottable;
              */
             Map.prototype.get = function (key) {
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
-                    if (this._keyValuePairs[i][0] === key) {
-                        return this._keyValuePairs[i][1];
+                    if (this._keyValuePairs[i].key === key) {
+                        return this._keyValuePairs[i].value;
                     }
                 }
                 return undefined;
@@ -417,7 +417,7 @@ var Plottable;
              */
             Map.prototype.has = function (key) {
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
-                    if (this._keyValuePairs[i][0] === key) {
+                    if (this._keyValuePairs[i].key === key) {
                         return true;
                     }
                 }
@@ -429,7 +429,7 @@ var Plottable;
              * @return {V[]} The values in the store
              */
             Map.prototype.values = function () {
-                return this._keyValuePairs.map(function (x) { return x[1]; });
+                return this._keyValuePairs.map(function (keyValuePair) { return keyValuePair.value; });
             };
             /**
              * Return an array of keys in the key-value store
@@ -437,17 +437,17 @@ var Plottable;
              * @return {K[]} The keys in the store
              */
             Map.prototype.keys = function () {
-                return this._keyValuePairs.map(function (x) { return x[0]; });
+                return this._keyValuePairs.map(function (keyValuePair) { return keyValuePair.key; });
             };
             /**
              * Execute a callback for each entry in the array.
              *
-             * @param {(key: K, val?: V, index?: number) => any} callback The callback to execute
+             * @param {(key: K, val?: V, index?: number) => void} callback The callback to execute
              * @return {any[]} The results of mapping the callback over the entries
              */
             Map.prototype.map = function (cb) {
-                return this._keyValuePairs.map(function (kv, index) {
-                    return cb(kv[0], kv[1], index);
+                return this._keyValuePairs.map(function (keyValuePair, index) {
+                    return cb(keyValuePair.key, keyValuePair.value, index);
                 });
             };
             /**
@@ -458,7 +458,7 @@ var Plottable;
              */
             Map.prototype.delete = function (key) {
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
-                    if (this._keyValuePairs[i][0] === key) {
+                    if (this._keyValuePairs[i].key === key) {
                         this._keyValuePairs.splice(i, 1);
                         return true;
                     }

--- a/plottable.js
+++ b/plottable.js
@@ -1118,7 +1118,6 @@ var Plottable;
             if (metadata === void 0) { metadata = {}; }
             this._data = data;
             this._metadata = metadata;
-            this._accessor2cachedExtent = new Plottable.Utils.Map();
             this._callbacks = new Plottable.Utils.CallbackSet();
         }
         Dataset.prototype.onUpdate = function (callback) {
@@ -1133,7 +1132,6 @@ var Plottable;
             }
             else {
                 this._data = data;
-                this._accessor2cachedExtent = new Plottable.Utils.Map();
                 this._callbacks.callCallbacks(this);
                 return this;
             }
@@ -1144,7 +1142,6 @@ var Plottable;
             }
             else {
                 this._metadata = metadata;
-                this._accessor2cachedExtent = new Plottable.Utils.Map();
                 this._callbacks.callCallbacks(this);
                 return this;
             }

--- a/plottable.js
+++ b/plottable.js
@@ -363,21 +363,16 @@ var Plottable;
 (function (Plottable) {
     var Utils;
     (function (Utils) {
-        /**
-         * An associative array that can be keyed by anything (inc objects).
-         * Uses pointer equality checks which is why this works.
-         * This power has a price: everything is linear time since it is actually backed by an array...
-         */
         var Map = (function () {
             function Map() {
                 this._keyValuePairs = [];
             }
             /**
-             * Set a new key/value pair in the store.
+             * Set a new key/value pair in the Map.
              *
-             * @param {K} key Key to set in the store
-             * @param {V} value Value to set in the store
-             * @return {boolean} True if key already in store, false otherwise
+             * @param {K} key Key to set in the Map
+             * @param {V} value Value to set in the Map
+             * @return {boolean} True if key already in Map, false otherwise
              */
             Map.prototype.set = function (key, value) {
                 if (key !== key) {
@@ -424,7 +419,7 @@ var Plottable;
                 return false;
             };
             /**
-             * Return an array of the values in the key-value store
+             * Return an array of the values in the Map
              *
              * @return {V[]} The values in the store
              */
@@ -432,7 +427,7 @@ var Plottable;
                 return this._keyValuePairs.map(function (keyValuePair) { return keyValuePair.value; });
             };
             /**
-             * Return an array of keys in the key-value store
+             * Return an array of keys in the Map.
              *
              * @return {K[]} The keys in the store
              */
@@ -440,18 +435,7 @@ var Plottable;
                 return this._keyValuePairs.map(function (keyValuePair) { return keyValuePair.key; });
             };
             /**
-             * Execute a callback for each entry in the array.
-             *
-             * @param {(key: K, val?: V, index?: number) => void} callback The callback to execute
-             * @return {any[]} The results of mapping the callback over the entries
-             */
-            Map.prototype.map = function (cb) {
-                return this._keyValuePairs.map(function (keyValuePair, index) {
-                    return cb(keyValuePair.key, keyValuePair.value, index);
-                });
-            };
-            /**
-             * Delete a key from the key-value store. Return whether the key was present.
+             * Delete a key from the Map. Return whether the key was present.
              *
              * @param {K} The key to remove
              * @return {boolean} Whether a matching entry was found and removed

--- a/src/core/dataset.ts
+++ b/src/core/dataset.ts
@@ -7,7 +7,6 @@ module Plottable {
   export class Dataset {
     private _data: any[];
     private _metadata: any;
-    private _accessor2cachedExtent: Utils.Map<any, any>;
     private _callbacks: Utils.CallbackSet<DatasetCallback>;
 
     /**
@@ -23,7 +22,6 @@ module Plottable {
     constructor(data: any[] = [], metadata: any = {}) {
       this._data = data;
       this._metadata = metadata;
-      this._accessor2cachedExtent = new Utils.Map<any, any>();
       this._callbacks = new Utils.CallbackSet<DatasetCallback>();
     }
 
@@ -53,7 +51,6 @@ module Plottable {
         return this._data;
       } else {
         this._data = data;
-        this._accessor2cachedExtent = new Utils.Map<any, any>();
         this._callbacks.callCallbacks(this);
         return this;
       }
@@ -78,7 +75,6 @@ module Plottable {
         return this._metadata;
       } else {
         this._metadata = metadata;
-        this._accessor2cachedExtent = new Utils.Map<any, any>();
         this._callbacks.callCallbacks(this);
         return this;
       }

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -2,20 +2,15 @@
 
 module Plottable {
 export module Utils {
-  /**
-   * An associative array that can be keyed by anything (inc objects).
-   * Uses pointer equality checks which is why this works.
-   * This power has a price: everything is linear time since it is actually backed by an array...
-   */
   export class Map<K, V> {
     private _keyValuePairs: { key: K; value: V; }[] = [];
 
     /**
-     * Set a new key/value pair in the store.
+     * Set a new key/value pair in the Map.
      *
-     * @param {K} key Key to set in the store
-     * @param {V} value Value to set in the store
-     * @return {boolean} True if key already in store, false otherwise
+     * @param {K} key Key to set in the Map
+     * @param {V} value Value to set in the Map
+     * @return {boolean} True if key already in Map, false otherwise
      */
     public set(key: K, value: V) {
       if (key !== key) {
@@ -65,7 +60,7 @@ export module Utils {
     }
 
     /**
-     * Return an array of the values in the key-value store
+     * Return an array of the values in the Map
      *
      * @return {V[]} The values in the store
      */
@@ -74,7 +69,7 @@ export module Utils {
     }
 
     /**
-     * Return an array of keys in the key-value store
+     * Return an array of keys in the Map.
      *
      * @return {K[]} The keys in the store
      */
@@ -83,19 +78,7 @@ export module Utils {
     }
 
     /**
-     * Execute a callback for each entry in the array.
-     *
-     * @param {(key: K, val?: V, index?: number) => void} callback The callback to execute
-     * @return {any[]} The results of mapping the callback over the entries
-     */
-     public map(cb: (key?: K, value?: V, index?: number) => void) {
-      return this._keyValuePairs.map((keyValuePair, index) => {
-        return cb(keyValuePair.key, keyValuePair.value, index);
-      });
-     }
-
-    /**
-     * Delete a key from the key-value store. Return whether the key was present.
+     * Delete a key from the Map. Return whether the key was present.
      *
      * @param {K} The key to remove
      * @return {boolean} Whether a matching entry was found and removed

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -8,7 +8,7 @@ export module Utils {
    * This power has a price: everything is linear time since it is actually backed by an array...
    */
   export class Map<K, V> {
-    private _keyValuePairs: any[][] = [];
+    private _keyValuePairs: { key: K; value: V; }[] = [];
 
     /**
      * Set a new key/value pair in the store.
@@ -22,12 +22,12 @@ export module Utils {
         throw new Error("NaN may not be used as a key to the Map");
       }
       for (var i = 0; i < this._keyValuePairs.length; i++) {
-        if (this._keyValuePairs[i][0] === key) {
-          this._keyValuePairs[i][1] = value;
+        if (this._keyValuePairs[i].key === key) {
+          this._keyValuePairs[i].value = value;
           return true;
         }
       }
-      this._keyValuePairs.push([key, value]);
+      this._keyValuePairs.push({ key: key, value: value });
       return false;
     }
 
@@ -39,8 +39,8 @@ export module Utils {
      */
     public get(key: K) {
       for (var i = 0; i < this._keyValuePairs.length; i++) {
-        if (this._keyValuePairs[i][0] === key) {
-          return this._keyValuePairs[i][1];
+        if (this._keyValuePairs[i].key === key) {
+          return this._keyValuePairs[i].value;
         }
       }
       return undefined;
@@ -57,7 +57,7 @@ export module Utils {
      */
     public has(key: K) {
       for (var i = 0; i < this._keyValuePairs.length; i++) {
-        if (this._keyValuePairs[i][0] === key) {
+        if (this._keyValuePairs[i].key === key) {
           return true;
         }
       }
@@ -70,7 +70,7 @@ export module Utils {
      * @return {V[]} The values in the store
      */
     public values() {
-      return this._keyValuePairs.map((x) => x[1]);
+      return this._keyValuePairs.map((keyValuePair) => keyValuePair.value);
     }
 
     /**
@@ -79,18 +79,18 @@ export module Utils {
      * @return {K[]} The keys in the store
      */
     public keys() {
-      return this._keyValuePairs.map((x) => x[0]);
+      return this._keyValuePairs.map((keyValuePair) => keyValuePair.key);
     }
 
     /**
      * Execute a callback for each entry in the array.
      *
-     * @param {(key: K, val?: V, index?: number) => any} callback The callback to execute
+     * @param {(key: K, val?: V, index?: number) => void} callback The callback to execute
      * @return {any[]} The results of mapping the callback over the entries
      */
-     public map(cb: (key?: K, val?: V, index?: number) => any) {
-      return this._keyValuePairs.map((kv: any[], index: number) => {
-        return cb(kv[0], kv[1], index);
+     public map(cb: (key?: K, value?: V, index?: number) => void) {
+      return this._keyValuePairs.map((keyValuePair, index) => {
+        return cb(keyValuePair.key, keyValuePair.value, index);
       });
      }
 
@@ -102,7 +102,7 @@ export module Utils {
      */
     public delete(key: K) {
       for (var i = 0; i < this._keyValuePairs.length; i++) {
-        if (this._keyValuePairs[i][0] === key) {
+        if (this._keyValuePairs[i].key === key) {
           this._keyValuePairs.splice(i, 1);
           return true;
         }

--- a/test/tests.js
+++ b/test/tests.js
@@ -7806,37 +7806,66 @@ describe("Formatters", function () {
 ///<reference path="../testReference.ts" />
 var assert = chai.assert;
 describe("Map", function () {
-    it("Map works as expected", function () {
+    it("set() and get()", function () {
         var map = new Plottable.Utils.Map();
-        var o1 = {};
-        var o2 = {};
-        assert.isFalse(map.has(o1));
-        assert.isFalse(map.delete(o1));
-        assert.isUndefined(map.get(o1));
-        assert.isFalse(map.set(o1, "foo"));
-        assert.strictEqual(map.get(o1), "foo");
-        assert.isTrue(map.set(o1, "bar"));
-        assert.strictEqual(map.get(o1), "bar");
-        map.set(o2, "baz");
-        map.set(3, "bam");
-        map.set("3", "ball");
-        assert.strictEqual(map.get(o1), "bar");
-        assert.strictEqual(map.get(o2), "baz");
-        assert.strictEqual(map.get(3), "bam");
-        assert.strictEqual(map.get("3"), "ball");
-        assert.isTrue(map.delete(3));
-        assert.isUndefined(map.get(3));
-        assert.strictEqual(map.get(o2), "baz");
-        assert.strictEqual(map.get("3"), "ball");
+        var key1 = "key1";
+        var value1 = "1";
+        map.set(key1, value1);
+        assert.strictEqual(map.get(key1), value1, "value was successfully set on the Map");
+        var value1b = "1b";
+        map.set(key1, value1b);
+        assert.strictEqual(map.get(key1), value1b, "overwrote old value with new one");
+        var key2 = "key2";
+        assert.isUndefined(map.get(key2), "returns undefined if key is not present in the Map");
     });
-    it("Array-level operations (retrieve keys, vals, and map)", function () {
+    it("has()", function () {
         var map = new Plottable.Utils.Map();
-        map.set(2, "foo");
-        map.set(3, "bar");
-        map.set(4, "baz");
-        assert.deepEqual(map.values(), ["foo", "bar", "baz"]);
-        assert.deepEqual(map.keys(), [2, 3, 4]);
-        assert.deepEqual(map.map(function (k, v, i) { return [k, v, i]; }), [[2, "foo", 0], [3, "bar", 1], [4, "baz", 2]]);
+        var key1 = "key1";
+        var value1 = "1";
+        assert.isFalse(map.has(key1), "returns false if the key has not been set");
+        map.set(key1, value1);
+        assert.isTrue(map.has(key1), "returns true if the key has been set");
+        map.set(key1, undefined);
+        assert.isTrue(map.has(key1), "returns true if the value is explicitly set to undefined");
+    });
+    it("delete()", function () {
+        var map = new Plottable.Utils.Map();
+        var key1 = "key1";
+        var value1 = "1";
+        map.set(key1, value1);
+        assert.isTrue(map.delete(key1), "returns true if the key was present in the Map");
+        assert.isFalse(map.has(key1), "key is no longer present in the Map");
+        assert.isFalse(map.delete(key1), "returns false if the key was not present in the Map");
+    });
+    it("keys()", function () {
+        var map = new Plottable.Utils.Map();
+        var key1 = "key1";
+        var value1 = "1";
+        map.set(key1, value1);
+        var key2 = "key2";
+        var value2 = "2";
+        map.set(key2, value2);
+        assert.deepEqual(map.keys(), [key1, key2], "retrieved all keys");
+    });
+    it("keys()", function () {
+        var map = new Plottable.Utils.Map();
+        var key1 = "key1";
+        var value1 = "1";
+        map.set(key1, value1);
+        var key2 = "key2";
+        var value2 = "2";
+        map.set(key2, value2);
+        assert.deepEqual(map.keys(), [key1, key2], "retrieved all keys");
+    });
+    it("values()", function () {
+        var map = new Plottable.Utils.Map();
+        var key1 = "key1";
+        var value1 = "1";
+        map.set(key1, value1);
+        var key2 = "key2";
+        var value2 = "2";
+        map.set(key2, value2);
+        assert.deepEqual(map.values(), [value1, value2], "retrieved all values");
     });
 });
 

--- a/test/utils/mapTests.ts
+++ b/test/utils/mapTests.ts
@@ -3,38 +3,70 @@
 var assert = chai.assert;
 
 describe("Map", () => {
-
-  it("Map works as expected", () => {
-    var map = new Plottable.Utils.Map<any, any>();
-    var o1 = {};
-    var o2 = {};
-    assert.isFalse(map.has(o1));
-    assert.isFalse(map.delete(o1));
-    assert.isUndefined(map.get(o1));
-    assert.isFalse(map.set(o1, "foo"));
-    assert.strictEqual(map.get(o1), "foo");
-    assert.isTrue(map.set(o1, "bar"));
-    assert.strictEqual(map.get(o1), "bar");
-    map.set(o2, "baz");
-    map.set(3, "bam");
-    map.set("3", "ball");
-    assert.strictEqual(map.get(o1), "bar");
-    assert.strictEqual(map.get(o2), "baz");
-    assert.strictEqual(map.get(3), "bam");
-    assert.strictEqual(map.get("3"), "ball");
-    assert.isTrue(map.delete(3));
-    assert.isUndefined(map.get(3));
-    assert.strictEqual(map.get(o2), "baz");
-    assert.strictEqual(map.get("3"), "ball");
+  it("set() and get()", () => {
+    var map = new Plottable.Utils.Map<string, string>();
+    var key1 = "key1";
+    var value1 = "1";
+    map.set(key1, value1);
+    assert.strictEqual(map.get(key1), value1, "value was successfully set on the Map");
+    var value1b = "1b";
+    map.set(key1, value1b);
+    assert.strictEqual(map.get(key1), value1b, "overwrote old value with new one");
+    var key2 = "key2";
+    assert.isUndefined(map.get(key2), "returns undefined if key is not present in the Map");
   });
 
-  it("Array-level operations (retrieve keys, vals, and map)", () => {
-    var map = new Plottable.Utils.Map<number, string>();
-    map.set(2, "foo");
-    map.set(3, "bar");
-    map.set(4, "baz");
-    assert.deepEqual(map.values(), ["foo", "bar", "baz"]);
-    assert.deepEqual(map.keys(), [2, 3, 4]);
-    assert.deepEqual(map.map((k, v, i) => [k, v, i]), [[2, "foo", 0], [3, "bar", 1], [4, "baz", 2]]);
+  it("has()", () => {
+    var map = new Plottable.Utils.Map<string, string>();
+    var key1 = "key1";
+    var value1 = "1";
+    assert.isFalse(map.has(key1), "returns false if the key has not been set");
+    map.set(key1, value1);
+    assert.isTrue(map.has(key1), "returns true if the key has been set");
+    map.set(key1, undefined);
+    assert.isTrue(map.has(key1), "returns true if the value is explicitly set to undefined");
+  });
+
+  it("delete()", () => {
+    var map = new Plottable.Utils.Map<string, string>();
+    var key1 = "key1";
+    var value1 = "1";
+    map.set(key1, value1);
+    assert.isTrue(map.delete(key1), "returns true if the key was present in the Map");
+    assert.isFalse(map.has(key1), "key is no longer present in the Map");
+    assert.isFalse(map.delete(key1), "returns false if the key was not present in the Map");
+  });
+
+  it("keys()", () => {
+    var map = new Plottable.Utils.Map<string, string>();
+    var key1 = "key1";
+    var value1 = "1";
+    map.set(key1, value1);
+    var key2 = "key2";
+    var value2 = "2";
+    map.set(key2, value2);
+    assert.deepEqual(map.keys(), [key1, key2], "retrieved all keys");
+  });
+
+  it("keys()", () => {
+    var map = new Plottable.Utils.Map<string, string>();
+    var key1 = "key1";
+    var value1 = "1";
+    map.set(key1, value1);
+    var key2 = "key2";
+    var value2 = "2";
+    map.set(key2, value2);
+    assert.deepEqual(map.keys(), [key1, key2], "retrieved all keys");
+  });
+
+  it("values()", () => {
+    var map = new Plottable.Utils.Map<string, string>();
+    var key1 = "key1";
+    var value1 = "1";
+    map.set(key1, value1);
+    var key2 = "key2";
+    var value2 = "2";
+    map.set(key2, value2);
+    assert.deepEqual(map.values(), [value1, value2], "retrieved all values");
   });
 });


### PR DESCRIPTION
`keys()` and values() used to return `<any>`, which wasn't very helpful.

On a `Map<K, V>`, `keys()` now returns `K[]`, `values()` now returns `V[]`.

Also got rid of `Map.map()`, which besides being really goofy wasn't used anywhere.