### PR TITLE
Plot.animate() should also function as a getter

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2310,9 +2310,13 @@ declare module Plottable {
         protected _generateAttrToProjector(): AttributeToProjector;
         renderImmediately(): Plot;
         /**
-         * Enables or disables animation.
+         * Returns whether or not the plot will be animated
          */
-        animated(enabled: boolean): Plot;
+        animated(): boolean;
+        /**
+         * Enables or disables animation of the plot.
+         */
+        animated(willAnimate: boolean): Plot;
         detach(): Plot;
         /**
          * Updates the extents associated with each attribute, then autodomains all scales the Plot uses.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2310,11 +2310,11 @@ declare module Plottable {
         protected _generateAttrToProjector(): AttributeToProjector;
         renderImmediately(): Plot;
         /**
-         * Returns whether or not the plot will be animated
+         * Returns whether the plot will be animated.
          */
         animated(): boolean;
         /**
-         * Enables or disables animation of the plot.
+         * Enables or disables animation.
          */
         animated(willAnimate: boolean): Plot;
         detach(): Plot;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2312,7 +2312,7 @@ declare module Plottable {
         /**
          * Enables or disables animation.
          */
-        animate(enabled: boolean): Plot;
+        animated(enabled: boolean): Plot;
         detach(): Plot;
         /**
          * Updates the extents associated with each attribute, then autodomains all scales the Plot uses.

--- a/plottable.js
+++ b/plottable.js
@@ -6085,11 +6085,11 @@ var Plottable;
             }
             return this;
         };
-        /**
-         * Enables or disables animation.
-         */
-        Plot.prototype.animated = function (enabled) {
-            this._animate = enabled;
+        Plot.prototype.animated = function (willAnimate) {
+            if (willAnimate == null) {
+                return this._animate;
+            }
+            this._animate = willAnimate;
             return this;
         };
         Plot.prototype.detach = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -6088,7 +6088,7 @@ var Plottable;
         /**
          * Enables or disables animation.
          */
-        Plot.prototype.animate = function (enabled) {
+        Plot.prototype.animated = function (enabled) {
             this._animate = enabled;
             return this;
         };

--- a/quicktests/overlaying/tests/animations/animate_area.js
+++ b/quicktests/overlaying/tests/animations/animate_area.js
@@ -24,7 +24,7 @@ function run(svg, data, Plottable) {
             .attr("opacity", 0.75)
             .x(function(d) { return d.x; }, xScale)
             .y(function(d) { return d.y; }, yScale)
-            .animate(doAnimate);
+            .animated(doAnimate);
 
   var areaChart = new Plottable.Components.Table([[yAxis, areaRenderer],
    [null,  xAxis]]);

--- a/quicktests/overlaying/tests/animations/animate_horizontalBar.js
+++ b/quicktests/overlaying/tests/animations/animate_horizontalBar.js
@@ -22,7 +22,7 @@ function run(svg, data, Plottable) {
   hBarRenderer.attr("opacity", 0.75);
   hBarRenderer.x(function(d) { return d.x; }, xScale);
   hBarRenderer.y(function(d) { return d.y; }, yScale);
-  hBarRenderer.animate(doAnimate);
+  hBarRenderer.animated(doAnimate);
 
   var hBarChart = new Plottable.Components.Table([[yAxis, hBarRenderer],
    [null,  xAxis]]);

--- a/quicktests/overlaying/tests/animations/animate_line.js
+++ b/quicktests/overlaying/tests/animations/animate_line.js
@@ -24,7 +24,7 @@ function run(svg, data, Plottable) {
               .x(function(d) { return d.x; }, xScale)
               .y(function(d) { return d.y; }, yScale)
               .attr("opacity", 0.75)
-              .animate(doAnimate);
+              .animated(doAnimate);
 
   var lineChart = new Plottable.Components.Table([[yAxis, lineRenderer],
                                                  [null,  xAxis]]);

--- a/quicktests/overlaying/tests/animations/animate_scatter.js
+++ b/quicktests/overlaying/tests/animations/animate_scatter.js
@@ -22,7 +22,7 @@ function run(svg, data, Plottable) {
                                                                  .x(function(d) { return d.x; }, xScale)
                                                                  .y(function(d) { return d.y; }, yScale)
                                                                  .attr("opacity", 0.75)
-                                                                 .animate(true);
+                                                                 .animated(true);
 
   var circleChart = new Plottable.Components.Table([[yAxis, circleRenderer],
    [null,  xAxis]]);

--- a/quicktests/overlaying/tests/animations/animate_verticalBar.js
+++ b/quicktests/overlaying/tests/animations/animate_verticalBar.js
@@ -22,7 +22,7 @@ function run(svg, data, Plottable) {
                               .x(function(d) { return d.x; }, xScale)
                               .y(function(d) { return d.y; }, yScale)
                               .attr("opacity", 0.75)
-                              .animate(doAnimate);
+                              .animated(doAnimate);
 
   var chart = new Plottable.Components.Table([[yAxis, verticalBarPlot],
    [null,  xAxis]]);

--- a/quicktests/overlaying/tests/basic/missing_stacked_area.js
+++ b/quicktests/overlaying/tests/basic/missing_stacked_area.js
@@ -25,7 +25,7 @@ function run(svg, data, Plottable) {
                                          .addDataset(new Plottable.Dataset(data[0]))
                                          .addDataset(new Plottable.Dataset(data[1]))
                                          .addDataset(new Plottable.Dataset(data[2]))
-                                         .animate(true);
+                                         .animated(true);
 
   var center = new Plottable.Components.Group([stackedAreaPlot, new Plottable.Components.Legend(colorScale)]);
 

--- a/quicktests/overlaying/tests/basic/negative_stacked_bar.js
+++ b/quicktests/overlaying/tests/basic/negative_stacked_bar.js
@@ -46,7 +46,7 @@ function run(svg, data, Plottable) {
     .addDataset(dataset5)
     .labelsEnabled(true)
     .labelFormatter(Plottable.Formatters.siSuffix())
-    .animate(true);
+    .animated(true);
 
   var horizontalPlot = new Plottable.Plots.StackedBar("horizontal");
   horizontalPlot.x(function(d) { return d.earnings; }, xScale2)
@@ -59,7 +59,7 @@ function run(svg, data, Plottable) {
     .addDataset(dataset5)
     .labelsEnabled(true)
     .labelFormatter(Plottable.Formatters.siSuffix())
-    .animate(true);
+    .animated(true);
 
   var chart1 = new Plottable.Components.Table([
     [yAxis1, verticalPlot], [null, xAxis1]

--- a/quicktests/overlaying/tests/functional/base_animator.js
+++ b/quicktests/overlaying/tests/functional/base_animator.js
@@ -31,7 +31,7 @@ function run(svg, data, Plottable) {
       .labelFormatter(function(text){return text + "!";})
       .addDataset(new Plottable.Dataset(data))
       .animator( "bars", animator)
-      .animate(true);
+      .animated(true);
 
 
     var chart = new Plottable.Components.Table([

--- a/quicktests/overlaying/tests/realistic/stocks.js
+++ b/quicktests/overlaying/tests/realistic/stocks.js
@@ -66,7 +66,7 @@ function run(svg, data, Plottable) {
           var aaplSource = new Plottable.Dataset(aapl, {name: "AAPL"} );
           var googSource = new Plottable.Dataset(goog, {name: "GOOG"} );
 
-          var line_aapl = new Plottable.Plots.Line().animate(true)
+          var line_aapl = new Plottable.Plots.Line().animated(true)
                                   .addDataset(aaplSource)
                                   .x(function(d) { return d.Date; }, xScale)
                                   .y(function(d) { return d["Adj Close"]; }, yScale_aapl)
@@ -76,7 +76,7 @@ function run(svg, data, Plottable) {
           } else {
             line_aapl.automaticallyAdjustYScaleOverVisiblePoints(true);
           }
-          var line_goog = new Plottable.Plots.Line().animate(true)
+          var line_goog = new Plottable.Plots.Line().animated(true)
                                   .addDataset(googSource)
                                   .x(function(d) { return d.Date; }, xScale)
                                   .y(function(d) { return d["Adj Close"]; }, yScale_goog)
@@ -98,7 +98,7 @@ function run(svg, data, Plottable) {
           var yAxis_diff = new Plottable.Axes.Numeric(yScale_diff, "left");
 
           var DAY_MILLIS = 24 * 60 * 60 * 1000;
-          var bar_diff = new Plottable.Plots.Bar("vertical").animate(true)
+          var bar_diff = new Plottable.Plots.Bar("vertical").animated(true)
                                   .addDataset(new Plottable.Dataset(diffData))
                                   .x(function(d) { return d.Date; }, xScale)
                                   .y(function(d) { return d["net change"]; }, yScale_diff)

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -217,7 +217,7 @@ module Plottable {
     /**
      * Enables or disables animation.
      */
-    public animate(enabled: boolean) {
+    public animated(enabled: boolean) {
       this._animate = enabled;
       return this;
     }

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -215,11 +215,11 @@ module Plottable {
     }
 
     /**
-     * Returns whether or not the plot will be animated
+     * Returns whether the plot will be animated.
      */
     public animated(): boolean;
     /**
-     * Enables or disables animation of the plot.
+     * Enables or disables animation.
      */
     public animated(willAnimate: boolean): Plot;
     public animated(willAnimate?: boolean): any {

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -215,10 +215,19 @@ module Plottable {
     }
 
     /**
-     * Enables or disables animation.
+     * Returns whether or not the plot will be animated
      */
-    public animated(enabled: boolean) {
-      this._animate = enabled;
+    public animated(): boolean;
+    /**
+     * Enables or disables animation of the plot.
+     */
+    public animated(willAnimate: boolean): Plot;
+    public animated(willAnimate?: boolean): any {
+      if (willAnimate == null) {
+        return this._animate;
+      }
+
+      this._animate = willAnimate;
       return this;
     }
 

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -55,7 +55,7 @@ describe("Plots", () => {
         dataset = new Plottable.Dataset(data);
         barPlot = new Plottable.Plots.Bar<string, number>();
         barPlot.addDataset(dataset);
-        barPlot.animate(false);
+        barPlot.animated(false);
         barPlot.baselineValue(0);
         yScale.domain([-2, 2]);
         barPlot.x((d) => d.x, xScale);
@@ -282,7 +282,7 @@ describe("Plots", () => {
         dataset = new Plottable.Dataset(data);
         barPlot = new Plottable.Plots.Bar<number, number>();
         barPlot.addDataset(dataset);
-        barPlot.animate(false);
+        barPlot.animated(false);
         barPlot.baselineValue(0);
         yScale.domain([-2, 2]);
         barPlot.x((d) => d.x, xScale);
@@ -440,7 +440,7 @@ describe("Plots", () => {
         dataset = new Plottable.Dataset(data);
         barPlot = new Plottable.Plots.Bar<number, string>(Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
         barPlot.addDataset(dataset);
-        barPlot.animate(false);
+        barPlot.animated(false);
         barPlot.baselineValue(0);
         barPlot.x((d) => d.x, xScale);
         barPlot.y((d) => d.y, yScale);

--- a/test/components/plots/plotTests.ts
+++ b/test/components/plots/plotTests.ts
@@ -485,7 +485,7 @@ describe("Plots", () => {
       assert.strictEqual(plot.animated(true), plot, "toggling animation returns the plot");
       assert.strictEqual(plot.animated(), true, "animated toggled on");
       plot.animated(false);
-      assert.strictEqual(plot.animated(), true, "animated toggled off");
+      assert.strictEqual(plot.animated(), false, "animated toggled off");
     });
   });
 });

--- a/test/components/plots/plotTests.ts
+++ b/test/components/plots/plotTests.ts
@@ -478,5 +478,14 @@ describe("Plots", () => {
       assert.deepEqual(categoryScale.domain(), ["B", "A"], "extent is in the right order");
       svg.remove();
     });
+
+    it("animated() getter", () => {
+      var plot = new Plottable.Plot();
+      assert.strictEqual(plot.animated(), false, "by default the plot is not animated");
+      assert.strictEqual(plot.animated(true), plot, "toggling animation returns the plot");
+      assert.strictEqual(plot.animated(), true, "animated toggled on");
+      plot.animated(false);
+      assert.strictEqual(plot.animated(), true, "animated toggled off");
+    });
   });
 });

--- a/test/components/plots/plotTests.ts
+++ b/test/components/plots/plotTests.ts
@@ -448,7 +448,7 @@ describe("Plots", () => {
       var x = new Plottable.Scales.Linear();
       var y = new Plottable.Scales.Linear();
       var plot = new Plottable.Plots.Bar();
-      plot.addDataset(new Plottable.Dataset([])).animate(true);
+      plot.addDataset(new Plottable.Dataset([])).animated(true);
       var recordedTime: number = -1;
       var additionalPaint = (x: number) => {
         recordedTime = Math.max(x, recordedTime);

--- a/test/tests.js
+++ b/test/tests.js
@@ -2423,7 +2423,7 @@ describe("Plots", function () {
             assert.strictEqual(plot.animated(true), plot, "toggling animation returns the plot");
             assert.strictEqual(plot.animated(), true, "animated toggled on");
             plot.animated(false);
-            assert.strictEqual(plot.animated(), true, "animated toggled off");
+            assert.strictEqual(plot.animated(), false, "animated toggled off");
         });
     });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -2390,7 +2390,7 @@ describe("Plots", function () {
             var x = new Plottable.Scales.Linear();
             var y = new Plottable.Scales.Linear();
             var plot = new Plottable.Plots.Bar();
-            plot.addDataset(new Plottable.Dataset([])).animate(true);
+            plot.addDataset(new Plottable.Dataset([])).animated(true);
             var recordedTime = -1;
             var additionalPaint = function (x) {
                 recordedTime = Math.max(x, recordedTime);
@@ -3220,7 +3220,7 @@ describe("Plots", function () {
                 dataset = new Plottable.Dataset(data);
                 barPlot = new Plottable.Plots.Bar();
                 barPlot.addDataset(dataset);
-                barPlot.animate(false);
+                barPlot.animated(false);
                 barPlot.baselineValue(0);
                 yScale.domain([-2, 2]);
                 barPlot.x(function (d) { return d.x; }, xScale);
@@ -3412,7 +3412,7 @@ describe("Plots", function () {
                 dataset = new Plottable.Dataset(data);
                 barPlot = new Plottable.Plots.Bar();
                 barPlot.addDataset(dataset);
-                barPlot.animate(false);
+                barPlot.animated(false);
                 barPlot.baselineValue(0);
                 yScale.domain([-2, 2]);
                 barPlot.x(function (d) { return d.x; }, xScale);
@@ -3545,7 +3545,7 @@ describe("Plots", function () {
                 dataset = new Plottable.Dataset(data);
                 barPlot = new Plottable.Plots.Bar(Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
                 barPlot.addDataset(dataset);
-                barPlot.animate(false);
+                barPlot.animated(false);
                 barPlot.baselineValue(0);
                 barPlot.x(function (d) { return d.x; }, xScale);
                 barPlot.y(function (d) { return d.y; }, yScale);

--- a/test/tests.js
+++ b/test/tests.js
@@ -2417,6 +2417,14 @@ describe("Plots", function () {
             assert.deepEqual(categoryScale.domain(), ["B", "A"], "extent is in the right order");
             svg.remove();
         });
+        it("animated() getter", function () {
+            var plot = new Plottable.Plot();
+            assert.strictEqual(plot.animated(), false, "by default the plot is not animated");
+            assert.strictEqual(plot.animated(true), plot, "toggling animation returns the plot");
+            assert.strictEqual(plot.animated(), true, "animated toggled on");
+            plot.animated(false);
+            assert.strictEqual(plot.animated(), true, "animated toggled off");
+        });
     });
 });
 


### PR DESCRIPTION
Closes #2185

Also renamed it to `animated()`

**RFC** I prefer `willAnimate()`