### PR TITLE
[InterpolatedColorLegend] - InterpolatedColorLegend -> InterpolatedLegend

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2007,7 +2007,7 @@ declare module Plottable {
 
 declare module Plottable {
     module Components {
-        class InterpolatedColorLegend extends Component {
+        class InterpolatedLegend extends Component {
             /**
              * The css class applied to the legend labels.
              */
@@ -2034,7 +2034,7 @@ declare module Plottable {
              * @param {Formatter} formatter
              * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
              */
-            formatter(formatter: Formatter): InterpolatedColorLegend;
+            formatter(formatter: Formatter): InterpolatedLegend;
             /**
              * Gets the orientation.
              */
@@ -2045,12 +2045,12 @@ declare module Plottable {
              * @param {string} orientation One of "horizontal"/"left"/"right".
              * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
              */
-            orientation(orientation: string): InterpolatedColorLegend;
+            orientation(orientation: string): InterpolatedLegend;
             fixedWidth(): boolean;
             fixedHeight(): boolean;
             protected _setup(): void;
             requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
-            renderImmediately(): InterpolatedColorLegend;
+            renderImmediately(): InterpolatedLegend;
         }
     }
 }
@@ -2729,14 +2729,14 @@ declare module Plottable {
             /**
              * Gets the Formatter for the labels.
              */
-            labelsFormatter(): Formatter;
+            labelFormatter(): Formatter;
             /**
              * Sets the Formatter for the labels.
              *
              * @param {Formatter} formatter
              * @returns {Bar} The calling Bar Plot.
              */
-            labelsFormatter(formatter: Formatter): Bar<X, Y>;
+            labelFormatter(formatter: Formatter): Bar<X, Y>;
             protected _createNodesForDataset(dataset: Dataset): Drawer;
             protected _removeDatasetNodes(dataset: Dataset): void;
             /**

--- a/plottable.js
+++ b/plottable.js
@@ -5168,8 +5168,8 @@ var Plottable;
 (function (Plottable) {
     var Components;
     (function (Components) {
-        var InterpolatedColorLegend = (function (_super) {
-            __extends(InterpolatedColorLegend, _super);
+        var InterpolatedLegend = (function (_super) {
+            __extends(InterpolatedLegend, _super);
             /**
              * Creates an InterpolatedColorLegend.
              *
@@ -5180,7 +5180,7 @@ var Plottable;
              * @constructor
              * @param {Scales.InterpolatedColor} interpolatedColorScale
              */
-            function InterpolatedColorLegend(interpolatedColorScale) {
+            function InterpolatedLegend(interpolatedColorScale) {
                 var _this = this;
                 _super.call(this);
                 this._padding = 5;
@@ -5195,11 +5195,11 @@ var Plottable;
                 this._orientation = "horizontal";
                 this.classed("legend", true).classed("interpolated-color-legend", true);
             }
-            InterpolatedColorLegend.prototype.destroy = function () {
+            InterpolatedLegend.prototype.destroy = function () {
                 _super.prototype.destroy.call(this);
                 this._scale.offUpdate(this._redrawCallback);
             };
-            InterpolatedColorLegend.prototype.formatter = function (formatter) {
+            InterpolatedLegend.prototype.formatter = function (formatter) {
                 if (formatter === undefined) {
                     return this._formatter;
                 }
@@ -5207,7 +5207,7 @@ var Plottable;
                 this.redraw();
                 return this;
             };
-            InterpolatedColorLegend._ensureOrientation = function (orientation) {
+            InterpolatedLegend._ensureOrientation = function (orientation) {
                 orientation = orientation.toLowerCase();
                 if (orientation === "horizontal" || orientation === "left" || orientation === "right") {
                     return orientation;
@@ -5216,23 +5216,23 @@ var Plottable;
                     throw new Error("\"" + orientation + "\" is not a valid orientation for InterpolatedColorLegend");
                 }
             };
-            InterpolatedColorLegend.prototype.orientation = function (orientation) {
+            InterpolatedLegend.prototype.orientation = function (orientation) {
                 if (orientation == null) {
                     return this._orientation;
                 }
                 else {
-                    this._orientation = InterpolatedColorLegend._ensureOrientation(orientation);
+                    this._orientation = InterpolatedLegend._ensureOrientation(orientation);
                     this.redraw();
                     return this;
                 }
             };
-            InterpolatedColorLegend.prototype.fixedWidth = function () {
+            InterpolatedLegend.prototype.fixedWidth = function () {
                 return true;
             };
-            InterpolatedColorLegend.prototype.fixedHeight = function () {
+            InterpolatedLegend.prototype.fixedHeight = function () {
                 return true;
             };
-            InterpolatedColorLegend.prototype._generateTicks = function () {
+            InterpolatedLegend.prototype._generateTicks = function () {
                 var domain = this._scale.domain();
                 var slope = (domain[1] - domain[0]) / this._numSwatches;
                 var ticks = [];
@@ -5241,17 +5241,17 @@ var Plottable;
                 }
                 return ticks;
             };
-            InterpolatedColorLegend.prototype._setup = function () {
+            InterpolatedLegend.prototype._setup = function () {
                 _super.prototype._setup.call(this);
                 this._swatchContainer = this.content().append("g").classed("swatch-container", true);
                 this._swatchBoundingBox = this.content().append("rect").classed("swatch-bounding-box", true);
-                this._lowerLabel = this.content().append("g").classed(InterpolatedColorLegend.LEGEND_LABEL_CLASS, true);
-                this._upperLabel = this.content().append("g").classed(InterpolatedColorLegend.LEGEND_LABEL_CLASS, true);
+                this._lowerLabel = this.content().append("g").classed(InterpolatedLegend.LEGEND_LABEL_CLASS, true);
+                this._upperLabel = this.content().append("g").classed(InterpolatedLegend.LEGEND_LABEL_CLASS, true);
                 this._measurer = new SVGTypewriter.Measurers.Measurer(this.content());
                 this._wrapper = new SVGTypewriter.Wrappers.Wrapper();
                 this._writer = new SVGTypewriter.Writers.Writer(this._measurer, this._wrapper);
             };
-            InterpolatedColorLegend.prototype.requestedSpace = function (offeredWidth, offeredHeight) {
+            InterpolatedLegend.prototype.requestedSpace = function (offeredWidth, offeredHeight) {
                 var _this = this;
                 var textHeight = this._measurer.measure().height;
                 var ticks = this._generateTicks();
@@ -5274,10 +5274,10 @@ var Plottable;
                     minHeight: desiredHeight
                 };
             };
-            InterpolatedColorLegend.prototype._isVertical = function () {
+            InterpolatedLegend.prototype._isVertical = function () {
                 return this._orientation !== "horizontal";
             };
-            InterpolatedColorLegend.prototype.renderImmediately = function () {
+            InterpolatedLegend.prototype.renderImmediately = function () {
                 var _this = this;
                 _super.prototype.renderImmediately.call(this);
                 var domain = this._scale.domain();
@@ -5375,10 +5375,10 @@ var Plottable;
             /**
              * The css class applied to the legend labels.
              */
-            InterpolatedColorLegend.LEGEND_LABEL_CLASS = "legend-label";
-            return InterpolatedColorLegend;
+            InterpolatedLegend.LEGEND_LABEL_CLASS = "legend-label";
+            return InterpolatedLegend;
         })(Plottable.Component);
-        Components.InterpolatedColorLegend = InterpolatedColorLegend;
+        Components.InterpolatedLegend = InterpolatedLegend;
     })(Components = Plottable.Components || (Plottable.Components = {}));
 })(Plottable || (Plottable = {}));
 
@@ -7106,7 +7106,7 @@ var Plottable;
                     return this;
                 }
             };
-            Bar.prototype.labelsFormatter = function (formatter) {
+            Bar.prototype.labelFormatter = function (formatter) {
                 if (formatter == null) {
                     return this._labelFormatter;
                 }

--- a/src/components/interpolatedLegend.ts
+++ b/src/components/interpolatedLegend.ts
@@ -2,7 +2,7 @@
 
 module Plottable {
 export module Components {
-  export class InterpolatedColorLegend extends Component {
+  export class InterpolatedLegend extends Component {
     private _measurer: SVGTypewriter.Measurers.Measurer;
     private _wrapper: SVGTypewriter.Wrappers.Wrapper;
     private _writer: SVGTypewriter.Writers.Writer;
@@ -62,7 +62,7 @@ export module Components {
      * @param {Formatter} formatter
      * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
      */
-    public formatter(formatter: Formatter): InterpolatedColorLegend;
+    public formatter(formatter: Formatter): InterpolatedLegend;
     public formatter(formatter?: Formatter): any {
       if (formatter === undefined) {
         return this._formatter;
@@ -91,12 +91,12 @@ export module Components {
      * @param {string} orientation One of "horizontal"/"left"/"right".
      * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
      */
-    public orientation(orientation: string): InterpolatedColorLegend;
+    public orientation(orientation: string): InterpolatedLegend;
     public orientation(orientation?: string): any {
       if (orientation == null) {
         return this._orientation;
       } else {
-        this._orientation = InterpolatedColorLegend._ensureOrientation(orientation);
+        this._orientation = InterpolatedLegend._ensureOrientation(orientation);
         this.redraw();
         return this;
       }
@@ -125,8 +125,8 @@ export module Components {
 
       this._swatchContainer = this.content().append("g").classed("swatch-container", true);
       this._swatchBoundingBox = this.content().append("rect").classed("swatch-bounding-box", true);
-      this._lowerLabel = this.content().append("g").classed(InterpolatedColorLegend.LEGEND_LABEL_CLASS, true);
-      this._upperLabel = this.content().append("g").classed(InterpolatedColorLegend.LEGEND_LABEL_CLASS, true);
+      this._lowerLabel = this.content().append("g").classed(InterpolatedLegend.LEGEND_LABEL_CLASS, true);
+      this._upperLabel = this.content().append("g").classed(InterpolatedLegend.LEGEND_LABEL_CLASS, true);
 
       this._measurer = new SVGTypewriter.Measurers.Measurer(this.content());
       this._wrapper = new SVGTypewriter.Wrappers.Wrapper();

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -52,7 +52,7 @@
 
 /// <reference path="components/label.ts" />
 /// <reference path="components/legend.ts" />
-/// <reference path="components/interpolatedColorLegend.ts" />
+/// <reference path="components/interpolatedLegend.ts" />
 /// <reference path="components/gridlines.ts" />
 /// <reference path="components/table.ts" />
 /// <reference path="components/selectionBoxLayer.ts" />

--- a/test/components/interpolatedLegendTests.ts
+++ b/test/components/interpolatedLegendTests.ts
@@ -2,7 +2,7 @@
 
 var assert = chai.assert;
 
-describe("InterpolatedColorLegend", () => {
+describe("InterpolatedLegend", () => {
   var svg: d3.Selection<void>;
   var colorScale: Plottable.Scales.InterpolatedColor;
 
@@ -11,7 +11,7 @@ describe("InterpolatedColorLegend", () => {
     colorScale = new Plottable.Scales.InterpolatedColor();
   });
 
-  function assertBasicRendering(legend: Plottable.Components.InterpolatedColorLegend) {
+  function assertBasicRendering(legend: Plottable.Components.InterpolatedLegend) {
     var scaleDomain = colorScale.domain();
     var legendElement: d3.Selection<void> = (<any> legend)._element;
 
@@ -41,7 +41,7 @@ describe("InterpolatedColorLegend", () => {
   }
 
   it("renders correctly (orientation: horizontal)", () => {
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    var legend = new Plottable.Components.InterpolatedLegend(colorScale);
     legend.renderTo(svg);
 
     assertBasicRendering(legend);
@@ -60,7 +60,7 @@ describe("InterpolatedColorLegend", () => {
   });
 
   it("renders correctly (orientation: right)", () => {
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    var legend = new Plottable.Components.InterpolatedLegend(colorScale);
     legend.orientation("right");
     legend.renderTo(svg);
 
@@ -81,7 +81,7 @@ describe("InterpolatedColorLegend", () => {
   });
 
   it("renders correctly (orientation: left)", () => {
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    var legend = new Plottable.Components.InterpolatedLegend(colorScale);
     legend.orientation("left");
     legend.renderTo(svg);
 
@@ -102,7 +102,7 @@ describe("InterpolatedColorLegend", () => {
   });
 
   it("re-renders when scale domain updates", () => {
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    var legend = new Plottable.Components.InterpolatedLegend(colorScale);
     legend.orientation("horizontal");
     legend.renderTo(svg);
 
@@ -113,7 +113,7 @@ describe("InterpolatedColorLegend", () => {
   });
 
   it("orientation() input-checking", () => {
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    var legend = new Plottable.Components.InterpolatedLegend(colorScale);
 
     legend.orientation("horizontal"); // should work
     legend.orientation("right"); // should work
@@ -124,7 +124,7 @@ describe("InterpolatedColorLegend", () => {
   });
 
   it("orient() triggers layout computation", () => {
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    var legend = new Plottable.Components.InterpolatedLegend(colorScale);
     legend.renderTo(svg);
 
     var widthBefore = legend.width();
@@ -138,7 +138,7 @@ describe("InterpolatedColorLegend", () => {
 
   it("renders correctly when width is constrained (orientation: horizontal)", () => {
     svg.attr("width", 100);
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    var legend = new Plottable.Components.InterpolatedLegend(colorScale);
     legend.orientation("horizontal");
     legend.renderTo(svg);
     assertBasicRendering(legend);
@@ -147,7 +147,7 @@ describe("InterpolatedColorLegend", () => {
 
   it("renders correctly when height is constrained (orientation: horizontal)", () => {
     svg.attr("height", 20);
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    var legend = new Plottable.Components.InterpolatedLegend(colorScale);
     legend.orientation("horizontal");
     legend.renderTo(svg);
     assertBasicRendering(legend);
@@ -156,7 +156,7 @@ describe("InterpolatedColorLegend", () => {
 
   it("renders correctly when width is constrained (orientation: right)", () => {
     svg.attr("width", 30);
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    var legend = new Plottable.Components.InterpolatedLegend(colorScale);
     legend.orientation("right");
     legend.renderTo(svg);
     assertBasicRendering(legend);
@@ -165,7 +165,7 @@ describe("InterpolatedColorLegend", () => {
 
   it("renders correctly when height is constrained (orientation: right)", () => {
     svg.attr("height", 100);
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    var legend = new Plottable.Components.InterpolatedLegend(colorScale);
     legend.orientation("right");
     legend.renderTo(svg);
     assertBasicRendering(legend);
@@ -174,7 +174,7 @@ describe("InterpolatedColorLegend", () => {
 
   it("renders correctly when width is constrained (orientation: left)", () => {
     svg.attr("width", 30);
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    var legend = new Plottable.Components.InterpolatedLegend(colorScale);
     legend.orientation("left");
     legend.renderTo(svg);
     assertBasicRendering(legend);
@@ -183,7 +183,7 @@ describe("InterpolatedColorLegend", () => {
 
   it("renders correctly when height is constrained (orientation: left)", () => {
     svg.attr("height", 100);
-    var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    var legend = new Plottable.Components.InterpolatedLegend(colorScale);
     legend.orientation("left");
     legend.renderTo(svg);
     assertBasicRendering(legend);

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -22,7 +22,7 @@
 ///<reference path="components/gridlinesTests.ts" />
 ///<reference path="components/labelTests.ts" />
 ///<reference path="components/legendTests.ts" />
-///<reference path="components/interpolatedColorLegendTests.ts" />
+///<reference path="components/interpolatedLegendTests.ts" />
 ///<reference path="components/selectionBoxLayerTests.ts" />
 
 ///<reference path="components/plots/plotTests.ts" />

--- a/test/tests.js
+++ b/test/tests.js
@@ -1998,7 +1998,7 @@ describe("Legend", function () {
 
 ///<reference path="../testReference.ts" />
 var assert = chai.assert;
-describe("InterpolatedColorLegend", function () {
+describe("InterpolatedLegend", function () {
     var svg;
     var colorScale;
     beforeEach(function () {
@@ -2024,7 +2024,7 @@ describe("InterpolatedColorLegend", function () {
         assert.deepEqual(labelTexts, formattedDomainValues, "formatter is used to format label text");
     }
     it("renders correctly (orientation: horizontal)", function () {
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        var legend = new Plottable.Components.InterpolatedLegend(colorScale);
         legend.renderTo(svg);
         assertBasicRendering(legend);
         var legendElement = legend._element;
@@ -2038,7 +2038,7 @@ describe("InterpolatedColorLegend", function () {
         svg.remove();
     });
     it("renders correctly (orientation: right)", function () {
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        var legend = new Plottable.Components.InterpolatedLegend(colorScale);
         legend.orientation("right");
         legend.renderTo(svg);
         assertBasicRendering(legend);
@@ -2054,7 +2054,7 @@ describe("InterpolatedColorLegend", function () {
         svg.remove();
     });
     it("renders correctly (orientation: left)", function () {
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        var legend = new Plottable.Components.InterpolatedLegend(colorScale);
         legend.orientation("left");
         legend.renderTo(svg);
         assertBasicRendering(legend);
@@ -2070,7 +2070,7 @@ describe("InterpolatedColorLegend", function () {
         svg.remove();
     });
     it("re-renders when scale domain updates", function () {
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        var legend = new Plottable.Components.InterpolatedLegend(colorScale);
         legend.orientation("horizontal");
         legend.renderTo(svg);
         colorScale.domain([0, 85]);
@@ -2078,7 +2078,7 @@ describe("InterpolatedColorLegend", function () {
         svg.remove();
     });
     it("orientation() input-checking", function () {
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        var legend = new Plottable.Components.InterpolatedLegend(colorScale);
         legend.orientation("horizontal"); // should work
         legend.orientation("right"); // should work
         legend.orientation("left"); // should work
@@ -2086,7 +2086,7 @@ describe("InterpolatedColorLegend", function () {
         svg.remove();
     });
     it("orient() triggers layout computation", function () {
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        var legend = new Plottable.Components.InterpolatedLegend(colorScale);
         legend.renderTo(svg);
         var widthBefore = legend.width();
         var heightBefore = legend.height();
@@ -2097,7 +2097,7 @@ describe("InterpolatedColorLegend", function () {
     });
     it("renders correctly when width is constrained (orientation: horizontal)", function () {
         svg.attr("width", 100);
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        var legend = new Plottable.Components.InterpolatedLegend(colorScale);
         legend.orientation("horizontal");
         legend.renderTo(svg);
         assertBasicRendering(legend);
@@ -2105,7 +2105,7 @@ describe("InterpolatedColorLegend", function () {
     });
     it("renders correctly when height is constrained (orientation: horizontal)", function () {
         svg.attr("height", 20);
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        var legend = new Plottable.Components.InterpolatedLegend(colorScale);
         legend.orientation("horizontal");
         legend.renderTo(svg);
         assertBasicRendering(legend);
@@ -2113,7 +2113,7 @@ describe("InterpolatedColorLegend", function () {
     });
     it("renders correctly when width is constrained (orientation: right)", function () {
         svg.attr("width", 30);
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        var legend = new Plottable.Components.InterpolatedLegend(colorScale);
         legend.orientation("right");
         legend.renderTo(svg);
         assertBasicRendering(legend);
@@ -2121,7 +2121,7 @@ describe("InterpolatedColorLegend", function () {
     });
     it("renders correctly when height is constrained (orientation: right)", function () {
         svg.attr("height", 100);
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        var legend = new Plottable.Components.InterpolatedLegend(colorScale);
         legend.orientation("right");
         legend.renderTo(svg);
         assertBasicRendering(legend);
@@ -2129,7 +2129,7 @@ describe("InterpolatedColorLegend", function () {
     });
     it("renders correctly when width is constrained (orientation: left)", function () {
         svg.attr("width", 30);
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        var legend = new Plottable.Components.InterpolatedLegend(colorScale);
         legend.orientation("left");
         legend.renderTo(svg);
         assertBasicRendering(legend);
@@ -2137,7 +2137,7 @@ describe("InterpolatedColorLegend", function () {
     });
     it("renders correctly when height is constrained (orientation: left)", function () {
         svg.attr("height", 100);
-        var legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+        var legend = new Plottable.Components.InterpolatedLegend(colorScale);
         legend.orientation("left");
         legend.renderTo(svg);
         assertBasicRendering(legend);


### PR DESCRIPTION
Similar to how `Legend` is not called `ColorLegend`, the "Color" part in `InterpolatedColorLegend` is redundant I feel.

API Changes:
* `InterpolatedColorLegend` has been renamed to `InterpolatedLegend`