### PR TITLE
Fix destroy() method on Group

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -3399,7 +3399,7 @@ var Plottable;
                 components.forEach(function (c) { return _this.append(c); });
             }
             Group.prototype._forEach = function (callback) {
-                this._components.forEach(callback);
+                this.components().forEach(callback);
             };
             /**
              * Checks whether the specified Component is in the Group.

--- a/src/components/group.ts
+++ b/src/components/group.ts
@@ -21,7 +21,7 @@ export module Components {
     }
 
     protected _forEach(callback: (component: Component) => any) {
-      this._components.forEach(callback);
+      this.components().forEach(callback);
     }
 
     /**

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -190,6 +190,21 @@ describe("ComponentGroups", () => {
     svg.remove();
   });
 
+  it("destroy()s its Components when destroy()ed", () => {
+    var c1 = new Plottable.Component().classed("component-1", true);
+    var c2 = new Plottable.Component().classed("component-2", true);
+    var cg = new Plottable.Components.Group([c1, c2]);
+
+    var svg = TestMethods.generateSVG(200, 200);
+    cg.renderTo(svg);
+
+    cg.destroy();
+    assert.throws(() => c1.renderTo(svg), Error);
+    assert.throws(() => c2.renderTo(svg), Error);
+
+    svg.remove();
+  });
+
   describe("requests space based on contents, but occupies total offered space", () => {
     var SVG_WIDTH = 400;
     var SVG_HEIGHT = 400;

--- a/test/tests.js
+++ b/test/tests.js
@@ -6225,6 +6225,17 @@ describe("ComponentGroups", function () {
         assert.isNotNull(c1Node, "componet 1 was also added back to the DOM");
         svg.remove();
     });
+    it("destroy()s its Components when destroy()ed", function () {
+        var c1 = new Plottable.Component().classed("component-1", true);
+        var c2 = new Plottable.Component().classed("component-2", true);
+        var cg = new Plottable.Components.Group([c1, c2]);
+        var svg = TestMethods.generateSVG(200, 200);
+        cg.renderTo(svg);
+        cg.destroy();
+        assert.throws(function () { return c1.renderTo(svg); }, Error);
+        assert.throws(function () { return c2.renderTo(svg); }, Error);
+        svg.remove();
+    });
     describe("requests space based on contents, but occupies total offered space", function () {
         var SVG_WIDTH = 400;
         var SVG_HEIGHT = 400;


### PR DESCRIPTION
The list of `Component`s in the implementation of `_forEach()` should be a shallow copy.