### PR TITLE
[Plots.Area] Fix regression: clean up line when removing datasets

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2874,6 +2874,7 @@ declare module Plottable {
             y0(y0: number | Accessor<number>): Area<X>;
             protected _onDatasetUpdate(): void;
             addDataset(dataset: Dataset): Area<X>;
+            protected _removeDatasetNodes(dataset: Dataset): void;
             protected _additionalPaint(): void;
             protected _getDrawer(dataset: Dataset): Drawers.Area;
             protected _generateDrawSteps(): Drawers.DrawStep[];

--- a/plottable.js
+++ b/plottable.js
@@ -7672,6 +7672,10 @@ var Plottable;
                 _super.prototype.addDataset.call(this, dataset);
                 return this;
             };
+            Area.prototype._removeDatasetNodes = function (dataset) {
+                _super.prototype._removeDatasetNodes.call(this, dataset);
+                this._lineDrawers.get(dataset).remove();
+            };
             Area.prototype._additionalPaint = function () {
                 var _this = this;
                 var drawSteps = this._generateLineDrawSteps();

--- a/quicktests/overlaying/tests/realistic/add_remove_dataset.js
+++ b/quicktests/overlaying/tests/realistic/add_remove_dataset.js
@@ -1,0 +1,72 @@
+function makeData() {
+  "use strict";
+  function makeSquigglyData(n, startValue) {
+    startValue = startValue ? startValue : 0;
+    var toReturn = new Array(n);
+    for (var i = 0; i < n; i++) {
+      toReturn[i] = {
+        x: startValue + i,
+        y: i > 0 ? toReturn[i-1].y + Math.random()*2-1 : Math.random() * 5
+      };
+    }
+    return toReturn;
+  }
+
+  var data = [];
+  for (var i = 0; i < 10; i++) {
+    data.push(makeSquigglyData(100));
+  }
+
+  return data;
+}
+
+function run(svg, data, Plottable) {
+  "use strict";
+
+  var xScale = new Plottable.Scales.Linear();
+  var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
+  var yScale = new Plottable.Scales.Linear();
+  var yAxis = new Plottable.Axes.Numeric(yScale, "left");
+
+  var plot = new Plottable.Plots.Area();
+  plot.x(function(d) { return d.x; }, xScale);
+  plot.y(function(d) { return d.y; }, yScale);
+  var colorScale = new Plottable.Scales.Color();
+  plot.attr("stroke", function(d, i, ds) { return ds.metadata().id; }, colorScale);
+  plot.attr("fill", function(d, i, ds) { return ds.metadata().id; }, colorScale);
+  var legend = new Plottable.Components.Legend(colorScale);
+
+  var addButton = new Plottable.Components.Label("Add Dataset");
+  addButton.xAlignment("left").padding(5);
+  new Plottable.Interactions.Click()
+    .onClick(function(p) {
+      var numDatasets = plot.datasets().length;
+      if (numDatasets >= 10) {
+        return;
+      }
+      var datasetID = String(numDatasets);
+      var dataset = new Plottable.Dataset(data[numDatasets - 1], { id: datasetID });
+      plot.addDataset(dataset);
+    })
+    .attachTo(addButton);
+  var removeButton = new Plottable.Components.Label("Remove Dataset");
+  removeButton.xAlignment("right").padding(5);
+  new Plottable.Interactions.Click()
+    .onClick(function(p) {
+      var datasets = plot.datasets();
+      if (datasets.length > 0) {
+        plot.removeDataset(datasets[datasets.length - 1]);
+      }
+    })
+    .attachTo(removeButton);
+  var buttonGroup = new Plottable.Components.Group([addButton, removeButton]);
+
+  var chart = new Plottable.Components.Table([
+    [yAxis, plot, legend],
+    [null, xAxis, null],
+    [null, buttonGroup, null]
+  ]);
+  chart.renderTo(svg);
+  addButton.background().select(".background-fill").style("stroke", "black");
+  removeButton.background().select(".background-fill").style("stroke", "black");
+}

--- a/src/components/plots/areaPlot.ts
+++ b/src/components/plots/areaPlot.ts
@@ -93,6 +93,11 @@ export module Plots {
       return this;
     }
 
+    protected _removeDatasetNodes(dataset: Dataset) {
+      super._removeDatasetNodes(dataset);
+      this._lineDrawers.get(dataset).remove();
+    }
+
     protected _additionalPaint() {
       var drawSteps = this._generateLineDrawSteps();
       var dataToDraw = this._getDataToDraw();

--- a/test/components/plots/areaPlotTests.ts
+++ b/test/components/plots/areaPlotTests.ts
@@ -108,6 +108,14 @@ describe("Plots", () => {
       svg.remove();
     });
 
+    it("cleans up correctly when removing Datasets", () => {
+      areaPlot.renderTo(svg);
+      areaPlot.removeDataset(simpleDataset);
+      var paths = areaPlot.content().selectAll("path");
+      assert.strictEqual(paths.size(), 0, "removing a Dataset cleans up all <path>s associated with it");
+      svg.remove();
+    });
+
     it("correctly handles NaN and undefined x and y values", () => {
       var areaData = [
         { foo: 0.0, bar: 0.0 },

--- a/test/tests.js
+++ b/test/tests.js
@@ -3096,6 +3096,13 @@ describe("Plots", function () {
             assert.operator(paths.indexOf(areaSelection), "<", paths.indexOf(lineSelection), "area appended before line");
             svg.remove();
         });
+        it("cleans up correctly when removing Datasets", function () {
+            areaPlot.renderTo(svg);
+            areaPlot.removeDataset(simpleDataset);
+            var paths = areaPlot.content().selectAll("path");
+            assert.strictEqual(paths.size(), 0, "removing a Dataset cleans up all <path>s associated with it");
+            svg.remove();
+        });
         it("correctly handles NaN and undefined x and y values", function () {
             var areaData = [
                 { foo: 0.0, bar: 0.0 },


### PR DESCRIPTION
The `Drawers.Line` wasn't being cleaned up when its associated `Dataset was` removed.

Added a test.
Added a quicktest.