### PR TITLE
[Plot] - propertyToProjectors handled on a subclass basis

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2531,6 +2531,7 @@ declare module Plottable {
         protected _uninstallScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _installScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _generatePropertyToProjectors(): AttributeToProjector;
+        protected static _scaledAccessor<D, R>(binding: Plots.AccessorScaleBinding<D, R>): Accessor<any>;
     }
 }
 
@@ -2557,6 +2558,7 @@ declare module Plottable {
             outerRadius<R>(): AccessorScaleBinding<R, number>;
             outerRadius(outerRadius: number | Accessor<number>): Plots.Pie;
             outerRadius<R>(outerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Pie;
+            protected _generatePropertyToProjectors(): AttributeToProjector;
         }
     }
 }
@@ -2651,6 +2653,7 @@ declare module Plottable {
             y2(): AccessorScaleBinding<Y, number>;
             y2(y2: number | Accessor<number>): Plots.Rectangle<X, Y>;
             y2(y2: Y | Accessor<Y>, scale: Scale<Y, number>): Plots.Rectangle<X, Y>;
+            protected _generatePropertyToProjectors(): AttributeToProjector;
         }
     }
 }
@@ -2885,6 +2888,7 @@ declare module Plottable {
             protected _updateYDomainer(): void;
             protected _getResetYFunction(): (datum: any, index: number, dataset: Dataset) => any;
             protected _wholeDatumAttributes(): string[];
+            protected _generatePropertyToProjectors(): AttributeToProjector;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -6499,12 +6499,10 @@ var Plottable;
             scale._autoDomainIfAutomaticMode();
         };
         Plot.prototype._generatePropertyToProjectors = function () {
-            var attrToProjector = {};
-            this._propertyBindings.forEach(function (key, binding) {
-                var scaledAccessor = function (d, i, dataset) { return binding.scale.scale(binding.accessor(d, i, dataset)); };
-                attrToProjector[key] = binding.scale == null ? binding.accessor : scaledAccessor;
-            });
-            return attrToProjector;
+            return {};
+        };
+        Plot._scaledAccessor = function (binding) {
+            return binding.scale == null ? binding.accessor : function (d, i, ds) { return binding.scale.scale(binding.accessor(d, i, ds)); };
         };
         return Plot;
     })(Plottable.Component);
@@ -6597,6 +6595,13 @@ var Plottable;
                 this._bindProperty(Pie._OUTER_RADIUS_KEY, outerRadius, scale);
                 this.renderImmediately();
                 return this;
+            };
+            Pie.prototype._generatePropertyToProjectors = function () {
+                var attrToProjector = _super.prototype._generatePropertyToProjectors.call(this);
+                attrToProjector[Pie._INNER_RADIUS_KEY] = Plottable.Plot._scaledAccessor(this.innerRadius());
+                attrToProjector[Pie._OUTER_RADIUS_KEY] = Plottable.Plot._scaledAccessor(this.outerRadius());
+                attrToProjector[Pie._SECTOR_VALUE_KEY] = Plottable.Plot._scaledAccessor(this.sectorValue());
+                return attrToProjector;
             };
             Pie._INNER_RADIUS_KEY = "inner-radius";
             Pie._OUTER_RADIUS_KEY = "outer-radius";
@@ -6741,12 +6746,13 @@ var Plottable;
             return this;
         };
         XYPlot.prototype._generatePropertyToProjectors = function () {
+            var _this = this;
             var attrToProjector = _super.prototype._generatePropertyToProjectors.call(this);
-            var positionXFn = attrToProjector["x"];
-            var positionYFn = attrToProjector["y"];
+            attrToProjector["x"] = Plottable.Plot._scaledAccessor(this.x());
+            attrToProjector["y"] = Plottable.Plot._scaledAccessor(this.y());
             attrToProjector["defined"] = function (d, i, dataset) {
-                var positionX = positionXFn(d, i, dataset);
-                var positionY = positionYFn(d, i, dataset);
+                var positionX = Plottable.Plot._scaledAccessor(_this.x())(d, i, dataset);
+                var positionY = Plottable.Plot._scaledAccessor(_this.y())(d, i, dataset);
                 return positionX != null && positionX === positionX && positionY != null && positionY === positionY;
             };
             return attrToProjector;
@@ -6922,6 +6928,14 @@ var Plottable;
                 this._bindProperty(Rectangle._Y2_KEY, y2, scale);
                 this.renderImmediately();
                 return this;
+            };
+            Rectangle.prototype._generatePropertyToProjectors = function () {
+                var attrToProjector = _super.prototype._generatePropertyToProjectors.call(this);
+                attrToProjector["x1"] = Plottable.Plot._scaledAccessor(this.x1());
+                attrToProjector["y2"] = Plottable.Plot._scaledAccessor(this.y2());
+                attrToProjector["x2"] = Plottable.Plot._scaledAccessor(this.x2());
+                attrToProjector["y1"] = Plottable.Plot._scaledAccessor(this.y1());
+                return attrToProjector;
             };
             Rectangle._X1_KEY = "x1";
             Rectangle._X2_KEY = "x2";
@@ -7730,6 +7744,11 @@ var Plottable;
                 var wholeDatumAttributes = _super.prototype._wholeDatumAttributes.call(this);
                 wholeDatumAttributes.push("y0");
                 return wholeDatumAttributes;
+            };
+            Area.prototype._generatePropertyToProjectors = function () {
+                var attrToProjector = _super.prototype._generatePropertyToProjectors.call(this);
+                attrToProjector["y0"] = Plottable.Plot._scaledAccessor(this.y0());
+                return attrToProjector;
             };
             Area._Y0_KEY = "y0";
             return Area;

--- a/src/components/plots/areaPlot.ts
+++ b/src/components/plots/areaPlot.ts
@@ -82,6 +82,13 @@ export module Plots {
       wholeDatumAttributes.push("y0");
       return wholeDatumAttributes;
     }
+
+    protected _generatePropertyToProjectors(): AttributeToProjector {
+      var attrToProjector = super._generatePropertyToProjectors();
+      attrToProjector["y0"] = Plot._scaledAccessor(this.y0());
+      return attrToProjector;
+    }
+
   }
 }
 }

--- a/src/components/plots/piePlot.ts
+++ b/src/components/plots/piePlot.ts
@@ -97,6 +97,14 @@ export module Plots {
       this.renderImmediately();
       return this;
     }
+
+    protected _generatePropertyToProjectors(): AttributeToProjector {
+      var attrToProjector = super._generatePropertyToProjectors();
+      attrToProjector[Pie._INNER_RADIUS_KEY] = Plot._scaledAccessor(this.innerRadius());
+      attrToProjector[Pie._OUTER_RADIUS_KEY] = Plot._scaledAccessor(this.outerRadius());
+      attrToProjector[Pie._SECTOR_VALUE_KEY] = Plot._scaledAccessor(this.sectorValue());
+      return attrToProjector;
+    }
   }
 }
 }

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -564,12 +564,13 @@ module Plottable {
     }
 
     protected _generatePropertyToProjectors(): AttributeToProjector {
-      var attrToProjector: AttributeToProjector = {};
-      this._propertyBindings.forEach((key, binding) => {
-        var scaledAccessor = (d: any, i: number, dataset: Dataset) => binding.scale.scale(binding.accessor(d, i, dataset));
-        attrToProjector[key] = binding.scale == null ? binding.accessor : scaledAccessor;
-      });
-      return attrToProjector;
+      return {};
+    }
+
+    protected static _scaledAccessor<D, R>(binding: Plots.AccessorScaleBinding<D, R>) {
+      return binding.scale == null ?
+               binding.accessor :
+               (d: any, i: number, ds: Dataset) => binding.scale.scale(binding.accessor(d, i, ds));
     }
   }
 }

--- a/src/components/plots/rectanglePlot.ts
+++ b/src/components/plots/rectanglePlot.ts
@@ -108,6 +108,15 @@ export module Plots {
       this.renderImmediately();
       return this;
     }
+
+    protected _generatePropertyToProjectors(): AttributeToProjector {
+      var attrToProjector = super._generatePropertyToProjectors();
+      attrToProjector["x1"] = Plot._scaledAccessor(this.x1());
+      attrToProjector["y2"] = Plot._scaledAccessor(this.y2());
+      attrToProjector["x2"] = Plot._scaledAccessor(this.x2());
+      attrToProjector["y1"] = Plot._scaledAccessor(this.y1());
+      return attrToProjector;
+    }
   }
 }
 }

--- a/src/components/plots/xyPlot.ts
+++ b/src/components/plots/xyPlot.ts
@@ -153,11 +153,11 @@ module Plottable {
 
     protected _generatePropertyToProjectors(): AttributeToProjector {
       var attrToProjector = super._generatePropertyToProjectors();
-      var positionXFn = attrToProjector["x"];
-      var positionYFn = attrToProjector["y"];
+      attrToProjector["x"] = Plot._scaledAccessor(this.x());
+      attrToProjector["y"] = Plot._scaledAccessor(this.y());
       attrToProjector["defined"] = (d: any, i: number, dataset: Dataset) => {
-        var positionX = positionXFn(d, i, dataset);
-        var positionY = positionYFn(d, i, dataset);
+        var positionX = Plot._scaledAccessor(this.x())(d, i, dataset);
+        var positionY = Plot._scaledAccessor(this.y())(d, i, dataset);
         return positionX != null && positionX === positionX &&
                positionY != null && positionY === positionY;
       };


### PR DESCRIPTION
Found that in order to move the calculation from the `Drawer`s to the `Plot`s it would be significantly easier if each subclass were to just define the junk attributes themselves and then I can clean them up steadily in a much more obvious manner