### PR TITLE
[Drawer] - the `draw()` endpoint should return this

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1187,13 +1187,14 @@ declare module Plottable {
          */
         protected _drawStep(step: Drawers.AppliedDrawStep): void;
         protected _numberOfAnimationIterations(data: any[]): number;
+        totalDrawTime(data: any[], drawSteps: Drawers.DrawStep[]): number;
         /**
          * Draws the data into the renderArea using the spefic steps and metadata
          *
          * @param{any[]} data The data to be drawn
          * @param{DrawStep[]} drawSteps The list of steps, which needs to be drawn
          */
-        draw(data: any[], drawSteps: Drawers.DrawStep[]): number;
+        draw(data: any[], drawSteps: Drawers.DrawStep[]): Drawer;
         /**
          * Returns the CSS selector for this Drawer's visual elements.
          */

--- a/plottable.js
+++ b/plottable.js
@@ -8177,7 +8177,7 @@ var Plottable;
             Base.prototype.totalTime = function (numberOfIterations) {
                 var maxDelayForLastIteration = Math.max(this.maxTotalDuration() - this.duration(), 0);
                 var adjustedIterativeDelay = Math.min(this.maxIterativeDelay(), maxDelayForLastIteration / Math.max(numberOfIterations - 1, 1));
-                var time = adjustedIterativeDelay * numberOfIterations + this.delay() + this.duration();
+                var time = adjustedIterativeDelay * (numberOfIterations - 1) + this.delay() + this.duration();
                 return time;
             };
             Base.prototype.animate = function (selection, attrToAppliedProjector) {

--- a/plottable.js
+++ b/plottable.js
@@ -2611,6 +2611,14 @@ var Plottable;
             });
             return modifiedAttrToProjector;
         };
+        Drawer.prototype.totalDrawTime = function (data, drawSteps) {
+            var numberOfIterations = this._numberOfAnimationIterations(data);
+            var delay = 0;
+            drawSteps.forEach(function (drawStep, i) {
+                delay += drawStep.animator.totalTime(numberOfIterations);
+            });
+            return delay;
+        };
         /**
          * Draws the data into the renderArea using the spefic steps and metadata
          *
@@ -2633,7 +2641,7 @@ var Plottable;
                 Plottable.Utils.Window.setTimeout(function () { return _this._drawStep(drawStep); }, delay);
                 delay += drawStep.animator.totalTime(numberOfIterations);
             });
-            return delay;
+            return this;
         };
         /**
          * Returns the CSS selector for this Drawer's visual elements.
@@ -6256,7 +6264,8 @@ var Plottable;
             var drawSteps = this._generateDrawSteps();
             var dataToDraw = this._getDataToDraw();
             var drawers = this._getDrawersInOrder();
-            var times = this.datasets().map(function (ds, i) { return drawers[i].draw(dataToDraw.get(ds), drawSteps); });
+            this.datasets().forEach(function (ds, i) { return drawers[i].draw(dataToDraw.get(ds), drawSteps); });
+            var times = this.datasets().map(function (ds, i) { return drawers[i].totalDrawTime(dataToDraw.get(ds), drawSteps); });
             var maxTime = Plottable.Utils.Math.max(times, 0);
             this._additionalPaint(maxTime);
         };

--- a/quicktests/overlaying/tests/functional/base_animator.js
+++ b/quicktests/overlaying/tests/functional/base_animator.js
@@ -30,7 +30,7 @@ function run(svg, data, Plottable) {
       .labelsEnabled(true)
       .labelFormatter(function(text){return text + "!";})
       .addDataset(new Plottable.Dataset(data))
-      .animator( "bars", animator)
+      .animator("main", animator)
       .animated(true);
 
 

--- a/src/animators/baseAnimator.ts
+++ b/src/animators/baseAnimator.ts
@@ -59,7 +59,7 @@ export module Animators {
     public totalTime(numberOfIterations: number) {
       var maxDelayForLastIteration = Math.max(this.maxTotalDuration() - this.duration(), 0);
       var adjustedIterativeDelay = Math.min(this.maxIterativeDelay(), maxDelayForLastIteration / Math.max(numberOfIterations - 1, 1));
-      var time = adjustedIterativeDelay * numberOfIterations + this.delay() + this.duration();
+      var time = adjustedIterativeDelay * (numberOfIterations - 1) + this.delay() + this.duration();
       return time;
     }
 

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -418,11 +418,9 @@ module Plottable {
       var dataToDraw = this._getDataToDraw();
       var drawers = this._getDrawersInOrder();
 
-      var times = this.datasets().map((ds, i) =>
-        drawers[i].draw(
-          dataToDraw.get(ds),
-          drawSteps
-        ));
+      this.datasets().forEach((ds, i) => drawers[i].draw(dataToDraw.get(ds), drawSteps));
+
+      var times = this.datasets().map((ds, i) => drawers[i].totalDrawTime(dataToDraw.get(ds), drawSteps));
       var maxTime = Utils.Math.max(times, 0);
       this._additionalPaint(maxTime);
     }

--- a/src/drawers/drawer.ts
+++ b/src/drawers/drawer.ts
@@ -40,7 +40,7 @@ export module Drawers {
     public renderArea(): d3.Selection<void>;
     /**
      * Sets the renderArea selection for the Drawer.
-     * 
+     *
      * @param {d3.Selection} Selection containing the <g> to render to.
      * @returns {Drawer} The calling Drawer.
      */
@@ -94,6 +94,16 @@ export module Drawers {
       return modifiedAttrToProjector;
     }
 
+    public totalDrawTime(data: any[], drawSteps: Drawers.DrawStep[]) {
+      var numberOfIterations = this._numberOfAnimationIterations(data);
+      var delay = 0;
+      drawSteps.forEach((drawStep, i) => {
+        delay += drawStep.animator.totalTime(numberOfIterations);
+      });
+
+      return delay;
+    }
+
     /**
      * Draws the data into the renderArea using the spefic steps and metadata
      *
@@ -118,7 +128,7 @@ export module Drawers {
         delay += drawStep.animator.totalTime(numberOfIterations);
       });
 
-      return delay;
+      return this;
     }
 
     /**

--- a/test/drawers/drawerTests.ts
+++ b/test/drawers/drawerTests.ts
@@ -102,5 +102,36 @@ describe("Drawers", () => {
       assert.strictEqual(selection.node(), circles[0][1], "correct selection gotten");
       svg.remove();
     });
+
+    it("totalDrawTime()", () => {
+      var svg = TestMethods.generateSVG(300, 300);
+      var drawer = new Plottable.Drawer(null);
+
+      var dataObjects = 9;
+      var stepDuration = 987;
+      var stepDelay = 133;
+      var startDelay = 245;
+
+      var expectedAnimationDuration = startDelay + (dataObjects - 1) * stepDelay + stepDuration;
+
+      var data = Plottable.Utils.Array.createFilledArray({}, dataObjects);
+
+      var attrToProjector: Plottable.AttributeToProjector = null;
+
+      var animator = new Plottable.Animators.Base();
+      animator.maxTotalDuration(Infinity);
+      animator.duration(stepDuration);
+      animator.maxIterativeDelay(stepDelay);
+      animator.delay(startDelay);
+
+      var mockDrawStep = [{attrToProjector: attrToProjector, animator: animator}];
+
+      var drawTime = drawer.totalDrawTime(data, mockDrawStep);
+
+      assert.strictEqual(drawTime, expectedAnimationDuration, "Total Draw time");
+
+      svg.remove();
+
+    });
   });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -410,6 +410,26 @@ describe("Drawers", function () {
             assert.strictEqual(selection.node(), circles[0][1], "correct selection gotten");
             svg.remove();
         });
+        it("totalDrawTime()", function () {
+            var svg = TestMethods.generateSVG(300, 300);
+            var drawer = new Plottable.Drawer(null);
+            var dataObjects = 9;
+            var stepDuration = 987;
+            var stepDelay = 133;
+            var startDelay = 245;
+            var expectedAnimationDuration = startDelay + (dataObjects - 1) * stepDelay + stepDuration;
+            var data = Plottable.Utils.Array.createFilledArray({}, dataObjects);
+            var attrToProjector = null;
+            var animator = new Plottable.Animators.Base();
+            animator.maxTotalDuration(Infinity);
+            animator.duration(stepDuration);
+            animator.maxIterativeDelay(stepDelay);
+            animator.delay(startDelay);
+            var mockDrawStep = [{ attrToProjector: attrToProjector, animator: animator }];
+            var drawTime = drawer.totalDrawTime(data, mockDrawStep);
+            assert.strictEqual(drawTime, expectedAnimationDuration, "Total Draw time");
+            svg.remove();
+        });
     });
 });
 


### PR DESCRIPTION
Closes #2197 

Separated the `draw()` method into 2 separate methods, one used for drawing, one used for retrieving the total draw time needed. 

Additions:
`Drawer.totalDrawTime()`

**BugFix:** The total drawing time on the animator was not computed correctly, as it was adding an extra step Delay

**QE Notes:**
In general nothing should have changed except:
- For a `Plots.Bar`, if we have labels on the bars (like in the `base_animator` overlaying test), the labels used to show up 1 interval later, which was not correct, now they show up correctly
- Added a new endpoint on the drawer called `totalDrawTime()`. For quick use case, this is copy+paste from the test I've written
```typescript
    it("totalDrawTime()", () => {
      var svg = TestMethods.generateSVG(300, 300);
      var drawer = new Plottable.Drawer(null);

      var dataObjects = 9;
      var stepDuration = 987;
      var stepDelay = 133;
      var startDelay = 245;

      var expectedAnimationDuration = startDelay + (dataObjects - 1) * stepDelay + stepDuration;

      var data = Plottable.Utils.Array.createFilledArray({}, dataObjects);

      var attrToProjector: Plottable.AttributeToProjector = null;

      var animator = new Plottable.Animators.Base();
      animator.maxTotalDuration(Infinity);
      animator.duration(stepDuration);
      animator.maxIterativeDelay(stepDelay);
      animator.delay(startDelay);

      var mockDrawStep = [{attrToProjector: attrToProjector, animator: animator}];

      var drawTime = drawer.totalDrawTime(data, mockDrawStep);

      assert.strictEqual(drawTime, expectedAnimationDuration, "Total Draw time");

      svg.remove();

    });
```

Also, I altered the `basic_animator` `run()` method to show the totalDrawTime. Maybe this will make more sense
```typescript
function run(svg, data, Plottable) {
  "use strict";

    var xScale = new Plottable.Scales.Category();
    var yScale = new Plottable.Scales.Linear();
    var colorScale = new Plottable.Scales.Color();


    var xAxis = new Plottable.Axes.Category(xScale, "bottom");
    var yAxis = new Plottable.Axes.Numeric(yScale, "left");
    var animator = new Plottable.Animators.Base();
    animator.maxTotalDuration(Infinity);
    animator.duration(1000);
    animator.maxIterativeDelay(1000);


    var vbar = new Plottable.Plots.Bar()
      .x(function(d) { return d.x; }, xScale)
      .y(function(d) { return d.y; }, yScale)
      .attr("fill", function(d) { return d.type; }, colorScale)
      .labelsEnabled(true)
      .labelFormatter(function(text){return text + "!";})
      .addDataset(new Plottable.Dataset(data))
      .animator("main", animator)
      .animated(true);


    var chart = new Plottable.Components.Table([
      [yAxis, vbar],
      [null,  xAxis]
    ]);

    var drawer = new Plottable.Drawer(null);
    var time = drawer.totalDrawTime(data, vbar._generateDrawSteps());
    console.log(time);


    var cb = function(){
      vbar.datasets()[0].data(data);
    };
    var click = new Plottable.Interactions.Click().onClick(cb);

    click.attachTo(vbar);

    chart.renderTo(svg);
}
```
Nothing else should be broken 