### PR TITLE
[Plots.StackedArea] - removing redundant class line

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -7859,7 +7859,7 @@ var Plottable;
              */
             function Area(xScale, yScale) {
                 _super.call(this, xScale, yScale);
-                this.classed("area-plot", true);
+                this.classed("stacked-area-plot", true);
                 this.y0(0, yScale); // default
                 this.animator("reset", new Plottable.Animators.Null());
                 this.animator("main", new Plottable.Animators.Base().duration(600).easing("exp-in-out"));

--- a/plottable.js
+++ b/plottable.js
@@ -7859,7 +7859,7 @@ var Plottable;
              */
             function Area(xScale, yScale) {
                 _super.call(this, xScale, yScale);
-                this.classed("stacked-area-plot", true);
+                this.classed("area-plot", true);
                 this.y0(0, yScale); // default
                 this.animator("reset", new Plottable.Animators.Null());
                 this.animator("main", new Plottable.Animators.Base().duration(600).easing("exp-in-out"));

--- a/plottable.js
+++ b/plottable.js
@@ -8011,6 +8011,7 @@ var Plottable;
             function StackedArea(xScale, yScale) {
                 _super.call(this, xScale, yScale);
                 this._baselineValue = 0;
+                this.classed("area-plot", true);
                 this.attr("fill-opacity", 1);
                 this._stackOffsets = new Plottable.Utils.Map();
                 this._stackedExtent = [];

--- a/plottable.js
+++ b/plottable.js
@@ -8011,7 +8011,7 @@ var Plottable;
             function StackedArea(xScale, yScale) {
                 _super.call(this, xScale, yScale);
                 this._baselineValue = 0;
-                this.classed("area-plot", true);
+                this.classed("stacked-area-plot", true);
                 this.attr("fill-opacity", 1);
                 this._stackOffsets = new Plottable.Utils.Map();
                 this._stackedExtent = [];

--- a/plottable.js
+++ b/plottable.js
@@ -8011,7 +8011,6 @@ var Plottable;
             function StackedArea(xScale, yScale) {
                 _super.call(this, xScale, yScale);
                 this._baselineValue = 0;
-                this.classed("area-plot", true);
                 this.attr("fill-opacity", 1);
                 this._stackOffsets = new Plottable.Utils.Map();
                 this._stackedExtent = [];

--- a/plottable.js
+++ b/plottable.js
@@ -8151,6 +8151,7 @@ var Plottable;
             function StackedBar(xScale, yScale, orientation) {
                 if (orientation === void 0) { orientation = Plots.Bar.ORIENTATION_VERTICAL; }
                 _super.call(this, xScale, yScale, orientation);
+                this.classed("stacked-bar-plot", true);
                 this._stackOffsets = new Plottable.Utils.Map();
                 this._stackedExtent = [];
             }

--- a/src/components/plots/areaPlot.ts
+++ b/src/components/plots/areaPlot.ts
@@ -17,7 +17,7 @@ export module Plots {
      */
     constructor(xScale: QuantitativeScale<X>, yScale: QuantitativeScale<number>) {
       super(xScale, yScale);
-      this.classed("stacked-area-plot", true);
+      this.classed("area-plot", true);
       this.y0(0, yScale); // default
 
       this.animator("reset", new Animators.Null());

--- a/src/components/plots/areaPlot.ts
+++ b/src/components/plots/areaPlot.ts
@@ -17,7 +17,7 @@ export module Plots {
      */
     constructor(xScale: QuantitativeScale<X>, yScale: QuantitativeScale<number>) {
       super(xScale, yScale);
-      this.classed("area-plot", true);
+      this.classed("stacked-area-plot", true);
       this.y0(0, yScale); // default
 
       this.animator("reset", new Animators.Null());

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -18,7 +18,6 @@ export module Plots {
      */
     constructor(xScale: QuantitativeScale<X>, yScale: QuantitativeScale<number>) {
       super(xScale, yScale);
-      this.classed("area-plot", true);
       this.attr("fill-opacity", 1);
       this._stackOffsets = new Utils.Map<Dataset, D3.Map<number>>();
       this._stackedExtent = [];

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -18,6 +18,7 @@ export module Plots {
      */
     constructor(xScale: QuantitativeScale<X>, yScale: QuantitativeScale<number>) {
       super(xScale, yScale);
+      this.classed("area-plot", true);
       this.attr("fill-opacity", 1);
       this._stackOffsets = new Utils.Map<Dataset, D3.Map<number>>();
       this._stackedExtent = [];

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -18,7 +18,7 @@ export module Plots {
      */
     constructor(xScale: QuantitativeScale<X>, yScale: QuantitativeScale<number>) {
       super(xScale, yScale);
-      this.classed("area-plot", true);
+      this.classed("stacked-area-plot", true);
       this.attr("fill-opacity", 1);
       this._stackOffsets = new Utils.Map<Dataset, D3.Map<number>>();
       this._stackedExtent = [];

--- a/src/components/plots/stackedBarPlot.ts
+++ b/src/components/plots/stackedBarPlot.ts
@@ -17,6 +17,7 @@ export module Plots {
      */
     constructor(xScale: Scale<X, number>, yScale: Scale<Y, number>, orientation = Bar.ORIENTATION_VERTICAL) {
       super(xScale, yScale, orientation);
+      this.classed("stacked-bar-plot", true);
       this._stackOffsets = new Utils.Map<Dataset, D3.Map<number>>();
       this._stackedExtent = [];
     }


### PR DESCRIPTION
It's already on `Plots.Area`.  Shouldn't need to be redeclared in `Plots.StackedArea`