### PR TITLE
Scale Refactor

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1067,25 +1067,12 @@ declare module Plottable {
              */
             constructor(scaleType?: string);
             extentOfValues(values: number[]): number[];
-            /**
-             * Gets the color range.
-             *
-             * @returns {string[]}
-             */
-            colorRange(): string[];
-            /**
-             * Sets the color range.
-             *
-             * @param {string[]} colorRange
-             * @returns {InterpolatedColor} The calling InterpolatedColor Scale.
-             */
-            colorRange(colorRange: string[]): InterpolatedColor;
             autoDomain(): InterpolatedColor;
             scale(value: number): string;
             protected _getDomain(): number[];
             protected _setBackingScaleDomain(values: number[]): void;
             protected _getRange(): string[];
-            protected _setRange(values: string[]): void;
+            protected _setRange(range: string[]): void;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1063,12 +1063,9 @@ declare module Plottable {
             /**
              * An InterpolatedColor Scale maps numbers to color hex values, expressed as strings.
              *
-             * @constructor
-             * @param {string[]} [colors=InterpolatedColor.REDS] an array of strings representing color hex values
-             *   ("#FFFFFF") or keywords ("white").
              * @param {string} [scaleType="linear"] One of "linear"/"log"/"sqrt"/"pow".
              */
-            constructor(colorRange?: string[], scaleType?: string);
+            constructor(scaleType?: string);
             extentOfValues(values: number[]): number[];
             /**
              * Gets the color range.

--- a/plottable.js
+++ b/plottable.js
@@ -1795,7 +1795,7 @@ var Plottable;
                 return this._d3Scale.invert(value);
             };
             Linear.prototype.defaultTicks = function () {
-                return this._d3Scale.ticks(Plottable.QuantitativeScale._DEFAULT_NUM_TICKS);
+                return this._d3Scale.ticks(Scales.Linear._DEFAULT_NUM_TICKS);
             };
             Linear.prototype._niceDomain = function (domain, count) {
                 return this._d3Scale.copy().domain(domain).nice(count).domain();
@@ -1910,7 +1910,7 @@ var Plottable;
                 var ticks = negativeLogTicks.concat(linearTicks).concat(positiveLogTicks);
                 // If you only have 1 tick, you can't tell how big the scale is.
                 if (ticks.length <= 1) {
-                    ticks = d3.scale.linear().domain([min, max]).ticks(ModifiedLog._DEFAULT_NUM_TICKS);
+                    ticks = d3.scale.linear().domain([min, max]).ticks(Scales.ModifiedLog._DEFAULT_NUM_TICKS);
                 }
                 return ticks;
             };
@@ -1957,7 +1957,7 @@ var Plottable;
                 var adjustedLower = this._adjustedLog(lower);
                 var adjustedUpper = this._adjustedLog(upper);
                 var proportion = (adjustedUpper - adjustedLower) / (adjustedMax - adjustedMin);
-                var ticks = Math.ceil(proportion * ModifiedLog._DEFAULT_NUM_TICKS);
+                var ticks = Math.ceil(proportion * Scales.ModifiedLog._DEFAULT_NUM_TICKS);
                 return ticks;
             };
             ModifiedLog.prototype._niceDomain = function (domain, count) {
@@ -1988,7 +1988,7 @@ var Plottable;
                 this._d3Scale.range(values);
             };
             ModifiedLog.prototype.defaultTicks = function () {
-                return this._d3Scale.ticks(Plottable.QuantitativeScale._DEFAULT_NUM_TICKS);
+                return this._d3Scale.ticks(Scales.ModifiedLog._DEFAULT_NUM_TICKS);
             };
             return ModifiedLog;
         })(Plottable.QuantitativeScale);
@@ -2298,7 +2298,7 @@ var Plottable;
                 return this._d3Scale.invert(value);
             };
             Time.prototype.defaultTicks = function () {
-                return this._d3Scale.ticks(Plottable.QuantitativeScale._DEFAULT_NUM_TICKS);
+                return this._d3Scale.ticks(Scales.Time._DEFAULT_NUM_TICKS);
             };
             Time.prototype._niceDomain = function (domain) {
                 return this._d3Scale.copy().domain(domain).nice().domain();

--- a/plottable.js
+++ b/plottable.js
@@ -2325,16 +2325,12 @@ var Plottable;
             /**
              * An InterpolatedColor Scale maps numbers to color hex values, expressed as strings.
              *
-             * @constructor
-             * @param {string[]} [colors=InterpolatedColor.REDS] an array of strings representing color hex values
-             *   ("#FFFFFF") or keywords ("white").
              * @param {string} [scaleType="linear"] One of "linear"/"log"/"sqrt"/"pow".
              */
-            function InterpolatedColor(colorRange, scaleType) {
-                if (colorRange === void 0) { colorRange = InterpolatedColor.REDS; }
+            function InterpolatedColor(scaleType) {
                 if (scaleType === void 0) { scaleType = "linear"; }
                 _super.call(this);
-                this._colorRange = colorRange;
+                this._colorRange = InterpolatedColor.REDS;
                 switch (scaleType) {
                     case "linear":
                         this._colorScale = d3.scale.linear();

--- a/plottable.js
+++ b/plottable.js
@@ -2330,7 +2330,6 @@ var Plottable;
             function InterpolatedColor(scaleType) {
                 if (scaleType === void 0) { scaleType = "linear"; }
                 _super.call(this);
-                this._colorRange = InterpolatedColor.REDS;
                 switch (scaleType) {
                     case "linear":
                         this._colorScale = d3.scale.linear();
@@ -2348,7 +2347,7 @@ var Plottable;
                 if (this._colorScale == null) {
                     throw new Error("unknown QuantitativeScale scale type " + scaleType);
                 }
-                this._d3Scale = this._d3InterpolatedScale();
+                this.range(InterpolatedColor.REDS);
             }
             InterpolatedColor.prototype.extentOfValues = function (values) {
                 var extent = d3.extent(values);

--- a/plottable.js
+++ b/plottable.js
@@ -2388,14 +2388,6 @@ var Plottable;
                     };
                 };
             };
-            InterpolatedColor.prototype.colorRange = function (colorRange) {
-                if (colorRange == null) {
-                    return this._colorRange;
-                }
-                this._colorRange = colorRange;
-                this._resetScale();
-                return this;
-            };
             InterpolatedColor.prototype._resetScale = function () {
                 this._d3Scale = this._d3InterpolatedScale();
                 this._autoDomainIfAutomaticMode();
@@ -2419,10 +2411,11 @@ var Plottable;
                 this._d3Scale.domain(values);
             };
             InterpolatedColor.prototype._getRange = function () {
-                return this.colorRange();
+                return this._colorRange;
             };
-            InterpolatedColor.prototype._setRange = function (values) {
-                this.colorRange(values);
+            InterpolatedColor.prototype._setRange = function (range) {
+                this._colorRange = range;
+                this._resetScale();
             };
             InterpolatedColor.REDS = [
                 "#FFFFFF",

--- a/quicktests/overlaying/tests/realistic/category_grid.js
+++ b/quicktests/overlaying/tests/realistic/category_grid.js
@@ -57,7 +57,7 @@ function run(svg, data, Plottable) {
   var xScale = new Plottable.Scales.Category();
   var yScale = new Plottable.Scales.Category();
   var cs = new Plottable.Scales.InterpolatedColor();
-  cs.colorRange(["#ADD8E6", "#67818A"]);
+  cs.range(["#ADD8E6", "#67818A"]);
 
   var xAxis = new Plottable.Axes.Category(xScale, "top");
   var yAxis = new Plottable.Axes.Category(yScale, "left");

--- a/quicktests/overlaying/tests/realistic/category_grid.js
+++ b/quicktests/overlaying/tests/realistic/category_grid.js
@@ -56,7 +56,8 @@ function run(svg, data, Plottable) {
 
   var xScale = new Plottable.Scales.Category();
   var yScale = new Plottable.Scales.Category();
-  var cs = new Plottable.Scales.InterpolatedColor(["#ADD8E6", "#67818A"]);
+  var cs = new Plottable.Scales.InterpolatedColor();
+  cs.colorRange(["#ADD8E6", "#67818A"]);
 
   var xAxis = new Plottable.Axes.Category(xScale, "top");
   var yAxis = new Plottable.Axes.Category(yScale, "left");

--- a/src/scales/interpolatedColorScale.ts
+++ b/src/scales/interpolatedColorScale.ts
@@ -2,7 +2,7 @@
 
 module Plottable {
 export module Scales {
-  type supportedScale = d3.scale.Linear<number, string> | d3.scale.Log<number, string> | d3.scale.Pow<number, string>
+  type supportedScale = d3.scale.Linear<number, string> | d3.scale.Log<number, string> | d3.scale.Pow<number, string>;
 
   export class InterpolatedColor extends Scale<number, string> {
     public static REDS = [
@@ -53,14 +53,11 @@ export module Scales {
     /**
      * An InterpolatedColor Scale maps numbers to color hex values, expressed as strings.
      *
-     * @constructor
-     * @param {string[]} [colors=InterpolatedColor.REDS] an array of strings representing color hex values
-     *   ("#FFFFFF") or keywords ("white").
      * @param {string} [scaleType="linear"] One of "linear"/"log"/"sqrt"/"pow".
      */
-    constructor(colorRange = InterpolatedColor.REDS, scaleType = "linear") {
+    constructor(scaleType = "linear") {
       super();
-      this._colorRange = colorRange;
+      this._colorRange = InterpolatedColor.REDS;
       switch (scaleType) {
         case "linear":
           this._colorScale = d3.scale.linear<number, string>();

--- a/src/scales/interpolatedColorScale.ts
+++ b/src/scales/interpolatedColorScale.ts
@@ -57,7 +57,6 @@ export module Scales {
      */
     constructor(scaleType = "linear") {
       super();
-      this._colorRange = InterpolatedColor.REDS;
       switch (scaleType) {
         case "linear":
           this._colorScale = d3.scale.linear<number, string>();
@@ -75,7 +74,7 @@ export module Scales {
       if (this._colorScale == null) {
         throw new Error("unknown QuantitativeScale scale type " + scaleType);
       }
-      this._d3Scale = this._d3InterpolatedScale();
+      this.range(InterpolatedColor.REDS);
     }
 
     public extentOfValues(values: number[]): number[] {

--- a/src/scales/interpolatedColorScale.ts
+++ b/src/scales/interpolatedColorScale.ts
@@ -119,28 +119,6 @@ export module Scales {
       };
     }
 
-    /**
-     * Gets the color range.
-     *
-     * @returns {string[]}
-     */
-    public colorRange(): string[];
-    /**
-     * Sets the color range.
-     *
-     * @param {string[]} colorRange
-     * @returns {InterpolatedColor} The calling InterpolatedColor Scale.
-     */
-    public colorRange(colorRange: string[]): InterpolatedColor;
-    public colorRange(colorRange?: string[]): any {
-      if (colorRange == null) {
-        return this._colorRange;
-      }
-      this._colorRange = colorRange;
-      this._resetScale();
-      return this;
-    }
-
     private _resetScale(): any {
       this._d3Scale = this._d3InterpolatedScale();
       this._autoDomainIfAutomaticMode();
@@ -169,11 +147,12 @@ export module Scales {
     }
 
     protected _getRange() {
-      return this.colorRange();
+      return this._colorRange;
     }
 
-    protected _setRange(values: string[]) {
-      this.colorRange(values);
+    protected _setRange(range: string[]) {
+      this._colorRange = range;
+      this._resetScale();
     }
   }
 }

--- a/src/scales/linearScale.ts
+++ b/src/scales/linearScale.ts
@@ -49,7 +49,7 @@ export module Scales {
     }
 
     public defaultTicks(): number[] {
-      return this._d3Scale.ticks(QuantitativeScale._DEFAULT_NUM_TICKS);
+      return this._d3Scale.ticks(Scales.Linear._DEFAULT_NUM_TICKS);
     }
 
     protected _niceDomain(domain: number[], count?: number): number[] {

--- a/src/scales/modifiedLogScale.ts
+++ b/src/scales/modifiedLogScale.ts
@@ -114,7 +114,7 @@ export module Scales {
       var ticks = negativeLogTicks.concat(linearTicks).concat(positiveLogTicks);
       // If you only have 1 tick, you can't tell how big the scale is.
       if (ticks.length <= 1) {
-        ticks = d3.scale.linear().domain([min, max]).ticks(ModifiedLog._DEFAULT_NUM_TICKS);
+        ticks = d3.scale.linear().domain([min, max]).ticks(Scales.ModifiedLog._DEFAULT_NUM_TICKS);
       }
       return ticks;
     }
@@ -162,7 +162,7 @@ export module Scales {
       var adjustedLower = this._adjustedLog(lower);
       var adjustedUpper = this._adjustedLog(upper);
       var proportion = (adjustedUpper - adjustedLower) / (adjustedMax - adjustedMin);
-      var ticks = Math.ceil(proportion * ModifiedLog._DEFAULT_NUM_TICKS);
+      var ticks = Math.ceil(proportion * Scales.ModifiedLog._DEFAULT_NUM_TICKS);
       return ticks;
     }
 
@@ -197,7 +197,7 @@ export module Scales {
     }
 
     public defaultTicks(): number[] {
-      return this._d3Scale.ticks(QuantitativeScale._DEFAULT_NUM_TICKS);
+      return this._d3Scale.ticks(Scales.ModifiedLog._DEFAULT_NUM_TICKS);
     }
   }
 }

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -77,7 +77,7 @@ export module Scales {
     }
 
     public defaultTicks(): Date[] {
-      return this._d3Scale.ticks(QuantitativeScale._DEFAULT_NUM_TICKS);
+      return this._d3Scale.ticks(Scales.Time._DEFAULT_NUM_TICKS);
     }
 
     protected _niceDomain(domain: Date[]) {

--- a/test/components/plots/rectanglePlotTests.ts
+++ b/test/components/plots/rectanglePlotTests.ts
@@ -134,7 +134,7 @@ describe("Plots", () => {
       var xScale = new Plottable.Scales.Category();
       var yScale = new Plottable.Scales.Category();
       var colorScale = new Plottable.Scales.InterpolatedColor();
-      colorScale.colorRange(["black", "white"]);
+      colorScale.range(["black", "white"]);
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var gridPlot = new Plottable.Plots.Rectangle();
       gridPlot.addDataset(new Plottable.Dataset(DATA))
@@ -150,7 +150,7 @@ describe("Plots", () => {
       var xScale = new Plottable.Scales.Category();
       var yScale = new Plottable.Scales.Category();
       var colorScale = new Plottable.Scales.InterpolatedColor();
-      colorScale.colorRange(["black", "white"]);
+      colorScale.range(["black", "white"]);
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var dataset = new Plottable.Dataset();
       var gridPlot = new Plottable.Plots.Rectangle();
@@ -170,7 +170,7 @@ describe("Plots", () => {
       var xScale = new Plottable.Scales.Category();
       var yScale = new Plottable.Scales.Category();
       var colorScale = new Plottable.Scales.InterpolatedColor();
-      colorScale.colorRange(["black", "white"]);
+      colorScale.range(["black", "white"]);
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var dataset = new Plottable.Dataset();
       var gridPlot = new Plottable.Plots.Rectangle();
@@ -202,7 +202,7 @@ describe("Plots", () => {
       var xScale = new Plottable.Scales.Category();
       var yScale = new Plottable.Scales.Category();
       var colorScale = new Plottable.Scales.InterpolatedColor();
-      colorScale.colorRange(["black", "white"]);
+      colorScale.range(["black", "white"]);
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var gridPlot = new Plottable.Plots.Rectangle();
       gridPlot.addDataset(new Plottable.Dataset(DATA))
@@ -245,7 +245,7 @@ describe("Plots", () => {
         var xScale = new Plottable.Scales.Category();
         var yScale = new Plottable.Scales.Category();
         var colorScale = new Plottable.Scales.InterpolatedColor();
-        colorScale.colorRange(["black", "white"]);
+        colorScale.range(["black", "white"]);
         var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         var gridPlot = new Plottable.Plots.Rectangle();
         var dataset = new Plottable.Dataset(DATA);
@@ -265,7 +265,7 @@ describe("Plots", () => {
         var xScale = new Plottable.Scales.Category();
         var yScale = new Plottable.Scales.Category();
         var colorScale = new Plottable.Scales.InterpolatedColor();
-        colorScale.colorRange(["black", "white"]);
+        colorScale.range(["black", "white"]);
         var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         var gridPlot = new Plottable.Plots.Rectangle();
         var dataset = new Plottable.Dataset(DATA);
@@ -287,7 +287,7 @@ describe("Plots", () => {
         var xScale = new Plottable.Scales.Category();
         var yScale = new Plottable.Scales.Category();
         var colorScale = new Plottable.Scales.InterpolatedColor();
-        colorScale.colorRange(["black", "white"]);
+        colorScale.range(["black", "white"]);
         var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         var gridPlot = new Plottable.Plots.Rectangle();
         var dataset = new Plottable.Dataset(DATA);

--- a/test/components/plots/rectanglePlotTests.ts
+++ b/test/components/plots/rectanglePlotTests.ts
@@ -133,7 +133,8 @@ describe("Plots", () => {
     it("renders correctly", () => {
       var xScale = new Plottable.Scales.Category();
       var yScale = new Plottable.Scales.Category();
-      var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+      var colorScale = new Plottable.Scales.InterpolatedColor();
+      colorScale.colorRange(["black", "white"]);
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var gridPlot = new Plottable.Plots.Rectangle();
       gridPlot.addDataset(new Plottable.Dataset(DATA))
@@ -148,7 +149,8 @@ describe("Plots", () => {
     it("renders correctly when data is set after construction", () => {
       var xScale = new Plottable.Scales.Category();
       var yScale = new Plottable.Scales.Category();
-      var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+      var colorScale = new Plottable.Scales.InterpolatedColor();
+      colorScale.colorRange(["black", "white"]);
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var dataset = new Plottable.Dataset();
       var gridPlot = new Plottable.Plots.Rectangle();
@@ -167,7 +169,8 @@ describe("Plots", () => {
       var CELL_WIDTH = 100;
       var xScale = new Plottable.Scales.Category();
       var yScale = new Plottable.Scales.Category();
-      var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+      var colorScale = new Plottable.Scales.InterpolatedColor();
+      colorScale.colorRange(["black", "white"]);
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var dataset = new Plottable.Dataset();
       var gridPlot = new Plottable.Plots.Rectangle();
@@ -198,7 +201,8 @@ describe("Plots", () => {
     it("can invert y axis correctly", () => {
       var xScale = new Plottable.Scales.Category();
       var yScale = new Plottable.Scales.Category();
-      var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+      var colorScale = new Plottable.Scales.InterpolatedColor();
+      colorScale.colorRange(["black", "white"]);
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var gridPlot = new Plottable.Plots.Rectangle();
       gridPlot.addDataset(new Plottable.Dataset(DATA))
@@ -240,7 +244,8 @@ describe("Plots", () => {
       it("retrieves all selections with no args", () => {
         var xScale = new Plottable.Scales.Category();
         var yScale = new Plottable.Scales.Category();
-        var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+        var colorScale = new Plottable.Scales.InterpolatedColor();
+        colorScale.colorRange(["black", "white"]);
         var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         var gridPlot = new Plottable.Plots.Rectangle();
         var dataset = new Plottable.Dataset(DATA);
@@ -259,7 +264,8 @@ describe("Plots", () => {
       it("retrieves correct selections", () => {
         var xScale = new Plottable.Scales.Category();
         var yScale = new Plottable.Scales.Category();
-        var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+        var colorScale = new Plottable.Scales.InterpolatedColor();
+        colorScale.colorRange(["black", "white"]);
         var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         var gridPlot = new Plottable.Plots.Rectangle();
         var dataset = new Plottable.Dataset(DATA);
@@ -280,7 +286,8 @@ describe("Plots", () => {
       it("skips invalid Datasets", () => {
         var xScale = new Plottable.Scales.Category();
         var yScale = new Plottable.Scales.Category();
-        var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+        var colorScale = new Plottable.Scales.InterpolatedColor();
+        colorScale.colorRange(["black", "white"]);
         var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         var gridPlot = new Plottable.Plots.Rectangle();
         var dataset = new Plottable.Dataset(DATA);

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -195,7 +195,8 @@ describe("Scales", () => {
     });
 
     it("accepts array types with color hex values", () => {
-      var scale = new Plottable.Scales.InterpolatedColor(["#000", "#FFF"]);
+      var scale = new Plottable.Scales.InterpolatedColor();
+      scale.colorRange(["#000", "#FFF"]);
       scale.domain([0, 16]);
       assert.strictEqual("#000000", scale.scale(0));
       assert.strictEqual("#ffffff", scale.scale(16));
@@ -203,7 +204,8 @@ describe("Scales", () => {
     });
 
     it("accepts array types with color names", () => {
-      var scale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+      var scale = new Plottable.Scales.InterpolatedColor();
+      scale.colorRange(["black", "white"]);
       scale.domain([0, 16]);
       assert.strictEqual("#000000", scale.scale(0));
       assert.strictEqual("#ffffff", scale.scale(16));
@@ -211,7 +213,8 @@ describe("Scales", () => {
     });
 
     it("overflow scale values clamp to range", () => {
-      var scale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+      var scale = new Plottable.Scales.InterpolatedColor();
+      scale.colorRange(["black", "white"]);
       scale.domain([0, 16]);
       assert.strictEqual("#000000", scale.scale(0));
       assert.strictEqual("#ffffff", scale.scale(16));
@@ -220,7 +223,8 @@ describe("Scales", () => {
     });
 
     it("can be converted to a different range", () => {
-      var scale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+      var scale = new Plottable.Scales.InterpolatedColor();
+      scale.colorRange(["black", "white"]);
       scale.domain([0, 16]);
       assert.strictEqual("#000000", scale.scale(0));
       assert.strictEqual("#ffffff", scale.scale(16));

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -196,7 +196,7 @@ describe("Scales", () => {
 
     it("accepts array types with color hex values", () => {
       var scale = new Plottable.Scales.InterpolatedColor();
-      scale.colorRange(["#000", "#FFF"]);
+      scale.range(["#000", "#FFF"]);
       scale.domain([0, 16]);
       assert.strictEqual("#000000", scale.scale(0));
       assert.strictEqual("#ffffff", scale.scale(16));
@@ -205,7 +205,7 @@ describe("Scales", () => {
 
     it("accepts array types with color names", () => {
       var scale = new Plottable.Scales.InterpolatedColor();
-      scale.colorRange(["black", "white"]);
+      scale.range(["black", "white"]);
       scale.domain([0, 16]);
       assert.strictEqual("#000000", scale.scale(0));
       assert.strictEqual("#ffffff", scale.scale(16));
@@ -214,7 +214,7 @@ describe("Scales", () => {
 
     it("overflow scale values clamp to range", () => {
       var scale = new Plottable.Scales.InterpolatedColor();
-      scale.colorRange(["black", "white"]);
+      scale.range(["black", "white"]);
       scale.domain([0, 16]);
       assert.strictEqual("#000000", scale.scale(0));
       assert.strictEqual("#ffffff", scale.scale(16));
@@ -224,11 +224,11 @@ describe("Scales", () => {
 
     it("can be converted to a different range", () => {
       var scale = new Plottable.Scales.InterpolatedColor();
-      scale.colorRange(["black", "white"]);
+      scale.range(["black", "white"]);
       scale.domain([0, 16]);
       assert.strictEqual("#000000", scale.scale(0));
       assert.strictEqual("#ffffff", scale.scale(16));
-      scale.colorRange(Plottable.Scales.InterpolatedColor.REDS);
+      scale.range(Plottable.Scales.InterpolatedColor.REDS);
       assert.strictEqual("#b10026", scale.scale(16));
     });
   });

--- a/test/tests.js
+++ b/test/tests.js
@@ -4148,7 +4148,8 @@ describe("Plots", function () {
         it("renders correctly", function () {
             var xScale = new Plottable.Scales.Category();
             var yScale = new Plottable.Scales.Category();
-            var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+            var colorScale = new Plottable.Scales.InterpolatedColor();
+            colorScale.colorRange(["black", "white"]);
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var gridPlot = new Plottable.Plots.Rectangle();
             gridPlot.addDataset(new Plottable.Dataset(DATA)).attr("fill", function (d) { return d.magnitude; }, colorScale);
@@ -4160,7 +4161,8 @@ describe("Plots", function () {
         it("renders correctly when data is set after construction", function () {
             var xScale = new Plottable.Scales.Category();
             var yScale = new Plottable.Scales.Category();
-            var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+            var colorScale = new Plottable.Scales.InterpolatedColor();
+            colorScale.colorRange(["black", "white"]);
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var dataset = new Plottable.Dataset();
             var gridPlot = new Plottable.Plots.Rectangle();
@@ -4175,7 +4177,8 @@ describe("Plots", function () {
             var CELL_WIDTH = 100;
             var xScale = new Plottable.Scales.Category();
             var yScale = new Plottable.Scales.Category();
-            var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+            var colorScale = new Plottable.Scales.InterpolatedColor();
+            colorScale.colorRange(["black", "white"]);
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var dataset = new Plottable.Dataset();
             var gridPlot = new Plottable.Plots.Rectangle();
@@ -4202,7 +4205,8 @@ describe("Plots", function () {
         it("can invert y axis correctly", function () {
             var xScale = new Plottable.Scales.Category();
             var yScale = new Plottable.Scales.Category();
-            var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+            var colorScale = new Plottable.Scales.InterpolatedColor();
+            colorScale.colorRange(["black", "white"]);
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var gridPlot = new Plottable.Plots.Rectangle();
             gridPlot.addDataset(new Plottable.Dataset(DATA)).attr("fill", function (d) { return d.magnitude; }, colorScale);
@@ -4233,7 +4237,8 @@ describe("Plots", function () {
             it("retrieves all selections with no args", function () {
                 var xScale = new Plottable.Scales.Category();
                 var yScale = new Plottable.Scales.Category();
-                var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+                var colorScale = new Plottable.Scales.InterpolatedColor();
+                colorScale.colorRange(["black", "white"]);
                 var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
                 var gridPlot = new Plottable.Plots.Rectangle();
                 var dataset = new Plottable.Dataset(DATA);
@@ -4247,7 +4252,8 @@ describe("Plots", function () {
             it("retrieves correct selections", function () {
                 var xScale = new Plottable.Scales.Category();
                 var yScale = new Plottable.Scales.Category();
-                var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+                var colorScale = new Plottable.Scales.InterpolatedColor();
+                colorScale.colorRange(["black", "white"]);
                 var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
                 var gridPlot = new Plottable.Plots.Rectangle();
                 var dataset = new Plottable.Dataset(DATA);
@@ -4263,7 +4269,8 @@ describe("Plots", function () {
             it("skips invalid Datasets", function () {
                 var xScale = new Plottable.Scales.Category();
                 var yScale = new Plottable.Scales.Category();
-                var colorScale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+                var colorScale = new Plottable.Scales.InterpolatedColor();
+                colorScale.colorRange(["black", "white"]);
                 var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
                 var gridPlot = new Plottable.Plots.Rectangle();
                 var dataset = new Plottable.Dataset(DATA);
@@ -7388,21 +7395,24 @@ describe("Scales", function () {
             assert.strictEqual("#d9151f", scale.scale(0.9));
         });
         it("accepts array types with color hex values", function () {
-            var scale = new Plottable.Scales.InterpolatedColor(["#000", "#FFF"]);
+            var scale = new Plottable.Scales.InterpolatedColor();
+            scale.colorRange(["#000", "#FFF"]);
             scale.domain([0, 16]);
             assert.strictEqual("#000000", scale.scale(0));
             assert.strictEqual("#ffffff", scale.scale(16));
             assert.strictEqual("#777777", scale.scale(8));
         });
         it("accepts array types with color names", function () {
-            var scale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+            var scale = new Plottable.Scales.InterpolatedColor();
+            scale.colorRange(["black", "white"]);
             scale.domain([0, 16]);
             assert.strictEqual("#000000", scale.scale(0));
             assert.strictEqual("#ffffff", scale.scale(16));
             assert.strictEqual("#777777", scale.scale(8));
         });
         it("overflow scale values clamp to range", function () {
-            var scale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+            var scale = new Plottable.Scales.InterpolatedColor();
+            scale.colorRange(["black", "white"]);
             scale.domain([0, 16]);
             assert.strictEqual("#000000", scale.scale(0));
             assert.strictEqual("#ffffff", scale.scale(16));
@@ -7410,7 +7420,8 @@ describe("Scales", function () {
             assert.strictEqual("#ffffff", scale.scale(100));
         });
         it("can be converted to a different range", function () {
-            var scale = new Plottable.Scales.InterpolatedColor(["black", "white"]);
+            var scale = new Plottable.Scales.InterpolatedColor();
+            scale.colorRange(["black", "white"]);
             scale.domain([0, 16]);
             assert.strictEqual("#000000", scale.scale(0));
             assert.strictEqual("#ffffff", scale.scale(16));

--- a/test/tests.js
+++ b/test/tests.js
@@ -4149,7 +4149,7 @@ describe("Plots", function () {
             var xScale = new Plottable.Scales.Category();
             var yScale = new Plottable.Scales.Category();
             var colorScale = new Plottable.Scales.InterpolatedColor();
-            colorScale.colorRange(["black", "white"]);
+            colorScale.range(["black", "white"]);
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var gridPlot = new Plottable.Plots.Rectangle();
             gridPlot.addDataset(new Plottable.Dataset(DATA)).attr("fill", function (d) { return d.magnitude; }, colorScale);
@@ -4162,7 +4162,7 @@ describe("Plots", function () {
             var xScale = new Plottable.Scales.Category();
             var yScale = new Plottable.Scales.Category();
             var colorScale = new Plottable.Scales.InterpolatedColor();
-            colorScale.colorRange(["black", "white"]);
+            colorScale.range(["black", "white"]);
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var dataset = new Plottable.Dataset();
             var gridPlot = new Plottable.Plots.Rectangle();
@@ -4178,7 +4178,7 @@ describe("Plots", function () {
             var xScale = new Plottable.Scales.Category();
             var yScale = new Plottable.Scales.Category();
             var colorScale = new Plottable.Scales.InterpolatedColor();
-            colorScale.colorRange(["black", "white"]);
+            colorScale.range(["black", "white"]);
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var dataset = new Plottable.Dataset();
             var gridPlot = new Plottable.Plots.Rectangle();
@@ -4206,7 +4206,7 @@ describe("Plots", function () {
             var xScale = new Plottable.Scales.Category();
             var yScale = new Plottable.Scales.Category();
             var colorScale = new Plottable.Scales.InterpolatedColor();
-            colorScale.colorRange(["black", "white"]);
+            colorScale.range(["black", "white"]);
             var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var gridPlot = new Plottable.Plots.Rectangle();
             gridPlot.addDataset(new Plottable.Dataset(DATA)).attr("fill", function (d) { return d.magnitude; }, colorScale);
@@ -4238,7 +4238,7 @@ describe("Plots", function () {
                 var xScale = new Plottable.Scales.Category();
                 var yScale = new Plottable.Scales.Category();
                 var colorScale = new Plottable.Scales.InterpolatedColor();
-                colorScale.colorRange(["black", "white"]);
+                colorScale.range(["black", "white"]);
                 var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
                 var gridPlot = new Plottable.Plots.Rectangle();
                 var dataset = new Plottable.Dataset(DATA);
@@ -4253,7 +4253,7 @@ describe("Plots", function () {
                 var xScale = new Plottable.Scales.Category();
                 var yScale = new Plottable.Scales.Category();
                 var colorScale = new Plottable.Scales.InterpolatedColor();
-                colorScale.colorRange(["black", "white"]);
+                colorScale.range(["black", "white"]);
                 var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
                 var gridPlot = new Plottable.Plots.Rectangle();
                 var dataset = new Plottable.Dataset(DATA);
@@ -4270,7 +4270,7 @@ describe("Plots", function () {
                 var xScale = new Plottable.Scales.Category();
                 var yScale = new Plottable.Scales.Category();
                 var colorScale = new Plottable.Scales.InterpolatedColor();
-                colorScale.colorRange(["black", "white"]);
+                colorScale.range(["black", "white"]);
                 var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
                 var gridPlot = new Plottable.Plots.Rectangle();
                 var dataset = new Plottable.Dataset(DATA);
@@ -7396,7 +7396,7 @@ describe("Scales", function () {
         });
         it("accepts array types with color hex values", function () {
             var scale = new Plottable.Scales.InterpolatedColor();
-            scale.colorRange(["#000", "#FFF"]);
+            scale.range(["#000", "#FFF"]);
             scale.domain([0, 16]);
             assert.strictEqual("#000000", scale.scale(0));
             assert.strictEqual("#ffffff", scale.scale(16));
@@ -7404,7 +7404,7 @@ describe("Scales", function () {
         });
         it("accepts array types with color names", function () {
             var scale = new Plottable.Scales.InterpolatedColor();
-            scale.colorRange(["black", "white"]);
+            scale.range(["black", "white"]);
             scale.domain([0, 16]);
             assert.strictEqual("#000000", scale.scale(0));
             assert.strictEqual("#ffffff", scale.scale(16));
@@ -7412,7 +7412,7 @@ describe("Scales", function () {
         });
         it("overflow scale values clamp to range", function () {
             var scale = new Plottable.Scales.InterpolatedColor();
-            scale.colorRange(["black", "white"]);
+            scale.range(["black", "white"]);
             scale.domain([0, 16]);
             assert.strictEqual("#000000", scale.scale(0));
             assert.strictEqual("#ffffff", scale.scale(16));
@@ -7421,11 +7421,11 @@ describe("Scales", function () {
         });
         it("can be converted to a different range", function () {
             var scale = new Plottable.Scales.InterpolatedColor();
-            scale.colorRange(["black", "white"]);
+            scale.range(["black", "white"]);
             scale.domain([0, 16]);
             assert.strictEqual("#000000", scale.scale(0));
             assert.strictEqual("#ffffff", scale.scale(16));
-            scale.colorRange(Plottable.Scales.InterpolatedColor.REDS);
+            scale.range(Plottable.Scales.InterpolatedColor.REDS);
             assert.strictEqual("#b10026", scale.scale(16));
         });
     });


### PR DESCRIPTION
Closes #2271

Interpolated Color scale no longer takes the colorRange as a constructor argument. Instead, it is now set via the `range()` method

**Reason:** We want InterpolatedColor to be consistent with Color, which takes as a first argument the scale type. In the same time, the argument was optional, and could have been set by the `colorRange()` method

Changelog:
- `Scales.InterpolatedColor.colorRange()` -> `Scales.InterpolatedColor.range()`
- `new Scales.InterpolatedColor(colorRange, scaleType)` -> `new Scales.InterpolatedColor(scaleType)`

**QE Notes** Regression pass on interpolated color scale. Checked the overlaying tests myself