### PR TITLE
Fixes to autodomain logic.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -806,7 +806,7 @@ declare module Plottable {
          * numbers.
          */
         _niceDomain(domain: D[], count?: number): D[];
-        _defaultExtent(): D[];
+        protected _defaultExtent(): D[];
         /**
          * Gets the tick generator of the QuantitativeScale.
          *
@@ -838,7 +838,7 @@ declare module Plottable {
              */
             constructor();
             constructor(scale: D3.Scale.LinearScale);
-            _defaultExtent(): number[];
+            protected _defaultExtent(): number[];
             protected _expandSingleValueDomain(singleValueDomain: number[]): number[];
         }
     }
@@ -896,7 +896,7 @@ declare module Plottable {
              * @returns {ModifiedLog} The calling ModifiedLog.
              */
             showIntermediateTicks(show: boolean): ModifiedLog;
-            _defaultExtent(): number[];
+            protected _defaultExtent(): number[];
             protected _expandSingleValueDomain(singleValueDomain: number[]): number[];
         }
     }
@@ -1021,7 +1021,7 @@ declare module Plottable {
              */
             tickInterval(interval: string, step?: number): Date[];
             protected _setDomain(values: Date[]): void;
-            _defaultExtent(): Date[];
+            protected _defaultExtent(): Date[];
             protected _expandSingleValueDomain(singleValueDomain: Date[]): Date[];
         }
     }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -704,7 +704,7 @@ declare module Plottable {
          * @returns {Scale} The calling Scale.
          */
         autoDomain(): Scale<D, R>;
-        _autoDomainIfAutomaticMode(): void;
+        protected _autoDomainIfAutomaticMode(): void;
         /**
          * Computes the range value corresponding to a given domain value. In other
          * words, apply the function to value.

--- a/plottable.js
+++ b/plottable.js
@@ -1446,10 +1446,12 @@ var Plottable;
         };
         Scale.prototype.addExtentsProvider = function (provider) {
             this._extentsProviders.add(provider);
+            this._autoDomainIfAutomaticMode();
             return this;
         };
         Scale.prototype.removeExtentsProvider = function (provider) {
             this._extentsProviders.delete(provider);
+            this._autoDomainIfAutomaticMode();
             return this;
         };
         return Scale;
@@ -6196,7 +6198,7 @@ var Plottable;
             var _this = this;
             this._attrBindings.forEach(function (attr) { return _this._updateExtentsForAttr(attr); });
             this._propertyExtents.forEach(function (property) { return _this._updateExtentsForProperty(property); });
-            this._scales().forEach(function (scale) { return scale._autoDomainIfAutomaticMode(); });
+            this._scales().forEach(function (scale) { return scale.addExtentsProvider(_this._extentsProvider); });
         };
         Plot.prototype._updateExtentsForAttr = function (attr) {
             // Filters should never be applied to attributes
@@ -6457,12 +6459,10 @@ var Plottable;
         Plot.prototype._uninstallScaleForKey = function (scale, key) {
             scale.offUpdate(this._renderCallback);
             scale.removeExtentsProvider(this._extentsProvider);
-            scale._autoDomainIfAutomaticMode();
         };
         Plot.prototype._installScaleForKey = function (scale, key) {
             scale.onUpdate(this._renderCallback);
             scale.addExtentsProvider(this._extentsProvider);
-            scale._autoDomainIfAutomaticMode();
         };
         Plot.prototype._generatePropertyToProjectors = function () {
             var attrToProjector = {};

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -273,7 +273,7 @@ module Plottable {
     protected _updateExtents() {
       this._attrBindings.forEach((attr) => this._updateExtentsForAttr(attr));
       this._propertyExtents.forEach((property) => this._updateExtentsForProperty(property));
-      this._scales().forEach((scale) => scale._autoDomainIfAutomaticMode());
+      this._scales().forEach((scale) => scale.addExtentsProvider(this._extentsProvider));
     }
 
     private _updateExtentsForAttr(attr: string) {
@@ -574,13 +574,11 @@ module Plottable {
     protected _uninstallScaleForKey(scale: Scale<any, any>, key: string) {
       scale.offUpdate(this._renderCallback);
       scale.removeExtentsProvider(this._extentsProvider);
-      scale._autoDomainIfAutomaticMode();
     }
 
     protected _installScaleForKey(scale: Scale<any, any>, key: string) {
       scale.onUpdate(this._renderCallback);
       scale.addExtentsProvider(this._extentsProvider);
-      scale._autoDomainIfAutomaticMode();
     }
 
     protected _generatePropertyToProjectors(): AttributeToProjector {

--- a/src/scales/linearScale.ts
+++ b/src/scales/linearScale.ts
@@ -19,7 +19,7 @@ export module Scales {
       super(scale == null ? d3.scale.linear() : scale);
     }
 
-    public _defaultExtent(): number[] {
+    protected _defaultExtent(): number[] {
       return [0, 1];
     }
 

--- a/src/scales/modifiedLogScale.ts
+++ b/src/scales/modifiedLogScale.ts
@@ -200,7 +200,7 @@ export module Scales {
       }
     }
 
-    public _defaultExtent(): number[] {
+    protected _defaultExtent(): number[] {
       return [0, this._base];
     }
 

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -155,7 +155,7 @@ module Plottable {
       return this._d3Scale.copy().domain(domain).nice(count).domain();
     }
 
-    public _defaultExtent(): D[] {
+    protected _defaultExtent(): D[] {
       throw Error("The quantitative scale itself does not have a default extent");
     }
 

--- a/src/scales/scale.ts
+++ b/src/scales/scale.ts
@@ -79,7 +79,7 @@ module Plottable {
       return this;
     }
 
-    public _autoDomainIfAutomaticMode() {
+    protected _autoDomainIfAutomaticMode() {
       if (this._autoDomainAutomatically) {
         this.autoDomain();
       }
@@ -167,11 +167,13 @@ module Plottable {
 
     public addExtentsProvider(provider: Scales.ExtentsProvider<D>) {
       this._extentsProviders.add(provider);
+      this._autoDomainIfAutomaticMode();
       return this;
     }
 
     public removeExtentsProvider(provider: Scales.ExtentsProvider<D>) {
       this._extentsProviders.delete(provider);
+      this._autoDomainIfAutomaticMode();
       return this;
     }
   }

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -42,7 +42,7 @@ export module Scales {
       return super._setDomain(values);
     }
 
-    public _defaultExtent(): Date[] {
+    protected _defaultExtent(): Date[] {
       var endTimeValue = new Date().valueOf();
       var startTimeValue = endTimeValue - MILLISECONDS_IN_ONE_DAY;
       return [new Date(startTimeValue), new Date(endTimeValue)];

--- a/test/scales/modifiedLogScaleTests.ts
+++ b/test/scales/modifiedLogScaleTests.ts
@@ -55,14 +55,12 @@ describe("Scales", () => {
       scale.padProportion(0);
       var singleValue = 15;
       scale.addExtentsProvider((scale: Plottable.Scales.ModifiedLog) => [[singleValue, singleValue]]);
-      scale.autoDomain();
       assert.deepEqual(scale.domain(), [singleValue / base, singleValue * base], "single-value extent was expanded");
     });
 
     it("gives reasonable values for ticks()", () => {
       var providedExtents = [[0, base / 2]];
       scale.addExtentsProvider((scale: Plottable.Scale<number, number>) => providedExtents);
-      scale.autoDomain();
       var ticks = scale.ticks();
       assert.operator(ticks.length, ">", 0);
 

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -91,11 +91,9 @@ describe("Scales", () => {
 
     it("addExtentsProvider()", () => {
       scale.addExtentsProvider((scale: Plottable.Scale<number, number>) => [[0, 10]]);
-      scale.autoDomain();
       assert.deepEqual(scale.domain(), [0, 10], "scale domain accounts for first provider");
 
       scale.addExtentsProvider((scale: Plottable.Scale<number, number>) => [[-10, 0]]);
-      scale.autoDomain();
       assert.deepEqual(scale.domain(), [-10, 10], "scale domain accounts for second provider");
     });
 
@@ -104,11 +102,9 @@ describe("Scales", () => {
       scale.addExtentsProvider(posProvider);
       var negProvider = (scale: Plottable.Scale<number, number>) => [[-10, 0]];
       scale.addExtentsProvider(negProvider);
-      scale.autoDomain();
       assert.deepEqual(scale.domain(), [-10, 10], "scale domain accounts for both providers");
 
       scale.removeExtentsProvider(negProvider);
-      scale.autoDomain();
       assert.deepEqual(scale.domain(), [0, 10], "scale domain only accounts for remaining provider");
     });
 
@@ -153,7 +149,6 @@ describe("Scales", () => {
       scale.padProportion(0);
       var singleValue = 15;
       scale.addExtentsProvider((scale: Plottable.Scales.Linear) => [[singleValue, singleValue]]);
-      scale.autoDomain();
       assert.deepEqual(scale.domain(), [singleValue - 1, singleValue + 1], "single-value extent was expanded");
     });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -6968,10 +6968,8 @@ describe("Scales", function () {
         });
         it("addExtentsProvider()", function () {
             scale.addExtentsProvider(function (scale) { return [[0, 10]]; });
-            scale.autoDomain();
             assert.deepEqual(scale.domain(), [0, 10], "scale domain accounts for first provider");
             scale.addExtentsProvider(function (scale) { return [[-10, 0]]; });
-            scale.autoDomain();
             assert.deepEqual(scale.domain(), [-10, 10], "scale domain accounts for second provider");
         });
         it("removeExtentsProvider()", function () {
@@ -6979,10 +6977,8 @@ describe("Scales", function () {
             scale.addExtentsProvider(posProvider);
             var negProvider = function (scale) { return [[-10, 0]]; };
             scale.addExtentsProvider(negProvider);
-            scale.autoDomain();
             assert.deepEqual(scale.domain(), [-10, 10], "scale domain accounts for both providers");
             scale.removeExtentsProvider(negProvider);
-            scale.autoDomain();
             assert.deepEqual(scale.domain(), [0, 10], "scale domain only accounts for remaining provider");
         });
         it("should resize when a plot is removed", function () {
@@ -7024,7 +7020,6 @@ describe("Scales", function () {
             scale.padProportion(0);
             var singleValue = 15;
             scale.addExtentsProvider(function (scale) { return [[singleValue, singleValue]]; });
-            scale.autoDomain();
             assert.deepEqual(scale.domain(), [singleValue - 1, singleValue + 1], "single-value extent was expanded");
         });
         it("domain can't include NaN or Infinity", function () {
@@ -7256,13 +7251,11 @@ describe("Scales", function () {
             scale.padProportion(0);
             var singleValue = 15;
             scale.addExtentsProvider(function (scale) { return [[singleValue, singleValue]]; });
-            scale.autoDomain();
             assert.deepEqual(scale.domain(), [singleValue / base, singleValue * base], "single-value extent was expanded");
         });
         it("gives reasonable values for ticks()", function () {
             var providedExtents = [[0, base / 2]];
             scale.addExtentsProvider(function (scale) { return providedExtents; });
-            scale.autoDomain();
             var ticks = scale.ticks();
             assert.operator(ticks.length, ">", 0);
             providedExtents = [[-base * 2, base * 2]];


### PR DESCRIPTION
Adding or removing an `ExtentsProvider` now causes the scale to `autoDomain()` if it's in automatic mode.

Made `_autoDomainIfAutomaticMode()` `protected`.

Made `_defaultExtent()` protected.

Addresses #2057, which I will close when this makes it to **develop**.