### PR TITLE
ban d3.keys

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -240,7 +240,7 @@ var Plottable;
              */
             function copyMap(oldMap) {
                 var newMap = {};
-                d3.keys(oldMap).forEach(function (key) { return newMap[key] = oldMap[key]; });
+                Object.keys(oldMap).forEach(function (key) { return newMap[key] = oldMap[key]; });
                 return newMap;
             }
             Methods.copyMap = copyMap;
@@ -2666,7 +2666,7 @@ var Plottable;
             };
             AbstractDrawer.prototype._applyMetadata = function (attrToProjector, dataset) {
                 var modifiedAttrToProjector = {};
-                d3.keys(attrToProjector).forEach(function (attr) {
+                Object.keys(attrToProjector).forEach(function (attr) {
                     modifiedAttrToProjector[attr] = function (datum, index) { return attrToProjector[attr](datum, index, dataset); };
                 });
                 return modifiedAttrToProjector;
@@ -7750,7 +7750,7 @@ var Plottable;
                 var attrToProjector = _super.prototype._generateAttrToProjector.call(this);
                 var wholeDatumAttributes = this._wholeDatumAttributes();
                 var isSingleDatumAttr = function (attr) { return wholeDatumAttributes.indexOf(attr) === -1; };
-                var singleDatumAttributes = d3.keys(attrToProjector).filter(isSingleDatumAttr);
+                var singleDatumAttributes = Object.keys(attrToProjector).filter(isSingleDatumAttr);
                 singleDatumAttributes.forEach(function (attribute) {
                     var projector = attrToProjector[attribute];
                     attrToProjector[attribute] = function (data, i, dataset) { return data.length > 0 ? projector(data[0], i, dataset) : null; };

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -52,7 +52,7 @@ export module Plots {
       var attrToProjector = super._generateAttrToProjector();
       var wholeDatumAttributes = this._wholeDatumAttributes();
       var isSingleDatumAttr = (attr: string) => wholeDatumAttributes.indexOf(attr) === -1;
-      var singleDatumAttributes = d3.keys(attrToProjector).filter(isSingleDatumAttr);
+      var singleDatumAttributes = Object.keys(attrToProjector).filter(isSingleDatumAttr);
       singleDatumAttributes.forEach((attribute: string) => {
         var projector = attrToProjector[attribute];
         attrToProjector[attribute] = (data: any[], i: number, dataset: Dataset) =>

--- a/src/drawers/drawer.ts
+++ b/src/drawers/drawer.ts
@@ -81,7 +81,7 @@ export module Drawers {
     private _applyMetadata(attrToProjector: AttributeToProjector,
                           dataset: Dataset): AttributeToAppliedProjector {
       var modifiedAttrToProjector: AttributeToAppliedProjector = {};
-      d3.keys(attrToProjector).forEach((attr: string) => {
+      Object.keys(attrToProjector).forEach((attr: string) => {
         modifiedAttrToProjector[attr] =
           (datum: any, index: number) => attrToProjector[attr](datum, index, dataset);
       });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -244,7 +244,7 @@ export module Utils {
      */
     export function copyMap<T>(oldMap: { [key: string]: T }): { [key: string]: T } {
       var newMap: { [key: string]: any } = {};
-      d3.keys(oldMap).forEach(key => newMap[key] = oldMap[key]);
+      Object.keys(oldMap).forEach(key => newMap[key] = oldMap[key]);
       return newMap;
     }
 

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
     "ban": [true,
         ["d3", "max"],
         ["d3", "min"],
+        ["d3", "keys"],
         ["assert", "equal"]
     ],
     "class-name": true,


### PR DESCRIPTION
We should be using `Object.keys()` instead