### PR TITLE
[Plots.Scatter] - animation starts at an empty path

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -7105,7 +7105,7 @@ var Plottable;
                 var drawSteps = [];
                 if (this._dataChanged && this._animate) {
                     var resetAttrToProjector = this._generateAttrToProjector();
-                    resetAttrToProjector["size"] = function () { return 0; };
+                    resetAttrToProjector["d"] = function () { return ""; };
                     drawSteps.push({ attrToProjector: resetAttrToProjector, animator: this._getAnimator("symbols-reset") });
                 }
                 drawSteps.push({ attrToProjector: this._generateAttrToProjector(), animator: this._getAnimator("symbols") });

--- a/src/components/plots/scatterPlot.ts
+++ b/src/components/plots/scatterPlot.ts
@@ -59,7 +59,7 @@ export module Plots {
       var drawSteps: Drawers.DrawStep[] = [];
       if (this._dataChanged && this._animate) {
         var resetAttrToProjector = this._generateAttrToProjector();
-        resetAttrToProjector["size"] = () => 0;
+        resetAttrToProjector["d"] = () => "";
         drawSteps.push({attrToProjector: resetAttrToProjector, animator: this._getAnimator("symbols-reset")});
       }
 


### PR DESCRIPTION
During the rework of Drawers and `_generateAttrToProjector()`, `Plots.Scatter` should be aligned with the idea that the projectors passed to the `Drawer`s are in fact the items that will be on the DOM node(s).

...And in doing so, I forgot to change the logic in the reset animation

QE: Animations were broken before for `Plots.Scatter`.  They should work now.