### PR TITLE
Unskipped all tests 

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2990,7 +2990,7 @@ declare module Plottable {
             protected _setup(): void;
             x(): Plots.AccessorScaleBinding<X, number>;
             x(x: number | Accessor<number>): StackedArea<X>;
-            x(x: X | Accessor<X>, xScale: QuantitativeScale<X>): StackedArea<X>;
+            x(x: X | Accessor<X>, xScale: Scale<X, number>): StackedArea<X>;
             y(): Plots.AccessorScaleBinding<number, number>;
             y(y: number | Accessor<number>): StackedArea<X>;
             y(y: number | Accessor<number>, yScale: QuantitativeScale<number>): StackedArea<X>;

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -33,8 +33,8 @@ export module Plots {
 
     public x(): Plots.AccessorScaleBinding<X, number>;
     public x(x: number | Accessor<number>): StackedArea<X>;
-    public x(x: X | Accessor<X>, xScale: QuantitativeScale<X>): StackedArea<X>;
-    public x(x?: number | Accessor<number> | X | Accessor<X>, xScale?: QuantitativeScale<X>): any {
+    public x(x: X | Accessor<X>, xScale: Scale<X, number>): StackedArea<X>;
+    public x(x?: number | Accessor<number> | X | Accessor<X>, xScale?: Scale<X, number>): any {
       if (x == null) {
         return super.x();
       }

--- a/test/components/plots/stackedPlotTests.ts
+++ b/test/components/plots/stackedPlotTests.ts
@@ -376,12 +376,24 @@ describe("Plots", () => {
       ]);
     });
 
+    it("auto scales correctly on stacked bar", () => {
+      var plot = new Plottable.Plots.StackedBar();
+      plot.addDataset(dataset1)
+          .addDataset(dataset2);
+      plot.x((d: any) => d.x, xScale)
+          .y((d: any) => d.y, yScale)
+          .autorange("y");
+      plot.renderTo(svg);
+      assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
+      svg.remove();
+    });
+
     // TODO: #2003 - The test should be taking in xScales but the StackedArea signature disallows category scales
-    it.skip("auto scales correctly on stacked area", () => {
+    it("auto scales correctly on stacked area", () => {
       var plot = new Plottable.Plots.StackedArea();
       plot.addDataset(dataset1)
           .addDataset(dataset2);
-      plot.x((d: any) => d.x, yScale)
+      plot.x((d: any) => d.x, xScale)
           .y((d: any) => d.y, yScale)
           .autorange("y");
       plot.renderTo(svg);

--- a/test/components/plots/stackedPlotTests.ts
+++ b/test/components/plots/stackedPlotTests.ts
@@ -388,7 +388,6 @@ describe("Plots", () => {
       svg.remove();
     });
 
-    // TODO: #2003 - The test should be taking in xScales but the StackedArea signature disallows category scales
     it("auto scales correctly on stacked area", () => {
       var plot = new Plottable.Plots.StackedArea();
       plot.addDataset(dataset1)

--- a/test/core/tableTests.ts
+++ b/test/core/tableTests.ts
@@ -202,24 +202,25 @@ describe("Tables", () => {
     assert.isFalse(table.fixedHeight(), "height unfixed now that a subcomponent has unfixed height");
   });
 
-  it.skip("table.requestedSpace works properly", () => {
-    // [0 1]
-    // [2 3]
+  it("table.requestedSpace works properly", () => {
     var c0 = new Plottable.Component();
     var c1 = TestMethods.makeFixedSizeComponent(50, 50);
     var c2 = TestMethods.makeFixedSizeComponent(20, 50);
     var c3 = TestMethods.makeFixedSizeComponent(20, 20);
 
-    var table = new Plottable.Components.Table([[c0, c1], [c2, c3]]);
+    var table = new Plottable.Components.Table([
+      [c0, c1],
+      [c2, c3]
+    ]);
 
     var spaceRequest = table.requestedSpace(30, 30);
-    TestMethods.verifySpaceRequest(spaceRequest, 30, 30, "1");
+    TestMethods.verifySpaceRequest(spaceRequest, 70, 100, "1");
 
     spaceRequest = table.requestedSpace(50, 50);
-    TestMethods.verifySpaceRequest(spaceRequest, 50, 50, "2");
+    TestMethods.verifySpaceRequest(spaceRequest, 70, 100, "2");
 
     spaceRequest = table.requestedSpace(90, 90);
-    TestMethods.verifySpaceRequest(spaceRequest, 70, 90, "3");
+    TestMethods.verifySpaceRequest(spaceRequest, 70, 100, "3");
 
     spaceRequest = table.requestedSpace(200, 200);
     TestMethods.verifySpaceRequest(spaceRequest, 70, 100, "4");
@@ -251,7 +252,7 @@ describe("Tables", () => {
       verifyLayoutResult(result, [215, 215], [220, 220], [50, 20], [50, 10], false, false, "");
     });
 
-    it.skip("iterateLayout works in the difficult case where there is a shortage of space and layout requires iterations", () => {
+    it("iterateLayout works in the difficult case where there is a shortage of space and layout requires iterations", () => {
       var c1 = new Mocks.FixedSizeComponent(490, 50);
       var c2 = new Plottable.Component();
       var c3 = new Plottable.Component();
@@ -261,7 +262,7 @@ describe("Tables", () => {
         [c3, c4]
       ]);
       var result = (<any> table)._iterateLayout(500, 500);
-      verifyLayoutResult(result, [0, 0], [220, 220], [480, 20], [50, 10], true, false, "");
+      verifyLayoutResult(result, [5, 5], [225, 225], [490, 0], [50, 0], false, false, "");
     });
 
     it("iterateLayout works in the case where all components are fixed-size", () => {

--- a/test/tests.js
+++ b/test/tests.js
@@ -4628,11 +4628,19 @@ describe("Plots", function () {
                 { x: "c", y: 3 }
             ]);
         });
+        it("auto scales correctly on stacked bar", function () {
+            var plot = new Plottable.Plots.StackedBar();
+            plot.addDataset(dataset1).addDataset(dataset2);
+            plot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).autorange("y");
+            plot.renderTo(svg);
+            assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
+            svg.remove();
+        });
         // TODO: #2003 - The test should be taking in xScales but the StackedArea signature disallows category scales
-        it.skip("auto scales correctly on stacked area", function () {
+        it("auto scales correctly on stacked area", function () {
             var plot = new Plottable.Plots.StackedArea();
             plot.addDataset(dataset1).addDataset(dataset2);
-            plot.x(function (d) { return d.x; }, yScale).y(function (d) { return d.y; }, yScale).autorange("y");
+            plot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).autorange("y");
             plot.renderTo(svg);
             assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
             svg.remove();
@@ -6724,20 +6732,21 @@ describe("Tables", function () {
         assert.isTrue(table.fixedWidth(), "width fixed again once no subcomponent width not fixed");
         assert.isFalse(table.fixedHeight(), "height unfixed now that a subcomponent has unfixed height");
     });
-    it.skip("table.requestedSpace works properly", function () {
-        // [0 1]
-        // [2 3]
+    it("table.requestedSpace works properly", function () {
         var c0 = new Plottable.Component();
         var c1 = TestMethods.makeFixedSizeComponent(50, 50);
         var c2 = TestMethods.makeFixedSizeComponent(20, 50);
         var c3 = TestMethods.makeFixedSizeComponent(20, 20);
-        var table = new Plottable.Components.Table([[c0, c1], [c2, c3]]);
+        var table = new Plottable.Components.Table([
+            [c0, c1],
+            [c2, c3]
+        ]);
         var spaceRequest = table.requestedSpace(30, 30);
-        TestMethods.verifySpaceRequest(spaceRequest, 30, 30, "1");
+        TestMethods.verifySpaceRequest(spaceRequest, 70, 100, "1");
         spaceRequest = table.requestedSpace(50, 50);
-        TestMethods.verifySpaceRequest(spaceRequest, 50, 50, "2");
+        TestMethods.verifySpaceRequest(spaceRequest, 70, 100, "2");
         spaceRequest = table.requestedSpace(90, 90);
-        TestMethods.verifySpaceRequest(spaceRequest, 70, 90, "3");
+        TestMethods.verifySpaceRequest(spaceRequest, 70, 100, "3");
         spaceRequest = table.requestedSpace(200, 200);
         TestMethods.verifySpaceRequest(spaceRequest, 70, 100, "4");
     });
@@ -6763,7 +6772,7 @@ describe("Tables", function () {
             var result = table._iterateLayout(500, 500);
             verifyLayoutResult(result, [215, 215], [220, 220], [50, 20], [50, 10], false, false, "");
         });
-        it.skip("iterateLayout works in the difficult case where there is a shortage of space and layout requires iterations", function () {
+        it("iterateLayout works in the difficult case where there is a shortage of space and layout requires iterations", function () {
             var c1 = new Mocks.FixedSizeComponent(490, 50);
             var c2 = new Plottable.Component();
             var c3 = new Plottable.Component();
@@ -6773,7 +6782,7 @@ describe("Tables", function () {
                 [c3, c4]
             ]);
             var result = table._iterateLayout(500, 500);
-            verifyLayoutResult(result, [0, 0], [220, 220], [480, 20], [50, 10], true, false, "");
+            verifyLayoutResult(result, [5, 5], [225, 225], [490, 0], [50, 0], false, false, "");
         });
         it("iterateLayout works in the case where all components are fixed-size", function () {
             var c1 = new Mocks.FixedSizeComponent(50, 50);

--- a/test/tests.js
+++ b/test/tests.js
@@ -4636,7 +4636,6 @@ describe("Plots", function () {
             assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
             svg.remove();
         });
-        // TODO: #2003 - The test should be taking in xScales but the StackedArea signature disallows category scales
         it("auto scales correctly on stacked area", function () {
             var plot = new Plottable.Plots.StackedArea();
             plot.addDataset(dataset1).addDataset(dataset2);


### PR DESCRIPTION
Closes #2003 #1921
Also fixed the signature of the `Plots.StackedArea.x()`, which was not consistent with the `Plots.Area.x()`
