### PR TITLE
[RenderController] Stringified policies

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -567,8 +567,13 @@ declare module Plottable {
      * ```
      */
     module RenderController {
+        module Policy {
+            var IMMEDIATE: string;
+            var ANIMATION_FRAME: string;
+            var TIMEOUT: string;
+        }
         var _renderPolicy: RenderPolicies.RenderPolicy;
-        function setRenderPolicy(policy: string | RenderPolicies.RenderPolicy): void;
+        function setRenderPolicy(policy: string): void;
         /**
          * If the RenderController is enabled, we enqueue the component for
          * render. Otherwise, it is rendered immediately.

--- a/plottable.js
+++ b/plottable.js
@@ -1334,25 +1334,28 @@ var Plottable;
         var _componentsNeedingComputeLayout = new Plottable.Utils.Set();
         var _animationRequested = false;
         var _isCurrentlyFlushing = false;
+        var Policy;
+        (function (Policy) {
+            Policy.IMMEDIATE = "immediate";
+            Policy.ANIMATION_FRAME = "animationframe";
+            Policy.TIMEOUT = "timeout";
+        })(Policy = RenderController.Policy || (RenderController.Policy = {}));
         RenderController._renderPolicy = new Plottable.RenderPolicies.AnimationFrame();
         function setRenderPolicy(policy) {
-            if (typeof (policy) === "string") {
-                switch (policy.toLowerCase()) {
-                    case "immediate":
-                        policy = new Plottable.RenderPolicies.Immediate();
-                        break;
-                    case "animationframe":
-                        policy = new Plottable.RenderPolicies.AnimationFrame();
-                        break;
-                    case "timeout":
-                        policy = new Plottable.RenderPolicies.Timeout();
-                        break;
-                    default:
-                        Plottable.Utils.Methods.warn("Unrecognized renderPolicy: " + policy);
-                        return;
-                }
+            switch (policy.toLowerCase()) {
+                case Policy.IMMEDIATE:
+                    RenderController._renderPolicy = new Plottable.RenderPolicies.Immediate();
+                    break;
+                case Policy.ANIMATION_FRAME:
+                    RenderController._renderPolicy = new Plottable.RenderPolicies.AnimationFrame();
+                    break;
+                case Policy.TIMEOUT:
+                    RenderController._renderPolicy = new Plottable.RenderPolicies.Timeout();
+                    break;
+                default:
+                    Plottable.Utils.Methods.warn("Unrecognized renderPolicy: " + policy);
+                    return;
             }
-            RenderController._renderPolicy = policy;
         }
         RenderController.setRenderPolicy = setRenderPolicy;
         /**

--- a/plottable.js
+++ b/plottable.js
@@ -1354,7 +1354,6 @@ var Plottable;
                     break;
                 default:
                     Plottable.Utils.Methods.warn("Unrecognized renderPolicy: " + policy);
-                    return;
             }
         }
         RenderController.setRenderPolicy = setRenderPolicy;

--- a/src/core/renderController.ts
+++ b/src/core/renderController.ts
@@ -31,19 +31,19 @@ module Plottable {
     }
     export var _renderPolicy: RenderPolicies.RenderPolicy = new RenderPolicies.AnimationFrame();
 
-    export function setRenderPolicy(policy: string): void {
-      switch ((<string> policy).toLowerCase()) {
+    export function setRenderPolicy(policy: string) {
+      switch (policy.toLowerCase()) {
         case Policy.IMMEDIATE:
-        _renderPolicy = new RenderPolicies.Immediate();
-        break;
+          _renderPolicy = new RenderPolicies.Immediate();
+          break;
         case Policy.ANIMATION_FRAME:
-        _renderPolicy = new RenderPolicies.AnimationFrame();
-        break;
+          _renderPolicy = new RenderPolicies.AnimationFrame();
+          break;
         case Policy.TIMEOUT:
-        _renderPolicy = new RenderPolicies.Timeout();
-        break;
+          _renderPolicy = new RenderPolicies.Timeout();
+          break;
         default:
-        Utils.Methods.warn("Unrecognized renderPolicy: " + policy);
+          Utils.Methods.warn("Unrecognized renderPolicy: " + policy);
         return;
       }
     }

--- a/src/core/renderController.ts
+++ b/src/core/renderController.ts
@@ -24,26 +24,28 @@ module Plottable {
     var _componentsNeedingComputeLayout = new Utils.Set<Component>();
     var _animationRequested = false;
     var _isCurrentlyFlushing = false;
+    export module Policy {
+      export var IMMEDIATE = "immediate";
+      export var ANIMATION_FRAME = "animationframe";
+      export var TIMEOUT = "timeout";
+    }
     export var _renderPolicy: RenderPolicies.RenderPolicy = new RenderPolicies.AnimationFrame();
 
-    export function setRenderPolicy(policy: string | RenderPolicies.RenderPolicy): void {
-      if (typeof(policy) === "string") {
-        switch ((<string> policy).toLowerCase()) {
-          case "immediate":
-          policy = new RenderPolicies.Immediate();
-          break;
-          case "animationframe":
-          policy = new RenderPolicies.AnimationFrame();
-          break;
-          case "timeout":
-          policy = new RenderPolicies.Timeout();
-          break;
-          default:
-          Utils.Methods.warn("Unrecognized renderPolicy: " + policy);
-          return;
-        }
+    export function setRenderPolicy(policy: string): void {
+      switch ((<string> policy).toLowerCase()) {
+        case Policy.IMMEDIATE:
+        _renderPolicy = new RenderPolicies.Immediate();
+        break;
+        case Policy.ANIMATION_FRAME:
+        _renderPolicy = new RenderPolicies.AnimationFrame();
+        break;
+        case Policy.TIMEOUT:
+        _renderPolicy = new RenderPolicies.Timeout();
+        break;
+        default:
+        Utils.Methods.warn("Unrecognized renderPolicy: " + policy);
+        return;
       }
-      _renderPolicy = <RenderPolicies.RenderPolicy> policy;
     }
 
     /**

--- a/src/core/renderController.ts
+++ b/src/core/renderController.ts
@@ -44,7 +44,6 @@ module Plottable {
           break;
         default:
           Utils.Methods.warn("Unrecognized renderPolicy: " + policy);
-        return;
       }
     }
 


### PR DESCRIPTION
Decided not to remove the `RenderPolicy` type and instead just do some stringy enum cleanup in `RenderController.ts`

Fixes #2061 