### PR TITLE
Restore "bar-area" CSS class; rename _setupDatasetNodes() to _createNodesForDataset

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2290,7 +2290,7 @@ declare module Plottable {
          * @returns {Plot} The calling Plot.
          */
         addDataset(dataset: Dataset): Plot;
-        protected _setupDatasetNodes(dataset: Dataset): void;
+        protected _createNodesForDataset(dataset: Dataset): Drawer;
         protected _getDrawer(dataset: Dataset): Drawer;
         protected _getAnimator(key: string): Animators.Plot;
         protected _onDatasetUpdate(): void;
@@ -2754,7 +2754,7 @@ declare module Plottable {
              * @returns {Bar} The calling Bar Plot.
              */
             labelFormatter(formatter: Formatter): Bar<X, Y>;
-            protected _setupDatasetNodes(dataset: Dataset): void;
+            protected _createNodesForDataset(dataset: Dataset): Drawer;
             protected _removeDatasetNodes(dataset: Dataset): void;
             /**
              * Returns the Entity nearest to the query point according to the following algorithm:

--- a/plottable.js
+++ b/plottable.js
@@ -6000,7 +6000,7 @@ var Plottable;
             var _this = this;
             _super.prototype._setup.call(this);
             this._renderArea = this._content.append("g").classed("render-area", true);
-            this.datasets().forEach(function (dataset) { return _this._setupDatasetNodes(dataset); });
+            this.datasets().forEach(function (dataset) { return _this._createNodesForDataset(dataset); });
         };
         Plot.prototype.destroy = function () {
             var _this = this;
@@ -6022,15 +6022,16 @@ var Plottable;
             var drawer = this._getDrawer(dataset);
             this._datasetToDrawer.set(dataset, drawer);
             if (this._isSetup) {
-                this._setupDatasetNodes(dataset);
+                this._createNodesForDataset(dataset);
             }
             dataset.onUpdate(this._onDatasetUpdateCallback);
             this._onDatasetUpdate();
             return this;
         };
-        Plot.prototype._setupDatasetNodes = function (dataset) {
+        Plot.prototype._createNodesForDataset = function (dataset) {
             var drawer = this._datasetToDrawer.get(dataset);
             drawer.setup(this._renderArea.append("g"));
+            return drawer;
         };
         Plot.prototype._getDrawer = function (dataset) {
             return new Plottable.Drawer(dataset);
@@ -7120,12 +7121,14 @@ var Plottable;
                     return this;
                 }
             };
-            Bar.prototype._setupDatasetNodes = function (dataset) {
-                _super.prototype._setupDatasetNodes.call(this, dataset);
+            Bar.prototype._createNodesForDataset = function (dataset) {
+                var drawer = _super.prototype._createNodesForDataset.call(this, dataset);
+                drawer._getRenderArea().classed(Bar._BAR_AREA_CLASS, true);
                 var labelArea = this._renderArea.append("g").classed(Bar._LABEL_AREA_CLASS, true);
                 var measurer = new SVGTypewriter.Measurers.CacheCharacterMeasurer(labelArea);
                 var writer = new SVGTypewriter.Writers.Writer(measurer);
                 this._labelConfig.set(dataset, { labelArea: labelArea, measurer: measurer, writer: writer });
+                return drawer;
             };
             Bar.prototype._removeDatasetNodes = function (dataset) {
                 _super.prototype._removeDatasetNodes.call(this, dataset);
@@ -7462,6 +7465,7 @@ var Plottable;
             Bar._DEFAULT_WIDTH = 10;
             Bar._BAR_WIDTH_RATIO = 0.95;
             Bar._SINGLE_BAR_DIMENSION_RATIO = 0.4;
+            Bar._BAR_AREA_CLASS = "bar-area";
             Bar._LABEL_AREA_CLASS = "bar-label-text-area";
             Bar._LABEL_VERTICAL_PADDING = 5;
             Bar._LABEL_HORIZONTAL_PADDING = 5;

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -15,6 +15,7 @@ export module Plots {
     protected static _DEFAULT_WIDTH = 10;
     private static _BAR_WIDTH_RATIO = 0.95;
     private static _SINGLE_BAR_DIMENSION_RATIO = 0.4;
+    private static _BAR_AREA_CLASS = "bar-area";
     private static _LABEL_AREA_CLASS = "bar-label-text-area";
     private static _LABEL_VERTICAL_PADDING = 5;
     private static _LABEL_HORIZONTAL_PADDING = 5;
@@ -171,12 +172,14 @@ export module Plots {
       }
     }
 
-    protected _setupDatasetNodes(dataset: Dataset) {
-      super._setupDatasetNodes(dataset);
+    protected _createNodesForDataset(dataset: Dataset) {
+      var drawer = super._createNodesForDataset(dataset);
+      drawer._getRenderArea().classed(Bar._BAR_AREA_CLASS, true);
       var labelArea = this._renderArea.append("g").classed(Bar._LABEL_AREA_CLASS, true);
       var measurer = new SVGTypewriter.Measurers.CacheCharacterMeasurer(labelArea);
       var writer = new SVGTypewriter.Writers.Writer(measurer);
       this._labelConfig.set(dataset, { labelArea: labelArea, measurer: measurer, writer: writer });
+      return drawer;
     }
 
     protected _removeDatasetNodes(dataset: Dataset) {

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -73,7 +73,7 @@ module Plottable {
     protected _setup() {
       super._setup();
       this._renderArea = this._content.append("g").classed("render-area", true);
-      this.datasets().forEach((dataset) => this._setupDatasetNodes(dataset));
+      this.datasets().forEach((dataset) => this._createNodesForDataset(dataset));
     }
 
     public destroy() {
@@ -96,7 +96,7 @@ module Plottable {
       this._datasetToDrawer.set(dataset, drawer);
 
       if (this._isSetup) {
-        this._setupDatasetNodes(dataset);
+        this._createNodesForDataset(dataset);
       }
 
       dataset.onUpdate(this._onDatasetUpdateCallback);
@@ -104,9 +104,10 @@ module Plottable {
       return this;
     }
 
-    protected _setupDatasetNodes(dataset: Dataset) {
+    protected _createNodesForDataset(dataset: Dataset) {
       var drawer = this._datasetToDrawer.get(dataset);
       drawer.setup(this._renderArea.append("g"));
+      return drawer;
     }
 
     protected _getDrawer(dataset: Dataset): Drawer {


### PR DESCRIPTION
In `Plots.Bar`, the `<g>` containing the bars (`<rect>`s) used to carry the `bar-area` CSS class.
That class has been restored.