### PR TITLE
Bring back TitleLabel and AxisLabel

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2010,8 +2010,6 @@ declare module Plottable {
 declare module Plottable {
     module Components {
         class Label extends Component {
-            static TITLE_LABEL_CLASS: string;
-            static AXIS_LABEL_CLASS: string;
             /**
              * Creates a Label.
              *
@@ -2068,6 +2066,22 @@ declare module Plottable {
             fixedWidth(): boolean;
             fixedHeight(): boolean;
             renderImmediately(): Label;
+        }
+        class TitleLabel extends Label {
+            /**
+             * Creates a TitleLabel, a type of label made for rendering titles.
+             *
+             * @constructor
+             */
+            constructor(text?: string, orientation?: string);
+        }
+        class AxisLabel extends Label {
+            /**
+             * Creates a AxisLabel, a type of label made for rendering axis labels.
+             *
+             * @constructor
+             */
+            constructor(text?: string, orientation?: string);
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2068,6 +2068,7 @@ declare module Plottable {
             renderImmediately(): Label;
         }
         class TitleLabel extends Label {
+            static TITLE_LABEL_CLASS: string;
             /**
              * Creates a TitleLabel, a type of label made for rendering titles.
              *
@@ -2076,6 +2077,7 @@ declare module Plottable {
             constructor(text?: string, orientation?: string);
         }
         class AxisLabel extends Label {
+            static AXIS_LABEL_CLASS: string;
             /**
              * Creates a AxisLabel, a type of label made for rendering axis labels.
              *

--- a/plottable.js
+++ b/plottable.js
@@ -5045,8 +5045,9 @@ var Plottable;
              */
             function TitleLabel(text, orientation) {
                 _super.call(this, text, orientation);
-                this.classed("title-label", true);
+                this.classed(TitleLabel.TITLE_LABEL_CLASS, true);
             }
+            TitleLabel.TITLE_LABEL_CLASS = "title-label";
             return TitleLabel;
         })(Label);
         Components.TitleLabel = TitleLabel;
@@ -5059,8 +5060,9 @@ var Plottable;
              */
             function AxisLabel(text, orientation) {
                 _super.call(this, text, orientation);
-                this.classed("axis-label", true);
+                this.classed(AxisLabel.AXIS_LABEL_CLASS, true);
             }
+            AxisLabel.AXIS_LABEL_CLASS = "axis-label";
             return AxisLabel;
         })(Label);
         Components.AxisLabel = AxisLabel;

--- a/plottable.js
+++ b/plottable.js
@@ -5033,13 +5033,37 @@ var Plottable;
                 this._writer.write(this._text, writeWidth, writeHeight, writeOptions);
                 return this;
             };
-            // Css class for labels that are made for rendering titles.
-            Label.TITLE_LABEL_CLASS = "title-label";
-            // Css class for labels that are made for rendering axis titles.
-            Label.AXIS_LABEL_CLASS = "axis-label";
             return Label;
         })(Plottable.Component);
         Components.Label = Label;
+        var TitleLabel = (function (_super) {
+            __extends(TitleLabel, _super);
+            /**
+             * Creates a TitleLabel, a type of label made for rendering titles.
+             *
+             * @constructor
+             */
+            function TitleLabel(text, orientation) {
+                _super.call(this, text, orientation);
+                this.classed("title-label", true);
+            }
+            return TitleLabel;
+        })(Label);
+        Components.TitleLabel = TitleLabel;
+        var AxisLabel = (function (_super) {
+            __extends(AxisLabel, _super);
+            /**
+             * Creates a AxisLabel, a type of label made for rendering axis labels.
+             *
+             * @constructor
+             */
+            function AxisLabel(text, orientation) {
+                _super.call(this, text, orientation);
+                this.classed("axis-label", true);
+            }
+            return AxisLabel;
+        })(Label);
+        Components.AxisLabel = AxisLabel;
     })(Components = Plottable.Components || (Plottable.Components = {}));
 })(Plottable || (Plottable = {}));
 

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -160,6 +160,7 @@ export module Components {
   }
 
   export class TitleLabel extends Label {
+    public static TITLE_LABEL_CLASS = "title-label";
     /**
      * Creates a TitleLabel, a type of label made for rendering titles.
      *
@@ -167,11 +168,12 @@ export module Components {
      */
     constructor(text?: string, orientation?: string) {
       super(text, orientation);
-      this.classed("title-label", true);
+      this.classed(TitleLabel.TITLE_LABEL_CLASS, true);
     }
   }
 
   export class AxisLabel extends Label {
+    public static AXIS_LABEL_CLASS = "axis-label";
     /**
      * Creates a AxisLabel, a type of label made for rendering axis labels.
      *
@@ -179,7 +181,7 @@ export module Components {
      */
     constructor(text?: string, orientation?: string) {
       super(text, orientation);
-      this.classed("axis-label", true);
+      this.classed(AxisLabel.AXIS_LABEL_CLASS, true);
     }
   }
 }

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -3,13 +3,6 @@
 module Plottable {
 export module Components {
   export class Label extends Component {
-
-    // Css class for labels that are made for rendering titles.
-    public static TITLE_LABEL_CLASS = "title-label";
-
-    // Css class for labels that are made for rendering axis titles.
-    public static AXIS_LABEL_CLASS = "axis-label";
-
     private _textContainer: D3.Selection;
     private _text: string; // text assigned to the Label; may not be the actual text displayed due to truncation
     private _orientation: string;
@@ -163,6 +156,30 @@ export module Components {
                     };
       this._writer.write(this._text, writeWidth, writeHeight, writeOptions);
       return this;
+    }
+  }
+
+  export class TitleLabel extends Label {
+    /**
+     * Creates a TitleLabel, a type of label made for rendering titles.
+     *
+     * @constructor
+     */
+    constructor(text?: string, orientation?: string) {
+      super(text, orientation);
+      this.classed("title-label", true);
+    }
+  }
+
+  export class AxisLabel extends Label {
+    /**
+     * Creates a AxisLabel, a type of label made for rendering axis labels.
+     *
+     * @constructor
+     */
+    constructor(text?: string, orientation?: string) {
+      super(text, orientation);
+      this.classed("axis-label", true);
     }
   }
 }

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -6,8 +6,7 @@ describe("Labels", () => {
 
   it("Standard text title label generates properly", () => {
     var svg = TestMethods.generateSVG(400, 80);
-    var label = new Plottable.Components.Label("A CHART TITLE");
-    label.classed(Plottable.Components.Label.TITLE_LABEL_CLASS, true);
+    var label = new Plottable.Components.TitleLabel("A CHART TITLE");
     label.renderTo(svg);
 
     var content = (<any> label)._content;
@@ -26,8 +25,7 @@ describe("Labels", () => {
   // Skipping due to FF odd client bounding rect computation - #1470.
   it.skip("Left-rotated text is handled properly", () => {
     var svg = TestMethods.generateSVG(100, 400);
-    var label = new Plottable.Components.Label("LEFT-ROTATED LABEL", "left");
-    label.classed(Plottable.Components.Label.AXIS_LABEL_CLASS, true);
+    var label = new Plottable.Components.AxisLabel("LEFT-ROTATED LABEL", "left");
     label.renderTo(svg);
     var content = (<any> label)._content;
     var text = content.select("text");
@@ -40,8 +38,7 @@ describe("Labels", () => {
   // Skipping due to FF odd client bounding rect computation - #1470.
   it.skip("Right-rotated text is handled properly", () => {
     var svg = TestMethods.generateSVG(100, 400);
-    var label = new Plottable.Components.Label("RIGHT-ROTATED LABEL", "right");
-    label.classed(Plottable.Components.Label.AXIS_LABEL_CLASS, true);
+    var label = new Plottable.Components.AxisLabel("RIGHT-ROTATED LABEL", "right");
     label.renderTo(svg);
     var content = (<any> label)._content;
     var text = content.select("text");
@@ -53,8 +50,7 @@ describe("Labels", () => {
 
   it("Label text can be changed after label is created", () => {
     var svg = TestMethods.generateSVG(400, 80);
-    var label = new Plottable.Components.Label("a");
-    label.classed(Plottable.Components.Label.TITLE_LABEL_CLASS, true);
+    var label = new Plottable.Components.TitleLabel("a");
     label.renderTo(svg);
     assert.strictEqual((<any> label)._content.select("text").text(), "a", "the text starts at the specified string");
     assert.operator(label.height(), ">", 0, "rowMin is > 0 for non-empty string");
@@ -69,8 +65,7 @@ describe("Labels", () => {
   it.skip("Superlong text is handled in a sane fashion", () => {
     var svgWidth = 400;
     var svg = TestMethods.generateSVG(svgWidth, 80);
-    var label = new Plottable.Components.Label("THIS LABEL IS SO LONG WHOEVER WROTE IT WAS PROBABLY DERANGED");
-    label.classed(Plottable.Components.Label.TITLE_LABEL_CLASS, true);
+    var label = new Plottable.Components.TitleLabel("THIS LABEL IS SO LONG WHOEVER WROTE IT WAS PROBABLY DERANGED");
     label.renderTo(svg);
     var content = (<any> label)._content;
     var text = content.select("text");
@@ -82,8 +77,7 @@ describe("Labels", () => {
 
   it("text in a tiny box is truncated to empty string", () => {
     var svg = TestMethods.generateSVG(10, 10);
-    var label = new Plottable.Components.Label("Yeah, not gonna fit...");
-    label.classed(Plottable.Components.Label.TITLE_LABEL_CLASS, true);
+    var label = new Plottable.Components.TitleLabel("Yeah, not gonna fit...");
     label.renderTo(svg);
     var text = (<any> label)._content.select("text");
     assert.strictEqual(text.text(), "", "text was truncated to empty string");
@@ -105,7 +99,7 @@ describe("Labels", () => {
 
   it("if a label text is changed to empty string, width updates to 0", () => {
     var svg = TestMethods.generateSVG(400, 400);
-    var label = new Plottable.Components.Label("foo");
+    var label = new Plottable.Components.TitleLabel("foo");
     label.renderTo(svg);
     label.text("");
     assert.strictEqual(label.width(), 0, "width updated to 0");
@@ -119,8 +113,7 @@ describe("Labels", () => {
   // Skipping due to FF odd client bounding rect computation - #1470.
   it.skip("Label orientation can be changed after label is created", () => {
     var svg = TestMethods.generateSVG(400, 400);
-    var label = new Plottable.Components.Label("CHANGING ORIENTATION");
-    label.classed(Plottable.Components.Label.AXIS_LABEL_CLASS, true);
+    var label = new Plottable.Components.AxisLabel("CHANGING ORIENTATION");
     label.renderTo(svg);
 
     var content = (<any> label)._content;

--- a/test/components/numericAxisTests.ts
+++ b/test/components/numericAxisTests.ts
@@ -304,8 +304,7 @@ describe("NumericAxis", () => {
     var xScale = new Plottable.Scales.Category();
     var yScale = new Plottable.Scales.Linear();
     var yAxis = new Plottable.Axes.Numeric(yScale, "left");
-    var yLabel = new Plottable.Components.Label("LABEL", "left");
-    yLabel.classed(Plottable.Components.Label.AXIS_LABEL_CLASS, true);
+    var yLabel = new Plottable.Components.AxisLabel("LABEL", "left");
     var barPlot = new Plottable.Plots.Bar(xScale, yScale);
     barPlot.x((d) => d.x, xScale);
     barPlot.y((d) => d.y, yScale);

--- a/test/tests.js
+++ b/test/tests.js
@@ -1174,8 +1174,7 @@ describe("NumericAxis", function () {
         var xScale = new Plottable.Scales.Category();
         var yScale = new Plottable.Scales.Linear();
         var yAxis = new Plottable.Axes.Numeric(yScale, "left");
-        var yLabel = new Plottable.Components.Label("LABEL", "left");
-        yLabel.classed(Plottable.Components.Label.AXIS_LABEL_CLASS, true);
+        var yLabel = new Plottable.Components.AxisLabel("LABEL", "left");
         var barPlot = new Plottable.Plots.Bar(xScale, yScale);
         barPlot.x(function (d) { return d.x; }, xScale);
         barPlot.y(function (d) { return d.y; }, yScale);
@@ -1489,8 +1488,7 @@ var assert = chai.assert;
 describe("Labels", function () {
     it("Standard text title label generates properly", function () {
         var svg = TestMethods.generateSVG(400, 80);
-        var label = new Plottable.Components.Label("A CHART TITLE");
-        label.classed(Plottable.Components.Label.TITLE_LABEL_CLASS, true);
+        var label = new Plottable.Components.TitleLabel("A CHART TITLE");
         label.renderTo(svg);
         var content = label._content;
         assert.isTrue(label._element.classed("label"), "title element has label css class");
@@ -1506,8 +1504,7 @@ describe("Labels", function () {
     // Skipping due to FF odd client bounding rect computation - #1470.
     it.skip("Left-rotated text is handled properly", function () {
         var svg = TestMethods.generateSVG(100, 400);
-        var label = new Plottable.Components.Label("LEFT-ROTATED LABEL", "left");
-        label.classed(Plottable.Components.Label.AXIS_LABEL_CLASS, true);
+        var label = new Plottable.Components.AxisLabel("LEFT-ROTATED LABEL", "left");
         label.renderTo(svg);
         var content = label._content;
         var text = content.select("text");
@@ -1519,8 +1516,7 @@ describe("Labels", function () {
     // Skipping due to FF odd client bounding rect computation - #1470.
     it.skip("Right-rotated text is handled properly", function () {
         var svg = TestMethods.generateSVG(100, 400);
-        var label = new Plottable.Components.Label("RIGHT-ROTATED LABEL", "right");
-        label.classed(Plottable.Components.Label.AXIS_LABEL_CLASS, true);
+        var label = new Plottable.Components.AxisLabel("RIGHT-ROTATED LABEL", "right");
         label.renderTo(svg);
         var content = label._content;
         var text = content.select("text");
@@ -1531,8 +1527,7 @@ describe("Labels", function () {
     });
     it("Label text can be changed after label is created", function () {
         var svg = TestMethods.generateSVG(400, 80);
-        var label = new Plottable.Components.Label("a");
-        label.classed(Plottable.Components.Label.TITLE_LABEL_CLASS, true);
+        var label = new Plottable.Components.TitleLabel("a");
         label.renderTo(svg);
         assert.strictEqual(label._content.select("text").text(), "a", "the text starts at the specified string");
         assert.operator(label.height(), ">", 0, "rowMin is > 0 for non-empty string");
@@ -1546,8 +1541,7 @@ describe("Labels", function () {
     it.skip("Superlong text is handled in a sane fashion", function () {
         var svgWidth = 400;
         var svg = TestMethods.generateSVG(svgWidth, 80);
-        var label = new Plottable.Components.Label("THIS LABEL IS SO LONG WHOEVER WROTE IT WAS PROBABLY DERANGED");
-        label.classed(Plottable.Components.Label.TITLE_LABEL_CLASS, true);
+        var label = new Plottable.Components.TitleLabel("THIS LABEL IS SO LONG WHOEVER WROTE IT WAS PROBABLY DERANGED");
         label.renderTo(svg);
         var content = label._content;
         var text = content.select("text");
@@ -1558,8 +1552,7 @@ describe("Labels", function () {
     });
     it("text in a tiny box is truncated to empty string", function () {
         var svg = TestMethods.generateSVG(10, 10);
-        var label = new Plottable.Components.Label("Yeah, not gonna fit...");
-        label.classed(Plottable.Components.Label.TITLE_LABEL_CLASS, true);
+        var label = new Plottable.Components.TitleLabel("Yeah, not gonna fit...");
         label.renderTo(svg);
         var text = label._content.select("text");
         assert.strictEqual(text.text(), "", "text was truncated to empty string");
@@ -1578,7 +1571,7 @@ describe("Labels", function () {
     });
     it("if a label text is changed to empty string, width updates to 0", function () {
         var svg = TestMethods.generateSVG(400, 400);
-        var label = new Plottable.Components.Label("foo");
+        var label = new Plottable.Components.TitleLabel("foo");
         label.renderTo(svg);
         label.text("");
         assert.strictEqual(label.width(), 0, "width updated to 0");
@@ -1590,8 +1583,7 @@ describe("Labels", function () {
     // Skipping due to FF odd client bounding rect computation - #1470.
     it.skip("Label orientation can be changed after label is created", function () {
         var svg = TestMethods.generateSVG(400, 400);
-        var label = new Plottable.Components.Label("CHANGING ORIENTATION");
-        label.classed(Plottable.Components.Label.AXIS_LABEL_CLASS, true);
+        var label = new Plottable.Components.AxisLabel("CHANGING ORIENTATION");
         label.renderTo(svg);
         var content = label._content;
         var text = content.select("text");


### PR DESCRIPTION
(Reverts 4aff28b80635da2f7ac1ab6b22db88e2d3474e00)

Basically, the syntactic sugar of being able to say
```Typescript
var title = new Plottable.Components.TitleLabel("My Title");
```
instead of
```Typescript
var title = new Plottable.Components.Label("My Title").classed(Plottable.Components.Label.TITLE_LABEL_CLASS, true);
```