### PR TITLE
Privitizing

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2693,7 +2693,6 @@ declare module Plottable {
         class Bar<X, Y> extends XYPlot<X, Y> {
             static ORIENTATION_VERTICAL: string;
             static ORIENTATION_HORIZONTAL: string;
-            protected static _DEFAULT_WIDTH: number;
             protected _isVertical: boolean;
             /**
              * @constructor

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -607,7 +607,6 @@ declare module Plottable {
      */
     type SymbolFactory = (symbolSize: number) => string;
     module SymbolFactories {
-        type StringAccessor = (datum: any, index: number) => string;
         function circle(): SymbolFactory;
         function square(): SymbolFactory;
         function cross(): SymbolFactory;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2269,7 +2269,6 @@ declare module Plottable {
     class Plot extends Component {
         protected _dataChanged: boolean;
         protected _renderArea: d3.Selection<void>;
-        protected _attrExtents: d3.Map<any[]>;
         protected _animate: boolean;
         protected _animateOnNextRender: boolean;
         protected _propertyExtents: d3.Map<any[]>;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2269,7 +2269,6 @@ declare module Plottable {
     class Plot extends Component {
         protected _dataChanged: boolean;
         protected _renderArea: d3.Selection<void>;
-        protected _attrBindings: d3.Map<Plots.AccessorScaleBinding<any, any>>;
         protected _attrExtents: d3.Map<any[]>;
         protected _animate: boolean;
         protected _animateOnNextRender: boolean;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1287,8 +1287,6 @@ declare module Plottable {
         }
     }
     class Component {
-        protected _element: d3.Selection<void>;
-        protected _content: d3.Selection<void>;
         protected _boundingBox: d3.Selection<void>;
         protected _clipPathEnabled: boolean;
         protected _isSetup: boolean;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2931,7 +2931,6 @@ declare module Plottable {
             protected _additionalPaint(): void;
             protected _updateYScale(): void;
             protected _onDatasetUpdate(): StackedArea<X>;
-            protected _wholeDatumAttributes(): string[];
             protected _updateExtentsForProperty(property: string): void;
             protected _extentsForProperty(attr: string): any[];
             protected _propertyProjectors(): AttributeToProjector;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2268,7 +2268,6 @@ declare module Plottable {
     }
     class Plot extends Component {
         protected _dataChanged: boolean;
-        protected _datasetToDrawer: Utils.Map<Dataset, Drawer>;
         protected _renderArea: d3.Selection<void>;
         protected _attrBindings: d3.Map<Plots.AccessorScaleBinding<any, any>>;
         protected _attrExtents: d3.Map<any[]>;

--- a/plottable.js
+++ b/plottable.js
@@ -3972,7 +3972,7 @@ var Plottable;
                 this._setupDomElements();
             };
             Time.prototype._setupDomElements = function () {
-                this._element.selectAll("." + Time.TIME_AXIS_TIER_CLASS).remove();
+                this._content.selectAll("." + Time.TIME_AXIS_TIER_CLASS).remove();
                 this._tierLabelContainers = [];
                 this._tierMarkContainers = [];
                 this._tierBaselines = [];
@@ -4116,14 +4116,14 @@ var Plottable;
                 var _this = this;
                 var availableHeight = this.height();
                 var usedHeight = 0;
-                this._element.selectAll("." + Time.TIME_AXIS_TIER_CLASS).attr("visibility", function (d, i) {
+                this._content.selectAll("." + Time.TIME_AXIS_TIER_CLASS).attr("visibility", function (d, i) {
                     usedHeight += _this._tierHeights[i];
                     return usedHeight <= availableHeight ? "inherit" : "hidden";
                 });
             };
             Time.prototype._hideOverlappingAndCutOffLabels = function (index) {
                 var _this = this;
-                var boundingBox = this._element.select(".bounding-box")[0][0].getBoundingClientRect();
+                var boundingBox = this._boundingBox.node().getBoundingClientRect();
                 var isInsideBBox = function (tickBox) {
                     return (Math.floor(boundingBox.left) <= Math.ceil(tickBox.left) && Math.floor(boundingBox.top) <= Math.ceil(tickBox.top) && Math.floor(tickBox.right) <= Math.ceil(boundingBox.left + _this.width()) && Math.floor(tickBox.bottom) <= Math.ceil(boundingBox.top + _this.height()));
                 };

--- a/plottable.js
+++ b/plottable.js
@@ -7808,7 +7808,7 @@ var Plottable;
             ClusteredBar.prototype._makeInnerScale = function () {
                 var innerScale = new Plottable.Scales.Category();
                 innerScale.domain(this.datasets().map(function (d, i) { return String(i); }));
-                var widthProjector = Plottable.Plot._scaledAccessor(this._attrBindings.get("width"));
+                var widthProjector = Plottable.Plot._scaledAccessor(this.attr("width"));
                 innerScale.range([0, widthProjector(null, 0, null)]);
                 return innerScale;
             };

--- a/plottable.js
+++ b/plottable.js
@@ -7464,7 +7464,6 @@ var Plottable;
             };
             Bar.ORIENTATION_VERTICAL = "vertical";
             Bar.ORIENTATION_HORIZONTAL = "horizontal";
-            Bar._DEFAULT_WIDTH = 10;
             Bar._BAR_WIDTH_RATIO = 0.95;
             Bar._SINGLE_BAR_DIMENSION_RATIO = 0.4;
             Bar._BAR_AREA_CLASS = "bar-area";

--- a/plottable.js
+++ b/plottable.js
@@ -3360,7 +3360,7 @@ var Plottable;
         ComponentContainer.prototype.anchor = function (selection) {
             var _this = this;
             _super.prototype.anchor.call(this, selection);
-            this._forEach(function (c) { return c.anchor(_this._content); });
+            this._forEach(function (c) { return c.anchor(_this.content()); });
             return this;
         };
         ComponentContainer.prototype.render = function () {
@@ -3377,7 +3377,7 @@ var Plottable;
             component.parent(this);
             component.onDetach(this._detachCallback);
             if (this._isAnchored) {
-                component.anchor(this._content);
+                component.anchor(this.content());
             }
         };
         /**
@@ -3619,9 +3619,9 @@ var Plottable;
         };
         Axis.prototype._setup = function () {
             _super.prototype._setup.call(this);
-            this._tickMarkContainer = this._content.append("g").classed(Axis.TICK_MARK_CLASS + "-container", true);
-            this._tickLabelContainer = this._content.append("g").classed(Axis.TICK_LABEL_CLASS + "-container", true);
-            this._baseline = this._content.append("line").classed("baseline", true);
+            this._tickMarkContainer = this.content().append("g").classed(Axis.TICK_MARK_CLASS + "-container", true);
+            this._tickLabelContainer = this.content().append("g").classed(Axis.TICK_LABEL_CLASS + "-container", true);
+            this._baseline = this.content().append("line").classed("baseline", true);
         };
         /*
          * Function for generating tick values in data-space (as opposed to pixel values).
@@ -3972,14 +3972,14 @@ var Plottable;
                 this._setupDomElements();
             };
             Time.prototype._setupDomElements = function () {
-                this._content.selectAll("." + Time.TIME_AXIS_TIER_CLASS).remove();
+                this.content().selectAll("." + Time.TIME_AXIS_TIER_CLASS).remove();
                 this._tierLabelContainers = [];
                 this._tierMarkContainers = [];
                 this._tierBaselines = [];
                 this._tickLabelContainer.remove();
                 this._baseline.remove();
                 for (var i = 0; i < this._numTiers; ++i) {
-                    var tierContainer = this._content.append("g").classed(Time.TIME_AXIS_TIER_CLASS, true);
+                    var tierContainer = this.content().append("g").classed(Time.TIME_AXIS_TIER_CLASS, true);
                     this._tierLabelContainers.push(tierContainer.append("g").classed(Plottable.Axis.TICK_LABEL_CLASS + "-container", true));
                     this._tierMarkContainers.push(tierContainer.append("g").classed(Plottable.Axis.TICK_MARK_CLASS + "-container", true));
                     this._tierBaselines.push(tierContainer.append("line").classed("baseline", true));
@@ -4116,7 +4116,7 @@ var Plottable;
                 var _this = this;
                 var availableHeight = this.height();
                 var usedHeight = 0;
-                this._content.selectAll("." + Time.TIME_AXIS_TIER_CLASS).attr("visibility", function (d, i) {
+                this.content().selectAll("." + Time.TIME_AXIS_TIER_CLASS).attr("visibility", function (d, i) {
                     usedHeight += _this._tierHeights[i];
                     return usedHeight <= availableHeight ? "inherit" : "hidden";
                 });
@@ -4815,7 +4815,7 @@ var Plottable;
             };
             Label.prototype._setup = function () {
                 _super.prototype._setup.call(this);
-                this._textContainer = this._content.append("g");
+                this._textContainer = this.content().append("g");
                 this._measurer = new SVGTypewriter.Measurers.Measurer(this._textContainer);
                 this._wrapper = new SVGTypewriter.Wrappers.Wrapper();
                 this._writer = new SVGTypewriter.Writers.Writer(this._measurer, this._wrapper);
@@ -4965,7 +4965,7 @@ var Plottable;
             }
             Legend.prototype._setup = function () {
                 _super.prototype._setup.call(this);
-                var fakeLegendRow = this._content.append("g").classed(Legend.LEGEND_ROW_CLASS, true);
+                var fakeLegendRow = this.content().append("g").classed(Legend.LEGEND_ROW_CLASS, true);
                 var fakeLegendEntry = fakeLegendRow.append("g").classed(Legend.LEGEND_ENTRY_CLASS, true);
                 fakeLegendEntry.append("text");
                 this._measurer = new SVGTypewriter.Measurers.Measurer(fakeLegendRow);
@@ -5080,7 +5080,7 @@ var Plottable;
                 var entry = d3.select(null);
                 var layout = this._calculateLayoutInfo(this.width(), this.height());
                 var legendPadding = this._padding;
-                this._content.selectAll("g." + Legend.LEGEND_ROW_CLASS).each(function (d, i) {
+                this.content().selectAll("g." + Legend.LEGEND_ROW_CLASS).each(function (d, i) {
                     var lowY = i * layout.textHeight + legendPadding;
                     var highY = (i + 1) * layout.textHeight + legendPadding;
                     var lowX = legendPadding;
@@ -5100,7 +5100,7 @@ var Plottable;
                 _super.prototype.renderImmediately.call(this);
                 var layout = this._calculateLayoutInfo(this.width(), this.height());
                 var rowsToDraw = layout.rows.slice(0, layout.numRowsToDraw);
-                var rows = this._content.selectAll("g." + Legend.LEGEND_ROW_CLASS).data(rowsToDraw);
+                var rows = this.content().selectAll("g." + Legend.LEGEND_ROW_CLASS).data(rowsToDraw);
                 rows.enter().append("g").classed(Legend.LEGEND_ROW_CLASS, true);
                 rows.exit().remove();
                 rows.attr("transform", function (d, i) { return "translate(0, " + (i * layout.textHeight + _this._padding) + ")"; });
@@ -5262,11 +5262,11 @@ var Plottable;
             };
             InterpolatedColorLegend.prototype._setup = function () {
                 _super.prototype._setup.call(this);
-                this._swatchContainer = this._content.append("g").classed("swatch-container", true);
-                this._swatchBoundingBox = this._content.append("rect").classed("swatch-bounding-box", true);
-                this._lowerLabel = this._content.append("g").classed(InterpolatedColorLegend.LEGEND_LABEL_CLASS, true);
-                this._upperLabel = this._content.append("g").classed(InterpolatedColorLegend.LEGEND_LABEL_CLASS, true);
-                this._measurer = new SVGTypewriter.Measurers.Measurer(this._content);
+                this._swatchContainer = this.content().append("g").classed("swatch-container", true);
+                this._swatchBoundingBox = this.content().append("rect").classed("swatch-bounding-box", true);
+                this._lowerLabel = this.content().append("g").classed(InterpolatedColorLegend.LEGEND_LABEL_CLASS, true);
+                this._upperLabel = this.content().append("g").classed(InterpolatedColorLegend.LEGEND_LABEL_CLASS, true);
+                this._measurer = new SVGTypewriter.Measurers.Measurer(this.content());
                 this._wrapper = new SVGTypewriter.Wrappers.Wrapper();
                 this._writer = new SVGTypewriter.Writers.Writer(this._measurer, this._wrapper);
             };
@@ -5451,8 +5451,8 @@ var Plottable;
             };
             Gridlines.prototype._setup = function () {
                 _super.prototype._setup.call(this);
-                this._xLinesContainer = this._content.append("g").classed("x-gridlines", true);
-                this._yLinesContainer = this._content.append("g").classed("y-gridlines", true);
+                this._xLinesContainer = this.content().append("g").classed("x-gridlines", true);
+                this._yLinesContainer = this.content().append("g").classed("y-gridlines", true);
             };
             Gridlines.prototype.renderImmediately = function () {
                 _super.prototype.renderImmediately.call(this);
@@ -5871,7 +5871,7 @@ var Plottable;
             }
             SelectionBoxLayer.prototype._setup = function () {
                 _super.prototype._setup.call(this);
-                this._box = this._content.append("g").classed("selection-box", true).remove();
+                this._box = this.content().append("g").classed("selection-box", true).remove();
                 this._boxArea = this._box.append("rect").classed("selection-area", true);
             };
             SelectionBoxLayer.prototype._getSize = function (availableWidth, availableHeight) {
@@ -5914,7 +5914,7 @@ var Plottable;
                         width: r - l,
                         height: b - t
                     });
-                    this._content.node().appendChild(this._box.node());
+                    this.content().node().appendChild(this._box.node());
                 }
                 else {
                     this._box.remove();
@@ -5993,7 +5993,7 @@ var Plottable;
         Plot.prototype._setup = function () {
             var _this = this;
             _super.prototype._setup.call(this);
-            this._renderArea = this._content.append("g").classed("render-area", true);
+            this._renderArea = this.content().append("g").classed("render-area", true);
             this.datasets().forEach(function (dataset) { return _this._createNodesForDataset(dataset); });
         };
         Plot.prototype.destroy = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -7906,9 +7906,6 @@ var Plottable;
                 _super.prototype._onDatasetUpdate.call(this);
                 return this;
             };
-            StackedArea.prototype._wholeDatumAttributes = function () {
-                return ["x", "y", "defined", "d"];
-            };
             StackedArea.prototype._updateExtentsForProperty = function (property) {
                 _super.prototype._updateExtentsForProperty.call(this, property);
                 if ((property === "x" || property === "y") && this._projectorsReady()) {

--- a/plottable.js
+++ b/plottable.js
@@ -7808,16 +7808,8 @@ var Plottable;
             ClusteredBar.prototype._makeInnerScale = function () {
                 var innerScale = new Plottable.Scales.Category();
                 innerScale.domain(this.datasets().map(function (d, i) { return String(i); }));
-                if (!this._attrBindings.get("width")) {
-                    innerScale.range([0, this._getBarPixelWidth()]);
-                }
-                else {
-                    var projection = this._attrBindings.get("width");
-                    var accessor = projection.accessor;
-                    var scale = projection.scale;
-                    var fn = scale ? function (d, i, dataset) { return scale.scale(accessor(d, i, dataset)); } : accessor;
-                    innerScale.range([0, fn(null, 0, null)]);
-                }
+                var widthProjector = Plottable.Plot._scaledAccessor(this._attrBindings.get("width"));
+                innerScale.range([0, widthProjector(null, 0, null)]);
                 return innerScale;
             };
             ClusteredBar.prototype._getDataToDraw = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -1685,7 +1685,7 @@ var Plottable;
          * @returns {D} The domain value corresponding to the supplied range value.
          */
         QuantitativeScale.prototype.invert = function (value) {
-            throw new Error("Subclasses should override _invert");
+            throw new Error("Subclasses should override invert");
         };
         QuantitativeScale.prototype.domain = function (values) {
             if (values != null) {

--- a/src/components/axes/axis.ts
+++ b/src/components/axes/axis.ts
@@ -125,11 +125,11 @@ module Plottable {
 
     protected _setup() {
       super._setup();
-      this._tickMarkContainer = this._content.append("g")
+      this._tickMarkContainer = this.content().append("g")
                                             .classed(Axis.TICK_MARK_CLASS + "-container", true);
-      this._tickLabelContainer = this._content.append("g")
+      this._tickLabelContainer = this.content().append("g")
                                              .classed(Axis.TICK_LABEL_CLASS + "-container", true);
-      this._baseline = this._content.append("line").classed("baseline", true);
+      this._baseline = this.content().append("line").classed("baseline", true);
     }
 
     /*

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -321,7 +321,7 @@ export module Axes {
     }
 
     private _setupDomElements() {
-      this._element.selectAll("." + Time.TIME_AXIS_TIER_CLASS).remove();
+      this._content.selectAll("." + Time.TIME_AXIS_TIER_CLASS).remove();
 
       this._tierLabelContainers = [];
       this._tierMarkContainers = [];
@@ -494,7 +494,7 @@ export module Axes {
       var availableHeight = this.height();
       var usedHeight = 0;
 
-      this._element
+      this._content
         .selectAll("." + Time.TIME_AXIS_TIER_CLASS)
         .attr("visibility", (d: any, i: number) => {
           usedHeight += this._tierHeights[i];
@@ -503,7 +503,7 @@ export module Axes {
     }
 
     private _hideOverlappingAndCutOffLabels(index: number) {
-      var boundingBox = (<Element> this._element.select(".bounding-box")[0][0]).getBoundingClientRect();
+      var boundingBox = (<Element> this._boundingBox.node()).getBoundingClientRect();
 
       var isInsideBBox = (tickBox: ClientRect) => {
         return (

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -321,7 +321,7 @@ export module Axes {
     }
 
     private _setupDomElements() {
-      this._content.selectAll("." + Time.TIME_AXIS_TIER_CLASS).remove();
+      this.content().selectAll("." + Time.TIME_AXIS_TIER_CLASS).remove();
 
       this._tierLabelContainers = [];
       this._tierMarkContainers = [];
@@ -330,7 +330,7 @@ export module Axes {
       this._baseline.remove();
 
       for (var i = 0; i < this._numTiers; ++i) {
-        var tierContainer = this._content.append("g").classed(Time.TIME_AXIS_TIER_CLASS, true);
+        var tierContainer = this.content().append("g").classed(Time.TIME_AXIS_TIER_CLASS, true);
         this._tierLabelContainers.push(tierContainer.append("g").classed(Axis.TICK_LABEL_CLASS + "-container", true));
         this._tierMarkContainers.push(tierContainer.append("g").classed(Axis.TICK_MARK_CLASS + "-container", true));
         this._tierBaselines.push(tierContainer.append("line").classed("baseline", true));
@@ -494,7 +494,7 @@ export module Axes {
       var availableHeight = this.height();
       var usedHeight = 0;
 
-      this._content
+      this.content()
         .selectAll("." + Time.TIME_AXIS_TIER_CLASS)
         .attr("visibility", (d: any, i: number) => {
           usedHeight += this._tierHeights[i];

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -14,8 +14,8 @@ module Plottable {
     }
   }
   export class Component {
-    protected _element: d3.Selection<void>;
-    protected _content: d3.Selection<void>;
+    private _element: d3.Selection<void>;
+    private _content: d3.Selection<void>;
     protected _boundingBox: d3.Selection<void>;
     private _backgroundContainer: d3.Selection<void>;
     private _foregroundContainer: d3.Selection<void>;

--- a/src/components/componentContainer.ts
+++ b/src/components/componentContainer.ts
@@ -15,7 +15,7 @@ module Plottable {
 
     public anchor(selection: d3.Selection<void>) {
       super.anchor(selection);
-      this._forEach((c) => c.anchor(this._content));
+      this._forEach((c) => c.anchor(this.content()));
       return this;
     }
 
@@ -35,7 +35,7 @@ module Plottable {
       component.parent(this);
       component.onDetach(this._detachCallback);
       if (this._isAnchored) {
-        component.anchor(this._content);
+        component.anchor(this.content());
       }
     }
 

--- a/src/components/gridlines.ts
+++ b/src/components/gridlines.ts
@@ -48,8 +48,8 @@ export module Components {
 
     protected _setup() {
       super._setup();
-      this._xLinesContainer = this._content.append("g").classed("x-gridlines", true);
-      this._yLinesContainer = this._content.append("g").classed("y-gridlines", true);
+      this._xLinesContainer = this.content().append("g").classed("x-gridlines", true);
+      this._yLinesContainer = this.content().append("g").classed("y-gridlines", true);
     }
 
     public renderImmediately() {

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -125,12 +125,12 @@ export module Components {
     protected _setup() {
       super._setup();
 
-      this._swatchContainer = this._content.append("g").classed("swatch-container", true);
-      this._swatchBoundingBox = this._content.append("rect").classed("swatch-bounding-box", true);
-      this._lowerLabel = this._content.append("g").classed(InterpolatedColorLegend.LEGEND_LABEL_CLASS, true);
-      this._upperLabel = this._content.append("g").classed(InterpolatedColorLegend.LEGEND_LABEL_CLASS, true);
+      this._swatchContainer = this.content().append("g").classed("swatch-container", true);
+      this._swatchBoundingBox = this.content().append("rect").classed("swatch-bounding-box", true);
+      this._lowerLabel = this.content().append("g").classed(InterpolatedColorLegend.LEGEND_LABEL_CLASS, true);
+      this._upperLabel = this.content().append("g").classed(InterpolatedColorLegend.LEGEND_LABEL_CLASS, true);
 
-      this._measurer = new SVGTypewriter.Measurers.Measurer(this._content);
+      this._measurer = new SVGTypewriter.Measurers.Measurer(this.content());
       this._wrapper = new SVGTypewriter.Wrappers.Wrapper();
       this._writer = new SVGTypewriter.Writers.Writer(this._measurer, this._wrapper);
     }

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -40,7 +40,7 @@ export module Components {
 
     protected _setup() {
       super._setup();
-      this._textContainer = this._content.append("g");
+      this._textContainer = this.content().append("g");
       this._measurer = new SVGTypewriter.Measurers.Measurer(this._textContainer);
       this._wrapper = new SVGTypewriter.Wrappers.Wrapper();
       this._writer = new SVGTypewriter.Writers.Writer(this._measurer, this._wrapper);

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -52,7 +52,7 @@ export module Components {
 
     protected _setup() {
       super._setup();
-      var fakeLegendRow = this._content.append("g").classed(Legend.LEGEND_ROW_CLASS, true);
+      var fakeLegendRow = this.content().append("g").classed(Legend.LEGEND_ROW_CLASS, true);
       var fakeLegendEntry = fakeLegendRow.append("g").classed(Legend.LEGEND_ENTRY_CLASS, true);
       fakeLegendEntry.append("text");
       this._measurer = new SVGTypewriter.Measurers.Measurer(fakeLegendRow);
@@ -220,7 +220,7 @@ export module Components {
       var entry = d3.select(null);
       var layout = this._calculateLayoutInfo(this.width(), this.height());
       var legendPadding = this._padding;
-      this._content.selectAll("g." + Legend.LEGEND_ROW_CLASS).each(function(d: any, i: number) {
+      this.content().selectAll("g." + Legend.LEGEND_ROW_CLASS).each(function(d: any, i: number) {
         var lowY = i * layout.textHeight + legendPadding;
         var highY = (i + 1) * layout.textHeight + legendPadding;
         var lowX = legendPadding;
@@ -244,7 +244,7 @@ export module Components {
       var layout = this._calculateLayoutInfo(this.width(), this.height());
 
       var rowsToDraw = layout.rows.slice(0, layout.numRowsToDraw);
-      var rows = this._content.selectAll("g." + Legend.LEGEND_ROW_CLASS).data(rowsToDraw);
+      var rows = this.content().selectAll("g." + Legend.LEGEND_ROW_CLASS).data(rowsToDraw);
       rows.enter().append("g").classed(Legend.LEGEND_ROW_CLASS, true);
       rows.exit().remove();
 

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -12,7 +12,6 @@ export module Plots {
   export class Bar<X, Y> extends XYPlot<X, Y> {
     public static ORIENTATION_VERTICAL = "vertical";
     public static ORIENTATION_HORIZONTAL = "horizontal";
-    protected static _DEFAULT_WIDTH = 10;
     private static _BAR_WIDTH_RATIO = 0.95;
     private static _SINGLE_BAR_DIMENSION_RATIO = 0.4;
     private static _BAR_AREA_CLASS = "bar-area";

--- a/src/components/plots/clusteredBarPlot.ts
+++ b/src/components/plots/clusteredBarPlot.ts
@@ -49,15 +49,8 @@ export module Plots {
     private _makeInnerScale() {
       var innerScale = new Scales.Category();
       innerScale.domain(this.datasets().map((d, i) => String(i)));
-      if (!this._attrBindings.get("width")) {
-        innerScale.range([0, this._getBarPixelWidth()]);
-      } else {
-        var projection = this._attrBindings.get("width");
-        var accessor = projection.accessor;
-        var scale = projection.scale;
-        var fn = scale ? (d: any, i: number, dataset: Dataset) => scale.scale(accessor(d, i, dataset)) : accessor;
-        innerScale.range([0, fn(null, 0, null)]);
-      }
+      var widthProjector = Plot._scaledAccessor(this._attrBindings.get("width"));
+      innerScale.range([0, widthProjector(null, 0, null)]);
       return innerScale;
     }
 

--- a/src/components/plots/clusteredBarPlot.ts
+++ b/src/components/plots/clusteredBarPlot.ts
@@ -49,7 +49,7 @@ export module Plots {
     private _makeInnerScale() {
       var innerScale = new Scales.Category();
       innerScale.domain(this.datasets().map((d, i) => String(i)));
-      var widthProjector = Plot._scaledAccessor(this._attrBindings.get("width"));
+      var widthProjector = Plot._scaledAccessor(this.attr("width"));
       innerScale.range([0, widthProjector(null, 0, null)]);
       return innerScale;
     }

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -30,7 +30,7 @@ module Plottable {
 
     protected _renderArea: d3.Selection<void>;
     private _attrBindings: d3.Map<Plots.AccessorScaleBinding<any, any>>;
-    protected _attrExtents: d3.Map<any[]>;
+    private _attrExtents: d3.Map<any[]>;
     private _includedValuesProvider: Scales.IncludedValuesProvider<any>;
 
     protected _animate: boolean = false;

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -29,7 +29,7 @@ module Plottable {
     private _datasetToDrawer: Utils.Map<Dataset, Drawer>;
 
     protected _renderArea: d3.Selection<void>;
-    protected _attrBindings: d3.Map<Plots.AccessorScaleBinding<any, any>>;
+    private _attrBindings: d3.Map<Plots.AccessorScaleBinding<any, any>>;
     protected _attrExtents: d3.Map<any[]>;
     private _includedValuesProvider: Scales.IncludedValuesProvider<any>;
 

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -72,7 +72,7 @@ module Plottable {
 
     protected _setup() {
       super._setup();
-      this._renderArea = this._content.append("g").classed("render-area", true);
+      this._renderArea = this.content().append("g").classed("render-area", true);
       this.datasets().forEach((dataset) => this._createNodesForDataset(dataset));
     }
 

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -26,7 +26,7 @@ module Plottable {
 
   export class Plot extends Component {
     protected _dataChanged = false;
-    protected _datasetToDrawer: Utils.Map<Dataset, Drawer>;
+    private _datasetToDrawer: Utils.Map<Dataset, Drawer>;
 
     protected _renderArea: d3.Selection<void>;
     protected _attrBindings: d3.Map<Plots.AccessorScaleBinding<any, any>>;

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -97,10 +97,6 @@ export module Plots {
       return this;
     }
 
-    protected _wholeDatumAttributes() {
-      return ["x", "y", "defined", "d"];
-    }
-
     protected _updateExtentsForProperty(property: string) {
       super._updateExtentsForProperty(property);
       if ((property === "x" || property === "y") && this._projectorsReady()) {

--- a/src/components/selectionBoxLayer.ts
+++ b/src/components/selectionBoxLayer.ts
@@ -19,7 +19,7 @@ export module Components {
     protected _setup() {
       super._setup();
 
-      this._box = this._content.append("g").classed("selection-box", true).remove();
+      this._box = this.content().append("g").classed("selection-box", true).remove();
       this._boxArea = this._box.append("rect").classed("selection-area", true);
     }
 
@@ -76,7 +76,7 @@ export module Components {
         this._boxArea.attr({
           x: l, y: t, width: r - l, height: b - t
         });
-        (<Node> this._content.node()).appendChild(<Node> this._box.node());
+        (<Node> this.content().node()).appendChild(<Node> this._box.node());
       } else {
         this._box.remove();
       }

--- a/src/core/symbolFactories.ts
+++ b/src/core/symbolFactories.ts
@@ -10,8 +10,6 @@ module Plottable {
 
   export module SymbolFactories {
 
-    export type StringAccessor = (datum: any, index: number) => string;
-
     export function circle(): SymbolFactory {
       return (symbolSize: number) => d3.svg.symbol().type("circle").size(Math.PI * Math.pow(symbolSize / 2, 2))(null);
     }

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -165,9 +165,8 @@ module Plottable {
      * @param {number} value: A value from the Scale's range.
      * @returns {D} The domain value corresponding to the supplied range value.
      */
-
     public invert(value: number): D {
-      throw new Error("Subclasses should override _invert");
+      throw new Error("Subclasses should override invert");
     }
 
     public domain(): D[];


### PR DESCRIPTION
There are several instance variables that are protected that should be instead private.  Few cleanups that we would want to do before 1.0

QE: Regression pass please.  The JS got affected functionally in very small ways, specifically with how `Axis.Time` sets up its DOM elements and how `Plots.ClusteredBar` lays out the bars for the cluster, but these changes should hopefully not affect you.