### PR TITLE
[RenderController] - Adding getter/setter renderPolicy endpoint

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -433,8 +433,8 @@ declare module Plottable {
             var ANIMATION_FRAME: string;
             var TIMEOUT: string;
         }
-        var _renderPolicy: RenderPolicies.RenderPolicy;
-        function setRenderPolicy(policy: string): void;
+        function renderPolicy(): RenderPolicies.RenderPolicy;
+        function renderPolicy(renderPolicy: string): void;
         /**
          * Enqueues the Component for rendering.
          *

--- a/plottable.js
+++ b/plottable.js
@@ -1016,23 +1016,26 @@ var Plottable;
             Policy.ANIMATION_FRAME = "animationframe";
             Policy.TIMEOUT = "timeout";
         })(Policy = RenderController.Policy || (RenderController.Policy = {}));
-        RenderController._renderPolicy = new Plottable.RenderPolicies.AnimationFrame();
-        function setRenderPolicy(policy) {
-            switch (policy.toLowerCase()) {
+        var _renderPolicy = new Plottable.RenderPolicies.AnimationFrame();
+        function renderPolicy(renderPolicy) {
+            if (renderPolicy == null) {
+                return _renderPolicy;
+            }
+            switch (renderPolicy.toLowerCase()) {
                 case Policy.IMMEDIATE:
-                    RenderController._renderPolicy = new Plottable.RenderPolicies.Immediate();
+                    _renderPolicy = new Plottable.RenderPolicies.Immediate();
                     break;
                 case Policy.ANIMATION_FRAME:
-                    RenderController._renderPolicy = new Plottable.RenderPolicies.AnimationFrame();
+                    _renderPolicy = new Plottable.RenderPolicies.AnimationFrame();
                     break;
                 case Policy.TIMEOUT:
-                    RenderController._renderPolicy = new Plottable.RenderPolicies.Timeout();
+                    _renderPolicy = new Plottable.RenderPolicies.Timeout();
                     break;
                 default:
-                    Plottable.Utils.Window.warn("Unrecognized renderPolicy: " + policy);
+                    Plottable.Utils.Window.warn("Unrecognized renderPolicy: " + renderPolicy);
             }
         }
-        RenderController.setRenderPolicy = setRenderPolicy;
+        RenderController.renderPolicy = renderPolicy;
         /**
          * Enqueues the Component for rendering.
          *
@@ -1061,7 +1064,7 @@ var Plottable;
             // Only run or enqueue flush on first request.
             if (!_animationRequested) {
                 _animationRequested = true;
-                RenderController._renderPolicy.render();
+                _renderPolicy.render();
             }
         }
         /**

--- a/src/core/renderController.ts
+++ b/src/core/renderController.ts
@@ -27,10 +27,15 @@ module Plottable {
       export var ANIMATION_FRAME = "animationframe";
       export var TIMEOUT = "timeout";
     }
-    export var _renderPolicy: RenderPolicies.RenderPolicy = new RenderPolicies.AnimationFrame();
+    var _renderPolicy: RenderPolicies.RenderPolicy = new RenderPolicies.AnimationFrame();
 
-    export function setRenderPolicy(policy: string) {
-      switch (policy.toLowerCase()) {
+    export function renderPolicy(): RenderPolicies.RenderPolicy;
+    export function renderPolicy(renderPolicy: string): void;
+    export function renderPolicy(renderPolicy?: string): any {
+      if (renderPolicy == null) {
+        return _renderPolicy;
+      }
+      switch (renderPolicy.toLowerCase()) {
         case Policy.IMMEDIATE:
           _renderPolicy = new RenderPolicies.Immediate();
           break;
@@ -41,7 +46,7 @@ module Plottable {
           _renderPolicy = new RenderPolicies.Timeout();
           break;
         default:
-          Utils.Window.warn("Unrecognized renderPolicy: " + policy);
+          Utils.Window.warn("Unrecognized renderPolicy: " + renderPolicy);
       }
     }
 

--- a/test/globalInitialization.ts
+++ b/test/globalInitialization.ts
@@ -7,7 +7,7 @@ interface Window {
 
 before(() => {
   // Set the render policy to immediate to make sure ETE tests can check DOM change immediately
-  Plottable.RenderController.setRenderPolicy("immediate");
+  Plottable.RenderController.renderPolicy("immediate");
   // Taken from https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
   var isFirefox = navigator.userAgent.indexOf("Firefox") !== -1;
   if (window.PHANTOMJS) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -274,7 +274,7 @@ var Mocks;
 ///<reference path="testReference.ts" />
 before(function () {
     // Set the render policy to immediate to make sure ETE tests can check DOM change immediately
-    Plottable.RenderController.setRenderPolicy("immediate");
+    Plottable.RenderController.renderPolicy("immediate");
     // Taken from https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
     var isFirefox = navigator.userAgent.indexOf("Firefox") !== -1;
     if (window.PHANTOMJS) {


### PR DESCRIPTION
API Breaks:
* `RenderController._renderPolicy` is no longer exposed
* `RenderController.setRenderPolicy()` -> `RenderController.renderPolicy()`

QE: Regression pass should be enough.  You can try setting the renderPolicy if you're so curious, albeit I don't think you'll see much functional changes and mainly performance changes.