### PR TITLE
[InterpolatedColorLegend] - removing optional arguments from the constructor

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2024,10 +2024,8 @@ declare module Plottable {
              *
              * @constructor
              * @param {Scales.InterpolatedColor} interpolatedColorScale
-             * @param {string} [orientation="horizontal"] One of "horizontal"/"left"/"right".
-             * @param {Formatter} [formatter=Formatters.general()] The Formatter for the labels.
              */
-            constructor(interpolatedColorScale: Scales.InterpolatedColor, orientation?: string, formatter?: (d: any) => string);
+            constructor(interpolatedColorScale: Scales.InterpolatedColor);
             destroy(): void;
             /**
              * Gets the Formatter for the labels.

--- a/plottable.js
+++ b/plottable.js
@@ -5182,13 +5182,9 @@ var Plottable;
              *
              * @constructor
              * @param {Scales.InterpolatedColor} interpolatedColorScale
-             * @param {string} [orientation="horizontal"] One of "horizontal"/"left"/"right".
-             * @param {Formatter} [formatter=Formatters.general()] The Formatter for the labels.
              */
-            function InterpolatedColorLegend(interpolatedColorScale, orientation, formatter) {
+            function InterpolatedColorLegend(interpolatedColorScale) {
                 var _this = this;
-                if (orientation === void 0) { orientation = "horizontal"; }
-                if (formatter === void 0) { formatter = Plottable.Formatters.general(); }
                 _super.call(this);
                 this._padding = 5;
                 this._numSwatches = 10;
@@ -5198,8 +5194,8 @@ var Plottable;
                 this._scale = interpolatedColorScale;
                 this._redrawCallback = function (scale) { return _this.redraw(); };
                 this._scale.onUpdate(this._redrawCallback);
-                this._formatter = formatter;
-                this._orientation = InterpolatedColorLegend._ensureOrientation(orientation);
+                this._formatter = Plottable.Formatters.general();
+                this._orientation = "horizontal";
                 this.classed("legend", true).classed("interpolated-color-legend", true);
             }
             InterpolatedColorLegend.prototype.destroy = function () {

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -32,10 +32,8 @@ export module Components {
      *
      * @constructor
      * @param {Scales.InterpolatedColor} interpolatedColorScale
-     * @param {string} [orientation="horizontal"] One of "horizontal"/"left"/"right".
-     * @param {Formatter} [formatter=Formatters.general()] The Formatter for the labels.
      */
-    constructor(interpolatedColorScale: Scales.InterpolatedColor, orientation = "horizontal", formatter = Formatters.general()) {
+    constructor(interpolatedColorScale: Scales.InterpolatedColor) {
       super();
       if (interpolatedColorScale == null ) {
         throw new Error("InterpolatedColorLegend requires a interpolatedColorScale");
@@ -43,8 +41,8 @@ export module Components {
       this._scale = interpolatedColorScale;
       this._redrawCallback = (scale) => this.redraw();
       this._scale.onUpdate(this._redrawCallback);
-      this._formatter = formatter;
-      this._orientation = InterpolatedColorLegend._ensureOrientation(orientation);
+      this._formatter = Formatters.general();
+      this._orientation = "horizontal";
 
       this.classed("legend", true).classed("interpolated-color-legend", true);
     }

--- a/test/components/interpolatedColorLegendTests.ts
+++ b/test/components/interpolatedColorLegendTests.ts
@@ -41,7 +41,7 @@ describe("InterpolatedColorLegend", () => {
   }
 
   it("renders correctly (orientation: horizontal)", () => {
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "horizontal");
+    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
     legend.renderTo(svg);
 
     assertBasicRendering(legend);
@@ -60,7 +60,8 @@ describe("InterpolatedColorLegend", () => {
   });
 
   it("renders correctly (orientation: right)", () => {
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "right");
+    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    legend.orientation("right");
     legend.renderTo(svg);
 
     assertBasicRendering(legend);
@@ -80,7 +81,8 @@ describe("InterpolatedColorLegend", () => {
   });
 
   it("renders correctly (orientation: left)", () => {
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "left");
+    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    legend.orientation("left");
     legend.renderTo(svg);
 
     assertBasicRendering(legend);
@@ -100,7 +102,8 @@ describe("InterpolatedColorLegend", () => {
   });
 
   it("re-renders when scale domain updates", () => {
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "horizontal");
+    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    legend.orientation("horizontal");
     legend.renderTo(svg);
 
     colorScale.domain([0, 85]);
@@ -110,7 +113,7 @@ describe("InterpolatedColorLegend", () => {
   });
 
   it("orientation() input-checking", () => {
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "horizontal");
+    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
 
     legend.orientation("horizontal"); // should work
     legend.orientation("right"); // should work
@@ -121,7 +124,7 @@ describe("InterpolatedColorLegend", () => {
   });
 
   it("orient() triggers layout computation", () => {
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "horizontal");
+    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
     legend.renderTo(svg);
 
     var widthBefore = legend.width();
@@ -135,7 +138,8 @@ describe("InterpolatedColorLegend", () => {
 
   it("renders correctly when width is constrained (orientation: horizontal)", () => {
     svg.attr("width", 100);
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "horizontal");
+    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    legend.orientation("horizontal");
     legend.renderTo(svg);
     assertBasicRendering(legend);
     svg.remove();
@@ -143,7 +147,8 @@ describe("InterpolatedColorLegend", () => {
 
   it("renders correctly when height is constrained (orientation: horizontal)", () => {
     svg.attr("height", 20);
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "horizontal");
+    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    legend.orientation("horizontal");
     legend.renderTo(svg);
     assertBasicRendering(legend);
     svg.remove();
@@ -151,7 +156,8 @@ describe("InterpolatedColorLegend", () => {
 
   it("renders correctly when width is constrained (orientation: right)", () => {
     svg.attr("width", 30);
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "right");
+    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    legend.orientation("right");
     legend.renderTo(svg);
     assertBasicRendering(legend);
     svg.remove();
@@ -159,7 +165,8 @@ describe("InterpolatedColorLegend", () => {
 
   it("renders correctly when height is constrained (orientation: right)", () => {
     svg.attr("height", 100);
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "right");
+    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    legend.orientation("right");
     legend.renderTo(svg);
     assertBasicRendering(legend);
     svg.remove();
@@ -167,7 +174,8 @@ describe("InterpolatedColorLegend", () => {
 
   it("renders correctly when width is constrained (orientation: left)", () => {
     svg.attr("width", 30);
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "left");
+    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    legend.orientation("left");
     legend.renderTo(svg);
     assertBasicRendering(legend);
     svg.remove();
@@ -175,7 +183,8 @@ describe("InterpolatedColorLegend", () => {
 
   it("renders correctly when height is constrained (orientation: left)", () => {
     svg.attr("height", 100);
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "left");
+    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    legend.orientation("left");
     legend.renderTo(svg);
     assertBasicRendering(legend);
     svg.remove();

--- a/test/tests.js
+++ b/test/tests.js
@@ -2021,7 +2021,7 @@ describe("InterpolatedColorLegend", function () {
         assert.deepEqual(labelTexts, formattedDomainValues, "formatter is used to format label text");
     }
     it("renders correctly (orientation: horizontal)", function () {
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "horizontal");
+        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
         legend.renderTo(svg);
         assertBasicRendering(legend);
         var legendElement = legend._element;
@@ -2035,7 +2035,8 @@ describe("InterpolatedColorLegend", function () {
         svg.remove();
     });
     it("renders correctly (orientation: right)", function () {
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "right");
+        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        legend.orientation("right");
         legend.renderTo(svg);
         assertBasicRendering(legend);
         var legendElement = legend._element;
@@ -2050,7 +2051,8 @@ describe("InterpolatedColorLegend", function () {
         svg.remove();
     });
     it("renders correctly (orientation: left)", function () {
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "left");
+        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        legend.orientation("left");
         legend.renderTo(svg);
         assertBasicRendering(legend);
         var legendElement = legend._element;
@@ -2065,14 +2067,15 @@ describe("InterpolatedColorLegend", function () {
         svg.remove();
     });
     it("re-renders when scale domain updates", function () {
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "horizontal");
+        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        legend.orientation("horizontal");
         legend.renderTo(svg);
         colorScale.domain([0, 85]);
         assertBasicRendering(legend);
         svg.remove();
     });
     it("orientation() input-checking", function () {
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "horizontal");
+        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
         legend.orientation("horizontal"); // should work
         legend.orientation("right"); // should work
         legend.orientation("left"); // should work
@@ -2080,7 +2083,7 @@ describe("InterpolatedColorLegend", function () {
         svg.remove();
     });
     it("orient() triggers layout computation", function () {
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "horizontal");
+        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
         legend.renderTo(svg);
         var widthBefore = legend.width();
         var heightBefore = legend.height();
@@ -2091,42 +2094,48 @@ describe("InterpolatedColorLegend", function () {
     });
     it("renders correctly when width is constrained (orientation: horizontal)", function () {
         svg.attr("width", 100);
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "horizontal");
+        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        legend.orientation("horizontal");
         legend.renderTo(svg);
         assertBasicRendering(legend);
         svg.remove();
     });
     it("renders correctly when height is constrained (orientation: horizontal)", function () {
         svg.attr("height", 20);
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "horizontal");
+        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        legend.orientation("horizontal");
         legend.renderTo(svg);
         assertBasicRendering(legend);
         svg.remove();
     });
     it("renders correctly when width is constrained (orientation: right)", function () {
         svg.attr("width", 30);
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "right");
+        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        legend.orientation("right");
         legend.renderTo(svg);
         assertBasicRendering(legend);
         svg.remove();
     });
     it("renders correctly when height is constrained (orientation: right)", function () {
         svg.attr("height", 100);
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "right");
+        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        legend.orientation("right");
         legend.renderTo(svg);
         assertBasicRendering(legend);
         svg.remove();
     });
     it("renders correctly when width is constrained (orientation: left)", function () {
         svg.attr("width", 30);
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "left");
+        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        legend.orientation("left");
         legend.renderTo(svg);
         assertBasicRendering(legend);
         svg.remove();
     });
     it("renders correctly when height is constrained (orientation: left)", function () {
         svg.attr("height", 100);
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale, "left");
+        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        legend.orientation("left");
         legend.renderTo(svg);
         assertBasicRendering(legend);
         svg.remove();


### PR DESCRIPTION
API Breaks:
* `InterpolatedColorLegend` no longer takes in an `orientation` parameter + `formatter` parameter as arguments to the constructor