### PR TITLE
[Plot] - removing generateProjectors

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2468,16 +2468,6 @@ declare module Plottable {
         attr<A>(attr: string, attrValue: A | Accessor<A>, scale: Scale<A, number | string>): Plot;
         protected _bindProperty(property: string, value: any, scale: Scale<any, any>): void;
         protected _generateAttrToProjector(): AttributeToProjector;
-        /**
-         * Generates a dictionary mapping an attribute to a function that calculate that attribute's value
-         * in accordance with the given datasetKey.
-         *
-         * Note that this will return all of the data attributes, which may not perfectly align to svg attributes
-         *
-         * @param {Dataset} dataset The dataset to generate the dictionary for
-         * @returns {AttributeToAppliedProjector} A dictionary mapping attributes to functions
-         */
-        generateProjectors(dataset: Dataset): AttributeToAppliedProjector;
         renderImmediately(): Plot;
         /**
          * Enables or disables animation.

--- a/plottable.js
+++ b/plottable.js
@@ -6209,30 +6209,6 @@ var Plottable;
             });
             return h;
         };
-        /**
-         * Generates a dictionary mapping an attribute to a function that calculate that attribute's value
-         * in accordance with the given datasetKey.
-         *
-         * Note that this will return all of the data attributes, which may not perfectly align to svg attributes
-         *
-         * @param {Dataset} dataset The dataset to generate the dictionary for
-         * @returns {AttributeToAppliedProjector} A dictionary mapping attributes to functions
-         */
-        Plot.prototype.generateProjectors = function (dataset) {
-            var attrToAppliedProjector = {};
-            var datasetKey = this._keyForDataset(dataset);
-            if (datasetKey != null) {
-                var attrToProjector = this._generateAttrToProjector();
-                var plotDatasetKey = this._key2PlotDatasetKey.get(datasetKey);
-                var plotMetadata = plotDatasetKey.plotMetadata;
-                d3.entries(attrToProjector).forEach(function (keyValue) {
-                    attrToAppliedProjector[keyValue.key] = function (datum, index) {
-                        return keyValue.value(datum, index, plotDatasetKey.dataset, plotMetadata);
-                    };
-                });
-            }
-            return attrToAppliedProjector;
-        };
         Plot.prototype.renderImmediately = function () {
             if (this._isAnchored) {
                 this._paint();

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -196,31 +196,6 @@ module Plottable {
       return h;
     }
 
-    /**
-     * Generates a dictionary mapping an attribute to a function that calculate that attribute's value
-     * in accordance with the given datasetKey.
-     *
-     * Note that this will return all of the data attributes, which may not perfectly align to svg attributes
-     *
-     * @param {Dataset} dataset The dataset to generate the dictionary for
-     * @returns {AttributeToAppliedProjector} A dictionary mapping attributes to functions
-     */
-    public generateProjectors(dataset: Dataset): AttributeToAppliedProjector {
-      var attrToAppliedProjector: AttributeToAppliedProjector = {};
-      var datasetKey = this._keyForDataset(dataset);
-      if (datasetKey != null) {
-        var attrToProjector = this._generateAttrToProjector();
-        var plotDatasetKey = this._key2PlotDatasetKey.get(datasetKey);
-        var plotMetadata = plotDatasetKey.plotMetadata;
-        d3.entries(attrToProjector).forEach((keyValue: any) => {
-          attrToAppliedProjector[keyValue.key] = (datum: any, index: number) => {
-            return keyValue.value(datum, index, plotDatasetKey.dataset, plotMetadata);
-          };
-        });
-      }
-      return attrToAppliedProjector;
-    }
-
     public renderImmediately() {
       if (this._isAnchored) {
         this._paint();


### PR DESCRIPTION
This function basically became redundant now that we have a nice `attr()` getter as well as appropriate property getters