### PR TITLE
Move index out of Entity into PlotEntity

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -508,7 +508,6 @@ declare module Plottable {
      */
     interface Entity<C extends Component> {
         datum: any;
-        index: number;
         position: Point;
         selection: d3.Selection<any>;
         component: C;
@@ -2246,6 +2245,7 @@ declare module Plottable {
     module Plots {
         interface PlotEntity extends Entity<Plot> {
             dataset: Dataset;
+            index: number;
             component: Plot;
         }
         interface AccessorScaleBinding<D, R> {

--- a/plottable.js
+++ b/plottable.js
@@ -5111,7 +5111,6 @@ var Plottable;
                             var index = domain.indexOf(datum);
                             entities.push({
                                 datum: datum,
-                                index: index,
                                 position: { x: symbolX, y: symbolY },
                                 selection: entrySelection,
                                 component: legend

--- a/plottable.js
+++ b/plottable.js
@@ -5094,7 +5094,6 @@ var Plottable;
                 var entities = [];
                 var layout = this._calculateLayoutInfo(this.width(), this.height());
                 var legendPadding = this._padding;
-                var domain = this._scale.domain();
                 var legend = this;
                 this.content().selectAll("g." + Legend.LEGEND_ROW_CLASS).each(function (d, i) {
                     var lowY = i * layout.textHeight + legendPadding;
@@ -5108,7 +5107,6 @@ var Plottable;
                         if (highX >= p.x && lowX <= p.x && highY >= p.y && lowY <= p.y) {
                             var entrySelection = d3.select(this);
                             var datum = entrySelection.datum();
-                            var index = domain.indexOf(datum);
                             entities.push({
                                 datum: datum,
                                 position: { x: symbolX, y: symbolY },

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -220,7 +220,6 @@ export module Components {
       var entities: Entity<Legend>[] = [];
       var layout = this._calculateLayoutInfo(this.width(), this.height());
       var legendPadding = this._padding;
-      var domain = this._scale.domain();
       var legend = this;
       this.content().selectAll("g." + Legend.LEGEND_ROW_CLASS).each(function(d: any, i: number) {
         var lowY = i * layout.textHeight + legendPadding;
@@ -235,7 +234,6 @@ export module Components {
               highY >= p.y && lowY <= p.y) {
             var entrySelection = d3.select(this);
             var datum = entrySelection.datum();
-            var index = domain.indexOf(datum);
             entities.push({
               datum: datum,
               position: { x: symbolX, y: symbolY },

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -238,7 +238,6 @@ export module Components {
             var index = domain.indexOf(datum);
             entities.push({
               datum: datum,
-              index: index,
               position: { x: symbolX, y: symbolY },
               selection: entrySelection,
               component: legend

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -5,6 +5,7 @@ module Plottable {
   export module Plots {
     export interface PlotEntity extends Entity<Plot> {
       dataset: Dataset;
+      index: number;
       component: Plot;
     }
 

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -52,7 +52,6 @@ module Plottable {
    */
   export interface Entity<C extends Component> {
     datum: any;
-    index: number;
     position: Point;
     selection: d3.Selection<any>;
     component: C;

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -96,7 +96,6 @@ module TestMethods {
       expected: Plottable.Entity<Plottable.Component>,
       msg: string) {
     assert.deepEqual(actual.datum, expected.datum, msg + " (datum)");
-    assert.strictEqual(actual.index, expected.index, msg + " (index)");
     assertPointsClose(actual.position, expected.position, 0.01, msg);
     assert.strictEqual(actual.selection.size(), expected.selection.size(), msg + " (selection length)");
     actual.selection[0].forEach((element: Element, index: number) => {
@@ -111,6 +110,7 @@ module TestMethods {
       msg: string) {
     assertEntitiesEqual(actual, expected, msg);
     assert.strictEqual(actual.dataset, expected.dataset, msg + " (dataset)");
+    assert.strictEqual(actual.index, expected.index, msg + " (index)");
   }
 
   export function makeLinearSeries(n: number): { x: number; y: number }[] {

--- a/test/tests.js
+++ b/test/tests.js
@@ -89,7 +89,6 @@ var TestMethods;
     TestMethods.assertWidthHeight = assertWidthHeight;
     function assertEntitiesEqual(actual, expected, msg) {
         assert.deepEqual(actual.datum, expected.datum, msg + " (datum)");
-        assert.strictEqual(actual.index, expected.index, msg + " (index)");
         assertPointsClose(actual.position, expected.position, 0.01, msg);
         assert.strictEqual(actual.selection.size(), expected.selection.size(), msg + " (selection length)");
         actual.selection[0].forEach(function (element, index) {
@@ -101,6 +100,7 @@ var TestMethods;
     function assertPlotEntitiesEqual(actual, expected, msg) {
         assertEntitiesEqual(actual, expected, msg);
         assert.strictEqual(actual.dataset, expected.dataset, msg + " (dataset)");
+        assert.strictEqual(actual.index, expected.index, msg + " (index)");
     }
     TestMethods.assertPlotEntitiesEqual = assertPlotEntitiesEqual;
     function makeLinearSeries(n) {


### PR DESCRIPTION
`index` doesn't have a well-defined meaning for a general `Component`, so I've removed it from the base `Entity` type.