### PR TITLE
Fix entity bug

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -1711,8 +1711,8 @@ var Plottable;
             return this;
         };
         QuantitativeScale.prototype.extentOfValues = function (values) {
-            // HACKHACK: TS1.4 doesn't consider numbers to be Number-like (valueOf() returning number), so D can't be typed correctly
-            var extent = d3.extent(values);
+            //       HACKHACK: TS1.4 doesn't consider numbers to be Number-like (valueOf() returning number), so D can't be typed correctly
+            var extent = d3.extent(values.filter(function (value) { return Plottable.Utils.Math.isValidNumber(+value); }));
             if (extent[0] == null || extent[1] == null) {
                 return [];
             }

--- a/plottable.js
+++ b/plottable.js
@@ -1711,7 +1711,7 @@ var Plottable;
             return this;
         };
         QuantitativeScale.prototype.extentOfValues = function (values) {
-            //       HACKHACK: TS1.4 doesn't consider numbers to be Number-like (valueOf() returning number), so D can't be typed correctly
+            // HACKHACK: TS1.4 doesn't consider numbers to be Number-like (valueOf() returning number), so D can't be typed correctly
             var extent = d3.extent(values.filter(function (value) { return Plottable.Utils.Math.isValidNumber(+value); }));
             if (extent[0] == null || extent[1] == null) {
                 return [];

--- a/plottable.js
+++ b/plottable.js
@@ -6295,19 +6295,21 @@ var Plottable;
             var entities = [];
             datasets.forEach(function (dataset) {
                 var drawer = _this._datasetToDrawer.get(dataset);
-                dataset.data().forEach(function (datum, index) {
-                    var position = _this._pixelPoint(datum, index, dataset);
+                var loopIndex = 0;
+                dataset.data().forEach(function (datum, datasetIndex) {
+                    var position = _this._pixelPoint(datum, datasetIndex, dataset);
                     if (position.x !== position.x || position.y !== position.y) {
                         return;
                     }
                     entities.push({
                         datum: datum,
-                        index: index,
+                        index: datasetIndex,
                         dataset: dataset,
                         position: position,
-                        selection: drawer.selectionForIndex(index),
+                        selection: drawer.selectionForIndex(loopIndex),
                         plot: _this
                     });
+                    loopIndex++;
                 });
             });
             return entities;

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -459,19 +459,21 @@ module Plottable {
       var entities: Plots.Entity[] = [];
       datasets.forEach((dataset) => {
         var drawer = this._datasetToDrawer.get(dataset);
-        dataset.data().forEach((datum: any, index: number) => {
-          var position = this._pixelPoint(datum, index, dataset);
+        var loopIndex = 0;
+        dataset.data().forEach((datum: any, datasetIndex: number) => {
+          var position = this._pixelPoint(datum, datasetIndex, dataset);
           if (position.x !== position.x || position.y !== position.y) {
             return;
           }
           entities.push({
             datum: datum,
-            index: index,
+            index: datasetIndex,
             dataset: dataset,
             position: position,
-            selection: drawer.selectionForIndex(index),
+            selection: drawer.selectionForIndex(loopIndex),
             plot: this
           });
+          loopIndex++;
         });
       });
       return entities;

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -223,8 +223,8 @@ module Plottable {
     }
 
     public extentOfValues(values: D[]): D[] {
-      // HACKHACK: TS1.4 doesn't consider numbers to be Number-like (valueOf() returning number), so D can't be typed correctly
-      var extent = d3.extent(<any[]> values);
+//       HACKHACK: TS1.4 doesn't consider numbers to be Number-like (valueOf() returning number), so D can't be typed correctly
+      var extent = d3.extent(<any[]> values.filter((value) => Utils.Math.isValidNumber(+value)));
       if (extent[0] == null || extent[1] == null) {
         return [];
       } else {

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -223,7 +223,7 @@ module Plottable {
     }
 
     public extentOfValues(values: D[]): D[] {
-//       HACKHACK: TS1.4 doesn't consider numbers to be Number-like (valueOf() returning number), so D can't be typed correctly
+      // HACKHACK: TS1.4 doesn't consider numbers to be Number-like (valueOf() returning number), so D can't be typed correctly
       var extent = d3.extent(<any[]> values.filter((value) => Utils.Math.isValidNumber(+value)));
       if (extent[0] == null || extent[1] == null) {
         return [];

--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -4,6 +4,14 @@ var assert = chai.assert;
 
 describe("Scales", () => {
   describe("Linear Scales", () => {
+    it("extentOfValues() filters out invalid numbers", () => {
+      var scale = new Plottable.Scales.Linear();
+      var expectedExtent = [0, 1];
+      var arrayWithBadValues: any[] = [null, NaN, undefined, Infinity, -Infinity, "a string", 0, 1];
+      var extent = scale.extentOfValues(arrayWithBadValues);
+      assert.deepEqual(extent, expectedExtent, "invalid values were filtered out");
+    });
+
     it("autoDomain() defaults to [0, 1]", () => {
       var scale = new Plottable.Scales.Linear();
       scale.autoDomain();

--- a/test/scales/timeScaleTests.ts
+++ b/test/scales/timeScaleTests.ts
@@ -3,6 +3,16 @@
 var assert = chai.assert;
 
 describe("TimeScale tests", () => {
+    it.skip("extentOfValues() filters out invalid Dates", () => {
+      var scale = new Plottable.Scales.Time();
+      var expectedExtent = [new Date("2015-06-05"), new Date("2015-06-04")];
+      var arrayWithBadValues: any[] = [null, NaN, undefined, Infinity, -Infinity, "a string",
+        0, new Date("2015-06-05"), new Date("2015-06-04")];
+      var extent = scale.extentOfValues(arrayWithBadValues);
+      assert.strictEqual(extent[0].getTime(), expectedExtent[0].getTime(), "returned correct min");
+      assert.strictEqual(extent[1].getTime(), expectedExtent[1].getTime(), "returned correct max");
+    });
+
   it("can be padded", () => {
     var scale = new Plottable.Scales.Time();
     scale.padProportion(0);

--- a/test/tests.js
+++ b/test/tests.js
@@ -7254,6 +7254,13 @@ describe("Scales", function () {
 var assert = chai.assert;
 describe("Scales", function () {
     describe("Linear Scales", function () {
+        it("extentOfValues() filters out invalid numbers", function () {
+            var scale = new Plottable.Scales.Linear();
+            var expectedExtent = [0, 1];
+            var arrayWithBadValues = [null, NaN, undefined, Infinity, -Infinity, "a string", 0, 1];
+            var extent = scale.extentOfValues(arrayWithBadValues);
+            assert.deepEqual(extent, expectedExtent, "invalid values were filtered out");
+        });
         it("autoDomain() defaults to [0, 1]", function () {
             var scale = new Plottable.Scales.Linear();
             scale.autoDomain();
@@ -7645,6 +7652,14 @@ describe("Scales", function () {
 ///<reference path="../testReference.ts" />
 var assert = chai.assert;
 describe("TimeScale tests", function () {
+    it.skip("extentOfValues() filters out invalid Dates", function () {
+        var scale = new Plottable.Scales.Time();
+        var expectedExtent = [new Date("2015-06-05"), new Date("2015-06-04")];
+        var arrayWithBadValues = [null, NaN, undefined, Infinity, -Infinity, "a string", 0, new Date("2015-06-05"), new Date("2015-06-04")];
+        var extent = scale.extentOfValues(arrayWithBadValues);
+        assert.strictEqual(extent[0].getTime(), expectedExtent[0].getTime(), "returned correct min");
+        assert.strictEqual(extent[1].getTime(), expectedExtent[1].getTime(), "returned correct max");
+    });
     it("can be padded", function () {
         var scale = new Plottable.Scales.Time();
         scale.padProportion(0);


### PR DESCRIPTION
The secondary bug mentioned on #2236.

Test fiddle showing the bug: http://jsfiddle.net/njqnu1vf/1/ (open the console)
**expected**: circles are drawn around the position of each `Entity`
**actual**: no circles drawn, error in console

#### The fix
Keep a different index that only counts the valid datums, and use that index to retrieve the `Selection`. Invalid datums are never drawn, so they have no `Selection`.

A better fix might be to have a method `selectionForDatum()` rather than `selectionForIndex()` on `Drawer`.