### PR TITLE
Rename autorange() to autorangeMode()

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2506,20 +2506,20 @@ declare module Plottable {
         protected _installScaleForKey(scale: Scale<any, any>, key: string): void;
         destroy(): XYPlot<X, Y>;
         /**
-         * Gets the automatic domain adjustment setting for visible points.
+         * Gets the automatic domain adjustment mode for visible points.
          */
-        autorange(): string;
+        autorangeMode(): string;
         /**
-         * Sets the automatic domain adjustment for visible points to operate against the X Scale, Y Scale, or neither.
+         * Sets the automatic domain adjustment mode for visible points to operate against the X Scale, Y Scale, or neither.
          * If "x" or "y" is specified the adjustment is immediately performed.
          *
-         * @param {string} scaleName One of "x"/"y"/"none".
+         * @param {string} mode One of "x"/"y"/"none".
          *   "x" will adjust the x Scale in relation to changes in the y domain.
          *   "y" will adjust the y Scale in relation to changes in the x domain.
          *   "none" means neither Scale will change automatically.
          * @returns {XYPlot} The calling XYPlot.
          */
-        autorange(scaleName: string): XYPlot<X, Y>;
+        autorangeMode(mode: string): XYPlot<X, Y>;
         computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): XYPlot<X, Y>;
         /**
          * Adjusts the domains of both X and Y scales to show all data.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2513,13 +2513,13 @@ declare module Plottable {
          * Sets the automatic domain adjustment mode for visible points to operate against the X Scale, Y Scale, or neither.
          * If "x" or "y" is specified the adjustment is immediately performed.
          *
-         * @param {string} mode One of "x"/"y"/"none".
+         * @param {string} autorangeMode One of "x"/"y"/"none".
          *   "x" will adjust the x Scale in relation to changes in the y domain.
          *   "y" will adjust the y Scale in relation to changes in the x domain.
          *   "none" means neither Scale will change automatically.
          * @returns {XYPlot} The calling XYPlot.
          */
-        autorangeMode(mode: string): XYPlot<X, Y>;
+        autorangeMode(autorangeMode: string): XYPlot<X, Y>;
         computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): XYPlot<X, Y>;
         /**
          * Adjusts the domains of both X and Y scales to show all data.

--- a/plottable.js
+++ b/plottable.js
@@ -6580,8 +6580,8 @@ var Plottable;
             }
             return this;
         };
-        XYPlot.prototype.autorangeMode = function (mode) {
-            if (mode == null) {
+        XYPlot.prototype.autorangeMode = function (autorangeMode) {
+            if (autorangeMode == null) {
                 if (this._autoAdjustXScaleDomain) {
                     return "x";
                 }
@@ -6590,7 +6590,7 @@ var Plottable;
                 }
                 return "none";
             }
-            switch (mode) {
+            switch (autorangeMode) {
                 case "x":
                     this._autoAdjustXScaleDomain = true;
                     this._autoAdjustYScaleDomain = false;
@@ -6606,7 +6606,7 @@ var Plottable;
                     this._autoAdjustYScaleDomain = false;
                     break;
                 default:
-                    throw new Error("Invalid scale name '" + mode + "', must be 'x', 'y' or 'none'");
+                    throw new Error("Invalid scale name '" + autorangeMode + "', must be 'x', 'y' or 'none'");
             }
             return this;
         };

--- a/plottable.js
+++ b/plottable.js
@@ -6580,8 +6580,8 @@ var Plottable;
             }
             return this;
         };
-        XYPlot.prototype.autorange = function (scaleName) {
-            if (scaleName == null) {
+        XYPlot.prototype.autorangeMode = function (mode) {
+            if (mode == null) {
                 if (this._autoAdjustXScaleDomain) {
                     return "x";
                 }
@@ -6590,7 +6590,7 @@ var Plottable;
                 }
                 return "none";
             }
-            switch (scaleName) {
+            switch (mode) {
                 case "x":
                     this._autoAdjustXScaleDomain = true;
                     this._autoAdjustYScaleDomain = false;
@@ -6606,7 +6606,7 @@ var Plottable;
                     this._autoAdjustYScaleDomain = false;
                     break;
                 default:
-                    throw new Error("Invalid scale name '" + scaleName + "', must be 'x', 'y' or 'none'");
+                    throw new Error("Invalid scale name '" + mode + "', must be 'x', 'y' or 'none'");
             }
             return this;
         };

--- a/quicktests/overlaying/tests/realistic/stocks.js
+++ b/quicktests/overlaying/tests/realistic/stocks.js
@@ -74,7 +74,7 @@ function run(svg, data, Plottable) {
           if (typeof line_aapl.autorange === "function") {
             line_aapl.autorange("y");
           } else {
-            line_aapl.automaticallyAdjustYScaleOverVisiblePoints(true);
+            line_aapl.autorangeMode("y");
           }
           var line_goog = new Plottable.Plots.Line().animated(true)
                                   .addDataset(googSource)
@@ -84,7 +84,7 @@ function run(svg, data, Plottable) {
           if (typeof line_aapl.autorange === "function") {
             line_goog.autorange("y");
           } else {
-            line_goog.automaticallyAdjustYScaleOverVisiblePoints(true);
+            line_goog.autorangeMode("y");
           }
 
           // should be one line plot, pending #917

--- a/quicktests/overlaying/tests/realistic/vertical_line.js
+++ b/quicktests/overlaying/tests/realistic/vertical_line.js
@@ -21,7 +21,7 @@ function run(svg, data, Plottable) {
   if (typeof plot.autorange === "function") {
     plot.autorange("x");
   } else {
-    plot.automaticallyAdjustXScaleOverVisiblePoints(true);
+    plot.autorangeMode("x");
   }
 
   var table = new Plottable.Components.Table([[yAxis, plot],

--- a/src/components/plots/xyPlot.ts
+++ b/src/components/plots/xyPlot.ts
@@ -149,22 +149,22 @@ module Plottable {
     }
 
     /**
-     * Gets the automatic domain adjustment setting for visible points.
+     * Gets the automatic domain adjustment mode for visible points.
      */
-    public autorange(): string;
+    public autorangeMode(): string;
     /**
-     * Sets the automatic domain adjustment for visible points to operate against the X Scale, Y Scale, or neither.
+     * Sets the automatic domain adjustment mode for visible points to operate against the X Scale, Y Scale, or neither.
      * If "x" or "y" is specified the adjustment is immediately performed.
      *
-     * @param {string} scaleName One of "x"/"y"/"none".
+     * @param {string} mode One of "x"/"y"/"none".
      *   "x" will adjust the x Scale in relation to changes in the y domain.
      *   "y" will adjust the y Scale in relation to changes in the x domain.
      *   "none" means neither Scale will change automatically.
      * @returns {XYPlot} The calling XYPlot.
      */
-    public autorange(scaleName: string): XYPlot<X, Y>;
-    public autorange(scaleName?: string): any {
-      if (scaleName == null) {
+    public autorangeMode(mode: string): XYPlot<X, Y>;
+    public autorangeMode(mode?: string): any {
+      if (mode == null) {
         if (this._autoAdjustXScaleDomain) {
           return "x";
         }
@@ -173,7 +173,7 @@ module Plottable {
         }
         return "none";
       }
-      switch (scaleName) {
+      switch (mode) {
         case "x":
           this._autoAdjustXScaleDomain = true;
           this._autoAdjustYScaleDomain = false;
@@ -189,7 +189,7 @@ module Plottable {
           this._autoAdjustYScaleDomain = false;
           break;
         default:
-          throw new Error("Invalid scale name '" + scaleName + "', must be 'x', 'y' or 'none'");
+          throw new Error("Invalid scale name '" + mode + "', must be 'x', 'y' or 'none'");
       }
       return this;
     }

--- a/src/components/plots/xyPlot.ts
+++ b/src/components/plots/xyPlot.ts
@@ -156,15 +156,15 @@ module Plottable {
      * Sets the automatic domain adjustment mode for visible points to operate against the X Scale, Y Scale, or neither.
      * If "x" or "y" is specified the adjustment is immediately performed.
      *
-     * @param {string} mode One of "x"/"y"/"none".
+     * @param {string} autorangeMode One of "x"/"y"/"none".
      *   "x" will adjust the x Scale in relation to changes in the y domain.
      *   "y" will adjust the y Scale in relation to changes in the x domain.
      *   "none" means neither Scale will change automatically.
      * @returns {XYPlot} The calling XYPlot.
      */
-    public autorangeMode(mode: string): XYPlot<X, Y>;
-    public autorangeMode(mode?: string): any {
-      if (mode == null) {
+    public autorangeMode(autorangeMode: string): XYPlot<X, Y>;
+    public autorangeMode(autorangeMode?: string): any {
+      if (autorangeMode == null) {
         if (this._autoAdjustXScaleDomain) {
           return "x";
         }
@@ -173,7 +173,7 @@ module Plottable {
         }
         return "none";
       }
-      switch (mode) {
+      switch (autorangeMode) {
         case "x":
           this._autoAdjustXScaleDomain = true;
           this._autoAdjustYScaleDomain = false;
@@ -189,7 +189,7 @@ module Plottable {
           this._autoAdjustYScaleDomain = false;
           break;
         default:
-          throw new Error("Invalid scale name '" + mode + "', must be 'x', 'y' or 'none'");
+          throw new Error("Invalid scale name '" + autorangeMode + "', must be 'x', 'y' or 'none'");
       }
       return this;
     }

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -765,7 +765,7 @@ describe("Plots", () => {
           .renderTo(svg);
       xScale.domain(["b", "c"]);
       assert.deepEqual(yScale.domain(), [-7, 7], "domain has not been adjusted to visible points");
-      plot.autorange("y");
+      plot.autorangeMode("y");
       assert.deepEqual(yScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points");
       svg.remove();
     });

--- a/test/components/plots/stackedPlotTests.ts
+++ b/test/components/plots/stackedPlotTests.ts
@@ -330,7 +330,7 @@ describe("Plots", () => {
           .addDataset(dataset2);
       plot.x((d: any) => d.x, xScale)
           .y((d: any) => d.y, yScale)
-          .autorange("y");
+          .autorangeMode("y");
       plot.renderTo(svg);
       assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
       svg.remove();
@@ -342,7 +342,7 @@ describe("Plots", () => {
           .addDataset(dataset2);
       plot.x((d: any) => d.x, xScale)
           .y((d: any) => d.y, yScale)
-          .autorange("y");
+          .autorangeMode("y");
       plot.renderTo(svg);
       assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
       svg.remove();
@@ -382,7 +382,7 @@ describe("Plots", () => {
           .addDataset(dataset2);
       plot.x((d: any) => d.x, xScale)
           .y((d: any) => d.y, yScale)
-          .autorange("y");
+          .autorangeMode("y");
       plot.renderTo(svg);
       assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
       svg.remove();
@@ -394,7 +394,7 @@ describe("Plots", () => {
           .addDataset(dataset2);
       plot.x((d: any) => d.x, xScale)
           .y((d: any) => d.y, yScale)
-          .autorange("y");
+          .autorangeMode("y");
       plot.renderTo(svg);
       assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
       svg.remove();

--- a/test/components/plots/xyPlotTests.ts
+++ b/test/components/plots/xyPlotTests.ts
@@ -27,20 +27,20 @@ describe("Plots", () => {
           .renderTo(svg);
     });
 
-    it("autorange() getter", () => {
-      assert.strictEqual(plot.autorange(), "none");
-      assert.strictEqual(plot.autorange("x"), plot, "autorange() setter did not return the original object");
-      assert.strictEqual(plot.autorange(), "x");
-      plot.autorange("y");
-      assert.strictEqual(plot.autorange(), "y");
-      plot.autorange("none");
-      assert.strictEqual(plot.autorange(), "none");
+    it("autorangeMode() getter", () => {
+      assert.strictEqual(plot.autorangeMode(), "none");
+      assert.strictEqual(plot.autorangeMode("x"), plot, "autorangeMode() setter did not return the original object");
+      assert.strictEqual(plot.autorangeMode(), "x");
+      plot.autorangeMode("y");
+      assert.strictEqual(plot.autorangeMode(), "y");
+      plot.autorangeMode("none");
+      assert.strictEqual(plot.autorangeMode(), "none");
       svg.remove();
     });
 
-    it("autorange() invalid inputs", () => {
+    it("autorangeMode() invalid inputs", () => {
       assert.throws(() => {
-        plot.autorange("foobar");
+        plot.autorangeMode("foobar");
       });
       svg.remove();
     });
@@ -48,21 +48,21 @@ describe("Plots", () => {
     it("automatically adjusting Y domain over visible points", () => {
       xScale.domain([-3, 3]);
       assert.deepEqual(yScale.domain(), [-7, 7], "domain has not been adjusted to visible points");
-      plot.autorange("y");
+      plot.autorangeMode("y");
       assert.deepEqual(yScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points");
-      plot.autorange("none");
+      plot.autorangeMode("none");
       svg.remove();
     });
 
     it("automatically adjusting Y domain when no points are visible", () => {
-      plot.autorange("y");
+      plot.autorangeMode("y");
       xScale.domain([-0.5, 0.5]);
       assert.deepEqual(yScale.domain(), [0, 1], "scale uses default domain");
       svg.remove();
     });
 
     it("automatically adjusting Y domain when X scale is replaced", () => {
-      plot.autorange("y");
+      plot.autorangeMode("y");
       var newXScale = new Plottable.Scales.Linear().domain([-3, 3]);
       plot.x(xAccessor, newXScale);
       assert.deepEqual(yScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points on new X scale domain");
@@ -74,21 +74,21 @@ describe("Plots", () => {
     it("automatically adjusting X domain over visible points", () => {
       yScale.domain([-3, 3]);
       assert.deepEqual(xScale.domain(), [-7, 7], "domain has not been adjusted to visible points");
-      plot.autorange("x");
+      plot.autorangeMode("x");
       assert.deepEqual(xScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points");
-      plot.autorange("none");
+      plot.autorangeMode("none");
       svg.remove();
     });
 
     it("automatically adjusting X domain when no points are visible", () => {
-      plot.autorange("x");
+      plot.autorangeMode("x");
       yScale.domain([-0.5, 0.5]);
       assert.deepEqual(xScale.domain(), [0, 1], "scale uses default domain");
       svg.remove();
     });
 
     it("automatically adjusting X domain when Y scale is replaced", () => {
-      plot.autorange("x");
+      plot.autorangeMode("x");
       var newYScale = new Plottable.Scales.Linear().domain([-3, 3]);
       plot.y(yAccessor, newYScale);
       assert.deepEqual(xScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points on new Y scale domain");
@@ -98,7 +98,7 @@ describe("Plots", () => {
     });
 
     it("showAllData()", () => {
-      plot.autorange("y");
+      plot.autorangeMode("y");
       xScale.domain([-0.5, 0.5]);
       plot.showAllData();
       assert.deepEqual(yScale.domain(), [-7, 7], "domain has been adjusted to show all data");
@@ -107,9 +107,9 @@ describe("Plots", () => {
     });
 
     it("show all data without auto adjust domain", () => {
-      plot.autorange("y");
+      plot.autorangeMode("y");
       xScale.domain([-0.5, 0.5]);
-      plot.autorange("none");
+      plot.autorangeMode("none");
       plot.showAllData();
       assert.deepEqual(yScale.domain(), [-7, 7], "domain has been adjusted to show all data");
       assert.deepEqual(xScale.domain(), [-7, 7], "domain has been adjusted to show all data");
@@ -117,7 +117,7 @@ describe("Plots", () => {
     });
 
     it("listeners are deregistered after removal", () => {
-      plot.autorange("y");
+      plot.autorangeMode("y");
       plot.destroy();
 
       assert.strictEqual((<any> xScale)._callbacks.size, 0, "the plot is no longer attached to xScale");

--- a/test/tests.js
+++ b/test/tests.js
@@ -2664,38 +2664,38 @@ describe("Plots", function () {
             plot.addDataset(simpleDataset);
             plot.x(xAccessor, xScale).y(yAccessor, yScale).renderTo(svg);
         });
-        it("autorange() getter", function () {
-            assert.strictEqual(plot.autorange(), "none");
-            assert.strictEqual(plot.autorange("x"), plot, "autorange() setter did not return the original object");
-            assert.strictEqual(plot.autorange(), "x");
-            plot.autorange("y");
-            assert.strictEqual(plot.autorange(), "y");
-            plot.autorange("none");
-            assert.strictEqual(plot.autorange(), "none");
+        it("autorangeMode() getter", function () {
+            assert.strictEqual(plot.autorangeMode(), "none");
+            assert.strictEqual(plot.autorangeMode("x"), plot, "autorangeMode() setter did not return the original object");
+            assert.strictEqual(plot.autorangeMode(), "x");
+            plot.autorangeMode("y");
+            assert.strictEqual(plot.autorangeMode(), "y");
+            plot.autorangeMode("none");
+            assert.strictEqual(plot.autorangeMode(), "none");
             svg.remove();
         });
-        it("autorange() invalid inputs", function () {
+        it("autorangeMode() invalid inputs", function () {
             assert.throws(function () {
-                plot.autorange("foobar");
+                plot.autorangeMode("foobar");
             });
             svg.remove();
         });
         it("automatically adjusting Y domain over visible points", function () {
             xScale.domain([-3, 3]);
             assert.deepEqual(yScale.domain(), [-7, 7], "domain has not been adjusted to visible points");
-            plot.autorange("y");
+            plot.autorangeMode("y");
             assert.deepEqual(yScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points");
-            plot.autorange("none");
+            plot.autorangeMode("none");
             svg.remove();
         });
         it("automatically adjusting Y domain when no points are visible", function () {
-            plot.autorange("y");
+            plot.autorangeMode("y");
             xScale.domain([-0.5, 0.5]);
             assert.deepEqual(yScale.domain(), [0, 1], "scale uses default domain");
             svg.remove();
         });
         it("automatically adjusting Y domain when X scale is replaced", function () {
-            plot.autorange("y");
+            plot.autorangeMode("y");
             var newXScale = new Plottable.Scales.Linear().domain([-3, 3]);
             plot.x(xAccessor, newXScale);
             assert.deepEqual(yScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points on new X scale domain");
@@ -2706,19 +2706,19 @@ describe("Plots", function () {
         it("automatically adjusting X domain over visible points", function () {
             yScale.domain([-3, 3]);
             assert.deepEqual(xScale.domain(), [-7, 7], "domain has not been adjusted to visible points");
-            plot.autorange("x");
+            plot.autorangeMode("x");
             assert.deepEqual(xScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points");
-            plot.autorange("none");
+            plot.autorangeMode("none");
             svg.remove();
         });
         it("automatically adjusting X domain when no points are visible", function () {
-            plot.autorange("x");
+            plot.autorangeMode("x");
             yScale.domain([-0.5, 0.5]);
             assert.deepEqual(xScale.domain(), [0, 1], "scale uses default domain");
             svg.remove();
         });
         it("automatically adjusting X domain when Y scale is replaced", function () {
-            plot.autorange("x");
+            plot.autorangeMode("x");
             var newYScale = new Plottable.Scales.Linear().domain([-3, 3]);
             plot.y(yAccessor, newYScale);
             assert.deepEqual(xScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points on new Y scale domain");
@@ -2727,7 +2727,7 @@ describe("Plots", function () {
             svg.remove();
         });
         it("showAllData()", function () {
-            plot.autorange("y");
+            plot.autorangeMode("y");
             xScale.domain([-0.5, 0.5]);
             plot.showAllData();
             assert.deepEqual(yScale.domain(), [-7, 7], "domain has been adjusted to show all data");
@@ -2735,16 +2735,16 @@ describe("Plots", function () {
             svg.remove();
         });
         it("show all data without auto adjust domain", function () {
-            plot.autorange("y");
+            plot.autorangeMode("y");
             xScale.domain([-0.5, 0.5]);
-            plot.autorange("none");
+            plot.autorangeMode("none");
             plot.showAllData();
             assert.deepEqual(yScale.domain(), [-7, 7], "domain has been adjusted to show all data");
             assert.deepEqual(xScale.domain(), [-7, 7], "domain has been adjusted to show all data");
             svg.remove();
         });
         it("listeners are deregistered after removal", function () {
-            plot.autorange("y");
+            plot.autorangeMode("y");
             plot.destroy();
             assert.strictEqual(xScale._callbacks.size, 0, "the plot is no longer attached to xScale");
             assert.strictEqual(yScale._callbacks.size, 0, "the plot is no longer attached to yScale");
@@ -4051,7 +4051,7 @@ describe("Plots", function () {
             plot.x(xAccessor, xScale).y(yAccessor, yScale).renderTo(svg);
             xScale.domain(["b", "c"]);
             assert.deepEqual(yScale.domain(), [-7, 7], "domain has not been adjusted to visible points");
-            plot.autorange("y");
+            plot.autorangeMode("y");
             assert.deepEqual(yScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points");
             svg.remove();
         });
@@ -4811,7 +4811,7 @@ describe("Plots", function () {
         it("auto scales correctly on stacked area", function () {
             var plot = new Plottable.Plots.StackedArea();
             plot.addDataset(dataset1).addDataset(dataset2);
-            plot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).autorange("y");
+            plot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).autorangeMode("y");
             plot.renderTo(svg);
             assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
             svg.remove();
@@ -4819,7 +4819,7 @@ describe("Plots", function () {
         it("auto scales correctly on stacked bar", function () {
             var plot = new Plottable.Plots.StackedBar();
             plot.addDataset(dataset1).addDataset(dataset2);
-            plot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).autorange("y");
+            plot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).autorangeMode("y");
             plot.renderTo(svg);
             assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
             svg.remove();
@@ -4851,7 +4851,7 @@ describe("Plots", function () {
         it("auto scales correctly on stacked bar", function () {
             var plot = new Plottable.Plots.StackedBar();
             plot.addDataset(dataset1).addDataset(dataset2);
-            plot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).autorange("y");
+            plot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).autorangeMode("y");
             plot.renderTo(svg);
             assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
             svg.remove();
@@ -4859,7 +4859,7 @@ describe("Plots", function () {
         it("auto scales correctly on stacked area", function () {
             var plot = new Plottable.Plots.StackedArea();
             plot.addDataset(dataset1).addDataset(dataset2);
-            plot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).autorange("y");
+            plot.x(function (d) { return d.x; }, xScale).y(function (d) { return d.y; }, yScale).autorangeMode("y");
             plot.renderTo(svg);
             assert.deepEqual(yScale.domain(), [0, 4.5], "auto scales takes stacking into account");
             svg.remove();


### PR DESCRIPTION
More accurately describes the functionality, and reduces confusion in the case of the getter:
```Javascript
plot.autorange(); // does this perform autoranging?
plot.autorangeMode(); // clearer
```
Also renamed the param to "autorangeMode".