### PR TITLE
Use loopIndex when searching for selection.

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -6295,7 +6295,7 @@ var Plottable;
             var entities = [];
             datasets.forEach(function (dataset) {
                 var drawer = _this._datasetToDrawer.get(dataset);
-                var loopIndex = 0;
+                var validDatumIndex = 0;
                 dataset.data().forEach(function (datum, datasetIndex) {
                     var position = _this._pixelPoint(datum, datasetIndex, dataset);
                     if (position.x !== position.x || position.y !== position.y) {
@@ -6306,10 +6306,10 @@ var Plottable;
                         index: datasetIndex,
                         dataset: dataset,
                         position: position,
-                        selection: drawer.selectionForIndex(loopIndex),
+                        selection: drawer.selectionForIndex(validDatumIndex),
                         plot: _this
                     });
-                    loopIndex++;
+                    validDatumIndex++;
                 });
             });
             return entities;

--- a/plottable.js
+++ b/plottable.js
@@ -6295,19 +6295,21 @@ var Plottable;
             var entities = [];
             datasets.forEach(function (dataset) {
                 var drawer = _this._datasetToDrawer.get(dataset);
-                dataset.data().forEach(function (datum, index) {
-                    var position = _this._pixelPoint(datum, index, dataset);
+                var loopIndex = 0;
+                dataset.data().forEach(function (datum, datasetIndex) {
+                    var position = _this._pixelPoint(datum, datasetIndex, dataset);
                     if (position.x !== position.x || position.y !== position.y) {
                         return;
                     }
                     entities.push({
                         datum: datum,
-                        index: index,
+                        index: datasetIndex,
                         dataset: dataset,
                         position: position,
-                        selection: drawer.selectionForIndex(index),
+                        selection: drawer.selectionForIndex(loopIndex),
                         plot: _this
                     });
+                    loopIndex++;
                 });
             });
             return entities;

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -459,19 +459,21 @@ module Plottable {
       var entities: Plots.Entity[] = [];
       datasets.forEach((dataset) => {
         var drawer = this._datasetToDrawer.get(dataset);
-        dataset.data().forEach((datum: any, index: number) => {
-          var position = this._pixelPoint(datum, index, dataset);
+        var loopIndex = 0;
+        dataset.data().forEach((datum: any, datasetIndex: number) => {
+          var position = this._pixelPoint(datum, datasetIndex, dataset);
           if (position.x !== position.x || position.y !== position.y) {
             return;
           }
           entities.push({
             datum: datum,
-            index: index,
+            index: datasetIndex,
             dataset: dataset,
             position: position,
-            selection: drawer.selectionForIndex(index),
+            selection: drawer.selectionForIndex(loopIndex),
             plot: this
           });
+          loopIndex++;
         });
       });
       return entities;

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -459,7 +459,7 @@ module Plottable {
       var entities: Plots.Entity[] = [];
       datasets.forEach((dataset) => {
         var drawer = this._datasetToDrawer.get(dataset);
-        var loopIndex = 0;
+        var validDatumIndex = 0;
         dataset.data().forEach((datum: any, datasetIndex: number) => {
           var position = this._pixelPoint(datum, datasetIndex, dataset);
           if (position.x !== position.x || position.y !== position.y) {
@@ -470,10 +470,10 @@ module Plottable {
             index: datasetIndex,
             dataset: dataset,
             position: position,
-            selection: drawer.selectionForIndex(loopIndex),
+            selection: drawer.selectionForIndex(validDatumIndex),
             plot: this
           });
-          loopIndex++;
+          validDatumIndex++;
         });
       });
       return entities;


### PR DESCRIPTION
The secondary bug mentioned on #2236, remake of #2237.

Test fiddle showing the bug: http://jsfiddle.net/njqnu1vf/1/ (open the console)
**expected**: circles are drawn around the position of each `Entity`
**actual**: no circles drawn, error in console

#### The fix
Keep a different index that only counts the valid datums, and use that index to retrieve the `Selection`. Invalid datums are never drawn, so they have no `Selection`.

A better fix might be to have a method `selectionForDatum()` rather than `selectionForIndex()` on `Drawer`.

Fiddle as fixed on this branch: http://jsfiddle.net/ap0ujhu0/