### PR TITLE
[Interaction.PanZoom] - privitizing PIXELS_PER_LINE

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3527,10 +3527,6 @@ declare module Plottable {
     module Interactions {
         class PanZoom extends Interaction {
             /**
-             * The number of pixels occupied in a line.
-             */
-            static PIXELS_PER_LINE: number;
-            /**
              * A PanZoom Interaction updates the domains of an x-scale and/or a y-scale
              * in response to the user panning or zooming.
              *

--- a/plottable.js
+++ b/plottable.js
@@ -9270,7 +9270,7 @@ var Plottable;
                 var translatedP = this._translateToComponentSpace(p);
                 if (this._isInsideComponent(translatedP)) {
                     e.preventDefault();
-                    var deltaPixelAmount = e.deltaY * (e.deltaMode ? PanZoom.PIXELS_PER_LINE : 1);
+                    var deltaPixelAmount = e.deltaY * (e.deltaMode ? PanZoom._PIXELS_PER_LINE : 1);
                     var zoomAmount = Math.pow(2, deltaPixelAmount * .002);
                     if (this._xScale != null) {
                         PanZoom._magnifyScale(this._xScale, zoomAmount, translatedP.x);
@@ -9303,7 +9303,7 @@ var Plottable;
             /**
              * The number of pixels occupied in a line.
              */
-            PanZoom.PIXELS_PER_LINE = 120;
+            PanZoom._PIXELS_PER_LINE = 120;
             return PanZoom;
         })(Plottable.Interaction);
         Interactions.PanZoom = PanZoom;

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -6,7 +6,7 @@ export module Interactions {
     /**
      * The number of pixels occupied in a line.
      */
-    public static PIXELS_PER_LINE = 120;
+    private static _PIXELS_PER_LINE = 120;
 
     private _xScale: QuantitativeScale<any>;
     private _yScale: QuantitativeScale<any>;
@@ -149,7 +149,7 @@ export module Interactions {
       if (this._isInsideComponent(translatedP)) {
         e.preventDefault();
 
-        var deltaPixelAmount = e.deltaY * (e.deltaMode ? PanZoom.PIXELS_PER_LINE : 1);
+        var deltaPixelAmount = e.deltaY * (e.deltaMode ? PanZoom._PIXELS_PER_LINE : 1);
         var zoomAmount = Math.pow(2, deltaPixelAmount * .002);
         if (this._xScale != null) {
           PanZoom._magnifyScale(this._xScale, zoomAmount, translatedP.x);


### PR DESCRIPTION
Doing this mainly so that we can answer the question for how to deal with this variable later.

The idea of PIXELS_PER_LINE is so the user has an understanding of the conversion for browsers like Firefox that report their wheel events differently than others.  This should in my opinion be configurable so that users can set it to a more correct value if they should so choose but currently as it is a static variable, it has the same on all plots which may or may not be correct.

What also is concerning is that I actually do not think that this belongs in `Interaction.PanZoom`.  It should instead be in something like `Interactions.Scroll` (which doesn't exist) or maybe even in `Dispatchers.Wheel`.

If we are certain that it should be a property of `Dispatchers.Wheel` then I can make it thus, but if we aren't sure, let's hide it for now until we are.

API Breaks:
* Interactions.PanZoom no longer exposes a `PIXELS_PER_LINE` static variable