### PR TITLE
[Plots.Pie] - All attribute calculations are done at the plot

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1339,8 +1339,6 @@ declare module Plottable {
     module Drawers {
         class Arc extends Element {
             constructor(key: string);
-            _drawStep(step: AppliedDrawStep): void;
-            draw(data: any[], drawSteps: DrawStep[], dataset: Dataset): number;
         }
     }
 }
@@ -2571,6 +2569,7 @@ declare module Plottable {
             outerRadius(outerRadius: number | Accessor<number>): Plots.Pie;
             outerRadius<R>(outerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Pie;
             protected _propertyProjectors(): AttributeToProjector;
+            protected _getDataToDraw(): D3.Map<any[]>;
             protected _pixelPoint(datum: any, index: number, dataset: Dataset): {
                 x: number;
                 y: number;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2557,6 +2557,8 @@ declare module Plottable {
             constructor();
             computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Pie;
             addDataset(dataset: Dataset): Pie;
+            removeDataset(dataset: Dataset): Pie;
+            protected _onDatasetUpdate(): void;
             protected _getDrawer(key: string): Drawers.AbstractDrawer;
             getAllPlotData(datasets?: Dataset[]): Plots.PlotData;
             sectorValue<S>(): AccessorScaleBinding<S, number>;

--- a/plottable.js
+++ b/plottable.js
@@ -6655,7 +6655,6 @@ var Plottable;
                 attrToProjector["d"] = function (datum, index, ds) {
                     return d3.svg.arc().innerRadius(innerRadiusAccessor(datum, index, ds)).outerRadius(outerRadiusAccessor(datum, index, ds)).startAngle(_this._startAngles.get(ds)[index]).endAngle(_this._endAngles.get(ds)[index])(datum, index);
                 };
-                attrToProjector["sector-value"] = Plottable.Plot._scaledAccessor(this.sectorValue());
                 return attrToProjector;
             };
             Pie.prototype._updatePieAngles = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -6670,14 +6670,16 @@ var Plottable;
                 this._endAngles = pie.map(function (slice) { return slice.endAngle; });
             };
             Pie.prototype._getDataToDraw = function () {
-                var _this = this;
                 var dataToDraw = _super.prototype._getDataToDraw.call(this);
+                if (this.datasets().length === 0) {
+                    return dataToDraw;
+                }
                 var sectorValueAccessor = Plottable.Plot._scaledAccessor(this.sectorValue());
-                dataToDraw.forEach(function (datasetKey, data) {
-                    var ds = _this._key2PlotDatasetKey.get(datasetKey).dataset;
-                    var filteredData = data.filter(function (d, i) { return Plottable.Utils.Methods.isValidNumber(sectorValueAccessor(d, i, ds)); });
-                    dataToDraw.set(datasetKey, filteredData);
-                });
+                var datasetKey = this._datasetKeysInOrder[0];
+                var data = dataToDraw.get(datasetKey);
+                var ds = this._key2PlotDatasetKey.get(datasetKey).dataset;
+                var filteredData = data.filter(function (d, i) { return Plottable.Utils.Methods.isValidNumber(sectorValueAccessor(d, i, ds)); });
+                dataToDraw.set(datasetKey, filteredData);
                 return dataToDraw;
             };
             Pie.prototype._pixelPoint = function (datum, index, dataset) {

--- a/src/components/plots/piePlot.ts
+++ b/src/components/plots/piePlot.ts
@@ -143,12 +143,13 @@ export module Plots {
 
     protected _getDataToDraw() {
       var dataToDraw = super._getDataToDraw();
+      if (this.datasets().length === 0) { return dataToDraw; }
       var sectorValueAccessor = Plot._scaledAccessor(this.sectorValue());
-      dataToDraw.forEach((datasetKey, data) => {
-        var ds = this._key2PlotDatasetKey.get(datasetKey).dataset;
-        var filteredData = data.filter((d, i) => Plottable.Utils.Methods.isValidNumber(sectorValueAccessor(d, i, ds)));
-        dataToDraw.set(datasetKey, filteredData);
-      });
+      var datasetKey = this._datasetKeysInOrder[0];
+      var data = dataToDraw.get(datasetKey);
+      var ds = this._key2PlotDatasetKey.get(datasetKey).dataset;
+      var filteredData = data.filter((d, i) => Plottable.Utils.Methods.isValidNumber(sectorValueAccessor(d, i, ds)));
+      dataToDraw.set(datasetKey, filteredData);
       return dataToDraw;
     }
 

--- a/src/components/plots/piePlot.ts
+++ b/src/components/plots/piePlot.ts
@@ -11,6 +11,8 @@ export module Plots {
     private static _INNER_RADIUS_KEY = "inner-radius";
     private static _OUTER_RADIUS_KEY = "outer-radius";
     private static _SECTOR_VALUE_KEY = "sector-value";
+    private _startAngles: Utils.Map<Dataset, number[]>;
+    private _endAngles: Utils.Map<Dataset, number[]>;
 
     /**
      * Constructs a PiePlot.
@@ -23,6 +25,8 @@ export module Plots {
       this.outerRadius(() => Math.min(this.width(), this.height()) / 2);
       this.classed("pie-plot", true);
       this.attr("fill", (d, i) => String(i), new Scales.Color());
+      this._startAngles = new Utils.Map<Dataset, number[]>();
+      this._endAngles = new Utils.Map<Dataset, number[]>();
     }
 
     public computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number) {
@@ -43,8 +47,24 @@ export module Plots {
         Utils.Methods.warn("Only one dataset is supported in Pie plots");
         return this;
       }
+      this._startAngles.set(dataset, []);
+      this._endAngles.set(dataset, []);
+      this._updatePieLayout();
       super.addDataset(dataset);
       return this;
+    }
+
+    public removeDataset(dataset: Dataset) {
+      super.removeDataset(dataset);
+      this._startAngles.delete(dataset);
+      this._endAngles.delete(dataset);
+      this._updatePieLayout();
+      return this;
+    }
+
+    protected _onDatasetUpdate() {
+      super._onDatasetUpdate();
+      this._updatePieLayout();
     }
 
     protected _getDrawer(key: string) {
@@ -70,6 +90,7 @@ export module Plots {
         return this._propertyBindings.get(Pie._SECTOR_VALUE_KEY);
       }
       this._bindProperty(Pie._SECTOR_VALUE_KEY, sectorValue, scale);
+      this._updatePieLayout();
       this.renderImmediately();
       return this;
     }
@@ -100,10 +121,32 @@ export module Plots {
 
     protected _propertyProjectors(): AttributeToProjector {
       var attrToProjector = super._propertyProjectors();
-      attrToProjector[Pie._INNER_RADIUS_KEY] = Plot._scaledAccessor(this.innerRadius());
-      attrToProjector[Pie._OUTER_RADIUS_KEY] = Plot._scaledAccessor(this.outerRadius());
-      attrToProjector[Pie._SECTOR_VALUE_KEY] = Plot._scaledAccessor(this.sectorValue());
+      var innerRadiusAccessor = Plot._scaledAccessor(this.innerRadius());
+      var outerRadiusAccessor = Plot._scaledAccessor(this.outerRadius());
+      attrToProjector["d"] = (datum: any, index: number, ds: Dataset) => {
+        return d3.svg.arc()
+                     .innerRadius(innerRadiusAccessor(datum, index, ds))
+                     .outerRadius(outerRadiusAccessor(datum, index, ds))(datum, index);
+      };
+      attrToProjector["sector-value"] = Plot._scaledAccessor(this.sectorValue());
       return attrToProjector;
+    }
+
+    private _updatePieLayout() {
+      if (this.sectorValue() == null) { return; }
+      var sectorValueAccessor = Plot._scaledAccessor(this.sectorValue());
+      this.datasets().forEach((ds) => {
+        var data = ds.data().filter((d, i) => Plottable.Utils.Methods.isValidNumber(+sectorValueAccessor(d, i, ds)));
+        var pie = d3.layout.pie().sort(null).value((d, i) => sectorValueAccessor(d, i, ds))(data);
+        if (pie.some((slice) => slice.value < 0)) {
+          Utils.Methods.warn("Negative values will not render correctly in a pie chart.");
+        }
+        pie.forEach((slice) => {
+          var index = slice.index;
+          this._startAngles.get(ds)[index] = slice.startAngle;
+          this._endAngles.get(ds)[index] = slice.endAngle;
+        });
+      });
     }
 
     protected _pixelPoint(datum: any, index: number, dataset: Dataset) {

--- a/src/components/plots/piePlot.ts
+++ b/src/components/plots/piePlot.ts
@@ -124,13 +124,11 @@ export module Plots {
       var innerRadiusAccessor = Plot._scaledAccessor(this.innerRadius());
       var outerRadiusAccessor = Plot._scaledAccessor(this.outerRadius());
       attrToProjector["d"] = (datum: any, index: number, ds: Dataset) => {
-        return d3.svg.arc()
-                     .innerRadius(innerRadiusAccessor(datum, index, ds))
-                     .outerRadius(outerRadiusAccessor(datum, index, ds))
-                     .startAngle(this._startAngles.get(ds)[index])
-                     .endAngle(this._endAngles.get(ds)[index])(datum, index);
+        return d3.svg.arc().innerRadius(innerRadiusAccessor(datum, index, ds))
+                           .outerRadius(outerRadiusAccessor(datum, index, ds))
+                           .startAngle(this._startAngles.get(ds)[index])
+                           .endAngle(this._endAngles.get(ds)[index])(datum, index);
       };
-      attrToProjector["sector-value"] = Plot._scaledAccessor(this.sectorValue());
       return attrToProjector;
     }
 

--- a/src/drawers/arcDrawer.ts
+++ b/src/drawers/arcDrawer.ts
@@ -9,12 +9,6 @@ export module Drawers {
       this._svgElement = "path";
     }
 
-    private _createArc(innerRadiusF: AppliedProjector, outerRadiusF: AppliedProjector) {
-      return d3.svg.arc()
-                   .innerRadius(innerRadiusF)
-                   .outerRadius(outerRadiusF);
-    }
-
     private retargetProjectors(attrToProjector: AttributeToAppliedProjector): AttributeToAppliedProjector {
       var retargetedAttrToProjector: AttributeToAppliedProjector = {};
       d3.entries(attrToProjector).forEach((entry) => {
@@ -25,13 +19,9 @@ export module Drawers {
 
     public _drawStep(step: AppliedDrawStep) {
       var attrToProjector = <AttributeToAppliedProjector>Utils.Methods.copyMap(step.attrToProjector);
+      var dProjector = attrToProjector["d"];
       attrToProjector = this.retargetProjectors(attrToProjector);
-      var innerRadiusAccessor = attrToProjector["inner-radius"];
-      var outerRadiusAccessor = attrToProjector["outer-radius"];
-      delete attrToProjector["inner-radius"];
-      delete attrToProjector["outer-radius"];
-
-      attrToProjector["d"] = this._createArc(innerRadiusAccessor, outerRadiusAccessor);
+      attrToProjector["d"] = dProjector;
       return super._drawStep({attrToProjector: attrToProjector, animator: step.animator});
     }
 

--- a/src/drawers/arcDrawer.ts
+++ b/src/drawers/arcDrawer.ts
@@ -8,41 +8,6 @@ export module Drawers {
       super(key);
       this._svgElement = "path";
     }
-
-    private retargetProjectors(attrToProjector: AttributeToAppliedProjector): AttributeToAppliedProjector {
-      var retargetedAttrToProjector: AttributeToAppliedProjector = {};
-      d3.entries(attrToProjector).forEach((entry) => {
-        retargetedAttrToProjector[entry.key] = (d: D3.Layout.ArcDescriptor, i: number) => entry.value(d.data, i);
-      });
-      return retargetedAttrToProjector;
-    }
-
-    public _drawStep(step: AppliedDrawStep) {
-      var attrToProjector = <AttributeToAppliedProjector>Utils.Methods.copyMap(step.attrToProjector);
-      var dProjector = attrToProjector["d"];
-      attrToProjector = this.retargetProjectors(attrToProjector);
-      attrToProjector["d"] = dProjector;
-      return super._drawStep({attrToProjector: attrToProjector, animator: step.animator});
-    }
-
-    public draw(data: any[], drawSteps: DrawStep[], dataset: Dataset) {
-      // HACKHACK Applying metadata should be done in base class
-      var valueAccessor = (d: any, i: number) => drawSteps[0].attrToProjector["sector-value"](d, i, dataset);
-
-      data = data.filter(e => Plottable.Utils.Methods.isValidNumber(+valueAccessor(e, null)));
-
-      var pie = d3.layout.pie()
-                          .sort(null)
-                          .value(valueAccessor)(data);
-
-      drawSteps.forEach(s => delete s.attrToProjector["sector-value"]);
-      pie.forEach((slice) => {
-        if (slice.value < 0) {
-          Utils.Methods.warn("Negative values will not render correctly in a pie chart.");
-        }
-      });
-      return super.draw(pie, drawSteps, dataset);
-    }
   }
 }
 }

--- a/src/drawers/arcDrawer.ts
+++ b/src/drawers/arcDrawer.ts
@@ -3,7 +3,6 @@
 module Plottable {
 export module Drawers {
   export class Arc extends Element {
-
     constructor(key: string) {
       super(key);
       this._svgElement = "path";

--- a/test/components/plots/piePlotTests.ts
+++ b/test/components/plots/piePlotTests.ts
@@ -100,7 +100,7 @@ describe("Plots", () => {
       svg.remove();
     });
 
-    it("innerRadius project", () => {
+    it("innerRadius", () => {
       piePlot.innerRadius(5);
       var arcPaths = renderArea.selectAll(".arc");
       assert.lengthOf(arcPaths[0], 2, "only has two sectors");
@@ -121,7 +121,7 @@ describe("Plots", () => {
       svg.remove();
     });
 
-    it("outerRadius project", () => {
+    it("outerRadius", () => {
       piePlot.outerRadius(() => 150);
       var arcPaths = renderArea.selectAll(".arc");
       assert.lengthOf(arcPaths[0], 2, "only has two sectors");
@@ -153,8 +153,7 @@ describe("Plots", () => {
       it("retrieves correct selections", () => {
         var allSectors = piePlot.getAllSelections([simpleDataset]);
         assert.strictEqual(allSectors.size(), 2, "all sectors retrieved");
-        var selectionData = allSectors.data();
-        assert.includeMembers(selectionData.map((datum) => datum.data), simpleData, "dataset data in selection data");
+        assert.includeMembers(allSectors.data(), simpleData, "dataset data in selection data");
 
         svg.remove();
       });
@@ -246,36 +245,6 @@ describe("Plots", () => {
 
       svg.remove();
 
-    });
-
-    it("nulls and 0s should be represented in a Pie Chart as DOM elements, but have radius 0", () => {
-      var svg = TestMethods.generateSVG();
-
-      var data1 = [
-        { v: 1 },
-        { v: 0 },
-        { v: null },
-        { v: 1 },
-      ];
-
-      var plot = new Plottable.Plots.Pie();
-      plot.addDataset(new Plottable.Dataset(data1));
-      plot.sectorValue((d) => d.v);
-
-      plot.renderTo(svg);
-
-      var elementsDrawnSel = (<any> plot)._element.selectAll(".arc");
-
-      assert.strictEqual(elementsDrawnSel.size(), 4,
-        "All 4 elements of the pie chart should have a DOM node");
-
-      assert.closeTo(elementsDrawnSel[0][1].getBBox().width, 0, 0.001,
-        "0 as a value should not be visible");
-
-      assert.closeTo(elementsDrawnSel[0][2].getBBox().width, 0, 0.001,
-        "null as a value should not be visible");
-
-      svg.remove();
     });
   });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -2609,7 +2609,7 @@ describe("Plots", function () {
             piePlot.sectorValue(function (d) { return d.value; });
             svg.remove();
         });
-        it("innerRadius project", function () {
+        it("innerRadius", function () {
             piePlot.innerRadius(5);
             var arcPaths = renderArea.selectAll(".arc");
             assert.lengthOf(arcPaths[0], 2, "only has two sectors");
@@ -2625,7 +2625,7 @@ describe("Plots", function () {
             piePlot.innerRadius(0);
             svg.remove();
         });
-        it("outerRadius project", function () {
+        it("outerRadius", function () {
             piePlot.outerRadius(function () { return 150; });
             var arcPaths = renderArea.selectAll(".arc");
             assert.lengthOf(arcPaths[0], 2, "only has two sectors");
@@ -2650,8 +2650,7 @@ describe("Plots", function () {
             it("retrieves correct selections", function () {
                 var allSectors = piePlot.getAllSelections([simpleDataset]);
                 assert.strictEqual(allSectors.size(), 2, "all sectors retrieved");
-                var selectionData = allSectors.data();
-                assert.includeMembers(selectionData.map(function (datum) { return datum.data; }), simpleData, "dataset data in selection data");
+                assert.includeMembers(allSectors.data(), simpleData, "dataset data in selection data");
                 svg.remove();
             });
             it("skips invalid Datsets", function () {
@@ -2715,24 +2714,6 @@ describe("Plots", function () {
             plot.renderTo(svg);
             var elementsDrawnSel = plot._element.selectAll(".arc");
             assert.strictEqual(elementsDrawnSel.size(), 4, "There should be exactly 4 slices in the pie chart, representing the valid values");
-            svg.remove();
-        });
-        it("nulls and 0s should be represented in a Pie Chart as DOM elements, but have radius 0", function () {
-            var svg = TestMethods.generateSVG();
-            var data1 = [
-                { v: 1 },
-                { v: 0 },
-                { v: null },
-                { v: 1 },
-            ];
-            var plot = new Plottable.Plots.Pie();
-            plot.addDataset(new Plottable.Dataset(data1));
-            plot.sectorValue(function (d) { return d.v; });
-            plot.renderTo(svg);
-            var elementsDrawnSel = plot._element.selectAll(".arc");
-            assert.strictEqual(elementsDrawnSel.size(), 4, "All 4 elements of the pie chart should have a DOM node");
-            assert.closeTo(elementsDrawnSel[0][1].getBBox().width, 0, 0.001, "0 as a value should not be visible");
-            assert.closeTo(elementsDrawnSel[0][2].getBBox().width, 0, 0.001, "null as a value should not be visible");
             svg.remove();
         });
     });


### PR DESCRIPTION
In accordance to #1913, the calculations for the attributes should not be done at the `Drawer` level but at the plot level.  I'm starting with `Plots.Pie` here