### PR TITLE
Dom utils refactor

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -142,7 +142,7 @@ declare module Plottable {
             function boxesOverlap(boxA: ClientRect, boxB: ClientRect): boolean;
             function boxIsInside(inner: ClientRect, outer: ClientRect): boolean;
             function boundingSVG(elem: SVGElement): SVGElement;
-            function getUniqueClipPathId(): string;
+            function generateUniqueClipPathId(): string;
             /**
              * Returns true if the supplied coordinates or Ranges intersect or are contained by bbox.
              *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -132,7 +132,7 @@ declare module Plottable {
              * @param {d3.Selection} element
              * @returns {SVGRed} The bounding box.
              */
-            function getBBox(element: d3.Selection<any>): SVGRect;
+            function elementBBox(element: d3.Selection<any>): SVGRect;
             var POLYFILL_TIMEOUT_MILLISECONDS: number;
             function requestAnimationFramePolyfill(fn: () => any): void;
             function elementWidth(element: Element): number;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -133,9 +133,8 @@ declare module Plottable {
              * @returns {SVGRed} The bounding box.
              */
             function getBBox(element: d3.Selection<any>): SVGRect;
-            var POLYFILL_TIMEOUT_MSEC: number;
+            var POLYFILL_TIMEOUT_MILLISECONDS: number;
             function requestAnimationFramePolyfill(fn: () => any): void;
-            function isSelectionRemovedFromSVG(selection: d3.Selection<any>): boolean;
             function getElementWidth(elem: Element): number;
             function getElementHeight(elem: Element): number;
             function getSVGPixelWidth(svg: d3.Selection<void>): number;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -134,7 +134,7 @@ declare module Plottable {
              */
             function elementBBox(element: d3.Selection<any>): SVGRect;
             var POLYFILL_TIMEOUT_MILLISECONDS: number;
-            function requestAnimationFramePolyfill(fn: () => any): void;
+            function requestAnimationFramePolyfill(fn: () => void): void;
             function elementWidth(element: Element): number;
             function elementHeight(element: Element): number;
             function translate(selection: d3.Selection<any>): d3.Transform;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -135,8 +135,8 @@ declare module Plottable {
             function getBBox(element: d3.Selection<any>): SVGRect;
             var POLYFILL_TIMEOUT_MILLISECONDS: number;
             function requestAnimationFramePolyfill(fn: () => any): void;
-            function getElementWidth(element: Element): number;
-            function getElementHeight(element: Element): number;
+            function elementWidth(element: Element): number;
+            function elementHeight(element: Element): number;
             function translate(selection: d3.Selection<any>): d3.Transform;
             function translate(selection: d3.Selection<any>, x: number, y: number): d3.Selection<any>;
             function boxesOverlap(boxA: ClientRect, boxB: ClientRect): boolean;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -141,7 +141,7 @@ declare module Plottable {
             function translate(selection: d3.Selection<any>, x: number, y: number): d3.Selection<any>;
             function boxesOverlap(boxA: ClientRect, boxB: ClientRect): boolean;
             function boxIsInside(inner: ClientRect, outer: ClientRect): boolean;
-            function getBoundingSVG(elem: SVGElement): SVGElement;
+            function boundingSVG(elem: SVGElement): SVGElement;
             function getUniqueClipPathId(): string;
             /**
              * Returns true if the supplied coordinates or Ranges intersect or are contained by bbox.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -135,10 +135,10 @@ declare module Plottable {
             function getBBox(element: d3.Selection<any>): SVGRect;
             var POLYFILL_TIMEOUT_MILLISECONDS: number;
             function requestAnimationFramePolyfill(fn: () => any): void;
-            function getElementWidth(elem: Element): number;
-            function getElementHeight(elem: Element): number;
-            function translate(s: d3.Selection<any>): d3.Transform;
-            function translate(s: d3.Selection<any>, x: number, y: number): d3.Selection<any>;
+            function getElementWidth(element: Element): number;
+            function getElementHeight(element: Element): number;
+            function translate(selection: d3.Selection<any>): d3.Transform;
+            function translate(selection: d3.Selection<any>, x: number, y: number): d3.Selection<any>;
             function boxesOverlap(boxA: ClientRect, boxB: ClientRect): boolean;
             function boxIsInside(inner: ClientRect, outer: ClientRect): boolean;
             function getBoundingSVG(elem: SVGElement): SVGElement;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -137,7 +137,6 @@ declare module Plottable {
             function requestAnimationFramePolyfill(fn: () => any): void;
             function getElementWidth(elem: Element): number;
             function getElementHeight(elem: Element): number;
-            function getSVGPixelWidth(svg: d3.Selection<void>): number;
             function translate(s: d3.Selection<any>): d3.Transform;
             function translate(s: d3.Selection<any>, x: number, y: number): d3.Selection<any>;
             function boxesOverlap(boxA: ClientRect, boxB: ClientRect): boolean;

--- a/plottable.js
+++ b/plottable.js
@@ -286,12 +286,12 @@ var Plottable;
             DOM.requestAnimationFramePolyfill = requestAnimationFramePolyfill;
             function elementWidth(element) {
                 var style = window.getComputedStyle(element);
-                return getParsedStyleValue(style, "width") + getParsedStyleValue(style, "padding-left") + getParsedStyleValue(style, "padding-right") + getParsedStyleValue(style, "border-left-width") + getParsedStyleValue(style, "border-right-width");
+                return _parseStyleValue(style, "width") + _parseStyleValue(style, "padding-left") + _parseStyleValue(style, "padding-right") + _parseStyleValue(style, "border-left-width") + _parseStyleValue(style, "border-right-width");
             }
             DOM.elementWidth = elementWidth;
             function elementHeight(element) {
                 var style = window.getComputedStyle(element);
-                return getParsedStyleValue(style, "height") + getParsedStyleValue(style, "padding-top") + getParsedStyleValue(style, "padding-bottom") + getParsedStyleValue(style, "border-top-width") + getParsedStyleValue(style, "border-bottom-width");
+                return _parseStyleValue(style, "height") + _parseStyleValue(style, "padding-top") + _parseStyleValue(style, "padding-bottom") + _parseStyleValue(style, "border-top-width") + _parseStyleValue(style, "border-bottom-width");
             }
             DOM.elementHeight = elementHeight;
             function translate(selection, x, y) {
@@ -358,8 +358,8 @@ var Plottable;
              */
             function intersectsBBox(xValOrRange, yValOrRange, bbox, tolerance) {
                 if (tolerance === void 0) { tolerance = 0.5; }
-                var xRange = parseRange(xValOrRange);
-                var yRange = parseRange(yValOrRange);
+                var xRange = _parseRange(xValOrRange);
+                var yRange = _parseRange(yValOrRange);
                 // SVGRects are positioned with sub-pixel accuracy (the default unit
                 // for the x, y, height & width attributes), but user selections (e.g. via
                 // mouse events) usually have pixel accuracy. A tolerance of half-a-pixel
@@ -374,7 +374,7 @@ var Plottable;
              *
              * @returns {Range} The generated Range
              */
-            function parseRange(input) {
+            function _parseRange(input) {
                 if (typeof (input) === "number") {
                     var value = input;
                     return { min: value, max: value };
@@ -385,7 +385,7 @@ var Plottable;
                 }
                 throw new Error("input '" + input + "' can't be parsed as an Range");
             }
-            function getParsedStyleValue(style, property) {
+            function _parseStyleValue(style, property) {
                 var value = style.getPropertyValue(property);
                 var parsedValue = parseFloat(value);
                 if (parsedValue !== parsedValue) {

--- a/plottable.js
+++ b/plottable.js
@@ -284,18 +284,18 @@ var Plottable;
                 }
             }
             DOM.requestAnimationFramePolyfill = requestAnimationFramePolyfill;
-            function getElementWidth(elem) {
-                var style = window.getComputedStyle(elem);
+            function getElementWidth(element) {
+                var style = window.getComputedStyle(element);
                 return getParsedStyleValue(style, "width") + getParsedStyleValue(style, "padding-left") + getParsedStyleValue(style, "padding-right") + getParsedStyleValue(style, "border-left-width") + getParsedStyleValue(style, "border-right-width");
             }
             DOM.getElementWidth = getElementWidth;
-            function getElementHeight(elem) {
-                var style = window.getComputedStyle(elem);
+            function getElementHeight(element) {
+                var style = window.getComputedStyle(element);
                 return getParsedStyleValue(style, "height") + getParsedStyleValue(style, "padding-top") + getParsedStyleValue(style, "padding-bottom") + getParsedStyleValue(style, "border-top-width") + getParsedStyleValue(style, "border-bottom-width");
             }
             DOM.getElementHeight = getElementHeight;
-            function translate(s, x, y) {
-                var xform = d3.transform(s.attr("transform"));
+            function translate(selection, x, y) {
+                var xform = d3.transform(selection.attr("transform"));
                 if (x == null) {
                     return xform.translate;
                 }
@@ -303,8 +303,8 @@ var Plottable;
                     y = (y == null) ? 0 : y;
                     xform.translate[0] = x;
                     xform.translate[1] = y;
-                    s.attr("transform", xform.toString());
-                    return s;
+                    selection.attr("transform", xform.toString());
+                    return selection;
                 }
             }
             DOM.translate = translate;

--- a/plottable.js
+++ b/plottable.js
@@ -284,14 +284,6 @@ var Plottable;
                 }
             }
             DOM.requestAnimationFramePolyfill = requestAnimationFramePolyfill;
-            function getParsedStyleValue(style, prop) {
-                var value = style.getPropertyValue(prop);
-                var parsedValue = parseFloat(value);
-                if (parsedValue !== parsedValue) {
-                    return 0;
-                }
-                return parsedValue;
-            }
             function isSelectionRemovedFromSVG(selection) {
                 var n = selection.node();
                 while (n !== null && n.nodeName.toLowerCase() !== "svg") {
@@ -421,6 +413,14 @@ var Plottable;
                 else {
                     throw new Error("input '" + input + "' can't be parsed as an Range");
                 }
+            }
+            function getParsedStyleValue(style, prop) {
+                var value = style.getPropertyValue(prop);
+                var parsedValue = parseFloat(value);
+                if (parsedValue !== parsedValue) {
+                    return 0;
+                }
+                return parsedValue;
             }
         })(DOM = Utils.DOM || (Utils.DOM = {}));
     })(Utils = Plottable.Utils || (Plottable.Utils = {}));
@@ -994,7 +994,7 @@ var Plottable;
          */
         var Timeout = (function () {
             function Timeout() {
-                this._timeoutMsec = Plottable.Utils.DOM.POLYFILL_TIMEOUT_MSEC;
+                this._timeoutMsec = Plottable.Utils.DOM.POLYFILL_TIMEOUT_MILLISECONDS;
             }
             Timeout.prototype.render = function () {
                 setTimeout(Plottable.RenderController.flush, this._timeoutMsec);

--- a/plottable.js
+++ b/plottable.js
@@ -340,10 +340,10 @@ var Plottable;
             }
             DOM.boundingSVG = boundingSVG;
             var _latestClipPathId = 0;
-            function getUniqueClipPathId() {
+            function generateUniqueClipPathId() {
                 return "plottableClipPath" + ++_latestClipPathId;
             }
-            DOM.getUniqueClipPathId = getUniqueClipPathId;
+            DOM.generateUniqueClipPathId = generateUniqueClipPathId;
             /**
              * Returns true if the supplied coordinates or Ranges intersect or are contained by bbox.
              *
@@ -3118,7 +3118,7 @@ var Plottable;
             // They don't need the current URL in the clip path reference.
             var prefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
             prefix = prefix.split("#")[0]; // To fix cases where an anchor tag was used
-            var clipPathId = Plottable.Utils.DOM.getUniqueClipPathId();
+            var clipPathId = Plottable.Utils.DOM.generateUniqueClipPathId();
             this._element.attr("clip-path", "url(\"" + prefix + "#" + clipPathId + "\")");
             var clipPathParent = this._boxContainer.append("clipPath").attr("id", clipPathId);
             this._addBox("clip-rect", clipPathParent);

--- a/plottable.js
+++ b/plottable.js
@@ -294,27 +294,6 @@ var Plottable;
                 return getParsedStyleValue(style, "height") + getParsedStyleValue(style, "padding-top") + getParsedStyleValue(style, "padding-bottom") + getParsedStyleValue(style, "border-top-width") + getParsedStyleValue(style, "border-bottom-width");
             }
             DOM.getElementHeight = getElementHeight;
-            function getSVGPixelWidth(svg) {
-                var width = svg.node().clientWidth;
-                if (width === 0) {
-                    var widthAttr = svg.attr("width");
-                    if (widthAttr.indexOf("%") !== -1) {
-                        var ancestorNode = svg.node().parentNode;
-                        while (ancestorNode != null && ancestorNode.clientWidth === 0) {
-                            ancestorNode = ancestorNode.parentNode;
-                        }
-                        if (ancestorNode == null) {
-                            throw new Error("Could not compute width of element");
-                        }
-                        width = ancestorNode.clientWidth * parseFloat(widthAttr) / 100;
-                    }
-                    else {
-                        width = parseFloat(widthAttr);
-                    }
-                }
-                return width;
-            }
-            DOM.getSVGPixelWidth = getSVGPixelWidth;
             function translate(s, x, y) {
                 var xform = d3.transform(s.attr("transform"));
                 if (x == null) {

--- a/plottable.js
+++ b/plottable.js
@@ -284,16 +284,16 @@ var Plottable;
                 }
             }
             DOM.requestAnimationFramePolyfill = requestAnimationFramePolyfill;
-            function getElementWidth(element) {
+            function elementWidth(element) {
                 var style = window.getComputedStyle(element);
                 return getParsedStyleValue(style, "width") + getParsedStyleValue(style, "padding-left") + getParsedStyleValue(style, "padding-right") + getParsedStyleValue(style, "border-left-width") + getParsedStyleValue(style, "border-right-width");
             }
-            DOM.getElementWidth = getElementWidth;
-            function getElementHeight(element) {
+            DOM.elementWidth = elementWidth;
+            function elementHeight(element) {
                 var style = window.getComputedStyle(element);
                 return getParsedStyleValue(style, "height") + getParsedStyleValue(style, "padding-top") + getParsedStyleValue(style, "padding-bottom") + getParsedStyleValue(style, "border-top-width") + getParsedStyleValue(style, "border-bottom-width");
             }
-            DOM.getElementHeight = getElementHeight;
+            DOM.elementHeight = elementHeight;
             function translate(selection, x, y) {
                 var xform = d3.transform(selection.attr("transform"));
                 if (x == null) {
@@ -2977,8 +2977,8 @@ var Plottable;
                         this._rootSVG.attr("height", "100%");
                     }
                     var elem = this._rootSVG.node();
-                    availableWidth = Plottable.Utils.DOM.getElementWidth(elem);
-                    availableHeight = Plottable.Utils.DOM.getElementHeight(elem);
+                    availableWidth = Plottable.Utils.DOM.elementWidth(elem);
+                    availableHeight = Plottable.Utils.DOM.elementHeight(elem);
                 }
                 else {
                     throw new Error("null arguments cannot be passed to computeLayout() on a non-root node");

--- a/plottable.js
+++ b/plottable.js
@@ -385,8 +385,8 @@ var Plottable;
                 }
                 throw new Error("input '" + input + "' can't be parsed as an Range");
             }
-            function getParsedStyleValue(style, prop) {
-                var value = style.getPropertyValue(prop);
+            function getParsedStyleValue(style, property) {
+                var value = style.getPropertyValue(property);
                 var parsedValue = parseFloat(value);
                 if (parsedValue !== parsedValue) {
                     return 0;

--- a/plottable.js
+++ b/plottable.js
@@ -264,12 +264,7 @@ var Plottable;
                     bbox = element.node().getBBox();
                 }
                 catch (err) {
-                    bbox = {
-                        x: 0,
-                        y: 0,
-                        width: 0,
-                        height: 0
-                    };
+                    bbox = { x: 0, y: 0, width: 0, height: 0 };
                 }
                 return bbox;
             }

--- a/plottable.js
+++ b/plottable.js
@@ -258,7 +258,7 @@ var Plottable;
              * @param {d3.Selection} element
              * @returns {SVGRed} The bounding box.
              */
-            function getBBox(element) {
+            function elementBBox(element) {
                 var bbox;
                 try {
                     bbox = element.node().getBBox();
@@ -268,7 +268,7 @@ var Plottable;
                 }
                 return bbox;
             }
-            DOM.getBBox = getBBox;
+            DOM.elementBBox = elementBBox;
             DOM.POLYFILL_TIMEOUT_MILLISECONDS = 1000 / 60; // 60 fps
             function requestAnimationFramePolyfill(fn) {
                 if (window.requestAnimationFrame != null) {
@@ -290,14 +290,14 @@ var Plottable;
             }
             DOM.elementHeight = elementHeight;
             function translate(selection, x, y) {
-                var xform = d3.transform(selection.attr("transform"));
+                var transformMatrix = d3.transform(selection.attr("transform"));
                 if (x == null) {
-                    return xform.translate;
+                    return transformMatrix.translate;
                 }
                 y = (y == null) ? 0 : y;
-                xform.translate[0] = x;
-                xform.translate[1] = y;
-                selection.attr("transform", xform.toString());
+                transformMatrix.translate[0] = x;
+                transformMatrix.translate[1] = y;
+                selection.attr("transform", transformMatrix.toString());
                 return selection;
             }
             DOM.translate = translate;
@@ -6943,7 +6943,7 @@ var Plottable;
                 var xRange = { min: 0, max: this.width() };
                 var yRange = { min: 0, max: this.height() };
                 var translation = d3.transform(selection.attr("transform")).translate;
-                var bbox = Plottable.Utils.DOM.getBBox(selection);
+                var bbox = Plottable.Utils.DOM.elementBBox(selection);
                 var translatedBbox = {
                     x: bbox.x + translation[0],
                     y: bbox.y + translation[1],
@@ -7136,7 +7136,7 @@ var Plottable;
                     var secondaryDist = 0;
                     var plotPt = entity.position;
                     // if we're inside a bar, distance in both directions should stay 0
-                    var barBBox = Plottable.Utils.DOM.getBBox(entity.selection);
+                    var barBBox = Plottable.Utils.DOM.elementBBox(entity.selection);
                     if (!Plottable.Utils.DOM.intersectsBBox(queryPoint.x, queryPoint.y, barBBox, tolerance)) {
                         var plotPtPrimary = _this._isVertical ? plotPt.x : plotPt.y;
                         primaryDist = Math.abs(queryPtPrimary - plotPtPrimary);
@@ -7164,7 +7164,7 @@ var Plottable;
             Bar.prototype._isVisibleOnPlot = function (datum, pixelPoint, selection) {
                 var xRange = { min: 0, max: this.width() };
                 var yRange = { min: 0, max: this.height() };
-                var barBBox = Plottable.Utils.DOM.getBBox(selection);
+                var barBBox = Plottable.Utils.DOM.elementBBox(selection);
                 return Plottable.Utils.DOM.intersectsBBox(xRange, yRange, barBBox);
             };
             /**
@@ -7193,7 +7193,7 @@ var Plottable;
             Bar.prototype._entitiesIntersecting = function (xValOrRange, yValOrRange) {
                 var intersected = [];
                 this.entities().forEach(function (entity) {
-                    if (Plottable.Utils.DOM.intersectsBBox(xValOrRange, yValOrRange, Plottable.Utils.DOM.getBBox(entity.selection))) {
+                    if (Plottable.Utils.DOM.intersectsBBox(xValOrRange, yValOrRange, Plottable.Utils.DOM.elementBBox(entity.selection))) {
                         intersected.push(entity);
                     }
                 });

--- a/plottable.js
+++ b/plottable.js
@@ -274,24 +274,16 @@ var Plottable;
                 return bbox;
             }
             DOM.getBBox = getBBox;
-            DOM.POLYFILL_TIMEOUT_MSEC = 1000 / 60; // 60 fps
+            DOM.POLYFILL_TIMEOUT_MILLISECONDS = 1000 / 60; // 60 fps
             function requestAnimationFramePolyfill(fn) {
                 if (window.requestAnimationFrame != null) {
                     window.requestAnimationFrame(fn);
                 }
                 else {
-                    setTimeout(fn, DOM.POLYFILL_TIMEOUT_MSEC);
+                    setTimeout(fn, DOM.POLYFILL_TIMEOUT_MILLISECONDS);
                 }
             }
             DOM.requestAnimationFramePolyfill = requestAnimationFramePolyfill;
-            function isSelectionRemovedFromSVG(selection) {
-                var n = selection.node();
-                while (n !== null && n.nodeName.toLowerCase() !== "svg") {
-                    n = n.parentNode;
-                }
-                return (n == null);
-            }
-            DOM.isSelectionRemovedFromSVG = isSelectionRemovedFromSVG;
             function getElementWidth(elem) {
                 var style = window.getComputedStyle(elem);
                 return getParsedStyleValue(style, "width") + getParsedStyleValue(style, "padding-left") + getParsedStyleValue(style, "padding-right") + getParsedStyleValue(style, "border-left-width") + getParsedStyleValue(style, "border-right-width");

--- a/plottable.js
+++ b/plottable.js
@@ -299,13 +299,11 @@ var Plottable;
                 if (x == null) {
                     return xform.translate;
                 }
-                else {
-                    y = (y == null) ? 0 : y;
-                    xform.translate[0] = x;
-                    xform.translate[1] = y;
-                    selection.attr("transform", xform.toString());
-                    return selection;
-                }
+                y = (y == null) ? 0 : y;
+                xform.translate[0] = x;
+                xform.translate[1] = y;
+                selection.attr("transform", xform.toString());
+                return selection;
             }
             DOM.translate = translate;
             function boxesOverlap(boxA, boxB) {

--- a/plottable.js
+++ b/plottable.js
@@ -376,14 +376,14 @@ var Plottable;
              */
             function parseRange(input) {
                 if (typeof (input) === "number") {
-                    return { min: input, max: input };
+                    var value = input;
+                    return { min: value, max: value };
                 }
-                else if (input instanceof Object && "min" in input && "max" in input) {
-                    return input;
+                var range = input;
+                if (range instanceof Object && "min" in range && "max" in range) {
+                    return range;
                 }
-                else {
-                    throw new Error("input '" + input + "' can't be parsed as an Range");
-                }
+                throw new Error("input '" + input + "' can't be parsed as an Range");
             }
             function getParsedStyleValue(style, prop) {
                 var value = style.getPropertyValue(prop);

--- a/plottable.js
+++ b/plottable.js
@@ -328,7 +328,7 @@ var Plottable;
                 return (nativeMath.floor(outer.left) <= nativeMath.ceil(inner.left) && nativeMath.floor(outer.top) <= nativeMath.ceil(inner.top) && nativeMath.floor(inner.right) <= nativeMath.ceil(outer.right) && nativeMath.floor(inner.bottom) <= nativeMath.ceil(outer.bottom));
             }
             DOM.boxIsInside = boxIsInside;
-            function getBoundingSVG(elem) {
+            function boundingSVG(elem) {
                 var ownerSVG = elem.ownerSVGElement;
                 if (ownerSVG != null) {
                     return ownerSVG;
@@ -338,7 +338,7 @@ var Plottable;
                 }
                 return null; // not in the DOM
             }
-            DOM.getBoundingSVG = getBoundingSVG;
+            DOM.boundingSVG = boundingSVG;
             var _latestClipPathId = 0;
             function getUniqueClipPathId() {
                 return "plottableClipPath" + ++_latestClipPathId;
@@ -798,7 +798,7 @@ var Plottable;
                 this._svg.appendChild(this._measureRect);
             }
             ClientToSVGTranslator.getTranslator = function (elem) {
-                var svg = Utils.DOM.getBoundingSVG(elem);
+                var svg = Utils.DOM.boundingSVG(elem);
                 var translator = svg[ClientToSVGTranslator._TRANSLATOR_KEY];
                 if (translator == null) {
                     translator = new ClientToSVGTranslator(svg);
@@ -8403,7 +8403,7 @@ var Plottable;
              * @return {Dispatchers.Mouse}
              */
             Mouse.getDispatcher = function (elem) {
-                var svg = Plottable.Utils.DOM.getBoundingSVG(elem);
+                var svg = Plottable.Utils.DOM.boundingSVG(elem);
                 var dispatcher = svg[Mouse._DISPATCHER_KEY];
                 if (dispatcher == null) {
                     dispatcher = new Mouse(svg);
@@ -8578,7 +8578,7 @@ var Plottable;
              * @return {Dispatchers.Touch}
              */
             Touch.getDispatcher = function (elem) {
-                var svg = Plottable.Utils.DOM.getBoundingSVG(elem);
+                var svg = Plottable.Utils.DOM.boundingSVG(elem);
                 var dispatcher = svg[Touch._DISPATCHER_KEY];
                 if (dispatcher == null) {
                     dispatcher = new Touch(svg);

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -173,8 +173,8 @@ module Plottable {
           }
 
           var elem: HTMLScriptElement = (<HTMLScriptElement> this._rootSVG.node());
-          availableWidth = Utils.DOM.getElementWidth(elem);
-          availableHeight = Utils.DOM.getElementHeight(elem);
+          availableWidth = Utils.DOM.elementWidth(elem);
+          availableHeight = Utils.DOM.elementHeight(elem);
         } else {
           throw new Error("null arguments cannot be passed to computeLayout() on a non-root node");
         }

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -344,7 +344,7 @@ module Plottable {
       // They don't need the current URL in the clip path reference.
       var prefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
       prefix = prefix.split("#")[0]; // To fix cases where an anchor tag was used
-      var clipPathId = Utils.DOM.getUniqueClipPathId();
+      var clipPathId = Utils.DOM.generateUniqueClipPathId();
       this._element.attr("clip-path", "url(\"" + prefix + "#" + clipPathId + "\")");
       var clipPathParent = this._boxContainer.append("clipPath")
                                              .attr("id", clipPathId);

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -236,7 +236,7 @@ export module Plots {
         var secondaryDist = 0;
         var plotPt = entity.position;
         // if we're inside a bar, distance in both directions should stay 0
-        var barBBox = Utils.DOM.getBBox(entity.selection);
+        var barBBox = Utils.DOM.elementBBox(entity.selection);
         if (!Utils.DOM.intersectsBBox(queryPoint.x, queryPoint.y, barBBox, tolerance)) {
           var plotPtPrimary = this._isVertical ? plotPt.x : plotPt.y;
           primaryDist = Math.abs(queryPtPrimary - plotPtPrimary);
@@ -268,7 +268,7 @@ export module Plots {
     protected _isVisibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean {
       var xRange = { min: 0, max: this.width() };
       var yRange = { min: 0, max: this.height() };
-      var barBBox = Utils.DOM.getBBox(selection);
+      var barBBox = Utils.DOM.elementBBox(selection);
 
       return Plottable.Utils.DOM.intersectsBBox(xRange, yRange, barBBox);
     }
@@ -315,7 +315,7 @@ export module Plots {
     private _entitiesIntersecting(xValOrRange: number | Range, yValOrRange: number | Range): Entity[] {
       var intersected: Entity[] = [];
       this.entities().forEach((entity) => {
-        if (Utils.DOM.intersectsBBox(xValOrRange, yValOrRange, Utils.DOM.getBBox(entity.selection))) {
+        if (Utils.DOM.intersectsBBox(xValOrRange, yValOrRange, Utils.DOM.elementBBox(entity.selection))) {
           intersected.push(entity);
         }
       });

--- a/src/components/plots/scatterPlot.ts
+++ b/src/components/plots/scatterPlot.ts
@@ -68,7 +68,7 @@ export module Plots {
       var yRange = { min: 0, max: this.height() };
 
       var translation = d3.transform(selection.attr("transform")).translate;
-      var bbox = Utils.DOM.getBBox(selection);
+      var bbox = Utils.DOM.elementBBox(selection);
       var translatedBbox: SVGRect = {
         x: bbox.x + translation[0],
         y: bbox.y + translation[1],

--- a/src/core/renderPolicy.ts
+++ b/src/core/renderPolicy.ts
@@ -35,7 +35,7 @@ module Plottable {
      * but useful for browsers that don't suppoort `requestAnimationFrame`.
      */
     export class Timeout implements RenderPolicy {
-      private _timeoutMsec: number = Utils.DOM.POLYFILL_TIMEOUT_MSEC;
+      private _timeoutMsec: number = Utils.DOM.POLYFILL_TIMEOUT_MILLISECONDS;
 
       public render() {
         setTimeout(RenderController.flush, this._timeoutMsec);

--- a/src/dispatchers/mouseDispatcher.ts
+++ b/src/dispatchers/mouseDispatcher.ts
@@ -23,7 +23,7 @@ export module Dispatchers {
      * @return {Dispatchers.Mouse}
      */
     public static getDispatcher(elem: SVGElement): Dispatchers.Mouse {
-      var svg = Utils.DOM.getBoundingSVG(elem);
+      var svg = Utils.DOM.boundingSVG(elem);
 
       var dispatcher: Mouse = (<any> svg)[Mouse._DISPATCHER_KEY];
       if (dispatcher == null) {

--- a/src/dispatchers/touchDispatcher.ts
+++ b/src/dispatchers/touchDispatcher.ts
@@ -20,7 +20,7 @@ export module Dispatchers {
      * @return {Dispatchers.Touch}
      */
     public static getDispatcher(elem: SVGElement): Dispatchers.Touch {
-      var svg = Utils.DOM.getBoundingSVG(elem);
+      var svg = Utils.DOM.boundingSVG(elem);
 
       var dispatcher: Touch = (<any> svg)[Touch._DISPATCHER_KEY];
       if (dispatcher == null) {

--- a/src/utils/clientToSVGTranslator.ts
+++ b/src/utils/clientToSVGTranslator.ts
@@ -8,7 +8,7 @@ export module Utils {
     private _measureRect: SVGElement;
 
     public static getTranslator(elem: SVGElement): ClientToSVGTranslator {
-      var svg = Utils.DOM.getBoundingSVG(elem);
+      var svg = Utils.DOM.boundingSVG(elem);
 
       var translator: ClientToSVGTranslator = (<any> svg)[ClientToSVGTranslator._TRANSLATOR_KEY];
       if (translator == null) {

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -32,14 +32,6 @@ export module Utils {
       }
     }
 
-    export function isSelectionRemovedFromSVG(selection: d3.Selection<any>) {
-      var n = (<Node> selection.node());
-      while (n !== null && n.nodeName.toLowerCase() !== "svg") {
-        n = n.parentNode;
-      }
-      return (n == null);
-    }
-
     export function getElementWidth(elem: Element): number {
       var style: CSSStyleDeclaration = window.getComputedStyle(elem);
       return getParsedStyleValue(style, "width")

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -82,7 +82,7 @@ export module Utils {
       );
     }
 
-    export function getBoundingSVG(elem: SVGElement): SVGElement {
+    export function boundingSVG(elem: SVGElement): SVGElement {
       var ownerSVG = elem.ownerSVGElement;
       if (ownerSVG != null) {
         return ownerSVG;

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -33,7 +33,7 @@ export module Utils {
     }
 
     export function getElementWidth(elem: Element): number {
-      var style: CSSStyleDeclaration = window.getComputedStyle(elem);
+      var style = window.getComputedStyle(elem);
       return getParsedStyleValue(style, "width")
         + getParsedStyleValue(style, "padding-left")
         + getParsedStyleValue(style, "padding-right")
@@ -42,35 +42,12 @@ export module Utils {
     }
 
     export function getElementHeight(elem: Element): number {
-      var style: CSSStyleDeclaration = window.getComputedStyle(elem);
+      var style = window.getComputedStyle(elem);
       return getParsedStyleValue(style, "height")
         + getParsedStyleValue(style, "padding-top")
         + getParsedStyleValue(style, "padding-bottom")
         + getParsedStyleValue(style, "border-top-width")
         + getParsedStyleValue(style, "border-bottom-width");
-    }
-
-    export function getSVGPixelWidth(svg: d3.Selection<void>) {
-      var width = (<Element> svg.node()).clientWidth;
-
-      if (width === 0) { // Firefox bug #874811
-        var widthAttr = svg.attr("width");
-
-        if (widthAttr.indexOf("%") !== -1) { // percentage
-          var ancestorNode = <Element> (<Element> svg.node()).parentNode;
-          while (ancestorNode != null && ancestorNode.clientWidth === 0) {
-            ancestorNode = <Element> ancestorNode.parentNode;
-          }
-          if (ancestorNode == null) {
-            throw new Error("Could not compute width of element");
-          }
-          width = ancestorNode.clientWidth * parseFloat(widthAttr) / 100;
-        } else {
-          width = parseFloat(widthAttr);
-        }
-      }
-
-      return width;
     }
 
     export function translate(s: d3.Selection<any>): d3.Transform;

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -147,8 +147,8 @@ export module Utils {
       throw new Error("input '" + input + "' can't be parsed as an Range");
     }
 
-    function getParsedStyleValue(style: CSSStyleDeclaration, prop: string): number {
-      var value: any = style.getPropertyValue(prop);
+    function getParsedStyleValue(style: CSSStyleDeclaration, property: string): number {
+      var value: any = style.getPropertyValue(property);
       var parsedValue = parseFloat(value);
       if (parsedValue !== parsedValue) {
           return 0;

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -22,22 +22,14 @@ export module Utils {
       return bbox;
     }
 
-    export var POLYFILL_TIMEOUT_MSEC = 1000 / 60; // 60 fps
+    export var POLYFILL_TIMEOUT_MILLISECONDS = 1000 / 60; // 60 fps
+
     export function requestAnimationFramePolyfill(fn: () => any): void {
       if (window.requestAnimationFrame != null) {
         window.requestAnimationFrame(fn);
       } else {
-        setTimeout(fn, POLYFILL_TIMEOUT_MSEC);
+        setTimeout(fn, POLYFILL_TIMEOUT_MILLISECONDS);
       }
-    }
-
-    function getParsedStyleValue(style: CSSStyleDeclaration, prop: string): number {
-      var value: any = style.getPropertyValue(prop);
-      var parsedValue = parseFloat(value);
-      if (parsedValue !== parsedValue) {
-          return 0;
-      }
-      return parsedValue;
     }
 
     export function isSelectionRemovedFromSVG(selection: d3.Selection<any>) {
@@ -90,7 +82,7 @@ export module Utils {
     }
 
     export function translate(s: d3.Selection<any>): d3.Transform;
-    export function translate(s: d3.Selection<any>, x: number, y: number): d3.Selection<any>
+    export function translate(s: d3.Selection<any>, x: number, y: number): d3.Selection<any>;
     export function translate(s: d3.Selection<any>, x?: number, y?: number): any {
       var xform = d3.transform(s.attr("transform"));
       if (x == null) {
@@ -177,6 +169,15 @@ export module Utils {
       } else {
         throw new Error("input '" + input + "' can't be parsed as an Range");
       }
+    }
+
+    function getParsedStyleValue(style: CSSStyleDeclaration, prop: string): number {
+      var value: any = style.getPropertyValue(prop);
+      var parsedValue = parseFloat(value);
+      if (parsedValue !== parsedValue) {
+          return 0;
+      }
+      return parsedValue;
     }
   }
 }

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -22,7 +22,7 @@ export module Utils {
 
     export var POLYFILL_TIMEOUT_MILLISECONDS = 1000 / 60; // 60 fps
 
-    export function requestAnimationFramePolyfill(fn: () => any) {
+    export function requestAnimationFramePolyfill(fn: () => void) {
       if (window.requestAnimationFrame != null) {
         window.requestAnimationFrame(fn);
       } else {

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -110,10 +110,13 @@ export module Utils {
      * @returns {boolean} True if the supplied coordinates or Ranges intersect or are
      * contained by bbox, false otherwise.
      */
-    export function intersectsBBox(xValOrRange: number | Range, yValOrRange: number | Range,
-      bbox: SVGRect, tolerance = 0.5): boolean {
-      var xRange: Range = parseRange(xValOrRange);
-      var yRange: Range = parseRange(yValOrRange);
+    export function intersectsBBox(
+        xValOrRange: number | Range,
+        yValOrRange: number | Range,
+        bbox: SVGRect,
+        tolerance = 0.5) {
+      var xRange = parseRange(xValOrRange);
+      var yRange = parseRange(yValOrRange);
 
       // SVGRects are positioned with sub-pixel accuracy (the default unit
       // for the x, y, height & width attributes), but user selections (e.g. via
@@ -130,14 +133,18 @@ export module Utils {
      *
      * @returns {Range} The generated Range
      */
-    function parseRange(input: any): Range {
+    function parseRange(input: number | Range): Range {
       if (typeof (input) === "number") {
-        return { min: input, max: input };
-      } else if (input instanceof Object && "min" in input && "max" in input) {
-        return <Range> input;
-      } else {
-        throw new Error("input '" + input + "' can't be parsed as an Range");
+        var value = <number>input;
+        return { min: value, max: value };
       }
+
+      var range = <Range>input;
+      if (range instanceof Object && "min" in range && "max" in range) {
+        return range;
+      }
+
+      throw new Error("input '" + input + "' can't be parsed as an Range");
     }
 
     function getParsedStyleValue(style: CSSStyleDeclaration, prop: string): number {

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -56,13 +56,13 @@ export module Utils {
       var xform = d3.transform(selection.attr("transform"));
       if (x == null) {
         return xform.translate;
-      } else {
-        y = (y == null) ? 0 : y;
-        xform.translate[0] = x;
-        xform.translate[1] = y;
-        selection.attr("transform", xform.toString());
-        return selection;
       }
+
+      y = (y == null) ? 0 : y;
+      xform.translate[0] = x;
+      xform.translate[1] = y;
+      selection.attr("transform", xform.toString());
+      return selection;
     }
 
     export function boxesOverlap(boxA: ClientRect, boxB: ClientRect) {
@@ -122,8 +122,10 @@ export module Utils {
       // for the x, y, height & width attributes), but user selections (e.g. via
       // mouse events) usually have pixel accuracy. A tolerance of half-a-pixel
       // seems appropriate.
-      return bbox.x + bbox.width >= xRange.min - tolerance && bbox.x <= xRange.max + tolerance &&
-        bbox.y + bbox.height >= yRange.min - tolerance && bbox.y <= yRange.max + tolerance;
+      return bbox.x + bbox.width >= xRange.min - tolerance &&
+        bbox.x <= xRange.max + tolerance &&
+        bbox.y + bbox.height >= yRange.min - tolerance &&
+        bbox.y <= yRange.max + tolerance;
     }
 
     /**
@@ -148,7 +150,7 @@ export module Utils {
     }
 
     function _parseStyleValue(style: CSSStyleDeclaration, property: string): number {
-      var value: any = style.getPropertyValue(property);
+      var value = style.getPropertyValue(property);
       var parsedValue = parseFloat(value);
       if (parsedValue !== parsedValue) {
           return 0;

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -32,7 +32,7 @@ export module Utils {
       }
     }
 
-    export function getElementWidth(element: Element) {
+    export function elementWidth(element: Element) {
       var style = window.getComputedStyle(element);
       return getParsedStyleValue(style, "width")
         + getParsedStyleValue(style, "padding-left")
@@ -41,7 +41,7 @@ export module Utils {
         + getParsedStyleValue(style, "border-right-width");
     }
 
-    export function getElementHeight(element: Element) {
+    export function elementHeight(element: Element) {
       var style = window.getComputedStyle(element);
       return getParsedStyleValue(style, "height")
         + getParsedStyleValue(style, "padding-top")

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -9,7 +9,7 @@ export module Utils {
      * @param {d3.Selection} element
      * @returns {SVGRed} The bounding box.
      */
-    export function getBBox(element: d3.Selection<any>): SVGRect {
+    export function getBBox(element: d3.Selection<any>) {
       var bbox: SVGRect;
       // HACKHACK: Firefox won't correctly measure nodes with style "display: none" or their descendents (FF Bug 612118).
       try {
@@ -24,7 +24,7 @@ export module Utils {
 
     export var POLYFILL_TIMEOUT_MILLISECONDS = 1000 / 60; // 60 fps
 
-    export function requestAnimationFramePolyfill(fn: () => any): void {
+    export function requestAnimationFramePolyfill(fn: () => any) {
       if (window.requestAnimationFrame != null) {
         window.requestAnimationFrame(fn);
       } else {
@@ -32,7 +32,7 @@ export module Utils {
       }
     }
 
-    export function getElementWidth(element: Element): number {
+    export function getElementWidth(element: Element) {
       var style = window.getComputedStyle(element);
       return getParsedStyleValue(style, "width")
         + getParsedStyleValue(style, "padding-left")
@@ -41,7 +41,7 @@ export module Utils {
         + getParsedStyleValue(style, "border-right-width");
     }
 
-    export function getElementHeight(element: Element): number {
+    export function getElementHeight(element: Element) {
       var style = window.getComputedStyle(element);
       return getParsedStyleValue(style, "height")
         + getParsedStyleValue(style, "padding-top")

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -32,8 +32,8 @@ export module Utils {
       }
     }
 
-    export function getElementWidth(elem: Element): number {
-      var style = window.getComputedStyle(elem);
+    export function getElementWidth(element: Element): number {
+      var style = window.getComputedStyle(element);
       return getParsedStyleValue(style, "width")
         + getParsedStyleValue(style, "padding-left")
         + getParsedStyleValue(style, "padding-right")
@@ -41,8 +41,8 @@ export module Utils {
         + getParsedStyleValue(style, "border-right-width");
     }
 
-    export function getElementHeight(elem: Element): number {
-      var style = window.getComputedStyle(elem);
+    export function getElementHeight(element: Element): number {
+      var style = window.getComputedStyle(element);
       return getParsedStyleValue(style, "height")
         + getParsedStyleValue(style, "padding-top")
         + getParsedStyleValue(style, "padding-bottom")
@@ -50,18 +50,18 @@ export module Utils {
         + getParsedStyleValue(style, "border-bottom-width");
     }
 
-    export function translate(s: d3.Selection<any>): d3.Transform;
-    export function translate(s: d3.Selection<any>, x: number, y: number): d3.Selection<any>;
-    export function translate(s: d3.Selection<any>, x?: number, y?: number): any {
-      var xform = d3.transform(s.attr("transform"));
+    export function translate(selection: d3.Selection<any>): d3.Transform;
+    export function translate(selection: d3.Selection<any>, x: number, y: number): d3.Selection<any>;
+    export function translate(selection: d3.Selection<any>, x?: number, y?: number): any {
+      var xform = d3.transform(selection.attr("transform"));
       if (x == null) {
         return xform.translate;
       } else {
         y = (y == null) ? 0 : y;
         xform.translate[0] = x;
         xform.translate[1] = y;
-        s.attr("transform", xform.toString());
-        return s;
+        selection.attr("transform", xform.toString());
+        return selection;
       }
     }
 

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -34,20 +34,20 @@ export module Utils {
 
     export function elementWidth(element: Element) {
       var style = window.getComputedStyle(element);
-      return getParsedStyleValue(style, "width")
-        + getParsedStyleValue(style, "padding-left")
-        + getParsedStyleValue(style, "padding-right")
-        + getParsedStyleValue(style, "border-left-width")
-        + getParsedStyleValue(style, "border-right-width");
+      return _parseStyleValue(style, "width")
+        + _parseStyleValue(style, "padding-left")
+        + _parseStyleValue(style, "padding-right")
+        + _parseStyleValue(style, "border-left-width")
+        + _parseStyleValue(style, "border-right-width");
     }
 
     export function elementHeight(element: Element) {
       var style = window.getComputedStyle(element);
-      return getParsedStyleValue(style, "height")
-        + getParsedStyleValue(style, "padding-top")
-        + getParsedStyleValue(style, "padding-bottom")
-        + getParsedStyleValue(style, "border-top-width")
-        + getParsedStyleValue(style, "border-bottom-width");
+      return _parseStyleValue(style, "height")
+        + _parseStyleValue(style, "padding-top")
+        + _parseStyleValue(style, "padding-bottom")
+        + _parseStyleValue(style, "border-top-width")
+        + _parseStyleValue(style, "border-bottom-width");
     }
 
     export function translate(selection: d3.Selection<any>): d3.Transform;
@@ -115,8 +115,8 @@ export module Utils {
         yValOrRange: number | Range,
         bbox: SVGRect,
         tolerance = 0.5) {
-      var xRange = parseRange(xValOrRange);
-      var yRange = parseRange(yValOrRange);
+      var xRange = _parseRange(xValOrRange);
+      var yRange = _parseRange(yValOrRange);
 
       // SVGRects are positioned with sub-pixel accuracy (the default unit
       // for the x, y, height & width attributes), but user selections (e.g. via
@@ -133,7 +133,7 @@ export module Utils {
      *
      * @returns {Range} The generated Range
      */
-    function parseRange(input: number | Range): Range {
+    function _parseRange(input: number | Range): Range {
       if (typeof (input) === "number") {
         var value = <number>input;
         return { min: value, max: value };
@@ -147,7 +147,7 @@ export module Utils {
       throw new Error("input '" + input + "' can't be parsed as an Range");
     }
 
-    function getParsedStyleValue(style: CSSStyleDeclaration, property: string): number {
+    function _parseStyleValue(style: CSSStyleDeclaration, property: string): number {
       var value: any = style.getPropertyValue(property);
       var parsedValue = parseFloat(value);
       if (parsedValue !== parsedValue) {

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -15,9 +15,7 @@ export module Utils {
       try {
         bbox = (<any> element.node()).getBBox();
       } catch (err) {
-        bbox = {
-          x: 0, y: 0, width: 0, height: 0
-        };
+        bbox = { x: 0, y: 0, width: 0, height: 0 };
       }
       return bbox;
     }

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -94,7 +94,7 @@ export module Utils {
     }
 
     var _latestClipPathId = 0;
-    export function getUniqueClipPathId() {
+    export function generateUniqueClipPathId() {
       return "plottableClipPath" + ++_latestClipPathId;
     }
 

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -9,7 +9,7 @@ export module Utils {
      * @param {d3.Selection} element
      * @returns {SVGRed} The bounding box.
      */
-    export function getBBox(element: d3.Selection<any>) {
+    export function elementBBox(element: d3.Selection<any>) {
       var bbox: SVGRect;
       // HACKHACK: Firefox won't correctly measure nodes with style "display: none" or their descendents (FF Bug 612118).
       try {
@@ -51,15 +51,16 @@ export module Utils {
     export function translate(selection: d3.Selection<any>): d3.Transform;
     export function translate(selection: d3.Selection<any>, x: number, y: number): d3.Selection<any>;
     export function translate(selection: d3.Selection<any>, x?: number, y?: number): any {
-      var xform = d3.transform(selection.attr("transform"));
+      var transformMatrix = d3.transform(selection.attr("transform"));
+
       if (x == null) {
-        return xform.translate;
+        return transformMatrix.translate;
       }
 
       y = (y == null) ? 0 : y;
-      xform.translate[0] = x;
-      xform.translate[1] = y;
-      selection.attr("transform", xform.toString());
+      transformMatrix.translate[0] = x;
+      transformMatrix.translate[1] = y;
+      selection.attr("transform", transformMatrix.toString());
       return selection;
     }
 

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -16,7 +16,7 @@ describe("Labels", () => {
     assert.lengthOf(textChildren, 1, "There is one text node in the parent element");
 
     var text = content.select("text");
-    var bbox = Plottable.Utils.DOM.getBBox(text);
+    var bbox = Plottable.Utils.DOM.elementBBox(text);
     assert.closeTo(bbox.height, label.height(), 0.5, "text height === label.minimumHeight()");
     assert.strictEqual(text.node().textContent, "A CHART TITLE", "node's text content is as expected");
     svg.remove();
@@ -40,7 +40,7 @@ describe("Labels", () => {
     label.renderTo(svg);
     var content = (<any> label)._content;
     var text = content.select("text");
-    var textBBox = Plottable.Utils.DOM.getBBox(text);
+    var textBBox = Plottable.Utils.DOM.elementBBox(text);
     TestMethods.assertBBoxInclusion((<any> label)._element.select(".bounding-box"), text);
     assert.closeTo(textBBox.height, label.width(), window.Pixel_CloseTo_Requirement, "text height");
     assert.closeTo(textBBox.width, label.height(), window.Pixel_CloseTo_Requirement, "text width");
@@ -53,7 +53,7 @@ describe("Labels", () => {
     label.renderTo(svg);
     var content = (<any> label)._content;
     var text = content.select("text");
-    var textBBox = Plottable.Utils.DOM.getBBox(text);
+    var textBBox = Plottable.Utils.DOM.elementBBox(text);
     TestMethods.assertBBoxInclusion((<any> label)._element.select(".bounding-box"), text);
     assert.closeTo(textBBox.height, label.width(), window.Pixel_CloseTo_Requirement, "text height");
     assert.closeTo(textBBox.width, label.height(), window.Pixel_CloseTo_Requirement, "text width");
@@ -80,7 +80,7 @@ describe("Labels", () => {
     label.renderTo(svg);
     var content = (<any> label)._content;
     var text = content.select("text");
-    var bbox = Plottable.Utils.DOM.getBBox(text);
+    var bbox = Plottable.Utils.DOM.elementBBox(text);
     assert.strictEqual(bbox.height, label.height(), "text height === label.minimumHeight()");
     assert.operator(bbox.width, "<=", svgWidth, "the text is not wider than the SVG width");
     svg.remove();
@@ -103,7 +103,7 @@ describe("Labels", () => {
     t.renderTo(svg);
     var textTranslate = d3.transform((<any> label)._content.select("g").attr("transform")).translate;
     var eleTranslate = d3.transform((<any> label)._element.attr("transform")).translate;
-    var textWidth = Plottable.Utils.DOM.getBBox((<any> label)._content.select("text")).width;
+    var textWidth = Plottable.Utils.DOM.elementBBox((<any> label)._content.select("text")).width;
     assert.closeTo(eleTranslate[0] + textTranslate[0] + textWidth / 2, 200, 5, "label is centered");
     svg.remove();
   });
@@ -124,12 +124,12 @@ describe("Labels", () => {
 
     var content = (<any> label)._content;
     var text = content.select("text");
-    var bbox = Plottable.Utils.DOM.getBBox(text);
+    var bbox = Plottable.Utils.DOM.elementBBox(text);
     assert.closeTo(bbox.height, label.height(), 1, "label is in horizontal position");
 
     label.angle(90);
     text = content.select("text");
-    bbox = Plottable.Utils.DOM.getBBox(text);
+    bbox = Plottable.Utils.DOM.elementBBox(text);
     TestMethods.assertBBoxInclusion((<any> label)._element.select(".bounding-box"), text);
     assert.closeTo(bbox.height, label.width(), window.Pixel_CloseTo_Requirement, "label is in vertical position");
 

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -54,9 +54,9 @@ describe("Legend", () => {
     color.domain(["alpha", "beta", "gamma", "delta", "omega", "omicron", "persei", "eight"]);
     legend.renderTo(svg);
 
-    var contentBBox = Plottable.Utils.DOM.getBBox((<any> legend)._content);
+    var contentBBox = Plottable.Utils.DOM.elementBBox((<any> legend)._content);
     var contentBottomEdge = contentBBox.y + contentBBox.height;
-    var bboxBBox = Plottable.Utils.DOM.getBBox((<any> legend)._element.select(".bounding-box"));
+    var bboxBBox = Plottable.Utils.DOM.elementBBox((<any> legend)._element.select(".bounding-box"));
     var bboxBottomEdge = bboxBBox.y + bboxBBox.height;
 
     assert.operator(contentBottomEdge, "<=", bboxBottomEdge, "content does not extend past bounding box");
@@ -154,7 +154,7 @@ describe("Legend", () => {
     function verifySymbolHeight() {
       var text = (<any> legend)._content.select("text");
       var icon = (<any> legend)._content.select("." + Plottable.Components.Legend.LEGEND_SYMBOL_CLASS);
-      var textHeight = Plottable.Utils.DOM.getBBox(text).height;
+      var textHeight = Plottable.Utils.DOM.elementBBox(text).height;
       var symbolHeight = icon.node().getBoundingClientRect().height;
       assert.operator(symbolHeight, "<", textHeight, "icons too small: symbolHeight < textHeight");
       assert.operator(symbolHeight, ">", textHeight / 2, "icons too big: textHeight / 2 > symbolHeight");

--- a/test/components/selectionBoxLayerTests.ts
+++ b/test/components/selectionBoxLayerTests.ts
@@ -44,7 +44,7 @@ describe("SelectionBoxLayer", () => {
 
     function assertCorrectRendering(expectedTL: Plottable.Point, expectedBR: Plottable.Point, msg: string) {
       var selectionBox = svg.select(".selection-box");
-      var bbox = Plottable.Utils.DOM.getBBox(selectionBox);
+      var bbox = Plottable.Utils.DOM.elementBBox(selectionBox);
       assert.strictEqual(bbox.x, expectedTL.x, msg + " (x-origin)");
       assert.strictEqual(bbox.x, expectedTL.y, msg + " (y-origin)");
       assert.strictEqual(bbox.width, expectedBR.x - expectedTL.x, msg + " (width)");

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -284,7 +284,7 @@ describe("Component behavior", () => {
     boxStrings.forEach((s) => {
       var box = boxContainer.select(s);
       assert.isNotNull(box.node(), s + " box was created and placed inside boxContainer");
-      var bb = Plottable.Utils.DOM.getBBox(box);
+      var bb = Plottable.Utils.DOM.elementBBox(box);
       assert.strictEqual(bb.width, SVG_WIDTH, s + " width as expected");
       assert.strictEqual(bb.height, SVG_HEIGHT, s + " height as expected");
     });

--- a/test/core/tableTests.ts
+++ b/test/core/tableTests.ts
@@ -117,7 +117,7 @@ describe("Tables", () => {
     assert.deepEqual(translates[1], [200, 0], "second element is located properly");
     assert.deepEqual(translates[2], [0, 200], "third element is located properly");
     assert.deepEqual(translates[3], [200, 200], "fourth element is located properly");
-    var bboxes = elements.map((e) => Plottable.Utils.DOM.getBBox(e));
+    var bboxes = elements.map((e) => Plottable.Utils.DOM.elementBBox(e));
     bboxes.forEach((b) => {
       assert.strictEqual(b.width, 200, "bbox is 200 pixels wide");
       assert.strictEqual(b.height, 200, "bbox is 200 pixels tall");
@@ -136,7 +136,7 @@ describe("Tables", () => {
 
     var elements = components.map((r) => (<any> r)._element);
     var translates = elements.map((e) => TestMethods.getTranslate(e));
-    var bboxes = elements.map((e) => Plottable.Utils.DOM.getBBox(e));
+    var bboxes = elements.map((e) => Plottable.Utils.DOM.elementBBox(e));
     assert.deepEqual(translates[0], [0, 0], "first element is centered properly");
     assert.deepEqual(translates[1], [210, 0], "second element is located properly");
     assert.deepEqual(translates[2], [0, 210], "third element is located properly");
@@ -170,7 +170,7 @@ describe("Tables", () => {
 
     var elements = components.map((r) => (<any> r)._element);
     var translates = elements.map((e) => TestMethods.getTranslate(e));
-    var bboxes = elements.map((e) => Plottable.Utils.DOM.getBBox(e));
+    var bboxes = elements.map((e) => Plottable.Utils.DOM.elementBBox(e));
     // test the translates
     assert.deepEqual(translates[0], [50, 0] , "top axis translate");
     assert.deepEqual(translates[4], [50, 370], "bottom axis translate");

--- a/test/tests.js
+++ b/test/tests.js
@@ -1428,7 +1428,7 @@ describe("Labels", function () {
         var textChildren = content.selectAll("text");
         assert.lengthOf(textChildren, 1, "There is one text node in the parent element");
         var text = content.select("text");
-        var bbox = Plottable.Utils.DOM.getBBox(text);
+        var bbox = Plottable.Utils.DOM.elementBBox(text);
         assert.closeTo(bbox.height, label.height(), 0.5, "text height === label.minimumHeight()");
         assert.strictEqual(text.node().textContent, "A CHART TITLE", "node's text content is as expected");
         svg.remove();
@@ -1450,7 +1450,7 @@ describe("Labels", function () {
         label.renderTo(svg);
         var content = label._content;
         var text = content.select("text");
-        var textBBox = Plottable.Utils.DOM.getBBox(text);
+        var textBBox = Plottable.Utils.DOM.elementBBox(text);
         TestMethods.assertBBoxInclusion(label._element.select(".bounding-box"), text);
         assert.closeTo(textBBox.height, label.width(), window.Pixel_CloseTo_Requirement, "text height");
         assert.closeTo(textBBox.width, label.height(), window.Pixel_CloseTo_Requirement, "text width");
@@ -1462,7 +1462,7 @@ describe("Labels", function () {
         label.renderTo(svg);
         var content = label._content;
         var text = content.select("text");
-        var textBBox = Plottable.Utils.DOM.getBBox(text);
+        var textBBox = Plottable.Utils.DOM.elementBBox(text);
         TestMethods.assertBBoxInclusion(label._element.select(".bounding-box"), text);
         assert.closeTo(textBBox.height, label.width(), window.Pixel_CloseTo_Requirement, "text height");
         assert.closeTo(textBBox.width, label.height(), window.Pixel_CloseTo_Requirement, "text width");
@@ -1487,7 +1487,7 @@ describe("Labels", function () {
         label.renderTo(svg);
         var content = label._content;
         var text = content.select("text");
-        var bbox = Plottable.Utils.DOM.getBBox(text);
+        var bbox = Plottable.Utils.DOM.elementBBox(text);
         assert.strictEqual(bbox.height, label.height(), "text height === label.minimumHeight()");
         assert.operator(bbox.width, "<=", svgWidth, "the text is not wider than the SVG width");
         svg.remove();
@@ -1507,7 +1507,7 @@ describe("Labels", function () {
         t.renderTo(svg);
         var textTranslate = d3.transform(label._content.select("g").attr("transform")).translate;
         var eleTranslate = d3.transform(label._element.attr("transform")).translate;
-        var textWidth = Plottable.Utils.DOM.getBBox(label._content.select("text")).width;
+        var textWidth = Plottable.Utils.DOM.elementBBox(label._content.select("text")).width;
         assert.closeTo(eleTranslate[0] + textTranslate[0] + textWidth / 2, 200, 5, "label is centered");
         svg.remove();
     });
@@ -1525,11 +1525,11 @@ describe("Labels", function () {
         label.renderTo(svg);
         var content = label._content;
         var text = content.select("text");
-        var bbox = Plottable.Utils.DOM.getBBox(text);
+        var bbox = Plottable.Utils.DOM.elementBBox(text);
         assert.closeTo(bbox.height, label.height(), 1, "label is in horizontal position");
         label.angle(90);
         text = content.select("text");
-        bbox = Plottable.Utils.DOM.getBBox(text);
+        bbox = Plottable.Utils.DOM.elementBBox(text);
         TestMethods.assertBBoxInclusion(label._element.select(".bounding-box"), text);
         assert.closeTo(bbox.height, label.width(), window.Pixel_CloseTo_Requirement, "label is in vertical position");
         svg.remove();
@@ -1622,9 +1622,9 @@ describe("Legend", function () {
     it("a legend with many labels does not overflow vertically", function () {
         color.domain(["alpha", "beta", "gamma", "delta", "omega", "omicron", "persei", "eight"]);
         legend.renderTo(svg);
-        var contentBBox = Plottable.Utils.DOM.getBBox(legend._content);
+        var contentBBox = Plottable.Utils.DOM.elementBBox(legend._content);
         var contentBottomEdge = contentBBox.y + contentBBox.height;
-        var bboxBBox = Plottable.Utils.DOM.getBBox(legend._element.select(".bounding-box"));
+        var bboxBBox = Plottable.Utils.DOM.elementBBox(legend._element.select(".bounding-box"));
         var bboxBottomEdge = bboxBBox.y + bboxBBox.height;
         assert.operator(contentBottomEdge, "<=", bboxBottomEdge, "content does not extend past bounding box");
         svg.remove();
@@ -1708,7 +1708,7 @@ describe("Legend", function () {
         function verifySymbolHeight() {
             var text = legend._content.select("text");
             var icon = legend._content.select("." + Plottable.Components.Legend.LEGEND_SYMBOL_CLASS);
-            var textHeight = Plottable.Utils.DOM.getBBox(text).height;
+            var textHeight = Plottable.Utils.DOM.elementBBox(text).height;
             var symbolHeight = icon.node().getBoundingClientRect().height;
             assert.operator(symbolHeight, "<", textHeight, "icons too small: symbolHeight < textHeight");
             assert.operator(symbolHeight, ">", textHeight / 2, "icons too big: textHeight / 2 > symbolHeight");
@@ -1996,7 +1996,7 @@ describe("SelectionBoxLayer", function () {
         sbl.renderTo(svg);
         function assertCorrectRendering(expectedTL, expectedBR, msg) {
             var selectionBox = svg.select(".selection-box");
-            var bbox = Plottable.Utils.DOM.getBBox(selectionBox);
+            var bbox = Plottable.Utils.DOM.elementBBox(selectionBox);
             assert.strictEqual(bbox.x, expectedTL.x, msg + " (x-origin)");
             assert.strictEqual(bbox.x, expectedTL.y, msg + " (y-origin)");
             assert.strictEqual(bbox.width, expectedBR.x - expectedTL.x, msg + " (width)");
@@ -6321,7 +6321,7 @@ describe("Component behavior", function () {
         boxStrings.forEach(function (s) {
             var box = boxContainer.select(s);
             assert.isNotNull(box.node(), s + " box was created and placed inside boxContainer");
-            var bb = Plottable.Utils.DOM.getBBox(box);
+            var bb = Plottable.Utils.DOM.elementBBox(box);
             assert.strictEqual(bb.width, SVG_WIDTH, s + " width as expected");
             assert.strictEqual(bb.height, SVG_HEIGHT, s + " height as expected");
         });
@@ -6677,7 +6677,7 @@ describe("Tables", function () {
         assert.deepEqual(translates[1], [200, 0], "second element is located properly");
         assert.deepEqual(translates[2], [0, 200], "third element is located properly");
         assert.deepEqual(translates[3], [200, 200], "fourth element is located properly");
-        var bboxes = elements.map(function (e) { return Plottable.Utils.DOM.getBBox(e); });
+        var bboxes = elements.map(function (e) { return Plottable.Utils.DOM.elementBBox(e); });
         bboxes.forEach(function (b) {
             assert.strictEqual(b.width, 200, "bbox is 200 pixels wide");
             assert.strictEqual(b.height, 200, "bbox is 200 pixels tall");
@@ -6693,7 +6693,7 @@ describe("Tables", function () {
         table.renderTo(svg);
         var elements = components.map(function (r) { return r._element; });
         var translates = elements.map(function (e) { return TestMethods.getTranslate(e); });
-        var bboxes = elements.map(function (e) { return Plottable.Utils.DOM.getBBox(e); });
+        var bboxes = elements.map(function (e) { return Plottable.Utils.DOM.elementBBox(e); });
         assert.deepEqual(translates[0], [0, 0], "first element is centered properly");
         assert.deepEqual(translates[1], [210, 0], "second element is located properly");
         assert.deepEqual(translates[2], [0, 210], "third element is located properly");
@@ -6724,7 +6724,7 @@ describe("Tables", function () {
         table.renderTo(svg);
         var elements = components.map(function (r) { return r._element; });
         var translates = elements.map(function (e) { return TestMethods.getTranslate(e); });
-        var bboxes = elements.map(function (e) { return Plottable.Utils.DOM.getBBox(e); });
+        var bboxes = elements.map(function (e) { return Plottable.Utils.DOM.elementBBox(e); });
         // test the translates
         assert.deepEqual(translates[0], [50, 0], "top axis translate");
         assert.deepEqual(translates[4], [50, 370], "bottom axis translate");
@@ -7907,7 +7907,7 @@ describe("Utils.DOM", function () {
             height: 20
         };
         var rect = svg.append("rect").attr(expectedBox);
-        var measuredBox = Plottable.Utils.DOM.getBBox(rect);
+        var measuredBox = Plottable.Utils.DOM.elementBBox(rect);
         assert.deepEqual(measuredBox, expectedBox, "getBBox measures correctly");
         svg.remove();
     });
@@ -7920,10 +7920,10 @@ describe("Utils.DOM", function () {
         };
         var removedSVG = TestMethods.generateSVG().remove();
         var rect = removedSVG.append("rect").attr(expectedBox);
-        Plottable.Utils.DOM.getBBox(rect); // could throw NS_ERROR on FF
+        Plottable.Utils.DOM.elementBBox(rect); // could throw NS_ERROR on FF
         var noneSVG = TestMethods.generateSVG().style("display", "none");
         rect = noneSVG.append("rect").attr(expectedBox);
-        Plottable.Utils.DOM.getBBox(rect); // could throw NS_ERROR on FF
+        Plottable.Utils.DOM.elementBBox(rect); // could throw NS_ERROR on FF
         noneSVG.remove();
     });
     describe("elementWidth(), elementHeight()", function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -7926,23 +7926,23 @@ describe("Utils.DOM", function () {
         Plottable.Utils.DOM.getBBox(rect); // could throw NS_ERROR on FF
         noneSVG.remove();
     });
-    describe("getElementWidth, getElementHeight", function () {
+    describe("elementWidth(), elementHeight()", function () {
         it("can get a plain element's size", function () {
             var parent = TestMethods.getSVGParent();
             parent.style("width", "300px");
             parent.style("height", "200px");
             var parentElem = parent[0][0];
-            var width = Plottable.Utils.DOM.getElementWidth(parentElem);
+            var width = Plottable.Utils.DOM.elementWidth(parentElem);
             assert.strictEqual(width, 300, "measured width matches set width");
-            var height = Plottable.Utils.DOM.getElementHeight(parentElem);
+            var height = Plottable.Utils.DOM.elementHeight(parentElem);
             assert.strictEqual(height, 200, "measured height matches set height");
         });
         it("can get the svg's size", function () {
             var svg = TestMethods.generateSVG(450, 120);
             var svgElem = svg[0][0];
-            var width = Plottable.Utils.DOM.getElementWidth(svgElem);
+            var width = Plottable.Utils.DOM.elementWidth(svgElem);
             assert.strictEqual(width, 450, "measured width matches set width");
-            var height = Plottable.Utils.DOM.getElementHeight(svgElem);
+            var height = Plottable.Utils.DOM.elementHeight(svgElem);
             assert.strictEqual(height, 120, "measured height matches set height");
             svg.remove();
         });
@@ -7953,20 +7953,20 @@ describe("Utils.DOM", function () {
             var childElem = child[0][0];
             parent.style("width", "200px");
             parent.style("height", "50px");
-            assert.strictEqual(Plottable.Utils.DOM.getElementWidth(parentElem), 200, "width is correct");
-            assert.strictEqual(Plottable.Utils.DOM.getElementHeight(parentElem), 50, "height is correct");
+            assert.strictEqual(Plottable.Utils.DOM.elementWidth(parentElem), 200, "width is correct");
+            assert.strictEqual(Plottable.Utils.DOM.elementHeight(parentElem), 50, "height is correct");
             child.style("width", "20px");
             child.style("height", "10px");
-            assert.strictEqual(Plottable.Utils.DOM.getElementWidth(childElem), 20, "width is correct");
-            assert.strictEqual(Plottable.Utils.DOM.getElementHeight(childElem), 10, "height is correct");
+            assert.strictEqual(Plottable.Utils.DOM.elementWidth(childElem), 20, "width is correct");
+            assert.strictEqual(Plottable.Utils.DOM.elementHeight(childElem), 10, "height is correct");
             child.style("width", "100%");
             child.style("height", "100%");
-            assert.strictEqual(Plottable.Utils.DOM.getElementWidth(childElem), 200, "width is correct");
-            assert.strictEqual(Plottable.Utils.DOM.getElementHeight(childElem), 50, "height is correct");
+            assert.strictEqual(Plottable.Utils.DOM.elementWidth(childElem), 200, "width is correct");
+            assert.strictEqual(Plottable.Utils.DOM.elementHeight(childElem), 50, "height is correct");
             child.style("width", "50%");
             child.style("height", "50%");
-            assert.strictEqual(Plottable.Utils.DOM.getElementWidth(childElem), 100, "width is correct");
-            assert.strictEqual(Plottable.Utils.DOM.getElementHeight(childElem), 25, "height is correct");
+            assert.strictEqual(Plottable.Utils.DOM.elementWidth(childElem), 100, "width is correct");
+            assert.strictEqual(Plottable.Utils.DOM.elementHeight(childElem), 25, "height is correct");
             // reset test page DOM
             parent.style("width", "auto");
             parent.style("height", "auto");

--- a/test/tests.js
+++ b/test/tests.js
@@ -7972,9 +7972,9 @@ describe("Utils.DOM", function () {
             parent.style("height", "auto");
             child.remove();
         });
-        it("getUniqueClipPathId works as expected", function () {
-            var firstClipPathId = Plottable.Utils.DOM.getUniqueClipPathId();
-            var secondClipPathId = Plottable.Utils.DOM.getUniqueClipPathId();
+        it("generateUniqueClipPathId()", function () {
+            var firstClipPathId = Plottable.Utils.DOM.generateUniqueClipPathId();
+            var secondClipPathId = Plottable.Utils.DOM.generateUniqueClipPathId();
             var firstClipPathIDPrefix = firstClipPathId.split(/\d/)[0];
             var secondClipPathIDPrefix = secondClipPathId.split(/\d/)[0];
             assert.strictEqual(firstClipPathIDPrefix, secondClipPathIDPrefix, "clip path ids should have the same prefix");
@@ -7984,7 +7984,7 @@ describe("Utils.DOM", function () {
             var secondClipPathIdNumber = +secondClipPathId.replace(prefix, "");
             assert.isFalse(Plottable.Utils.Math.isNaN(firstClipPathIdNumber), "first clip path id should only have a number after the prefix");
             assert.isFalse(Plottable.Utils.Math.isNaN(secondClipPathIdNumber), "second clip path id should only have a number after the prefix");
-            assert.strictEqual(firstClipPathIdNumber + 1, secondClipPathIdNumber, "Consecutive calls to getUniqueClipPathId should give consecutive numbers after the prefix");
+            assert.strictEqual(firstClipPathIdNumber + 1, secondClipPathIdNumber, "Consecutive calls to generateUniqueClipPathId should give consecutive numbers after the prefix");
         });
     });
 });

--- a/test/utils/domUtilsTests.ts
+++ b/test/utils/domUtilsTests.ts
@@ -93,9 +93,9 @@ describe("Utils.DOM", () => {
       child.remove();
     });
 
-    it("getUniqueClipPathId works as expected", () => {
-      var firstClipPathId = Plottable.Utils.DOM.getUniqueClipPathId();
-      var secondClipPathId = Plottable.Utils.DOM.getUniqueClipPathId();
+    it("generateUniqueClipPathId()", () => {
+      var firstClipPathId = Plottable.Utils.DOM.generateUniqueClipPathId();
+      var secondClipPathId = Plottable.Utils.DOM.generateUniqueClipPathId();
 
       var firstClipPathIDPrefix = firstClipPathId.split(/\d/)[0];
       var secondClipPathIDPrefix = secondClipPathId.split(/\d/)[0];
@@ -117,7 +117,7 @@ describe("Utils.DOM", () => {
         "second clip path id should only have a number after the prefix");
 
       assert.strictEqual(firstClipPathIdNumber + 1, secondClipPathIdNumber,
-        "Consecutive calls to getUniqueClipPathId should give consecutive numbers after the prefix");
+        "Consecutive calls to generateUniqueClipPathId should give consecutive numbers after the prefix");
     });
   });
 });

--- a/test/utils/domUtilsTests.ts
+++ b/test/utils/domUtilsTests.ts
@@ -13,7 +13,7 @@ describe("Utils.DOM", () => {
       height: 20
     };
     var rect = svg.append("rect").attr(expectedBox);
-    var measuredBox = Plottable.Utils.DOM.getBBox(rect);
+    var measuredBox = Plottable.Utils.DOM.elementBBox(rect);
     assert.deepEqual(measuredBox, expectedBox, "getBBox measures correctly");
     svg.remove();
   });
@@ -28,11 +28,11 @@ describe("Utils.DOM", () => {
 
     var removedSVG = TestMethods.generateSVG().remove();
     var rect = removedSVG.append("rect").attr(expectedBox);
-    Plottable.Utils.DOM.getBBox(rect); // could throw NS_ERROR on FF
+    Plottable.Utils.DOM.elementBBox(rect); // could throw NS_ERROR on FF
 
     var noneSVG = TestMethods.generateSVG().style("display", "none");
     rect = noneSVG.append("rect").attr(expectedBox);
-    Plottable.Utils.DOM.getBBox(rect); // could throw NS_ERROR on FF
+    Plottable.Utils.DOM.elementBBox(rect); // could throw NS_ERROR on FF
 
     noneSVG.remove();
   });

--- a/test/utils/domUtilsTests.ts
+++ b/test/utils/domUtilsTests.ts
@@ -37,16 +37,16 @@ describe("Utils.DOM", () => {
     noneSVG.remove();
   });
 
-  describe("getElementWidth, getElementHeight", () => {
+  describe("elementWidth(), elementHeight()", () => {
     it("can get a plain element's size", () => {
       var parent = TestMethods.getSVGParent();
       parent.style("width", "300px");
       parent.style("height", "200px");
       var parentElem = <Element> parent[0][0];
 
-      var width = Plottable.Utils.DOM.getElementWidth(parentElem);
+      var width = Plottable.Utils.DOM.elementWidth(parentElem);
       assert.strictEqual(width, 300, "measured width matches set width");
-      var height = Plottable.Utils.DOM.getElementHeight(parentElem);
+      var height = Plottable.Utils.DOM.elementHeight(parentElem);
       assert.strictEqual(height, 200, "measured height matches set height");
     });
 
@@ -54,9 +54,9 @@ describe("Utils.DOM", () => {
       var svg = TestMethods.generateSVG(450, 120);
       var svgElem = <Element> svg[0][0];
 
-      var width = Plottable.Utils.DOM.getElementWidth(svgElem);
+      var width = Plottable.Utils.DOM.elementWidth(svgElem);
       assert.strictEqual(width, 450, "measured width matches set width");
-      var height = Plottable.Utils.DOM.getElementHeight(svgElem);
+      var height = Plottable.Utils.DOM.elementHeight(svgElem);
       assert.strictEqual(height, 120, "measured height matches set height");
       svg.remove();
     });
@@ -69,23 +69,23 @@ describe("Utils.DOM", () => {
 
       parent.style("width", "200px");
       parent.style("height", "50px");
-      assert.strictEqual(Plottable.Utils.DOM.getElementWidth(parentElem), 200, "width is correct");
-      assert.strictEqual(Plottable.Utils.DOM.getElementHeight(parentElem), 50, "height is correct");
+      assert.strictEqual(Plottable.Utils.DOM.elementWidth(parentElem), 200, "width is correct");
+      assert.strictEqual(Plottable.Utils.DOM.elementHeight(parentElem), 50, "height is correct");
 
       child.style("width", "20px");
       child.style("height", "10px");
-      assert.strictEqual(Plottable.Utils.DOM.getElementWidth(childElem), 20, "width is correct");
-      assert.strictEqual(Plottable.Utils.DOM.getElementHeight(childElem), 10, "height is correct");
+      assert.strictEqual(Plottable.Utils.DOM.elementWidth(childElem), 20, "width is correct");
+      assert.strictEqual(Plottable.Utils.DOM.elementHeight(childElem), 10, "height is correct");
 
       child.style("width", "100%");
       child.style("height", "100%");
-      assert.strictEqual(Plottable.Utils.DOM.getElementWidth(childElem), 200, "width is correct");
-      assert.strictEqual(Plottable.Utils.DOM.getElementHeight(childElem), 50, "height is correct");
+      assert.strictEqual(Plottable.Utils.DOM.elementWidth(childElem), 200, "width is correct");
+      assert.strictEqual(Plottable.Utils.DOM.elementHeight(childElem), 50, "height is correct");
 
       child.style("width", "50%");
       child.style("height", "50%");
-      assert.strictEqual(Plottable.Utils.DOM.getElementWidth(childElem), 100, "width is correct");
-      assert.strictEqual(Plottable.Utils.DOM.getElementHeight(childElem), 25, "height is correct");
+      assert.strictEqual(Plottable.Utils.DOM.elementWidth(childElem), 100, "width is correct");
+      assert.strictEqual(Plottable.Utils.DOM.elementHeight(childElem), 25, "height is correct");
 
       // reset test page DOM
       parent.style("width", "auto");


### PR DESCRIPTION
Closes #2259

Changes:
- Things that can inferred (like return type of methods) are omitted now
- Style cleanup
- `getBBox` -> `elementBBox`
- `getParsedStyleValue` -> REMOVED (privatized)
- `isSelectionRemovedFromSVG` -> REMOVED
- `getElementWidth` -> `elementWidth`
- `getElementHeight` -> `elementHeight`
- `getSVGPixelWidth` -> REMOVED
- `getBoundingSVG` -> `boundingSVG`
- `getUniqueClipPathId` -> `generateUniqueClipPathId`

@bluong EDIT: second `getElementWidth` -> `getElementHeight`

**QE Notes** Regression pass