### PR TITLE
[Drawers.Element] - x/y/defined attributes removed

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2813,7 +2813,6 @@ declare module Plottable {
             protected _generateAttrToProjector(): {
                 [attrToSet: string]: (datum: any, index: number, dataset: Dataset) => any;
             };
-            protected _wholeDatumAttributes(): string[];
             getAllPlotData(datasets?: Dataset[]): Plots.PlotData;
             /**
              * Retrieves the closest PlotData to queryPoint.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2606,6 +2606,7 @@ declare module Plottable {
         showAllData(): XYPlot<X, Y>;
         protected _projectorsReady(): boolean;
         protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point;
+        protected _getDataToDraw(): D3.Map<any[]>;
     }
 }
 
@@ -2832,6 +2833,7 @@ declare module Plottable {
             getClosestPlotData(queryPoint: Point): PlotData;
             protected _propertyProjectors(): AttributeToProjector;
             protected _constructLineProjector(xProjector: _Projector, yProjector: _Projector): (datum: any, index: number, dataset: Dataset) => string;
+            protected _getDataToDraw(): D3.Map<any[]>;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1274,8 +1274,6 @@ declare module Plottable {
             svgElement(tag: string): Element;
             protected _drawStep(step: AppliedDrawStep): void;
             protected _enterData(data: any[]): void;
-            protected _prepareDrawSteps(drawSteps: AppliedDrawStep[]): void;
-            protected _prepareData(data: any[], drawSteps: AppliedDrawStep[]): any[];
             _getSelector(): string;
         }
     }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1212,8 +1212,6 @@ declare module Plottable {
              */
             protected _drawStep(step: AppliedDrawStep): void;
             protected _numberOfAnimationIterations(data: any[]): number;
-            protected _prepareDrawSteps(drawSteps: AppliedDrawStep[]): void;
-            protected _prepareData(data: any[], drawSteps: AppliedDrawStep[]): any[];
             /**
              * Draws the data into the renderArea using the spefic steps and metadata
              *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2592,7 +2592,6 @@ declare module Plottable {
          * @returns {XYPlot} The calling XYPlot.
          */
         autorange(scaleName: string): XYPlot<X, Y>;
-        protected _propertyProjectors(): AttributeToProjector;
         computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): XYPlot<X, Y>;
         /**
          * Adjusts both domains' extents to show all datasets.

--- a/plottable.js
+++ b/plottable.js
@@ -2851,22 +2851,6 @@ var Plottable;
                 }
                 dataElements.exit().remove();
             };
-            Element.prototype._filterDefinedData = function (data, definedFunction) {
-                return definedFunction ? data.filter(definedFunction) : data;
-            };
-            // HACKHACK To prevent populating undesired attribute to d3, we delete them here.
-            Element.prototype._prepareDrawSteps = function (drawSteps) {
-                _super.prototype._prepareDrawSteps.call(this, drawSteps);
-                drawSteps.forEach(function (d) {
-                    if (d.attrToProjector["defined"]) {
-                        delete d.attrToProjector["defined"];
-                    }
-                });
-            };
-            Element.prototype._prepareData = function (data, drawSteps) {
-                var _this = this;
-                return drawSteps.reduce(function (data, drawStep) { return _this._filterDefinedData(data, drawStep.attrToProjector["defined"]); }, _super.prototype._prepareData.call(this, data, drawSteps));
-            };
             Element.prototype._getSelector = function () {
                 return this._svgElement;
             };

--- a/plottable.js
+++ b/plottable.js
@@ -2670,12 +2670,6 @@ var Plottable;
                 });
                 return modifiedAttrToProjector;
             };
-            AbstractDrawer.prototype._prepareDrawSteps = function (drawSteps) {
-                // no-op
-            };
-            AbstractDrawer.prototype._prepareData = function (data, drawSteps) {
-                return data;
-            };
             /**
              * Draws the data into the renderArea using the spefic steps and metadata
              *
@@ -2691,10 +2685,8 @@ var Plottable;
                         animator: dr.animator
                     };
                 });
-                var preparedData = this._prepareData(data, appliedDrawSteps);
-                this._prepareDrawSteps(appliedDrawSteps);
-                this._enterData(preparedData);
-                var numberOfIterations = this._numberOfAnimationIterations(preparedData);
+                this._enterData(data);
+                var numberOfIterations = this._numberOfAnimationIterations(data);
                 var delay = 0;
                 appliedDrawSteps.forEach(function (drawStep, i) {
                     Plottable.Utils.Methods.setTimeout(function () { return _this._drawStep(drawStep); }, delay);

--- a/plottable.js
+++ b/plottable.js
@@ -7674,7 +7674,7 @@ var Plottable;
             };
             Line.prototype._generateAttrToProjector = function () {
                 var attrToProjector = _super.prototype._generateAttrToProjector.call(this);
-                d3.keys(attrToProjector).forEach(function (attribute) {
+                Object.keys(attrToProjector).forEach(function (attribute) {
                     if (attribute === "d") {
                         return;
                     }

--- a/plottable.js
+++ b/plottable.js
@@ -6968,7 +6968,7 @@ var Plottable;
             var definedFunction = function (d, i, dataset) {
                 var positionX = Plottable.Plot._scaledAccessor(_this.x())(d, i, dataset);
                 var positionY = Plottable.Plot._scaledAccessor(_this.y())(d, i, dataset);
-                return positionX != null && positionX === positionX && positionY != null && positionY === positionY;
+                return Plottable.Utils.Methods.isValidNumber(positionX) && Plottable.Utils.Methods.isValidNumber(positionY);
             };
             datasets.forEach(function (key, data) {
                 var dataset = _this._key2PlotDatasetKey.get(key).dataset;

--- a/plottable.js
+++ b/plottable.js
@@ -6997,6 +6997,20 @@ var Plottable;
             var attrToProjector = this._generateAttrToProjector();
             return { x: attrToProjector["x"](datum, index, dataset), y: attrToProjector["y"](datum, index, dataset) };
         };
+        XYPlot.prototype._getDataToDraw = function () {
+            var _this = this;
+            var datasets = _super.prototype._getDataToDraw.call(this);
+            var definedFunction = function (d, i, dataset) {
+                var positionX = Plottable.Plot._scaledAccessor(_this.x())(d, i, dataset);
+                var positionY = Plottable.Plot._scaledAccessor(_this.y())(d, i, dataset);
+                return positionX != null && positionX === positionX && positionY != null && positionY === positionY;
+            };
+            datasets.forEach(function (key, data) {
+                var dataset = _this._key2PlotDatasetKey.get(key).dataset;
+                datasets.set(key, data.filter(function (d, i) { return definedFunction(d, i, dataset); }));
+            });
+            return datasets;
+        };
         XYPlot._X_KEY = "x";
         XYPlot._Y_KEY = "y";
         return XYPlot;
@@ -7796,6 +7810,14 @@ var Plottable;
                 return function (datum, index, dataset) {
                     return d3.svg.line().x(function (innerDatum, innerIndex) { return xProjector(innerDatum, innerIndex, dataset); }).y(function (innerDatum, innerIndex) { return yProjector(innerDatum, innerIndex, dataset); }).defined(function (innerDatum, innerIndex) { return definedProjector(innerDatum, innerIndex, dataset); })(datum, index);
                 };
+            };
+            Line.prototype._getDataToDraw = function () {
+                var _this = this;
+                var datasets = d3.map();
+                this._datasetKeysInOrder.forEach(function (key) {
+                    datasets.set(key, _this._key2PlotDatasetKey.get(key).dataset.data());
+                });
+                return datasets;
             };
             return Line;
         })(Plottable.XYPlot);

--- a/plottable.js
+++ b/plottable.js
@@ -6897,18 +6897,6 @@ var Plottable;
             }
             return this;
         };
-        XYPlot.prototype._propertyProjectors = function () {
-            var _this = this;
-            var attrToProjector = _super.prototype._propertyProjectors.call(this);
-            attrToProjector["x"] = Plottable.Plot._scaledAccessor(this.x());
-            attrToProjector["y"] = Plottable.Plot._scaledAccessor(this.y());
-            attrToProjector["defined"] = function (d, i, dataset) {
-                var positionX = Plottable.Plot._scaledAccessor(_this.x())(d, i, dataset);
-                var positionY = Plottable.Plot._scaledAccessor(_this.y())(d, i, dataset);
-                return positionX != null && positionX === positionX && positionY != null && positionY === positionY;
-            };
-            return attrToProjector;
-        };
         XYPlot.prototype.computeLayout = function (origin, availableWidth, availableHeight) {
             _super.prototype.computeLayout.call(this, origin, availableWidth, availableHeight);
             var xScale = this.x().scale;
@@ -6970,8 +6958,9 @@ var Plottable;
             return this.x().accessor != null && this.y().accessor != null;
         };
         XYPlot.prototype._pixelPoint = function (datum, index, dataset) {
-            var attrToProjector = this._generateAttrToProjector();
-            return { x: attrToProjector["x"](datum, index, dataset), y: attrToProjector["y"](datum, index, dataset) };
+            var xProjector = Plottable.Plot._scaledAccessor(this.x());
+            var yProjector = Plottable.Plot._scaledAccessor(this.y());
+            return { x: xProjector(datum, index, dataset), y: yProjector(datum, index, dataset) };
         };
         XYPlot.prototype._getDataToDraw = function () {
             var _this = this;
@@ -7038,9 +7027,9 @@ var Plottable;
                 var _this = this;
                 var attrToProjector = _super.prototype._generateAttrToProjector.call(this);
                 // Copy each of the different projectors.
-                var xAttr = attrToProjector[Rectangle._X_KEY];
+                var xAttr = Plottable.Plot._scaledAccessor(this.x());
                 var x2Attr = attrToProjector[Rectangle._X2_KEY];
-                var yAttr = attrToProjector[Rectangle._Y_KEY];
+                var yAttr = Plottable.Plot._scaledAccessor(this.y());
                 var y2Attr = attrToProjector[Rectangle._Y2_KEY];
                 var xScale = this.x().scale;
                 var yScale = this.y().scale;
@@ -7511,9 +7500,9 @@ var Plottable;
                 var primaryAttr = this._isVertical ? "y" : "x";
                 var secondaryAttr = this._isVertical ? "x" : "y";
                 var scaledBaseline = primaryScale.scale(this._baselineValue);
-                var positionF = attrToProjector[secondaryAttr];
+                var positionF = this._isVertical ? Plottable.Plot._scaledAccessor(this.x()) : Plottable.Plot._scaledAccessor(this.y());
                 var widthF = attrToProjector["width"];
-                var originalPositionFn = attrToProjector[primaryAttr];
+                var originalPositionFn = this._isVertical ? Plottable.Plot._scaledAccessor(this.y()) : Plottable.Plot._scaledAccessor(this.x());
                 var heightF = function (d, i, dataset) {
                     return Math.abs(scaledBaseline - originalPositionFn(d, i, dataset));
                 };

--- a/plottable.js
+++ b/plottable.js
@@ -7674,17 +7674,14 @@ var Plottable;
             };
             Line.prototype._generateAttrToProjector = function () {
                 var attrToProjector = _super.prototype._generateAttrToProjector.call(this);
-                var wholeDatumAttributes = this._wholeDatumAttributes();
-                var isSingleDatumAttr = function (attr) { return wholeDatumAttributes.indexOf(attr) === -1; };
-                var singleDatumAttributes = d3.keys(attrToProjector).filter(isSingleDatumAttr);
-                singleDatumAttributes.forEach(function (attribute) {
+                d3.keys(attrToProjector).forEach(function (attribute) {
+                    if (attribute === "d") {
+                        return;
+                    }
                     var projector = attrToProjector[attribute];
                     attrToProjector[attribute] = function (data, i, dataset) { return data.length > 0 ? projector(data[0], i, dataset) : null; };
                 });
                 return attrToProjector;
-            };
-            Line.prototype._wholeDatumAttributes = function () {
-                return ["x", "y", "defined", "d"];
             };
             Line.prototype.getAllPlotData = function (datasets) {
                 var _this = this;

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -344,9 +344,9 @@ export module Plots {
       var secondaryAttr = this._isVertical ? "x" : "y";
       var scaledBaseline = primaryScale.scale(this._baselineValue);
 
-      var positionF = attrToProjector[secondaryAttr];
+      var positionF = this._isVertical ? Plot._scaledAccessor(this.x()) : Plot._scaledAccessor(this.y());
       var widthF = attrToProjector["width"];
-      var originalPositionFn = attrToProjector[primaryAttr];
+      var originalPositionFn = this._isVertical ? Plot._scaledAccessor(this.y()) : Plot._scaledAccessor(this.x());
       var heightF = (d: any, i: number, dataset: Dataset) => {
         return Math.abs(scaledBaseline - originalPositionFn(d, i, dataset));
       };

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -54,20 +54,14 @@ export module Plots {
 
     protected _generateAttrToProjector() {
       var attrToProjector = super._generateAttrToProjector();
-      var wholeDatumAttributes = this._wholeDatumAttributes();
-      var isSingleDatumAttr = (attr: string) => wholeDatumAttributes.indexOf(attr) === -1;
-      var singleDatumAttributes = d3.keys(attrToProjector).filter(isSingleDatumAttr);
-      singleDatumAttributes.forEach((attribute: string) => {
+      d3.keys(attrToProjector).forEach((attribute: string) => {
+        if (attribute === "d") { return; }
         var projector = attrToProjector[attribute];
         attrToProjector[attribute] = (data: any[], i: number, dataset: Dataset) =>
           data.length > 0 ? projector(data[0], i, dataset) : null;
       });
 
       return attrToProjector;
-    }
-
-    protected _wholeDatumAttributes() {
-      return ["x", "y", "defined", "d"];
     }
 
     public getAllPlotData(datasets = this.datasets()): Plots.PlotData {

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -172,6 +172,14 @@ export module Plots {
                      .defined((innerDatum, innerIndex) => definedProjector(innerDatum, innerIndex, dataset))(datum, index);
       };
     }
+
+    protected _getDataToDraw() {
+      var datasets: D3.Map<any[]> = d3.map();
+      this._datasetKeysInOrder.forEach((key: string) => {
+        datasets.set(key, this._key2PlotDatasetKey.get(key).dataset.data());
+      });
+      return datasets;
+    }
   }
 }
 }

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -54,7 +54,7 @@ export module Plots {
 
     protected _generateAttrToProjector() {
       var attrToProjector = super._generateAttrToProjector();
-      d3.keys(attrToProjector).forEach((attribute: string) => {
+      Object.keys(attrToProjector).forEach((attribute: string) => {
         if (attribute === "d") { return; }
         var projector = attrToProjector[attribute];
         attrToProjector[attribute] = (data: any[], i: number, dataset: Dataset) =>

--- a/src/components/plots/rectanglePlot.ts
+++ b/src/components/plots/rectanglePlot.ts
@@ -41,9 +41,9 @@ export module Plots {
       var attrToProjector = super._generateAttrToProjector();
 
       // Copy each of the different projectors.
-      var xAttr = attrToProjector[Rectangle._X_KEY];
+      var xAttr = Plot._scaledAccessor(this.x());
       var x2Attr = attrToProjector[Rectangle._X2_KEY];
-      var yAttr = attrToProjector[Rectangle._Y_KEY];
+      var yAttr = Plot._scaledAccessor(this.y());
       var y2Attr = attrToProjector[Rectangle._Y2_KEY];
 
       var xScale = this.x().scale;

--- a/src/components/plots/xyPlot.ts
+++ b/src/components/plots/xyPlot.ts
@@ -232,5 +232,22 @@ module Plottable {
       var attrToProjector = this._generateAttrToProjector();
       return { x: attrToProjector["x"](datum, index, dataset), y: attrToProjector["y"](datum, index, dataset) };
     }
+
+    protected _getDataToDraw() {
+      var datasets: D3.Map<any[]> = super._getDataToDraw();
+
+      var definedFunction = (d: any, i: number, dataset: Dataset) => {
+        var positionX = Plot._scaledAccessor(this.x())(d, i, dataset);
+        var positionY = Plot._scaledAccessor(this.y())(d, i, dataset);
+        return positionX != null && positionX === positionX &&
+               positionY != null && positionY === positionY;
+      };
+
+      datasets.forEach((key, data) => {
+        var dataset = this._key2PlotDatasetKey.get(key).dataset;
+        datasets.set(key, data.filter((d, i) => definedFunction(d, i, dataset)));
+      });
+      return datasets;
+    }
   }
 }

--- a/src/components/plots/xyPlot.ts
+++ b/src/components/plots/xyPlot.ts
@@ -227,8 +227,8 @@ module Plottable {
       var definedFunction = (d: any, i: number, dataset: Dataset) => {
         var positionX = Plot._scaledAccessor(this.x())(d, i, dataset);
         var positionY = Plot._scaledAccessor(this.y())(d, i, dataset);
-        return positionX != null && positionX === positionX &&
-               positionY != null && positionY === positionY;
+        return Utils.Methods.isValidNumber(positionX) &&
+               Utils.Methods.isValidNumber(positionY);
       };
 
       datasets.forEach((key, data) => {

--- a/src/components/plots/xyPlot.ts
+++ b/src/components/plots/xyPlot.ts
@@ -154,19 +154,6 @@ module Plottable {
       return this;
     }
 
-    protected _propertyProjectors(): AttributeToProjector {
-      var attrToProjector = super._propertyProjectors();
-      attrToProjector["x"] = Plot._scaledAccessor(this.x());
-      attrToProjector["y"] = Plot._scaledAccessor(this.y());
-      attrToProjector["defined"] = (d: any, i: number, dataset: Dataset) => {
-        var positionX = Plot._scaledAccessor(this.x())(d, i, dataset);
-        var positionY = Plot._scaledAccessor(this.y())(d, i, dataset);
-        return positionX != null && positionX === positionX &&
-               positionY != null && positionY === positionY;
-      };
-      return attrToProjector;
-    }
-
     public computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number) {
       super.computeLayout(origin, availableWidth, availableHeight);
       var xScale = this.x().scale;
@@ -229,8 +216,9 @@ module Plottable {
     }
 
     protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point {
-      var attrToProjector = this._generateAttrToProjector();
-      return { x: attrToProjector["x"](datum, index, dataset), y: attrToProjector["y"](datum, index, dataset) };
+      var xProjector = Plot._scaledAccessor(this.x());
+      var yProjector = Plot._scaledAccessor(this.y());
+      return { x: xProjector(datum, index, dataset), y: yProjector(datum, index, dataset) };
     }
 
     protected _getDataToDraw() {

--- a/src/drawers/drawer.ts
+++ b/src/drawers/drawer.ts
@@ -87,14 +87,6 @@ export module Drawers {
       return modifiedAttrToProjector;
     }
 
-    protected _prepareDrawSteps(drawSteps: AppliedDrawStep[]) {
-      // no-op
-    }
-
-    protected _prepareData(data: any[], drawSteps: AppliedDrawStep[]) {
-      return data;
-    }
-
     /**
      * Draws the data into the renderArea using the spefic steps and metadata
      *
@@ -110,12 +102,8 @@ export module Drawers {
         };
       });
 
-      var preparedData = this._prepareData(data, appliedDrawSteps);
-
-      this._prepareDrawSteps(appliedDrawSteps);
-
-      this._enterData(preparedData);
-      var numberOfIterations = this._numberOfAnimationIterations(preparedData);
+      this._enterData(data);
+      var numberOfIterations = this._numberOfAnimationIterations(data);
 
       var delay = 0;
       appliedDrawSteps.forEach((drawStep, i) => {

--- a/src/drawers/elementDrawer.ts
+++ b/src/drawers/elementDrawer.ts
@@ -38,25 +38,6 @@ export module Drawers {
       dataElements.exit().remove();
     }
 
-    private _filterDefinedData(data: any[], definedFunction: (d: any, i: number) => boolean): any[] {
-      return definedFunction ? data.filter(definedFunction) : data;
-    }
-
-    // HACKHACK To prevent populating undesired attribute to d3, we delete them here.
-    protected _prepareDrawSteps(drawSteps: AppliedDrawStep[]) {
-      super._prepareDrawSteps(drawSteps);
-      drawSteps.forEach((d: DrawStep) => {
-        if (d.attrToProjector["defined"]) {
-          delete d.attrToProjector["defined"];
-        }
-      });
-    }
-
-    protected _prepareData(data: any[], drawSteps: AppliedDrawStep[]) {
-      return drawSteps.reduce((data: any[], drawStep: AppliedDrawStep) =>
-              this._filterDefinedData(data, drawStep.attrToProjector["defined"]), super._prepareData(data, drawSteps));
-    }
-
     public _getSelector(): string {
       return this._svgElement;
     }


### PR DESCRIPTION
There was filtering done on the Drawer level.  This is now done on the appropriate `XYPlot` level.