### PR TITLE
[Plots.Bar] Fixed type for baselineValue()

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2719,17 +2719,17 @@ declare module Plottable {
              * Gets the baseline value.
              * The baseline is the line that the bars are drawn from.
              *
-             * @returns {number}
+             * @returns {X|Y}
              */
-            baselineValue(): number;
+            baselineValue(): X | Y;
             /**
              * Sets the baseline value.
              * The baseline is the line that the bars are drawn from.
              *
-             * @param {number} value
+             * @param {X|Y} value
              * @returns {Bar} The calling Bar Plot.
              */
-            baselineValue(value: number): Bar<X, Y>;
+            baselineValue(value: X | Y): Bar<X, Y>;
             /**
              * Get whether bar labels are enabled.
              *

--- a/plottable.js
+++ b/plottable.js
@@ -7097,19 +7097,14 @@ var Plottable;
                         return this._baselineValue;
                     }
                     if (!this._projectorsReady()) {
-                        Plottable.Utils.Methods.warn("Asking for the baseline value when no scale is attached is not safe");
                         return 0;
                     }
                     var valueScale = this._isVertical ? this.y().scale : this.x().scale;
                     if (!valueScale) {
-                        Plottable.Utils.Methods.warn("Asking for the baseline value when no value scale is attached is not safe");
                         return 0;
                     }
                     if (valueScale instanceof Plottable.Scales.Time) {
                         return new Date(0);
-                    }
-                    if (valueScale instanceof Plottable.Scales.Category) {
-                        throw new Error("The value scale cannot be a Category Scale");
                     }
                     return 0;
                 }

--- a/plottable.js
+++ b/plottable.js
@@ -7049,7 +7049,7 @@ var Plottable;
                 this.attr("fill", new Plottable.Scales.Color().range()[0]);
                 this.attr("width", function () { return _this._getBarPixelWidth(); });
                 this._labelConfig = new Plottable.Utils.Map();
-                this._baselineValueProvider = function () { return [_this._baselineValue]; };
+                this._baselineValueProvider = function () { return [_this.baselineValue()]; };
             }
             Bar.prototype.x = function (x, xScale) {
                 if (x == null) {
@@ -7248,7 +7248,7 @@ var Plottable;
             Bar.prototype._additionalPaint = function (time) {
                 var _this = this;
                 var primaryScale = this._isVertical ? this.y().scale : this.x().scale;
-                var scaledBaseline = primaryScale.scale(this._baselineValue);
+                var scaledBaseline = primaryScale.scale(this.baselineValue());
                 var baselineAttr = {
                     "x1": this._isVertical ? 0 : scaledBaseline,
                     "y1": this._isVertical ? scaledBaseline : 0,
@@ -7281,7 +7281,7 @@ var Plottable;
                     var primaryAccessor = _this._isVertical ? _this.y().accessor : _this.x().accessor;
                     var originalPositionFn = _this._isVertical ? Plottable.Plot._scaledAccessor(_this.y()) : Plottable.Plot._scaledAccessor(_this.x());
                     var primaryScale = _this._isVertical ? _this.y().scale : _this.x().scale;
-                    var scaledBaseline = primaryScale.scale(_this._baselineValue);
+                    var scaledBaseline = primaryScale.scale(_this.baselineValue());
                     var text = _this._labelFormatter(primaryAccessor(d, i, dataset)).toString();
                     var w = attrToProjector["width"](d, i, dataset);
                     var h = attrToProjector["height"](d, i, dataset);
@@ -7337,7 +7337,7 @@ var Plottable;
                 if (this._dataChanged && this._animate) {
                     var resetAttrToProjector = this._generateAttrToProjector();
                     var primaryScale = this._isVertical ? this.y().scale : this.x().scale;
-                    var scaledBaseline = primaryScale.scale(this._baselineValue);
+                    var scaledBaseline = primaryScale.scale(this.baselineValue());
                     var positionAttr = this._isVertical ? "y" : "x";
                     var dimensionAttr = this._isVertical ? "height" : "width";
                     resetAttrToProjector[positionAttr] = function () { return scaledBaseline; };
@@ -7354,7 +7354,7 @@ var Plottable;
                 var primaryScale = this._isVertical ? this.y().scale : this.x().scale;
                 var primaryAttr = this._isVertical ? "y" : "x";
                 var secondaryAttr = this._isVertical ? "x" : "y";
-                var scaledBaseline = primaryScale.scale(this._baselineValue);
+                var scaledBaseline = primaryScale.scale(this.baselineValue());
                 var positionF = this._isVertical ? Plottable.Plot._scaledAccessor(this.x()) : Plottable.Plot._scaledAccessor(this.y());
                 var widthF = attrToProjector["width"];
                 var originalPositionFn = this._isVertical ? Plottable.Plot._scaledAccessor(this.y()) : Plottable.Plot._scaledAccessor(this.x());

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -123,20 +123,15 @@ export module Plots {
           return this._baselineValue;
         }
         if (!this._projectorsReady()) {
-          Utils.Methods.warn("Asking for the baseline value when no scale is attached is not safe");
           return 0;
         }
         var valueScale = this._isVertical ? this.y().scale : this.x().scale;
         if (!valueScale) {
-          Utils.Methods.warn("Asking for the baseline value when no value scale is attached is not safe");
           return 0;
         }
 
         if (valueScale instanceof Scales.Time) {
           return new Date(0);
-        }
-        if (valueScale instanceof Scales.Category) {
-          throw new Error("The value scale cannot be a Category Scale");
         }
 
         return 0;

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -46,7 +46,7 @@ export module Plots {
       this.attr("fill", new Scales.Color().range()[0]);
       this.attr("width", () => this._getBarPixelWidth());
       this._labelConfig = new Utils.Map<Dataset, LabelConfig>();
-      this._baselineValueProvider = () => [this._baselineValue];
+      this._baselineValueProvider = () => [this.baselineValue()];
     }
 
     public x(): Plots.AccessorScaleBinding<X, number>;
@@ -326,7 +326,7 @@ export module Plots {
 
     protected _additionalPaint(time: number) {
       var primaryScale: Scale<any, number> = this._isVertical ? this.y().scale : this.x().scale;
-      var scaledBaseline = primaryScale.scale(this._baselineValue);
+      var scaledBaseline = primaryScale.scale(this.baselineValue());
 
       var baselineAttr: any = {
         "x1": this._isVertical ? 0 : scaledBaseline,
@@ -362,7 +362,7 @@ export module Plots {
         var primaryAccessor = this._isVertical ? this.y().accessor : this.x().accessor;
         var originalPositionFn = this._isVertical ? Plot._scaledAccessor(this.y()) : Plot._scaledAccessor(this.x());
         var primaryScale: Scale<any, number> = this._isVertical ? this.y().scale : this.x().scale;
-        var scaledBaseline = primaryScale.scale(this._baselineValue);
+        var scaledBaseline = primaryScale.scale(this.baselineValue());
         var text = this._labelFormatter(primaryAccessor(d, i, dataset)).toString();
         var w = attrToProjector["width"](d, i, dataset);
         var h = attrToProjector["height"](d, i, dataset);
@@ -417,7 +417,7 @@ export module Plots {
       if (this._dataChanged && this._animate) {
         var resetAttrToProjector = this._generateAttrToProjector();
         var primaryScale: Scale<any, number> = this._isVertical ? this.y().scale : this.x().scale;
-        var scaledBaseline = primaryScale.scale(this._baselineValue);
+        var scaledBaseline = primaryScale.scale(this.baselineValue());
         var positionAttr = this._isVertical ? "y" : "x";
         var dimensionAttr = this._isVertical ? "height" : "width";
         resetAttrToProjector[positionAttr] = () => scaledBaseline;
@@ -435,7 +435,7 @@ export module Plots {
       var primaryScale: Scale<any, number> = this._isVertical ? this.y().scale : this.x().scale;
       var primaryAttr = this._isVertical ? "y" : "x";
       var secondaryAttr = this._isVertical ? "x" : "y";
-      var scaledBaseline = primaryScale.scale(this._baselineValue);
+      var scaledBaseline = primaryScale.scale(this.baselineValue());
 
       var positionF = this._isVertical ? Plot._scaledAccessor(this.x()) : Plot._scaledAccessor(this.y());
       var widthF = attrToProjector["width"];

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -20,13 +20,13 @@ export module Plots {
     private static _LABEL_VERTICAL_PADDING = 5;
     private static _LABEL_HORIZONTAL_PADDING = 5;
     private _baseline: d3.Selection<void>;
-    private _baselineValue: number;
+    private _baselineValue: X|Y;
     protected _isVertical: boolean;
     private _labelFormatter: Formatter = Formatters.identity();
     private _labelsEnabled = false;
     private _hideBarsIfAnyAreTooWide = true;
     private _labelConfig: Utils.Map<Dataset, LabelConfig>;
-    private _baselineValueProvider: () => number[];
+    private _baselineValueProvider: () => (X|Y)[];
 
     /**
      * @constructor
@@ -106,18 +106,18 @@ export module Plots {
      * Gets the baseline value.
      * The baseline is the line that the bars are drawn from.
      *
-     * @returns {number}
+     * @returns {X|Y}
      */
-    public baselineValue(): number;
+    public baselineValue(): X|Y;
     /**
      * Sets the baseline value.
      * The baseline is the line that the bars are drawn from.
      *
-     * @param {number} value
+     * @param {X|Y} value
      * @returns {Bar} The calling Bar Plot.
      */
-    public baselineValue(value: number): Bar<X, Y>;
-    public baselineValue(value?: number): any {
+    public baselineValue(value: X|Y): Bar<X, Y>;
+    public baselineValue(value?: X|Y): any {
       if (value == null) {
         if (this._baselineValue != null) {
           return this._baselineValue;


### PR DESCRIPTION
Closes #2208.

Well, this is one way of doing it. I did not really like the proper way, where 8 classes (scales) get polluted with a `getBaseValue` public method

**QE Notes**
Nothing should be affected. Tested overlaying tests and all works fine. Regression pass only. Bar Plots affected by this commit.