### PR TITLE
Switch the template used for UMD.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -150,8 +150,8 @@ module.exports = function(grunt) {
     umd: {
       all: {
         src: "plottable.js", 
+        template: "unit",
         objectToExport: "Plottable",
-//        amdModuleId: "Plottable",
       }
     },
     concat: {

--- a/plottable.js
+++ b/plottable.js
@@ -4,22 +4,20 @@ Copyright 2014 Palantir Technologies
 Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
 */
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    // AMD. Register as an anonymous module unless amdModuleId is set
-    define([], function () {
-      return (root['Plottable'] = factory());
-    });
-  } else if (typeof exports === 'object') {
-    // Node. Does not work with strict CommonJS, but
-    // only CommonJS-like environments that support module.exports,
-    // like Node.
-    module.exports = factory();
-  } else {
-    root['Plottable'] = factory();
-  }
-}(this, function () {
-
+(function(root, factory) {
+    if(typeof exports === 'object') {
+        module.exports = factory(require, exports, module);
+    }
+    else if(typeof define === 'function' && define.amd) {
+        define(['require', 'exports', 'module'], factory);
+    }
+    else {
+        var req = function(id) {return root[id];},
+            exp = root,
+            mod = {exports: exp};
+        root['Plottable'] = factory(req, exp, mod);
+    }
+}(this, function(require, exports, module) {
 ///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
@@ -10821,5 +10819,4 @@ var SVGTypewriter;
 })(SVGTypewriter || (SVGTypewriter = {}));
 
 return Plottable;
-
 }));

--- a/quicktests/umd/app.js
+++ b/quicktests/umd/app.js
@@ -11,6 +11,10 @@ require.config({
 
 require(["d3"], function(d3) {
   require(["plottable"], function(Plottable) {
+    var output = d3.select("#output");
+    output.text(String(window.Plottable));
+    output.style("background-color", window.Plottable ? "#F00" : "#0F0");
+
     var dataset1 = new Plottable.Dataset([
       { name: "A", value: 2 },
       { name: "B", value: 5 },

--- a/quicktests/umd/index.html
+++ b/quicktests/umd/index.html
@@ -6,11 +6,15 @@
     <style>
       body { background-color: #AAA; }
       svg { background-color: #FFF; }
+      .code { font-family: monospace; }
     </style>
     <script src="lib/require.js" data-main="app"></script>
   </head>
   <body>
     <svg id="chart" width="640" height="480"></svg>
+    <p>
+      <span class="code">window.Plottable</span> is <span id="output" class="code"></span> (<span class="code">undefined</span> expected)
+    </p>
   </body>
 
 </html>


### PR DESCRIPTION
Avoids exporting `Plottable` to the global namespace if a module loader is used.