### PR TITLE
No longer allowed to change Bar Plot orientation after construction

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2740,10 +2740,6 @@ declare module Plottable {
 
 
 declare module Plottable {
-    class Orientation {
-        static VERTICAL: string;
-        static HORIZONTAL: string;
-    }
     module Plots {
         class Bar<X, Y> extends XYPlot<X, Y> {
             protected static _BarAlignmentToFactor: {
@@ -2757,8 +2753,9 @@ declare module Plottable {
              * @constructor
              * @param {Scale} xScale The x scale to use.
              * @param {Scale} yScale The y scale to use.
+             * @param {boolean} isVertical if the plot if vertical.
              */
-            constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>);
+            constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, isVertical?: boolean);
             protected _getDrawer(key: string): Drawers.Rect;
             protected _setup(): void;
             /**
@@ -2846,20 +2843,6 @@ declare module Plottable {
             protected _generateAttrToProjector(): {
                 [attrToSet: string]: (datum: any, index: number, dataset: Dataset) => any;
             };
-            /**
-             * Gets the orientation of the Plots.Bar.
-             *
-             * @returns {string} the current orientation.
-             */
-            orientation(): string;
-            /**
-             * Sets the orientation of the Plots.Bar.
-             *
-             * @param {string} orientation The desired orientation
-             * (horizontal/vertical).
-             * @returns {Plots.Bar} The calling Plots.Bar.
-             */
-            orientation(orientation: string): Plots.Bar<X, Y>;
             /**
              * Computes the barPixelWidth of all the bars in the plot.
              *
@@ -2950,8 +2933,9 @@ declare module Plottable {
              * @constructor
              * @param {Scale} xScale The x scale to use.
              * @param {Scale} yScale The y scale to use.
+             * @param {boolean} isVertical if the plot if vertical.
              */
-            constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>);
+            constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, isVertical?: boolean);
             protected _generateAttrToProjector(): {
                 [attrToSet: string]: (datum: any, index: number, dataset: Dataset) => any;
             };
@@ -3027,8 +3011,9 @@ declare module Plottable {
              * @constructor
              * @param {Scale} xScale the x scale of the plot.
              * @param {Scale} yScale the y scale of the plot.
+             * @param {boolean} isVertical if the plot if vertical.
              */
-            constructor(xScale?: Scale<X, number>, yScale?: Scale<Y, number>);
+            constructor(xScale?: Scale<X, number>, yScale?: Scale<Y, number>, isVertical?: boolean);
             protected _getAnimator(key: string): Animators.PlotAnimator;
             x(x?: number | Accessor<number> | X | Accessor<X>, xScale?: Scale<X, number>): any;
             y(y?: number | Accessor<number> | Y | Accessor<Y>, yScale?: Scale<Y, number>): any;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2742,20 +2742,22 @@ declare module Plottable {
 declare module Plottable {
     module Plots {
         class Bar<X, Y> extends XYPlot<X, Y> {
+            static ORIENTATION_VERTICAL: string;
+            static ORIENTATION_HORIZONTAL: string;
             protected static _BarAlignmentToFactor: {
                 [alignment: string]: number;
             };
             protected static _DEFAULT_WIDTH: number;
             protected _isVertical: boolean;
             /**
-             * Constructs a BarPlot.
+             * Constructs a Bar Plot.
              *
              * @constructor
              * @param {Scale} xScale The x scale to use.
              * @param {Scale} yScale The y scale to use.
-             * @param {boolean} isVertical if the plot if vertical.
+             * @param {string} orientation The orientation of the Bar Plot ("vertical"/"horizontal").
              */
-            constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, isVertical?: boolean);
+            constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, orientation?: string);
             protected _getDrawer(key: string): Drawers.Rect;
             protected _setup(): void;
             /**
@@ -2933,9 +2935,9 @@ declare module Plottable {
              * @constructor
              * @param {Scale} xScale The x scale to use.
              * @param {Scale} yScale The y scale to use.
-             * @param {boolean} isVertical if the plot if vertical.
+             * @param {string} orientation The orientation of the Bar Plot ("vertical"/"horizontal").
              */
-            constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, isVertical?: boolean);
+            constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, orientation?: string);
             protected _generateAttrToProjector(): {
                 [attrToSet: string]: (datum: any, index: number, dataset: Dataset) => any;
             };
@@ -3011,9 +3013,9 @@ declare module Plottable {
              * @constructor
              * @param {Scale} xScale the x scale of the plot.
              * @param {Scale} yScale the y scale of the plot.
-             * @param {boolean} isVertical if the plot if vertical.
+             * @param {string} orientation The orientation of the Bar Plot ("vertical"/"horizontal").
              */
-            constructor(xScale?: Scale<X, number>, yScale?: Scale<Y, number>, isVertical?: boolean);
+            constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, orientation?: string);
             protected _getAnimator(key: string): Animators.PlotAnimator;
             x(x?: number | Accessor<number> | X | Accessor<X>, xScale?: Scale<X, number>): any;
             y(y?: number | Accessor<number> | Y | Accessor<Y>, yScale?: Scale<Y, number>): any;

--- a/plottable.js
+++ b/plottable.js
@@ -7252,14 +7252,6 @@ var __extends = this.__extends || function (d, b) {
 };
 var Plottable;
 (function (Plottable) {
-    var Orientation = (function () {
-        function Orientation() {
-        }
-        Orientation.VERTICAL = "vertical";
-        Orientation.HORIZONTAL = "horizontal";
-        return Orientation;
-    })();
-    Plottable.Orientation = Orientation;
     var Plots;
     (function (Plots) {
         var Bar = (function (_super) {
@@ -7270,9 +7262,11 @@ var Plottable;
              * @constructor
              * @param {Scale} xScale The x scale to use.
              * @param {Scale} yScale The y scale to use.
+             * @param {boolean} isVertical if the plot if vertical.
              */
-            function Bar(xScale, yScale) {
+            function Bar(xScale, yScale, isVertical) {
                 var _this = this;
+                if (isVertical === void 0) { isVertical = true; }
                 _super.call(this, xScale, yScale);
                 this._barAlignmentFactor = 0.5;
                 this._labelFormatter = Plottable.Formatters.identity();
@@ -7282,7 +7276,7 @@ var Plottable;
                 this.animator("bars-reset", new Plottable.Animators.Null());
                 this.animator("bars", new Plottable.Animators.Base());
                 this.animator("baseline", new Plottable.Animators.Null());
-                this._isVertical = true;
+                this._isVertical = isVertical;
                 this.baseline(0);
                 this.attr("fill", new Plottable.Scales.Color().range()[0]);
                 this.attr("width", function () { return _this._getBarPixelWidth(); });
@@ -7563,16 +7557,6 @@ var Plottable;
                     attrToProjector["positive"] = function (d, i, dataset) { return originalPositionFn(d, i, dataset) <= scaledBaseline; };
                 }
                 return attrToProjector;
-            };
-            Bar.prototype.orientation = function (orientation) {
-                if (orientation == null) {
-                    return this._isVertical ? Orientation.VERTICAL : Orientation.HORIZONTAL;
-                }
-                else {
-                    this._isVertical = orientation === Orientation.VERTICAL;
-                    this.render();
-                    return this;
-                }
             };
             /**
              * Computes the barPixelWidth of all the bars in the plot.
@@ -7904,9 +7888,11 @@ var Plottable;
              * @constructor
              * @param {Scale} xScale The x scale to use.
              * @param {Scale} yScale The y scale to use.
+             * @param {boolean} isVertical if the plot if vertical.
              */
-            function ClusteredBar(xScale, yScale) {
-                _super.call(this, xScale, yScale);
+            function ClusteredBar(xScale, yScale, isVertical) {
+                if (isVertical === void 0) { isVertical = true; }
+                _super.call(this, xScale, yScale, isVertical);
                 this._clusterOffsets = new Plottable.Utils.Map();
             }
             ClusteredBar.prototype._generateAttrToProjector = function () {
@@ -8254,9 +8240,11 @@ var Plottable;
              * @constructor
              * @param {Scale} xScale the x scale of the plot.
              * @param {Scale} yScale the y scale of the plot.
+             * @param {boolean} isVertical if the plot if vertical.
              */
-            function StackedBar(xScale, yScale) {
-                _super.call(this, xScale, yScale);
+            function StackedBar(xScale, yScale, isVertical) {
+                if (isVertical === void 0) { isVertical = true; }
+                _super.call(this, xScale, yScale, isVertical);
                 this._stackOffsets = new Plottable.Utils.Map();
                 this._stackedExtent = [];
             }

--- a/plottable.js
+++ b/plottable.js
@@ -7273,10 +7273,13 @@ var Plottable;
                 this._labelsEnabled = false;
                 this._hideBarsIfAnyAreTooWide = true;
                 this.classed("bar-plot", true);
+                if (orientation !== Bar.ORIENTATION_VERTICAL && orientation !== Bar.ORIENTATION_HORIZONTAL) {
+                    throw new Error(orientation + " is not a valid orientation for Plots.Bar");
+                }
+                this._isVertical = orientation === Bar.ORIENTATION_VERTICAL;
                 this.animator("bars-reset", new Plottable.Animators.Null());
                 this.animator("bars", new Plottable.Animators.Base());
                 this.animator("baseline", new Plottable.Animators.Null());
-                this._isVertical = orientation === Bar.ORIENTATION_VERTICAL;
                 this.baseline(0);
                 this.attr("fill", new Plottable.Scales.Color().range()[0]);
                 this.attr("width", function () { return _this._getBarPixelWidth(); });

--- a/plottable.js
+++ b/plottable.js
@@ -7257,16 +7257,16 @@ var Plottable;
         var Bar = (function (_super) {
             __extends(Bar, _super);
             /**
-             * Constructs a BarPlot.
+             * Constructs a Bar Plot.
              *
              * @constructor
              * @param {Scale} xScale The x scale to use.
              * @param {Scale} yScale The y scale to use.
-             * @param {boolean} isVertical if the plot if vertical.
+             * @param {string} orientation The orientation of the Bar Plot ("vertical"/"horizontal").
              */
-            function Bar(xScale, yScale, isVertical) {
+            function Bar(xScale, yScale, orientation) {
                 var _this = this;
-                if (isVertical === void 0) { isVertical = true; }
+                if (orientation === void 0) { orientation = Bar.ORIENTATION_VERTICAL; }
                 _super.call(this, xScale, yScale);
                 this._barAlignmentFactor = 0.5;
                 this._labelFormatter = Plottable.Formatters.identity();
@@ -7276,7 +7276,7 @@ var Plottable;
                 this.animator("bars-reset", new Plottable.Animators.Null());
                 this.animator("bars", new Plottable.Animators.Base());
                 this.animator("baseline", new Plottable.Animators.Null());
-                this._isVertical = isVertical;
+                this._isVertical = orientation === Bar.ORIENTATION_VERTICAL;
                 this.baseline(0);
                 this.attr("fill", new Plottable.Scales.Color().range()[0]);
                 this.attr("width", function () { return _this._getBarPixelWidth(); });
@@ -7626,6 +7626,8 @@ var Plottable;
                 });
                 return plotData;
             };
+            Bar.ORIENTATION_VERTICAL = "vertical";
+            Bar.ORIENTATION_HORIZONTAL = "horizontal";
             Bar._BarAlignmentToFactor = { "left": 0, "center": 0.5, "right": 1 };
             Bar._DEFAULT_WIDTH = 10;
             Bar._BAR_WIDTH_RATIO = 0.95;
@@ -7888,11 +7890,11 @@ var Plottable;
              * @constructor
              * @param {Scale} xScale The x scale to use.
              * @param {Scale} yScale The y scale to use.
-             * @param {boolean} isVertical if the plot if vertical.
+             * @param {string} orientation The orientation of the Bar Plot ("vertical"/"horizontal").
              */
-            function ClusteredBar(xScale, yScale, isVertical) {
-                if (isVertical === void 0) { isVertical = true; }
-                _super.call(this, xScale, yScale, isVertical);
+            function ClusteredBar(xScale, yScale, orientation) {
+                if (orientation === void 0) { orientation = Plots.Bar.ORIENTATION_VERTICAL; }
+                _super.call(this, xScale, yScale, orientation);
                 this._clusterOffsets = new Plottable.Utils.Map();
             }
             ClusteredBar.prototype._generateAttrToProjector = function () {
@@ -8240,11 +8242,11 @@ var Plottable;
              * @constructor
              * @param {Scale} xScale the x scale of the plot.
              * @param {Scale} yScale the y scale of the plot.
-             * @param {boolean} isVertical if the plot if vertical.
+             * @param {string} orientation The orientation of the Bar Plot ("vertical"/"horizontal").
              */
-            function StackedBar(xScale, yScale, isVertical) {
-                if (isVertical === void 0) { isVertical = true; }
-                _super.call(this, xScale, yScale, isVertical);
+            function StackedBar(xScale, yScale, orientation) {
+                if (orientation === void 0) { orientation = Plots.Bar.ORIENTATION_VERTICAL; }
+                _super.call(this, xScale, yScale, orientation);
                 this._stackOffsets = new Plottable.Utils.Map();
                 this._stackedExtent = [];
             }

--- a/quicktests/overlaying/tests/animations/animate_horizontalBar.js
+++ b/quicktests/overlaying/tests/animations/animate_horizontalBar.js
@@ -17,9 +17,12 @@ function run(svg, data, Plottable) {
 
   var dataset = new Plottable.Dataset(data);
 
-  var hBarRenderer = new Plottable.Plots.Bar(xScale, yScale, false).addDataset(dataset);
+  var hBarRenderer = new Plottable.Plots.Bar(xScale, yScale, false);
+  if (typeof hBarRenderer.orientation === "function") {
+    hBarRenderer.orientation("horizontal");
+  }
+  hBarRenderer.addDataset(dataset);
   hBarRenderer.attr("opacity", 0.75);
-  hBarRenderer.orientation("horizontal");
   hBarRenderer.x(function(d) { return d.x; }, xScale);
   hBarRenderer.y(function(d) { return d.y; }, yScale);
   hBarRenderer.animate(doAnimate);

--- a/quicktests/overlaying/tests/animations/animate_horizontalBar.js
+++ b/quicktests/overlaying/tests/animations/animate_horizontalBar.js
@@ -17,7 +17,7 @@ function run(svg, data, Plottable) {
 
   var dataset = new Plottable.Dataset(data);
 
-  var hBarRenderer = new Plottable.Plots.Bar(xScale, yScale, false);
+  var hBarRenderer = new Plottable.Plots.Bar(xScale, yScale, "horizontal");
   if (typeof hBarRenderer.orientation === "function") {
     hBarRenderer.orientation("horizontal");
   }

--- a/quicktests/overlaying/tests/animations/animate_verticalBar.js
+++ b/quicktests/overlaying/tests/animations/animate_verticalBar.js
@@ -17,7 +17,7 @@ function run(svg, data, Plottable) {
   var yAxis = new Plottable.Axes.Numeric(yScale, "left");
 
   var dataset = new Plottable.Dataset(data);
-  var verticalBarPlot = new Plottable.Plots.Bar(xScale, yScale, true)
+  var verticalBarPlot = new Plottable.Plots.Bar(xScale, yScale, "vertical")
                               .addDataset(dataset)
                               .x(function(d) { return d.x; }, xScale)
                               .y(function(d) { return d.y; }, yScale)

--- a/quicktests/overlaying/tests/basic/basic_allPlots.js
+++ b/quicktests/overlaying/tests/basic/basic_allPlots.js
@@ -21,8 +21,8 @@ function run(svg, data, Plottable) {
     var scatterPlot = new Plottable.Plots.Scatter(xScale, yScale).addDataset(dataset).x(function(d) { return d.x; }, xScale).y(function(d) { return d.y; }, yScale);
     var linePlot = new Plottable.Plots.Line(xScale, yScale).addDataset(dataset).x(function(d) { return d.x; }, xScale).y(function(d) { return d.y; }, yScale);
     var areaPlot = new Plottable.Plots.Area(xScale, yScale).addDataset(dataset).x(function(d) { return d.x; }, xScale).y(function(d) { return d.y; }, yScale);
-    var vbarPlot = new Plottable.Plots.Bar(xScale, yScale, true).addDataset(dataset).x(function(d) { return d.x; }, xScale).y(function(d) { return d.y; }, yScale);
-    var hbarPlot = new Plottable.Plots.Bar(xScale, yScale, false).addDataset(dataset).x(function(d) { return d.x; }, xScale).y(function(d) { return d.y; }, yScale);
+    var vbarPlot = new Plottable.Plots.Bar(xScale, yScale, "vertical").addDataset(dataset).x(function(d) { return d.x; }, xScale).y(function(d) { return d.y; }, yScale);
+    var hbarPlot = new Plottable.Plots.Bar(xScale, yScale, "horizontal").addDataset(dataset).x(function(d) { return d.x; }, xScale).y(function(d) { return d.y; }, yScale);
     if (typeof hbarPlot.orientation === "function") {
       hbarPlot.orientation("horizontal");
     }

--- a/quicktests/overlaying/tests/basic/basic_allPlots.js
+++ b/quicktests/overlaying/tests/basic/basic_allPlots.js
@@ -22,7 +22,10 @@ function run(svg, data, Plottable) {
     var linePlot = new Plottable.Plots.Line(xScale, yScale).addDataset(dataset).x(function(d) { return d.x; }, xScale).y(function(d) { return d.y; }, yScale);
     var areaPlot = new Plottable.Plots.Area(xScale, yScale).addDataset(dataset).x(function(d) { return d.x; }, xScale).y(function(d) { return d.y; }, yScale);
     var vbarPlot = new Plottable.Plots.Bar(xScale, yScale, true).addDataset(dataset).x(function(d) { return d.x; }, xScale).y(function(d) { return d.y; }, yScale);
-    var hbarPlot = new Plottable.Plots.Bar(xScale, yScale, false).addDataset(dataset).x(function(d) { return d.x; }, xScale).y(function(d) { return d.y; }, yScale).orientation("horizontal");
+    var hbarPlot = new Plottable.Plots.Bar(xScale, yScale, false).addDataset(dataset).x(function(d) { return d.x; }, xScale).y(function(d) { return d.y; }, yScale);
+    if (typeof hbarPlot.orientation === "function") {
+      hbarPlot.orientation("horizontal");
+    }
 
     //title + legend
 

--- a/quicktests/overlaying/tests/basic/categoryAxis_timeAxis.js
+++ b/quicktests/overlaying/tests/basic/categoryAxis_timeAxis.js
@@ -15,7 +15,7 @@ function run(svg, data, Plottable) {
   var xScale = new Plottable.Scales.Time();
   var yScale = new Plottable.Scales.Category();
 
-  var hBarPlot = new Plottable.Plots.Bar(xScale, yScale, false);
+  var hBarPlot = new Plottable.Plots.Bar(xScale, yScale, "horizontal");
   if (typeof hBarPlot.orientation === "function") {
     hBarPlot.orientation("horizontal");
   }

--- a/quicktests/overlaying/tests/basic/categoryAxis_timeAxis.js
+++ b/quicktests/overlaying/tests/basic/categoryAxis_timeAxis.js
@@ -15,9 +15,11 @@ function run(svg, data, Plottable) {
   var xScale = new Plottable.Scales.Time();
   var yScale = new Plottable.Scales.Category();
 
-  var hBarPlot = new Plottable.Plots.Bar(xScale, yScale, false)
-    .addDataset(new Plottable.Dataset(data))
-    .orientation("horizontal")
+  var hBarPlot = new Plottable.Plots.Bar(xScale, yScale, false);
+  if (typeof hBarPlot.orientation === "function") {
+    hBarPlot.orientation("horizontal");
+  }
+  hBarPlot.addDataset(new Plottable.Dataset(data))
     .x(function (d) { return d3.time.format("%x").parse(d.x); }, xScale)
     .y(function(d) { return d.y; }, yScale);
 

--- a/quicktests/overlaying/tests/basic/negative_stacked_bar.js
+++ b/quicktests/overlaying/tests/basic/negative_stacked_bar.js
@@ -35,7 +35,7 @@ function run(svg, data, Plottable) {
   var dataset4 = new Plottable.Dataset(data[3]);
   var dataset5 = new Plottable.Dataset(data[4]);
 
-  var verticalPlot = new Plottable.Plots.StackedBar(xScale1, yScale1, true)
+  var verticalPlot = new Plottable.Plots.StackedBar(xScale1, yScale1, "vertical")
     .x(function(d) { return d.quarter; }, xScale1)
     .y(function(d) { return d.earnings; }, yScale1)
     .attr("fill", function(d) { return d.team; }, colorScale)
@@ -48,7 +48,7 @@ function run(svg, data, Plottable) {
     .labelFormatter(Plottable.Formatters.siSuffix())
     .animate(true);
 
-  var horizontalPlot = new Plottable.Plots.StackedBar(xScale2, yScale2, false);
+  var horizontalPlot = new Plottable.Plots.StackedBar(xScale2, yScale2, "horizontal");
   if (typeof horizontalPlot.orientation === "function") {
     horizontalPlot.orientation("horizontal");
   }

--- a/quicktests/overlaying/tests/basic/negative_stacked_bar.js
+++ b/quicktests/overlaying/tests/basic/negative_stacked_bar.js
@@ -48,10 +48,12 @@ function run(svg, data, Plottable) {
     .labelFormatter(Plottable.Formatters.siSuffix())
     .animate(true);
 
-  var horizontalPlot = new Plottable.Plots.StackedBar(xScale2, yScale2, false)
-    .x(function(d) { return d.earnings; }, xScale2)
+  var horizontalPlot = new Plottable.Plots.StackedBar(xScale2, yScale2, false);
+  if (typeof horizontalPlot.orientation === "function") {
+    horizontalPlot.orientation("horizontal");
+  }
+  horizontalPlot.x(function(d) { return d.earnings; }, xScale2)
     .y(function(d) { return d.quarter; }, yScale2)
-    .orientation("horizontal")
     .attr("fill", function(d) { return d.team; }, colorScale)
     .addDataset(dataset1)
     .addDataset(dataset2)

--- a/quicktests/overlaying/tests/interactions/interaction_BarHover.js
+++ b/quicktests/overlaying/tests/interactions/interaction_BarHover.js
@@ -15,7 +15,7 @@ function run(svg, data, Plottable) {
 
   var ds = new Plottable.Dataset(data, { foo: "!" });
 
-  var plot = new Plottable.Plots.Bar(xScale, yScale, true)
+  var plot = new Plottable.Plots.Bar(xScale, yScale, "vertical")
     .addDataset(ds)
     .x(function (d, i, dataset) { return d.name + dataset.metadata().foo; }, xScale)
     .y(function(d) { return d.y; }, yScale)

--- a/quicktests/overlaying/tests/realistic/rainfall_ClusteredBar.js
+++ b/quicktests/overlaying/tests/realistic/rainfall_ClusteredBar.js
@@ -18,7 +18,7 @@ function run(svg, data, Plottable){
   var xAxis = new Plottable.Axes.Category(xScale, "bottom");
   var yAxis = new Plottable.Axes.Numeric(yScale, "left");
 
-  var clusteredPlot = new Plottable.Plots.ClusteredBar(xScale, yScale, true)
+  var clusteredPlot = new Plottable.Plots.ClusteredBar(xScale, yScale, "vertical")
     .addDataset(new Plottable.Dataset(data[0]))
     .addDataset(new Plottable.Dataset(data[1]))
     .addDataset(new Plottable.Dataset(data[2]))

--- a/quicktests/overlaying/tests/realistic/stocks.js
+++ b/quicktests/overlaying/tests/realistic/stocks.js
@@ -85,7 +85,7 @@ function run(svg, data, Plottable) {
           var yAxis_diff = new Plottable.Axes.Numeric(yScale_diff, "left");
 
           var DAY_MILLIS = 24 * 60 * 60 * 1000;
-          var bar_diff = new Plottable.Plots.Bar(xScale, yScale_diff, true).animate(true)
+          var bar_diff = new Plottable.Plots.Bar(xScale, yScale_diff, "vertical").animate(true)
                                   .addDataset(new Plottable.Dataset(diffData))
                                   .x(function(d) { return d.Date; }, xScale)
                                   .y(function(d) { return d["net change"]; }, yScale_diff)

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -28,10 +28,13 @@ export module Plots {
     constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, orientation = Bar.ORIENTATION_VERTICAL) {
       super(xScale, yScale);
       this.classed("bar-plot", true);
+      if (orientation !== Bar.ORIENTATION_VERTICAL && orientation !== Bar.ORIENTATION_HORIZONTAL) {
+        throw new Error(orientation + " is not a valid orientation for Plots.Bar");
+      }
+      this._isVertical = orientation === Bar.ORIENTATION_VERTICAL;
       this.animator("bars-reset", new Animators.Null());
       this.animator("bars", new Animators.Base());
       this.animator("baseline", new Animators.Null());
-      this._isVertical = orientation === Bar.ORIENTATION_VERTICAL;
       this.baseline(0);
       this.attr("fill", new Scales.Color().range()[0]);
       this.attr("width", () => this._getBarPixelWidth());

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -1,10 +1,6 @@
 ///<reference path="../../reference.ts" />
 
 module Plottable {
-  export class Orientation {
-    public static VERTICAL = "vertical";
-    public static HORIZONTAL = "horizontal";
-  }
 export module Plots {
   export class Bar<X, Y> extends XYPlot<X, Y> {
     protected static _BarAlignmentToFactor: {[alignment: string]: number} = {"left": 0, "center": 0.5, "right": 1};
@@ -25,14 +21,15 @@ export module Plots {
      * @constructor
      * @param {Scale} xScale The x scale to use.
      * @param {Scale} yScale The y scale to use.
+     * @param {boolean} isVertical if the plot if vertical.
      */
-    constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>) {
+    constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, isVertical = true) {
       super(xScale, yScale);
       this.classed("bar-plot", true);
       this.animator("bars-reset", new Animators.Null());
       this.animator("bars", new Animators.Base());
       this.animator("baseline", new Animators.Null());
-      this._isVertical = true;
+      this._isVertical = isVertical;
       this.baseline(0);
       this.attr("fill", new Scales.Color().range()[0]);
       this.attr("width", () => this._getBarPixelWidth());
@@ -401,30 +398,6 @@ export module Plots {
       }
 
       return attrToProjector;
-    }
-
-    /**
-     * Gets the orientation of the Plots.Bar.
-     *
-     * @returns {string} the current orientation.
-     */
-    public orientation(): string;
-    /**
-     * Sets the orientation of the Plots.Bar.
-     *
-     * @param {string} orientation The desired orientation
-     * (horizontal/vertical).
-     * @returns {Plots.Bar} The calling Plots.Bar.
-     */
-    public orientation(orientation: string): Plots.Bar<X, Y>;
-    public orientation(orientation?: string): any {
-      if (orientation == null) {
-        return this._isVertical ? Orientation.VERTICAL : Orientation.HORIZONTAL;
-      } else {
-        this._isVertical = orientation === Orientation.VERTICAL;
-        this.render();
-        return this;
-      }
     }
 
     /**

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -3,6 +3,8 @@
 module Plottable {
 export module Plots {
   export class Bar<X, Y> extends XYPlot<X, Y> {
+    public static ORIENTATION_VERTICAL = "vertical";
+    public static ORIENTATION_HORIZONTAL = "horizontal";
     protected static _BarAlignmentToFactor: {[alignment: string]: number} = {"left": 0, "center": 0.5, "right": 1};
     protected static _DEFAULT_WIDTH = 10;
     private static _BAR_WIDTH_RATIO = 0.95;
@@ -16,20 +18,20 @@ export module Plots {
     private _hideBarsIfAnyAreTooWide = true;
 
     /**
-     * Constructs a BarPlot.
+     * Constructs a Bar Plot.
      *
      * @constructor
      * @param {Scale} xScale The x scale to use.
      * @param {Scale} yScale The y scale to use.
-     * @param {boolean} isVertical if the plot if vertical.
+     * @param {string} orientation The orientation of the Bar Plot ("vertical"/"horizontal").
      */
-    constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, isVertical = true) {
+    constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, orientation = Bar.ORIENTATION_VERTICAL) {
       super(xScale, yScale);
       this.classed("bar-plot", true);
       this.animator("bars-reset", new Animators.Null());
       this.animator("bars", new Animators.Base());
       this.animator("baseline", new Animators.Null());
-      this._isVertical = isVertical;
+      this._isVertical = orientation === Bar.ORIENTATION_VERTICAL;
       this.baseline(0);
       this.attr("fill", new Scales.Color().range()[0]);
       this.attr("width", () => this._getBarPixelWidth());

--- a/src/components/plots/clusteredBarPlot.ts
+++ b/src/components/plots/clusteredBarPlot.ts
@@ -16,9 +16,10 @@ export module Plots {
      * @constructor
      * @param {Scale} xScale The x scale to use.
      * @param {Scale} yScale The y scale to use.
+     * @param {boolean} isVertical if the plot if vertical.
      */
-    constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>) {
-      super(xScale, yScale);
+    constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, isVertical = true) {
+      super(xScale, yScale, isVertical);
       this._clusterOffsets = new Utils.Map<Dataset, number>();
     }
 

--- a/src/components/plots/clusteredBarPlot.ts
+++ b/src/components/plots/clusteredBarPlot.ts
@@ -16,10 +16,10 @@ export module Plots {
      * @constructor
      * @param {Scale} xScale The x scale to use.
      * @param {Scale} yScale The y scale to use.
-     * @param {boolean} isVertical if the plot if vertical.
+     * @param {string} orientation The orientation of the Bar Plot ("vertical"/"horizontal").
      */
-    constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, isVertical = true) {
-      super(xScale, yScale, isVertical);
+    constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, orientation = Bar.ORIENTATION_VERTICAL) {
+      super(xScale, yScale, orientation);
       this._clusterOffsets = new Utils.Map<Dataset, number>();
     }
 

--- a/src/components/plots/stackedBarPlot.ts
+++ b/src/components/plots/stackedBarPlot.ts
@@ -13,9 +13,10 @@ export module Plots {
      * @constructor
      * @param {Scale} xScale the x scale of the plot.
      * @param {Scale} yScale the y scale of the plot.
+     * @param {boolean} isVertical if the plot if vertical.
      */
-    constructor(xScale?: Scale<X, number>, yScale?: Scale<Y, number>) {
-      super(xScale, yScale);
+    constructor(xScale?: Scale<X, number>, yScale?: Scale<Y, number>, isVertical = true) {
+      super(xScale, yScale, isVertical);
       this._stackOffsets = new Utils.Map<Dataset, D3.Map<number>>();
       this._stackedExtent = [];
     }

--- a/src/components/plots/stackedBarPlot.ts
+++ b/src/components/plots/stackedBarPlot.ts
@@ -13,10 +13,10 @@ export module Plots {
      * @constructor
      * @param {Scale} xScale the x scale of the plot.
      * @param {Scale} yScale the y scale of the plot.
-     * @param {boolean} isVertical if the plot if vertical.
+     * @param {string} orientation The orientation of the Bar Plot ("vertical"/"horizontal").
      */
-    constructor(xScale?: Scale<X, number>, yScale?: Scale<Y, number>, isVertical = true) {
-      super(xScale, yScale, isVertical);
+    constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, orientation = Bar.ORIENTATION_VERTICAL) {
+      super(xScale, yScale, orientation);
       this._stackOffsets = new Utils.Map<Dataset, D3.Map<number>>();
       this._stackedExtent = [];
     }

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -449,7 +449,7 @@ describe("Plots", () => {
           {y: "B", x: 1} // duplicate Y-value
         ];
         dataset = new Plottable.Dataset(data);
-        barPlot = new Plottable.Plots.Bar(xScale, yScale, "horizontal");
+        barPlot = new Plottable.Plots.Bar(xScale, yScale, Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
         barPlot.addDataset(dataset);
         barPlot.animate(false);
         barPlot.baseline(0);

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -449,7 +449,7 @@ describe("Plots", () => {
           {y: "B", x: 1} // duplicate Y-value
         ];
         dataset = new Plottable.Dataset(data);
-        barPlot = new Plottable.Plots.Bar(xScale, yScale, false);
+        barPlot = new Plottable.Plots.Bar(xScale, yScale, "horizontal");
         barPlot.addDataset(dataset);
         barPlot.animate(false);
         barPlot.baseline(0);

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -449,8 +449,7 @@ describe("Plots", () => {
           {y: "B", x: 1} // duplicate Y-value
         ];
         dataset = new Plottable.Dataset(data);
-        barPlot = new Plottable.Plots.Bar(xScale, yScale);
-        barPlot.orientation(Plottable.Orientation.HORIZONTAL);
+        barPlot = new Plottable.Plots.Bar(xScale, yScale, false);
         barPlot.addDataset(dataset);
         barPlot.animate(false);
         barPlot.baseline(0);

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -19,6 +19,12 @@ describe("Plots", () => {
       svg.remove();
     });
 
+    it("rejects invalid orientations", () => {
+      var xScale = new Plottable.Scales.Linear();
+      var yScale = new Plottable.Scales.Linear();
+      assert.throws(() => new Plottable.Plots.Bar(xScale, yScale, "diagonal"), Error);
+    });
+
     function assertPlotDataEqual(expected: Plottable.Plots.PlotData, actual: Plottable.Plots.PlotData,
         msg: string) {
       assert.deepEqual(expected.data, actual.data, msg);

--- a/test/components/plots/clusteredBarPlotTests.ts
+++ b/test/components/plots/clusteredBarPlotTests.ts
@@ -127,8 +127,7 @@ describe("Plots", () => {
       dataset1 = new Plottable.Dataset(data1);
       dataset2 = new Plottable.Dataset(data2);
 
-      renderer = new Plottable.Plots.ClusteredBar<number, string>(xScale, yScale);
-      renderer.orientation(Plottable.Orientation.HORIZONTAL);
+      renderer = new Plottable.Plots.ClusteredBar<number, string>(xScale, yScale, false);
       renderer.addDataset(new Plottable.Dataset(data1));
       renderer.addDataset(new Plottable.Dataset(data2));
       renderer.baseline(0);
@@ -256,8 +255,7 @@ describe("Plots", () => {
       var data2 = [{y: "A", x: 2}, {y: "B", x: 4}];
       var data3 = [{y: "B", x: 15}, {y: "C", x: 15}];
 
-      plot = new Plottable.Plots.ClusteredBar(xScale, yScale);
-      plot.orientation(Plottable.Orientation.HORIZONTAL);
+      plot = new Plottable.Plots.ClusteredBar(xScale, yScale, false);
       plot.addDataset(new Plottable.Dataset(data1));
       plot.addDataset(new Plottable.Dataset(data2));
       plot.addDataset(new Plottable.Dataset(data3));

--- a/test/components/plots/clusteredBarPlotTests.ts
+++ b/test/components/plots/clusteredBarPlotTests.ts
@@ -127,7 +127,7 @@ describe("Plots", () => {
       dataset1 = new Plottable.Dataset(data1);
       dataset2 = new Plottable.Dataset(data2);
 
-      renderer = new Plottable.Plots.ClusteredBar<number, string>(xScale, yScale, false);
+      renderer = new Plottable.Plots.ClusteredBar<number, string>(xScale, yScale, "horizontal");
       renderer.addDataset(new Plottable.Dataset(data1));
       renderer.addDataset(new Plottable.Dataset(data2));
       renderer.baseline(0);
@@ -255,7 +255,7 @@ describe("Plots", () => {
       var data2 = [{y: "A", x: 2}, {y: "B", x: 4}];
       var data3 = [{y: "B", x: 15}, {y: "C", x: 15}];
 
-      plot = new Plottable.Plots.ClusteredBar(xScale, yScale, false);
+      plot = new Plottable.Plots.ClusteredBar(xScale, yScale, "horizontal");
       plot.addDataset(new Plottable.Dataset(data1));
       plot.addDataset(new Plottable.Dataset(data2));
       plot.addDataset(new Plottable.Dataset(data3));

--- a/test/components/plots/clusteredBarPlotTests.ts
+++ b/test/components/plots/clusteredBarPlotTests.ts
@@ -127,7 +127,7 @@ describe("Plots", () => {
       dataset1 = new Plottable.Dataset(data1);
       dataset2 = new Plottable.Dataset(data2);
 
-      renderer = new Plottable.Plots.ClusteredBar<number, string>(xScale, yScale, "horizontal");
+      renderer = new Plottable.Plots.ClusteredBar<number, string>(xScale, yScale, Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
       renderer.addDataset(new Plottable.Dataset(data1));
       renderer.addDataset(new Plottable.Dataset(data2));
       renderer.baseline(0);
@@ -255,7 +255,7 @@ describe("Plots", () => {
       var data2 = [{y: "A", x: 2}, {y: "B", x: 4}];
       var data3 = [{y: "B", x: 15}, {y: "C", x: 15}];
 
-      plot = new Plottable.Plots.ClusteredBar(xScale, yScale, "horizontal");
+      plot = new Plottable.Plots.ClusteredBar(xScale, yScale, Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
       plot.addDataset(new Plottable.Dataset(data1));
       plot.addDataset(new Plottable.Dataset(data2));
       plot.addDataset(new Plottable.Dataset(data3));

--- a/test/components/plots/stackedBarPlotTests.ts
+++ b/test/components/plots/stackedBarPlotTests.ts
@@ -237,7 +237,7 @@ describe("Plots", () => {
       dataset1 = new Plottable.Dataset(data1);
       dataset2 = new Plottable.Dataset(data2);
 
-      renderer = new Plottable.Plots.StackedBar(xScale, yScale, false);
+      renderer = new Plottable.Plots.StackedBar(xScale, yScale, "horizontal");
       renderer.y((d) => d.name, yScale);
       renderer.x((d) => d.y, xScale);
       renderer.addDataset(new Plottable.Dataset(data1));
@@ -372,7 +372,7 @@ describe("Plots", () => {
         {y: "C", x: 7, type: "c"}
       ];
 
-      plot = new Plottable.Plots.StackedBar(xScale, yScale, false);
+      plot = new Plottable.Plots.StackedBar(xScale, yScale, "horizontal");
       plot.addDataset(new Plottable.Dataset(data1));
       plot.addDataset(new Plottable.Dataset(data2));
       plot.addDataset(new Plottable.Dataset(data3));

--- a/test/components/plots/stackedBarPlotTests.ts
+++ b/test/components/plots/stackedBarPlotTests.ts
@@ -237,8 +237,7 @@ describe("Plots", () => {
       dataset1 = new Plottable.Dataset(data1);
       dataset2 = new Plottable.Dataset(data2);
 
-      renderer = new Plottable.Plots.StackedBar(xScale, yScale);
-      renderer.orientation(Plottable.Orientation.HORIZONTAL);
+      renderer = new Plottable.Plots.StackedBar(xScale, yScale, false);
       renderer.y((d) => d.name, yScale);
       renderer.x((d) => d.y, xScale);
       renderer.addDataset(new Plottable.Dataset(data1));
@@ -373,8 +372,7 @@ describe("Plots", () => {
         {y: "C", x: 7, type: "c"}
       ];
 
-      plot = new Plottable.Plots.StackedBar(xScale, yScale);
-      plot.orientation(Plottable.Orientation.HORIZONTAL);
+      plot = new Plottable.Plots.StackedBar(xScale, yScale, false);
       plot.addDataset(new Plottable.Dataset(data1));
       plot.addDataset(new Plottable.Dataset(data2));
       plot.addDataset(new Plottable.Dataset(data3));

--- a/test/components/plots/stackedBarPlotTests.ts
+++ b/test/components/plots/stackedBarPlotTests.ts
@@ -237,7 +237,7 @@ describe("Plots", () => {
       dataset1 = new Plottable.Dataset(data1);
       dataset2 = new Plottable.Dataset(data2);
 
-      renderer = new Plottable.Plots.StackedBar(xScale, yScale, "horizontal");
+      renderer = new Plottable.Plots.StackedBar(xScale, yScale, Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
       renderer.y((d) => d.name, yScale);
       renderer.x((d) => d.y, xScale);
       renderer.addDataset(new Plottable.Dataset(data1));
@@ -372,7 +372,7 @@ describe("Plots", () => {
         {y: "C", x: 7, type: "c"}
       ];
 
-      plot = new Plottable.Plots.StackedBar(xScale, yScale, "horizontal");
+      plot = new Plottable.Plots.StackedBar(xScale, yScale, Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
       plot.addDataset(new Plottable.Dataset(data1));
       plot.addDataset(new Plottable.Dataset(data2));
       plot.addDataset(new Plottable.Dataset(data3));

--- a/test/core/metadataTests.ts
+++ b/test/core/metadataTests.ts
@@ -115,9 +115,9 @@ describe("Metadata", () => {
     checkXYPlot(new Plottable.Plots.StackedArea(xScale, yScale));
     checkXYPlot(new Plottable.Plots.Bar(xScale, yScale));
     checkXYPlot(new Plottable.Plots.StackedBar(xScale, yScale));
-    checkXYPlot(new Plottable.Plots.StackedBar(yScale, xScale, false));
+    checkXYPlot(new Plottable.Plots.StackedBar(yScale, xScale, "horizontal"));
     checkXYPlot(new Plottable.Plots.ClusteredBar(xScale, yScale));
-    checkXYPlot(new Plottable.Plots.Bar(xScale, yScale, false));
+    checkXYPlot(new Plottable.Plots.Bar(xScale, yScale, "horizontal"));
     checkXYPlot(new Plottable.Plots.Scatter(xScale, yScale));
     checkPiePlot(new Plottable.Plots.Pie());
     svg.remove();

--- a/test/core/metadataTests.ts
+++ b/test/core/metadataTests.ts
@@ -115,9 +115,9 @@ describe("Metadata", () => {
     checkXYPlot(new Plottable.Plots.StackedArea(xScale, yScale));
     checkXYPlot(new Plottable.Plots.Bar(xScale, yScale));
     checkXYPlot(new Plottable.Plots.StackedBar(xScale, yScale));
-    checkXYPlot(new Plottable.Plots.StackedBar(yScale, xScale, "horizontal"));
+    checkXYPlot(new Plottable.Plots.StackedBar(yScale, xScale, Plottable.Plots.Bar.ORIENTATION_HORIZONTAL));
     checkXYPlot(new Plottable.Plots.ClusteredBar(xScale, yScale));
-    checkXYPlot(new Plottable.Plots.Bar(xScale, yScale, "horizontal"));
+    checkXYPlot(new Plottable.Plots.Bar(xScale, yScale, Plottable.Plots.Bar.ORIENTATION_HORIZONTAL));
     checkXYPlot(new Plottable.Plots.Scatter(xScale, yScale));
     checkPiePlot(new Plottable.Plots.Pie());
     svg.remove();

--- a/test/core/metadataTests.ts
+++ b/test/core/metadataTests.ts
@@ -115,9 +115,9 @@ describe("Metadata", () => {
     checkXYPlot(new Plottable.Plots.StackedArea(xScale, yScale));
     checkXYPlot(new Plottable.Plots.Bar(xScale, yScale));
     checkXYPlot(new Plottable.Plots.StackedBar(xScale, yScale));
-    checkXYPlot(new Plottable.Plots.StackedBar(yScale, xScale).orientation(Plottable.Orientation.HORIZONTAL));
+    checkXYPlot(new Plottable.Plots.StackedBar(yScale, xScale, false));
     checkXYPlot(new Plottable.Plots.ClusteredBar(xScale, yScale));
-    checkXYPlot(new Plottable.Plots.Bar(xScale, yScale).orientation(Plottable.Orientation.HORIZONTAL));
+    checkXYPlot(new Plottable.Plots.Bar(xScale, yScale, false));
     checkXYPlot(new Plottable.Plots.Scatter(xScale, yScale));
     checkPiePlot(new Plottable.Plots.Pie());
     svg.remove();

--- a/test/drawers/rectDrawerTests.ts
+++ b/test/drawers/rectDrawerTests.ts
@@ -32,7 +32,7 @@ describe("Drawers", () => {
       var data = [{ a: "foo", b: 10 }, { a: "bar", b: 24 }];
       var xScale = new Plottable.Scales.Linear();
       var yScale = new Plottable.Scales.Category();
-      var barPlot = new Plottable.Plots.Bar(xScale, yScale, false);
+      var barPlot = new Plottable.Plots.Bar(xScale, yScale, "horizontal");
 
       var drawer = new Plottable.Drawers.Rect("_0", false); // HACKHACK #1984: Dataset keys are being removed, so this is the internal key
       (<any> barPlot)._getDrawer = () => drawer;

--- a/test/drawers/rectDrawerTests.ts
+++ b/test/drawers/rectDrawerTests.ts
@@ -32,8 +32,7 @@ describe("Drawers", () => {
       var data = [{ a: "foo", b: 10 }, { a: "bar", b: 24 }];
       var xScale = new Plottable.Scales.Linear();
       var yScale = new Plottable.Scales.Category();
-      var barPlot = new Plottable.Plots.Bar(xScale, yScale);
-      barPlot.orientation(Plottable.Orientation.HORIZONTAL);
+      var barPlot = new Plottable.Plots.Bar(xScale, yScale, false);
 
       var drawer = new Plottable.Drawers.Rect("_0", false); // HACKHACK #1984: Dataset keys are being removed, so this is the internal key
       (<any> barPlot)._getDrawer = () => drawer;

--- a/test/drawers/rectDrawerTests.ts
+++ b/test/drawers/rectDrawerTests.ts
@@ -32,7 +32,7 @@ describe("Drawers", () => {
       var data = [{ a: "foo", b: 10 }, { a: "bar", b: 24 }];
       var xScale = new Plottable.Scales.Linear();
       var yScale = new Plottable.Scales.Category();
-      var barPlot = new Plottable.Plots.Bar(xScale, yScale, "horizontal");
+      var barPlot = new Plottable.Plots.Bar(xScale, yScale, Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
 
       var drawer = new Plottable.Drawers.Rect("_0", false); // HACKHACK #1984: Dataset keys are being removed, so this is the internal key
       (<any> barPlot)._getDrawer = () => drawer;

--- a/test/tests.js
+++ b/test/tests.js
@@ -445,8 +445,7 @@ describe("Drawers", function () {
             var data = [{ a: "foo", b: 10 }, { a: "bar", b: 24 }];
             var xScale = new Plottable.Scales.Linear();
             var yScale = new Plottable.Scales.Category();
-            var barPlot = new Plottable.Plots.Bar(xScale, yScale);
-            barPlot.orientation(Plottable.Orientation.HORIZONTAL);
+            var barPlot = new Plottable.Plots.Bar(xScale, yScale, false);
             var drawer = new Plottable.Drawers.Rect("_0", false); // HACKHACK #1984: Dataset keys are being removed, so this is the internal key
             barPlot._getDrawer = function () { return drawer; };
             barPlot.addDataset(new Plottable.Dataset(data));
@@ -3613,8 +3612,7 @@ describe("Plots", function () {
                     { y: "B", x: 1 }
                 ];
                 dataset = new Plottable.Dataset(data);
-                barPlot = new Plottable.Plots.Bar(xScale, yScale);
-                barPlot.orientation(Plottable.Orientation.HORIZONTAL);
+                barPlot = new Plottable.Plots.Bar(xScale, yScale, false);
                 barPlot.addDataset(dataset);
                 barPlot.animate(false);
                 barPlot.baseline(0);
@@ -5371,8 +5369,7 @@ describe("Plots", function () {
             ];
             dataset1 = new Plottable.Dataset(data1);
             dataset2 = new Plottable.Dataset(data2);
-            renderer = new Plottable.Plots.StackedBar(xScale, yScale);
-            renderer.orientation(Plottable.Orientation.HORIZONTAL);
+            renderer = new Plottable.Plots.StackedBar(xScale, yScale, false);
             renderer.y(function (d) { return d.name; }, yScale);
             renderer.x(function (d) { return d.y; }, xScale);
             renderer.addDataset(new Plottable.Dataset(data1));
@@ -5487,8 +5484,7 @@ describe("Plots", function () {
                 { y: "B", x: 1, type: "c" },
                 { y: "C", x: 7, type: "c" }
             ];
-            plot = new Plottable.Plots.StackedBar(xScale, yScale);
-            plot.orientation(Plottable.Orientation.HORIZONTAL);
+            plot = new Plottable.Plots.StackedBar(xScale, yScale, false);
             plot.addDataset(new Plottable.Dataset(data1));
             plot.addDataset(new Plottable.Dataset(data2));
             plot.addDataset(new Plottable.Dataset(data3));
@@ -5687,8 +5683,7 @@ describe("Plots", function () {
             ];
             dataset1 = new Plottable.Dataset(data1);
             dataset2 = new Plottable.Dataset(data2);
-            renderer = new Plottable.Plots.ClusteredBar(xScale, yScale);
-            renderer.orientation(Plottable.Orientation.HORIZONTAL);
+            renderer = new Plottable.Plots.ClusteredBar(xScale, yScale, false);
             renderer.addDataset(new Plottable.Dataset(data1));
             renderer.addDataset(new Plottable.Dataset(data2));
             renderer.baseline(0);
@@ -5787,8 +5782,7 @@ describe("Plots", function () {
             var data1 = [{ y: "A", x: 1 }, { y: "B", x: 2 }, { y: "C", x: 1 }];
             var data2 = [{ y: "A", x: 2 }, { y: "B", x: 4 }];
             var data3 = [{ y: "B", x: 15 }, { y: "C", x: 15 }];
-            plot = new Plottable.Plots.ClusteredBar(xScale, yScale);
-            plot.orientation(Plottable.Orientation.HORIZONTAL);
+            plot = new Plottable.Plots.ClusteredBar(xScale, yScale, false);
             plot.addDataset(new Plottable.Dataset(data1));
             plot.addDataset(new Plottable.Dataset(data2));
             plot.addDataset(new Plottable.Dataset(data3));
@@ -5917,9 +5911,9 @@ describe("Metadata", function () {
         checkXYPlot(new Plottable.Plots.StackedArea(xScale, yScale));
         checkXYPlot(new Plottable.Plots.Bar(xScale, yScale));
         checkXYPlot(new Plottable.Plots.StackedBar(xScale, yScale));
-        checkXYPlot(new Plottable.Plots.StackedBar(yScale, xScale).orientation(Plottable.Orientation.HORIZONTAL));
+        checkXYPlot(new Plottable.Plots.StackedBar(yScale, xScale, false));
         checkXYPlot(new Plottable.Plots.ClusteredBar(xScale, yScale));
-        checkXYPlot(new Plottable.Plots.Bar(xScale, yScale).orientation(Plottable.Orientation.HORIZONTAL));
+        checkXYPlot(new Plottable.Plots.Bar(xScale, yScale, false));
         checkXYPlot(new Plottable.Plots.Scatter(xScale, yScale));
         checkPiePlot(new Plottable.Plots.Pie());
         svg.remove();

--- a/test/tests.js
+++ b/test/tests.js
@@ -3252,6 +3252,11 @@ describe("Plots", function () {
             assert.strictEqual(plot.height(), 400, "was allocated height");
             svg.remove();
         });
+        it("rejects invalid orientations", function () {
+            var xScale = new Plottable.Scales.Linear();
+            var yScale = new Plottable.Scales.Linear();
+            assert.throws(function () { return new Plottable.Plots.Bar(xScale, yScale, "diagonal"); }, Error);
+        });
         function assertPlotDataEqual(expected, actual, msg) {
             assert.deepEqual(expected.data, actual.data, msg);
             assert.closeTo(expected.pixelPoints[0].x, actual.pixelPoints[0].x, 0.01, msg);

--- a/test/tests.js
+++ b/test/tests.js
@@ -445,7 +445,7 @@ describe("Drawers", function () {
             var data = [{ a: "foo", b: 10 }, { a: "bar", b: 24 }];
             var xScale = new Plottable.Scales.Linear();
             var yScale = new Plottable.Scales.Category();
-            var barPlot = new Plottable.Plots.Bar(xScale, yScale, "horizontal");
+            var barPlot = new Plottable.Plots.Bar(xScale, yScale, Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
             var drawer = new Plottable.Drawers.Rect("_0", false); // HACKHACK #1984: Dataset keys are being removed, so this is the internal key
             barPlot._getDrawer = function () { return drawer; };
             barPlot.addDataset(new Plottable.Dataset(data));
@@ -3612,7 +3612,7 @@ describe("Plots", function () {
                     { y: "B", x: 1 }
                 ];
                 dataset = new Plottable.Dataset(data);
-                barPlot = new Plottable.Plots.Bar(xScale, yScale, "horizontal");
+                barPlot = new Plottable.Plots.Bar(xScale, yScale, Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
                 barPlot.addDataset(dataset);
                 barPlot.animate(false);
                 barPlot.baseline(0);
@@ -5369,7 +5369,7 @@ describe("Plots", function () {
             ];
             dataset1 = new Plottable.Dataset(data1);
             dataset2 = new Plottable.Dataset(data2);
-            renderer = new Plottable.Plots.StackedBar(xScale, yScale, "horizontal");
+            renderer = new Plottable.Plots.StackedBar(xScale, yScale, Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
             renderer.y(function (d) { return d.name; }, yScale);
             renderer.x(function (d) { return d.y; }, xScale);
             renderer.addDataset(new Plottable.Dataset(data1));
@@ -5484,7 +5484,7 @@ describe("Plots", function () {
                 { y: "B", x: 1, type: "c" },
                 { y: "C", x: 7, type: "c" }
             ];
-            plot = new Plottable.Plots.StackedBar(xScale, yScale, "horizontal");
+            plot = new Plottable.Plots.StackedBar(xScale, yScale, Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
             plot.addDataset(new Plottable.Dataset(data1));
             plot.addDataset(new Plottable.Dataset(data2));
             plot.addDataset(new Plottable.Dataset(data3));
@@ -5683,7 +5683,7 @@ describe("Plots", function () {
             ];
             dataset1 = new Plottable.Dataset(data1);
             dataset2 = new Plottable.Dataset(data2);
-            renderer = new Plottable.Plots.ClusteredBar(xScale, yScale, "horizontal");
+            renderer = new Plottable.Plots.ClusteredBar(xScale, yScale, Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
             renderer.addDataset(new Plottable.Dataset(data1));
             renderer.addDataset(new Plottable.Dataset(data2));
             renderer.baseline(0);
@@ -5782,7 +5782,7 @@ describe("Plots", function () {
             var data1 = [{ y: "A", x: 1 }, { y: "B", x: 2 }, { y: "C", x: 1 }];
             var data2 = [{ y: "A", x: 2 }, { y: "B", x: 4 }];
             var data3 = [{ y: "B", x: 15 }, { y: "C", x: 15 }];
-            plot = new Plottable.Plots.ClusteredBar(xScale, yScale, "horizontal");
+            plot = new Plottable.Plots.ClusteredBar(xScale, yScale, Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
             plot.addDataset(new Plottable.Dataset(data1));
             plot.addDataset(new Plottable.Dataset(data2));
             plot.addDataset(new Plottable.Dataset(data3));
@@ -5911,9 +5911,9 @@ describe("Metadata", function () {
         checkXYPlot(new Plottable.Plots.StackedArea(xScale, yScale));
         checkXYPlot(new Plottable.Plots.Bar(xScale, yScale));
         checkXYPlot(new Plottable.Plots.StackedBar(xScale, yScale));
-        checkXYPlot(new Plottable.Plots.StackedBar(yScale, xScale, "horizontal"));
+        checkXYPlot(new Plottable.Plots.StackedBar(yScale, xScale, Plottable.Plots.Bar.ORIENTATION_HORIZONTAL));
         checkXYPlot(new Plottable.Plots.ClusteredBar(xScale, yScale));
-        checkXYPlot(new Plottable.Plots.Bar(xScale, yScale, "horizontal"));
+        checkXYPlot(new Plottable.Plots.Bar(xScale, yScale, Plottable.Plots.Bar.ORIENTATION_HORIZONTAL));
         checkXYPlot(new Plottable.Plots.Scatter(xScale, yScale));
         checkPiePlot(new Plottable.Plots.Pie());
         svg.remove();

--- a/test/tests.js
+++ b/test/tests.js
@@ -445,7 +445,7 @@ describe("Drawers", function () {
             var data = [{ a: "foo", b: 10 }, { a: "bar", b: 24 }];
             var xScale = new Plottable.Scales.Linear();
             var yScale = new Plottable.Scales.Category();
-            var barPlot = new Plottable.Plots.Bar(xScale, yScale, false);
+            var barPlot = new Plottable.Plots.Bar(xScale, yScale, "horizontal");
             var drawer = new Plottable.Drawers.Rect("_0", false); // HACKHACK #1984: Dataset keys are being removed, so this is the internal key
             barPlot._getDrawer = function () { return drawer; };
             barPlot.addDataset(new Plottable.Dataset(data));
@@ -3612,7 +3612,7 @@ describe("Plots", function () {
                     { y: "B", x: 1 }
                 ];
                 dataset = new Plottable.Dataset(data);
-                barPlot = new Plottable.Plots.Bar(xScale, yScale, false);
+                barPlot = new Plottable.Plots.Bar(xScale, yScale, "horizontal");
                 barPlot.addDataset(dataset);
                 barPlot.animate(false);
                 barPlot.baseline(0);
@@ -5369,7 +5369,7 @@ describe("Plots", function () {
             ];
             dataset1 = new Plottable.Dataset(data1);
             dataset2 = new Plottable.Dataset(data2);
-            renderer = new Plottable.Plots.StackedBar(xScale, yScale, false);
+            renderer = new Plottable.Plots.StackedBar(xScale, yScale, "horizontal");
             renderer.y(function (d) { return d.name; }, yScale);
             renderer.x(function (d) { return d.y; }, xScale);
             renderer.addDataset(new Plottable.Dataset(data1));
@@ -5484,7 +5484,7 @@ describe("Plots", function () {
                 { y: "B", x: 1, type: "c" },
                 { y: "C", x: 7, type: "c" }
             ];
-            plot = new Plottable.Plots.StackedBar(xScale, yScale, false);
+            plot = new Plottable.Plots.StackedBar(xScale, yScale, "horizontal");
             plot.addDataset(new Plottable.Dataset(data1));
             plot.addDataset(new Plottable.Dataset(data2));
             plot.addDataset(new Plottable.Dataset(data3));
@@ -5683,7 +5683,7 @@ describe("Plots", function () {
             ];
             dataset1 = new Plottable.Dataset(data1);
             dataset2 = new Plottable.Dataset(data2);
-            renderer = new Plottable.Plots.ClusteredBar(xScale, yScale, false);
+            renderer = new Plottable.Plots.ClusteredBar(xScale, yScale, "horizontal");
             renderer.addDataset(new Plottable.Dataset(data1));
             renderer.addDataset(new Plottable.Dataset(data2));
             renderer.baseline(0);
@@ -5782,7 +5782,7 @@ describe("Plots", function () {
             var data1 = [{ y: "A", x: 1 }, { y: "B", x: 2 }, { y: "C", x: 1 }];
             var data2 = [{ y: "A", x: 2 }, { y: "B", x: 4 }];
             var data3 = [{ y: "B", x: 15 }, { y: "C", x: 15 }];
-            plot = new Plottable.Plots.ClusteredBar(xScale, yScale, false);
+            plot = new Plottable.Plots.ClusteredBar(xScale, yScale, "horizontal");
             plot.addDataset(new Plottable.Dataset(data1));
             plot.addDataset(new Plottable.Dataset(data2));
             plot.addDataset(new Plottable.Dataset(data3));
@@ -5911,9 +5911,9 @@ describe("Metadata", function () {
         checkXYPlot(new Plottable.Plots.StackedArea(xScale, yScale));
         checkXYPlot(new Plottable.Plots.Bar(xScale, yScale));
         checkXYPlot(new Plottable.Plots.StackedBar(xScale, yScale));
-        checkXYPlot(new Plottable.Plots.StackedBar(yScale, xScale, false));
+        checkXYPlot(new Plottable.Plots.StackedBar(yScale, xScale, "horizontal"));
         checkXYPlot(new Plottable.Plots.ClusteredBar(xScale, yScale));
-        checkXYPlot(new Plottable.Plots.Bar(xScale, yScale, false));
+        checkXYPlot(new Plottable.Plots.Bar(xScale, yScale, "horizontal"));
         checkXYPlot(new Plottable.Plots.Scatter(xScale, yScale));
         checkPiePlot(new Plottable.Plots.Pie());
         svg.remove();


### PR DESCRIPTION
Reverts the "feature" added in #2075.

In particular, I don't find that it makes much sense to change the orientation of a `Plot.Bar` after construction. Doing so breaks both `x()` and `y()` property setters, as well as causes some major updating difficulties when setting up the scales to include the `baseline()` value.