### PR TITLE
Fix extent calculation on QuantitativeScale to account for non-numbers.

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -1711,8 +1711,8 @@ var Plottable;
             return this;
         };
         QuantitativeScale.prototype.extentOfValues = function (values) {
-            // HACKHACK: TS1.4 doesn't consider numbers to be Number-like (valueOf() returning number), so D can't be typed correctly
-            var extent = d3.extent(values);
+            //       HACKHACK: TS1.4 doesn't consider numbers to be Number-like (valueOf() returning number), so D can't be typed correctly
+            var extent = d3.extent(values.filter(function (value) { return Plottable.Utils.Math.isValidNumber(+value); }));
             if (extent[0] == null || extent[1] == null) {
                 return [];
             }

--- a/plottable.js
+++ b/plottable.js
@@ -1711,7 +1711,7 @@ var Plottable;
             return this;
         };
         QuantitativeScale.prototype.extentOfValues = function (values) {
-            //       HACKHACK: TS1.4 doesn't consider numbers to be Number-like (valueOf() returning number), so D can't be typed correctly
+            // HACKHACK: TS1.4 doesn't consider numbers to be Number-like (valueOf() returning number), so D can't be typed correctly
             var extent = d3.extent(values.filter(function (value) { return Plottable.Utils.Math.isValidNumber(+value); }));
             if (extent[0] == null || extent[1] == null) {
                 return [];

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -223,8 +223,8 @@ module Plottable {
     }
 
     public extentOfValues(values: D[]): D[] {
-      // HACKHACK: TS1.4 doesn't consider numbers to be Number-like (valueOf() returning number), so D can't be typed correctly
-      var extent = d3.extent(<any[]> values);
+//       HACKHACK: TS1.4 doesn't consider numbers to be Number-like (valueOf() returning number), so D can't be typed correctly
+      var extent = d3.extent(<any[]> values.filter((value) => Utils.Math.isValidNumber(+value)));
       if (extent[0] == null || extent[1] == null) {
         return [];
       } else {

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -223,7 +223,7 @@ module Plottable {
     }
 
     public extentOfValues(values: D[]): D[] {
-//       HACKHACK: TS1.4 doesn't consider numbers to be Number-like (valueOf() returning number), so D can't be typed correctly
+      // HACKHACK: TS1.4 doesn't consider numbers to be Number-like (valueOf() returning number), so D can't be typed correctly
       var extent = d3.extent(<any[]> values.filter((value) => Utils.Math.isValidNumber(+value)));
       if (extent[0] == null || extent[1] == null) {
         return [];

--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -4,6 +4,14 @@ var assert = chai.assert;
 
 describe("Scales", () => {
   describe("Linear Scales", () => {
+    it("extentOfValues() filters out invalid numbers", () => {
+      var scale = new Plottable.Scales.Linear();
+      var expectedExtent = [0, 1];
+      var arrayWithBadValues: any[] = [null, NaN, undefined, Infinity, -Infinity, "a string", 0, 1];
+      var extent = scale.extentOfValues(arrayWithBadValues);
+      assert.deepEqual(extent, expectedExtent, "invalid values were filtered out");
+    });
+
     it("autoDomain() defaults to [0, 1]", () => {
       var scale = new Plottable.Scales.Linear();
       scale.autoDomain();

--- a/test/scales/timeScaleTests.ts
+++ b/test/scales/timeScaleTests.ts
@@ -3,6 +3,16 @@
 var assert = chai.assert;
 
 describe("TimeScale tests", () => {
+    it.skip("extentOfValues() filters out invalid Dates", () => {
+      var scale = new Plottable.Scales.Time();
+      var expectedExtent = [new Date("2015-06-05"), new Date("2015-06-04")];
+      var arrayWithBadValues: any[] = [null, NaN, undefined, Infinity, -Infinity, "a string",
+        0, new Date("2015-06-05"), new Date("2015-06-04")];
+      var extent = scale.extentOfValues(arrayWithBadValues);
+      assert.strictEqual(extent[0].getTime(), expectedExtent[0].getTime(), "returned correct min");
+      assert.strictEqual(extent[1].getTime(), expectedExtent[1].getTime(), "returned correct max");
+    });
+
   it("can be padded", () => {
     var scale = new Plottable.Scales.Time();
     scale.padProportion(0);

--- a/test/tests.js
+++ b/test/tests.js
@@ -7254,6 +7254,13 @@ describe("Scales", function () {
 var assert = chai.assert;
 describe("Scales", function () {
     describe("Linear Scales", function () {
+        it("extentOfValues() filters out invalid numbers", function () {
+            var scale = new Plottable.Scales.Linear();
+            var expectedExtent = [0, 1];
+            var arrayWithBadValues = [null, NaN, undefined, Infinity, -Infinity, "a string", 0, 1];
+            var extent = scale.extentOfValues(arrayWithBadValues);
+            assert.deepEqual(extent, expectedExtent, "invalid values were filtered out");
+        });
         it("autoDomain() defaults to [0, 1]", function () {
             var scale = new Plottable.Scales.Linear();
             scale.autoDomain();
@@ -7645,6 +7652,14 @@ describe("Scales", function () {
 ///<reference path="../testReference.ts" />
 var assert = chai.assert;
 describe("TimeScale tests", function () {
+    it.skip("extentOfValues() filters out invalid Dates", function () {
+        var scale = new Plottable.Scales.Time();
+        var expectedExtent = [new Date("2015-06-05"), new Date("2015-06-04")];
+        var arrayWithBadValues = [null, NaN, undefined, Infinity, -Infinity, "a string", 0, new Date("2015-06-05"), new Date("2015-06-04")];
+        var extent = scale.extentOfValues(arrayWithBadValues);
+        assert.strictEqual(extent[0].getTime(), expectedExtent[0].getTime(), "returned correct min");
+        assert.strictEqual(extent[1].getTime(), expectedExtent[1].getTime(), "returned correct max");
+    });
     it("can be padded", function () {
         var scale = new Plottable.Scales.Time();
         scale.padProportion(0);


### PR DESCRIPTION
`d3.extent()` behaves differently if the first element in the array isn't a `number`, so I filtered the values before passing them in.

Test fiddle showing the bug (on develop): http://jsfiddle.net/b48jk5yx/

One thing we should consider is if we want to have `Scales.Time` reject non-`Date` objects -- see the skipped test in **timeScaleTests.ts**.

One more thing to fix here is that `entities()` returns corrupted data if there are datums that are skipped. going to get to that next.

Test fiddle showing the bug (on `numericExtent`): http://jsfiddle.net/njqnu1vf/ (open the console)