### PR TITLE
Classed refactor

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1362,9 +1362,9 @@ declare module Plottable {
          * @returns {Component} The calling Component.
          */
         classed(cssClass: string, addClass: boolean): Component;
+        hasClass(cssClass: string): boolean;
         addClass(cssClass: string): Component;
         removeClass(cssClass: string): Component;
-        hasClass(cssClass: string): boolean;
         /**
          * Checks if the Component has a fixed width or if it grows to fill available space.
          * Returns false by default on the base Component class.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1258,6 +1258,7 @@ declare module Plottable {
         protected _clipPathEnabled: boolean;
         protected _isSetup: boolean;
         protected _isAnchored: boolean;
+        constructor();
         /**
          * Attaches the Component as a child of a given d3 Selection.
          *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1348,20 +1348,6 @@ declare module Plottable {
          * @returns {Component} The calling Component.
          */
         yAlignment(yAlignment: string): Component;
-        /**
-         * Checks if the Component has a given CSS class.
-         *
-         * @param {string} cssClass The CSS class to check for.
-         */
-        classed(cssClass: string): boolean;
-        /**
-         * Adds/removes a given CSS class to/from the Component.
-         *
-         * @param {string} cssClass The CSS class to add or remove.
-         * @param {boolean} addClass If true, adds the provided CSS class; otherwise, removes it.
-         * @returns {Component} The calling Component.
-         */
-        classed(cssClass: string, addClass: boolean): Component;
         hasClass(cssClass: string): boolean;
         addClass(cssClass: string): Component;
         removeClass(cssClass: string): Component;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1348,8 +1348,25 @@ declare module Plottable {
          * @returns {Component} The calling Component.
          */
         yAlignment(yAlignment: string): Component;
+        /**
+         * Checks if the Component has a given CSS class.
+         *
+         * @param {string} cssClass The CSS class to check for.
+         */
         hasClass(cssClass: string): boolean;
+        /**
+         * Adds a given CSS class to the Component.
+         *
+         * @param {string} cssClass The CSS class to add.
+         * @returns {Component} The calling Component.
+         */
         addClass(cssClass: string): Component;
+        /**
+         * Removes a given CSS class from the Component.
+         *
+         * @param {string} cssClass The CSS class to remove.
+         * @returns {Component} The calling Component.
+         */
         removeClass(cssClass: string): Component;
         /**
          * Checks if the Component has a fixed width or if it grows to fill available space.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1362,6 +1362,9 @@ declare module Plottable {
          * @returns {Component} The calling Component.
          */
         classed(cssClass: string, addClass: boolean): Component;
+        addClass(cssClass: string): Component;
+        removeClass(cssClass: string): Component;
+        hasClass(cssClass: string): boolean;
         /**
          * Checks if the Component has a fixed width or if it grows to fill available space.
          * Returns false by default on the base Component class.

--- a/plottable.js
+++ b/plottable.js
@@ -3136,6 +3136,17 @@ var Plottable;
                 return this;
             }
         };
+        Component.prototype.hasClass = function (cssClass) {
+            if (cssClass == null) {
+                return false;
+            }
+            else if (this._element == null) {
+                return (this._cssClasses.indexOf(cssClass) !== -1);
+            }
+            else {
+                return this._element.classed(cssClass);
+            }
+        };
         Component.prototype.addClass = function (cssClass) {
             if (cssClass == null) {
                 return this;
@@ -3165,17 +3176,6 @@ var Plottable;
                 this._element.classed(cssClass, false);
             }
             return this;
-        };
-        Component.prototype.hasClass = function (cssClass) {
-            if (cssClass == null) {
-                return false;
-            }
-            else if (this._element == null) {
-                return (this._cssClasses.indexOf(cssClass) !== -1);
-            }
-            else {
-                return this._element.classed(cssClass);
-            }
         };
         /**
          * Checks if the Component has a fixed width or if it grows to fill available space.

--- a/plottable.js
+++ b/plottable.js
@@ -3105,46 +3105,11 @@ var Plottable;
             var clipPathParent = this._boxContainer.append("clipPath").attr("id", clipPathId);
             this._addBox("clip-rect", clipPathParent);
         };
-        // /**
-        //  * Checks if the Component has a given CSS class.
-        //  *
-        //  * @param {string} cssClass The CSS class to check for.
-        //  */
-        // public classed(cssClass: string): boolean;
-        // /**
-        //  * Adds/removes a given CSS class to/from the Component.
-        //  *
-        //  * @param {string} cssClass The CSS class to add or remove.
-        //  * @param {boolean} addClass If true, adds the provided CSS class; otherwise, removes it.
-        //  * @returns {Component} The calling Component.
-        //  */
-        // public classed(cssClass: string, addClass: boolean): Component;
-        // public classed(cssClass: string, addClass?: boolean): any {
-        //   if (addClass == null) {
-        //     if (cssClass == null) {
-        //       return false;
-        //     } else if (this._element == null) {
-        //       return (this._cssClasses.indexOf(cssClass) !== -1);
-        //     } else {
-        //       return this._element.classed(cssClass);
-        //     }
-        //   } else {
-        //     if (cssClass == null) {
-        //       return this;
-        //     }
-        //     if (this._element == null) {
-        //       var classIndex = this._cssClasses.indexOf(cssClass);
-        //       if (addClass && classIndex === -1) {
-        //         this._cssClasses.push(cssClass);
-        //       } else if (!addClass && classIndex !== -1) {
-        //         this._cssClasses.splice(classIndex, 1);
-        //       }
-        //     } else {
-        //       this._element.classed(cssClass, addClass);
-        //     }
-        //     return this;
-        //   }
-        // }
+        /**
+         * Checks if the Component has a given CSS class.
+         *
+         * @param {string} cssClass The CSS class to check for.
+         */
         Component.prototype.hasClass = function (cssClass) {
             if (cssClass == null) {
                 return false;
@@ -3156,6 +3121,12 @@ var Plottable;
                 return this._element.classed(cssClass);
             }
         };
+        /**
+         * Adds a given CSS class to the Component.
+         *
+         * @param {string} cssClass The CSS class to add.
+         * @returns {Component} The calling Component.
+         */
         Component.prototype.addClass = function (cssClass) {
             if (cssClass == null) {
                 return this;
@@ -3171,6 +3142,12 @@ var Plottable;
             }
             return this;
         };
+        /**
+         * Removes a given CSS class from the Component.
+         *
+         * @param {string} cssClass The CSS class to remove.
+         * @returns {Component} The calling Component.
+         */
         Component.prototype.removeClass = function (cssClass) {
             if (cssClass == null) {
                 return this;

--- a/plottable.js
+++ b/plottable.js
@@ -3137,13 +3137,45 @@ var Plottable;
             }
         };
         Component.prototype.addClass = function (cssClass) {
+            if (cssClass == null) {
+                return this;
+            }
+            if (this._element == null) {
+                var classIndex = this._cssClasses.indexOf(cssClass);
+                if (classIndex === -1) {
+                    this._cssClasses.push(cssClass);
+                }
+            }
+            else {
+                this._element.classed(cssClass, true);
+            }
             return this;
         };
         Component.prototype.removeClass = function (cssClass) {
+            if (cssClass == null) {
+                return this;
+            }
+            if (this._element == null) {
+                var classIndex = this._cssClasses.indexOf(cssClass);
+                if (classIndex !== -1) {
+                    this._cssClasses.splice(classIndex, 1);
+                }
+            }
+            else {
+                this._element.classed(cssClass, false);
+            }
             return this;
         };
         Component.prototype.hasClass = function (cssClass) {
-            return this;
+            if (cssClass == null) {
+                return false;
+            }
+            else if (this._element == null) {
+                return (this._cssClasses.indexOf(cssClass) !== -1);
+            }
+            else {
+                return this._element.classed(cssClass);
+            }
         };
         /**
          * Checks if the Component has a fixed width or if it grows to fill available space.

--- a/plottable.js
+++ b/plottable.js
@@ -3047,8 +3047,7 @@ var Plottable;
                 this.anchor(selection);
             }
             if (this._element == null) {
-                throw new Error("If a Component has never been rendered before, then renderTo must be given a node to render to, \
-          or a d3.Selection, or a selector string");
+                throw new Error("If a Component has never been rendered before, then renderTo must be given a node to render to, " + "or a d3.Selection, or a selector string");
             }
             this.computeLayout();
             this.render();
@@ -3136,6 +3135,15 @@ var Plottable;
                 }
                 return this;
             }
+        };
+        Component.prototype.addClass = function (cssClass) {
+            return this;
+        };
+        Component.prototype.removeClass = function (cssClass) {
+            return this;
+        };
+        Component.prototype.hasClass = function (cssClass) {
+            return this;
         };
         /**
          * Checks if the Component has a fixed width or if it grows to fill available space.

--- a/plottable.js
+++ b/plottable.js
@@ -3105,37 +3105,46 @@ var Plottable;
             var clipPathParent = this._boxContainer.append("clipPath").attr("id", clipPathId);
             this._addBox("clip-rect", clipPathParent);
         };
-        Component.prototype.classed = function (cssClass, addClass) {
-            if (addClass == null) {
-                if (cssClass == null) {
-                    return false;
-                }
-                else if (this._element == null) {
-                    return (this._cssClasses.indexOf(cssClass) !== -1);
-                }
-                else {
-                    return this._element.classed(cssClass);
-                }
-            }
-            else {
-                if (cssClass == null) {
-                    return this;
-                }
-                if (this._element == null) {
-                    var classIndex = this._cssClasses.indexOf(cssClass);
-                    if (addClass && classIndex === -1) {
-                        this._cssClasses.push(cssClass);
-                    }
-                    else if (!addClass && classIndex !== -1) {
-                        this._cssClasses.splice(classIndex, 1);
-                    }
-                }
-                else {
-                    this._element.classed(cssClass, addClass);
-                }
-                return this;
-            }
-        };
+        // /**
+        //  * Checks if the Component has a given CSS class.
+        //  *
+        //  * @param {string} cssClass The CSS class to check for.
+        //  */
+        // public classed(cssClass: string): boolean;
+        // /**
+        //  * Adds/removes a given CSS class to/from the Component.
+        //  *
+        //  * @param {string} cssClass The CSS class to add or remove.
+        //  * @param {boolean} addClass If true, adds the provided CSS class; otherwise, removes it.
+        //  * @returns {Component} The calling Component.
+        //  */
+        // public classed(cssClass: string, addClass: boolean): Component;
+        // public classed(cssClass: string, addClass?: boolean): any {
+        //   if (addClass == null) {
+        //     if (cssClass == null) {
+        //       return false;
+        //     } else if (this._element == null) {
+        //       return (this._cssClasses.indexOf(cssClass) !== -1);
+        //     } else {
+        //       return this._element.classed(cssClass);
+        //     }
+        //   } else {
+        //     if (cssClass == null) {
+        //       return this;
+        //     }
+        //     if (this._element == null) {
+        //       var classIndex = this._cssClasses.indexOf(cssClass);
+        //       if (addClass && classIndex === -1) {
+        //         this._cssClasses.push(cssClass);
+        //       } else if (!addClass && classIndex !== -1) {
+        //         this._cssClasses.splice(classIndex, 1);
+        //       }
+        //     } else {
+        //       this._element.classed(cssClass, addClass);
+        //     }
+        //     return this;
+        //   }
+        // }
         Component.prototype.hasClass = function (cssClass) {
             if (cssClass == null) {
                 return false;
@@ -3438,7 +3447,7 @@ var Plottable;
                 if (components === void 0) { components = []; }
                 _super.call(this);
                 this._components = [];
-                this.classed("component-group", true);
+                this.addClass("component-group");
                 components.forEach(function (c) { return _this.append(c); });
             }
             Group.prototype._forEach = function (callback) {
@@ -3539,12 +3548,12 @@ var Plottable;
             this._scale = scale;
             this.orientation(orientation);
             this._setDefaultAlignment();
-            this.classed("axis", true);
+            this.addClass("axis");
             if (this._isHorizontal()) {
-                this.classed("x-axis", true);
+                this.addClass("x-axis");
             }
             else {
-                this.classed("y-axis", true);
+                this.addClass("y-axis");
             }
             this.formatter(Plottable.Formatters.identity());
             this._rescaleCallback = function (scale) { return _this._rescale(); };
@@ -3859,7 +3868,7 @@ var Plottable;
             function Time(scale, orientation) {
                 _super.call(this, scale, orientation);
                 this._tierLabelPositions = [];
-                this.classed("time-axis", true);
+                this.addClass("time-axis");
                 this.tickLabelPadding(5);
                 this.axisConfigurations(Time._DEFAULT_TIME_AXIS_CONFIGURATIONS);
             }
@@ -4594,7 +4603,7 @@ var Plottable;
             function Category(scale, orientation) {
                 _super.call(this, scale, orientation);
                 this._tickLabelAngle = 0;
-                this.classed("category-axis", true);
+                this.addClass("category-axis");
             }
             Category.prototype._setup = function () {
                 _super.prototype._setup.call(this);
@@ -4785,7 +4794,7 @@ var Plottable;
                 if (displayText === void 0) { displayText = ""; }
                 if (angle === void 0) { angle = 0; }
                 _super.call(this);
-                this.classed("label", true);
+                this.addClass("label");
                 this.text(displayText);
                 this.angle(angle);
                 this.xAlignment("center").yAlignment("center");
@@ -4891,7 +4900,7 @@ var Plottable;
              */
             function TitleLabel(text, angle) {
                 _super.call(this, text, angle);
-                this.classed(TitleLabel.TITLE_LABEL_CLASS, true);
+                this.addClass(TitleLabel.TITLE_LABEL_CLASS);
             }
             TitleLabel.TITLE_LABEL_CLASS = "title-label";
             return TitleLabel;
@@ -4906,7 +4915,7 @@ var Plottable;
              */
             function AxisLabel(text, angle) {
                 _super.call(this, text, angle);
-                this.classed(AxisLabel.AXIS_LABEL_CLASS, true);
+                this.addClass(AxisLabel.AXIS_LABEL_CLASS);
             }
             AxisLabel.AXIS_LABEL_CLASS = "axis-label";
             return AxisLabel;
@@ -4938,7 +4947,7 @@ var Plottable;
                 var _this = this;
                 _super.call(this);
                 this._padding = 5;
-                this.classed("legend", true);
+                this.addClass("legend");
                 this.maxEntriesPerRow(1);
                 if (colorScale == null) {
                     throw new Error("Legend requires a colorScale");
@@ -5205,7 +5214,8 @@ var Plottable;
                 this._scale.onUpdate(this._redrawCallback);
                 this._formatter = Plottable.Formatters.general();
                 this._orientation = "horizontal";
-                this.classed("legend", true).classed("interpolated-color-legend", true);
+                this.addClass("legend");
+                this.addClass("interpolated-color-legend");
             }
             InterpolatedColorLegend.prototype.destroy = function () {
                 _super.prototype.destroy.call(this);
@@ -5421,7 +5431,7 @@ var Plottable;
                     throw new Error("yScale needs to inherit from Scale.QuantitativeScale");
                 }
                 _super.call(this);
-                this.classed("gridlines", true);
+                this.addClass("gridlines");
                 this._xScale = xScale;
                 this._yScale = yScale;
                 this._renderCallback = function (scale) { return _this.render(); };
@@ -5518,7 +5528,7 @@ var Plottable;
                 this._nRows = 0;
                 this._nCols = 0;
                 this._calculatedLayout = null;
-                this.classed("table", true);
+                this.addClass("table");
                 rows.forEach(function (row, rowIndex) {
                     row.forEach(function (component, colIndex) {
                         if (component != null) {
@@ -5860,7 +5870,7 @@ var Plottable;
                     topLeft: { x: 0, y: 0 },
                     bottomRight: { x: 0, y: 0 }
                 };
-                this.classed("selection-box-layer", true);
+                this.addClass("selection-box-layer");
             }
             SelectionBoxLayer.prototype._setup = function () {
                 _super.prototype._setup.call(this);
@@ -5963,7 +5973,7 @@ var Plottable;
             this._animate = false;
             this._animators = {};
             this._clipPathEnabled = true;
-            this.classed("plot", true);
+            this.addClass("plot");
             this._datasetToDrawer = new Plottable.Utils.Map();
             this._attrBindings = d3.map();
             this._attrExtents = d3.map();
@@ -6377,7 +6387,7 @@ var Plottable;
                 _super.call(this);
                 this.innerRadius(0);
                 this.outerRadius(function () { return Math.min(_this.width(), _this.height()) / 2; });
-                this.classed("pie-plot", true);
+                this.addClass("pie-plot");
                 this.attr("fill", function (d, i) { return String(i); }, new Plottable.Scales.Color());
             }
             Pie.prototype.computeLayout = function (origin, availableWidth, availableHeight) {
@@ -6531,7 +6541,7 @@ var Plottable;
             _super.call(this);
             this._autoAdjustXScaleDomain = false;
             this._autoAdjustYScaleDomain = false;
-            this.classed("xy-plot", true);
+            this.addClass("xy-plot");
             this._adjustYDomainOnChangeFromXCallback = function (scale) { return _this._adjustYDomainOnChangeFromX(); };
             this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
         }
@@ -6753,7 +6763,7 @@ var Plottable;
             function Rectangle() {
                 _super.call(this);
                 this.animator("rectangles", new Plottable.Animators.Null());
-                this.classed("rectangle-plot", true);
+                this.addClass("rectangle-plot");
             }
             Rectangle.prototype._getDrawer = function (dataset) {
                 return new Plottable.Drawers.Rectangle(dataset);
@@ -6936,7 +6946,7 @@ var Plottable;
              */
             function Scatter() {
                 _super.call(this);
-                this.classed("scatter-plot", true);
+                this.addClass("scatter-plot");
                 var animator = new Plottable.Animators.Easing();
                 animator.startDelay(5);
                 animator.stepDuration(250);
@@ -7034,7 +7044,7 @@ var Plottable;
                 this._labelFormatter = Plottable.Formatters.identity();
                 this._labelsEnabled = false;
                 this._hideBarsIfAnyAreTooWide = true;
-                this.classed("bar-plot", true);
+                this.addClass("bar-plot");
                 if (orientation !== Bar.ORIENTATION_VERTICAL && orientation !== Bar.ORIENTATION_HORIZONTAL) {
                     throw new Error(orientation + " is not a valid orientation for Plots.Bar");
                 }
@@ -7497,7 +7507,7 @@ var Plottable;
              */
             function Line() {
                 _super.call(this);
-                this.classed("line-plot", true);
+                this.addClass("line-plot");
                 var animator = new Plottable.Animators.Easing();
                 animator.stepDuration(Plottable.Plot.ANIMATION_MAX_DURATION);
                 animator.easingMode("exp-in-out");
@@ -7615,7 +7625,7 @@ var Plottable;
              */
             function Area() {
                 _super.call(this);
-                this.classed("area-plot", true);
+                this.addClass("area-plot");
                 this.y0(0); // default
                 this.attr("fill-opacity", 0.25);
                 this.attr("fill", new Plottable.Scales.Color().range()[0]);
@@ -7847,7 +7857,7 @@ var Plottable;
                 var _this = this;
                 _super.call(this);
                 this._baselineValue = 0;
-                this.classed("stacked-area-plot", true);
+                this.addClass("stacked-area-plot");
                 this.attr("fill-opacity", 1);
                 this._stackOffsets = new Plottable.Utils.Map();
                 this._stackedExtent = [];
@@ -7995,7 +8005,7 @@ var Plottable;
             function StackedBar(orientation) {
                 if (orientation === void 0) { orientation = Plots.Bar.ORIENTATION_VERTICAL; }
                 _super.call(this, orientation);
-                this.classed("stacked-bar-plot", true);
+                this.addClass("stacked-bar-plot");
                 this._stackOffsets = new Plottable.Utils.Map();
                 this._stackedExtent = [];
             }
@@ -9501,7 +9511,7 @@ var Plottable;
                  * wouldn't be able to grab the edges or corners for resizing.
                  */
                 this._clipPathEnabled = true;
-                this.classed("drag-box-layer", true);
+                this.addClass("drag-box-layer");
                 this._dragInteraction = new Plottable.Interactions.Drag();
                 this._setUpCallbacks();
                 this._dragInteraction.attachTo(this);
@@ -9680,8 +9690,14 @@ var Plottable;
             };
             // Sets resizable classes. Overridden by subclasses that only resize in one dimension.
             DragBoxLayer.prototype._setResizableClasses = function (canResize) {
-                this.classed("x-resizable", canResize);
-                this.classed("y-resizable", canResize);
+                if (canResize) {
+                    this.addClass("x-resizable");
+                    this.addClass("y-resizable");
+                }
+                else {
+                    this.removeClass("x-resizable");
+                    this.removeClass("y-resizable");
+                }
             };
             /**
              * Sets the callback to be called when dragging starts.
@@ -9776,7 +9792,7 @@ var Plottable;
              */
             function XDragBoxLayer() {
                 _super.call(this);
-                this.classed("x-drag-box-layer", true);
+                this.addClass("x-drag-box-layer");
                 this._hasCorners = false;
             }
             XDragBoxLayer.prototype.computeLayout = function (origin, availableWidth, availableHeight) {
@@ -9791,7 +9807,12 @@ var Plottable;
                 });
             };
             XDragBoxLayer.prototype._setResizableClasses = function (canResize) {
-                this.classed("x-resizable", canResize);
+                if (canResize) {
+                    this.addClass("x-resizable");
+                }
+                else {
+                    this.removeClass("x-resizable");
+                }
             };
             return XDragBoxLayer;
         })(Components.DragBoxLayer);
@@ -9820,7 +9841,7 @@ var Plottable;
              */
             function YDragBoxLayer() {
                 _super.call(this);
-                this.classed("y-drag-box-layer", true);
+                this.addClass("y-drag-box-layer");
                 this._hasCorners = false;
             }
             YDragBoxLayer.prototype.computeLayout = function (origin, availableWidth, availableHeight) {
@@ -9835,7 +9856,12 @@ var Plottable;
                 });
             };
             YDragBoxLayer.prototype._setResizableClasses = function (canResize) {
-                this.classed("y-resizable", canResize);
+                if (canResize) {
+                    this.addClass("y-resizable");
+                }
+                else {
+                    this.removeClass("y-resizable");
+                }
             };
             return YDragBoxLayer;
         })(Components.DragBoxLayer);

--- a/plottable.js
+++ b/plottable.js
@@ -2839,10 +2839,11 @@ var Plottable;
             this._isAnchored = false;
             this._boxes = [];
             this._isTopLevelComponent = false;
-            this._cssClasses = ["component"];
+            this._cssClasses = new Plottable.Utils.Set();
             this._destroyed = false;
             this._onAnchorCallbacks = new Plottable.Utils.CallbackSet();
             this._onDetachCallbacks = new Plottable.Utils.CallbackSet();
+            this._cssClasses.add("component");
         }
         /**
          * Attaches the Component as a child of a given d3 Selection.
@@ -2912,7 +2913,7 @@ var Plottable;
             this._cssClasses.forEach(function (cssClass) {
                 _this._element.classed(cssClass, true);
             });
-            this._cssClasses = null;
+            this._cssClasses = new Plottable.Utils.Set();
             this._backgroundContainer = this._element.append("g").classed("background-container", true);
             this._addBox("background-fill", this._backgroundContainer);
             this._content = this._element.append("g").classed("content", true);
@@ -3115,7 +3116,7 @@ var Plottable;
                 return false;
             }
             else if (this._element == null) {
-                return (this._cssClasses.indexOf(cssClass) !== -1);
+                return this._cssClasses.has(cssClass);
             }
             else {
                 return this._element.classed(cssClass);
@@ -3132,10 +3133,7 @@ var Plottable;
                 return this;
             }
             if (this._element == null) {
-                var classIndex = this._cssClasses.indexOf(cssClass);
-                if (classIndex === -1) {
-                    this._cssClasses.push(cssClass);
-                }
+                this._cssClasses.add(cssClass);
             }
             else {
                 this._element.classed(cssClass, true);
@@ -3153,10 +3151,7 @@ var Plottable;
                 return this;
             }
             if (this._element == null) {
-                var classIndex = this._cssClasses.indexOf(cssClass);
-                if (classIndex !== -1) {
-                    this._cssClasses.splice(classIndex, 1);
-                }
+                this._cssClasses.delete(cssClass);
             }
             else {
                 this._element.classed(cssClass, false);

--- a/plottable.js
+++ b/plottable.js
@@ -3115,7 +3115,7 @@ var Plottable;
             if (cssClass == null) {
                 return false;
             }
-            else if (this._element == null) {
+            if (this._element == null) {
                 return this._cssClasses.has(cssClass);
             }
             else {

--- a/quicktests/overlaying/tests/basic/negative_stacked_bar.js
+++ b/quicktests/overlaying/tests/basic/negative_stacked_bar.js
@@ -27,7 +27,7 @@ function run(svg, data, Plottable) {
   var legend = new Plottable.Components.Legend(colorScale);
   legend.xAlignment("center");
 
-  var title = new Plottable.Components.Label("Sample Net Earnings by Teams").classed("title-label", true);
+  var title = new Plottable.Components.Label("Sample Net Earnings by Teams").addClass("title-label");
 
   var dataset1 = new Plottable.Dataset(data[0]);
   var dataset2 = new Plottable.Dataset(data[1]);

--- a/quicktests/overlaying/tests/functional/titleLegend_change.js
+++ b/quicktests/overlaying/tests/functional/titleLegend_change.js
@@ -104,7 +104,7 @@ function run(svg, data, Plottable) {
   twoPlots();
 
   //title + legend
-  var title1 = new Plottable.Components.Label( "Two Data Series", 0).classed("title-label", true);
+  var title1 = new Plottable.Components.Label( "Two Data Series", 0).addClass("title-label");
   var legend1 = new Plottable.Components.Legend(colorScale1);
   legend1.maxEntriesPerRow(1);
   var titleTable = new Plottable.Components.Table([[title1, legend1]]);

--- a/quicktests/overlaying/tests/interactions/interaction_BarHover.js
+++ b/quicktests/overlaying/tests/interactions/interaction_BarHover.js
@@ -10,7 +10,7 @@ function run(svg, data, Plottable) {
   var yScale = new Plottable.Scales.Linear();
   var xAxis = new Plottable.Axes.Category(xScale, "bottom");
   var yAxis = new Plottable.Axes.Numeric(yScale, "left");
-  var title = new Plottable.Components.Label("Hover over bars").classed("title-label", true);
+  var title = new Plottable.Components.Label("Hover over bars").addClass("title-label");
   var colorScale = new Plottable.Scales.Color();
 
   var ds = new Plottable.Dataset(data, { foo: "!" });

--- a/quicktests/overlaying/tests/interactions/interaction_hover_scatter.js
+++ b/quicktests/overlaying/tests/interactions/interaction_hover_scatter.js
@@ -13,7 +13,7 @@ function run(svg, data, Plottable) {
   var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
   var yAxis = new Plottable.Axes.Numeric(yScale, "left");
   var defaultTitleText = "Hover over points";
-  var title = new Plottable.Components.Label(defaultTitleText).classed("title-label", true);
+  var title = new Plottable.Components.Label(defaultTitleText).addClass("title-label");
 
   var ds1 = new Plottable.Dataset(data[0], { color: "blue", size: 20 });
   var ds2 = new Plottable.Dataset(data[1], { color: "red", size: 30 });

--- a/quicktests/overlaying/tests/realistic/basic_pie_real.js
+++ b/quicktests/overlaying/tests/realistic/basic_pie_real.js
@@ -27,7 +27,7 @@ function run(svg, data, Plottable) {
   var colorScale = new Plottable.Scales.Color();
   var legend = new Plottable.Components.Legend(colorScale).xAlignment("left");
   legend.maxEntriesPerRow(1);
-  var title = new Plottable.Components.Label("Sales by Region").classed("title-label", true);
+  var title = new Plottable.Components.Label("Sales by Region").addClass("title-label");
   var Alabel = new Plottable.Components.Label("Product A");
   var Blabel = new Plottable.Components.Label("Product B");
   var ABlabel = new Plottable.Components.Label("Combined");

--- a/src/components/axes/axis.ts
+++ b/src/components/axes/axis.ts
@@ -43,11 +43,11 @@ module Plottable {
       this._scale = scale;
       this.orientation(orientation);
       this._setDefaultAlignment();
-      this.classed("axis", true);
+      this.addClass("axis");
       if (this._isHorizontal()) {
-        this.classed("x-axis", true);
+        this.addClass("x-axis");
       } else {
-        this.classed("y-axis", true);
+        this.addClass("y-axis");
       }
 
       this.formatter(Formatters.identity());

--- a/src/components/axes/categoryAxis.ts
+++ b/src/components/axes/categoryAxis.ts
@@ -19,7 +19,7 @@ export module Axes {
      */
     constructor(scale: Scales.Category, orientation: string) {
       super(scale, orientation);
-      this.classed("category-axis", true);
+      this.addClass("category-axis");
     }
 
     protected _setup() {

--- a/src/components/axes/timeAxis.ts
+++ b/src/components/axes/timeAxis.ts
@@ -174,7 +174,7 @@ export module Axes {
      */
     constructor(scale: Scales.Time, orientation: string) {
       super(scale, orientation);
-      this.classed("time-axis", true);
+      this.addClass("time-axis");
       this.tickLabelPadding(5);
       this.axisConfigurations(Time._DEFAULT_TIME_AXIS_CONFIGURATIONS);
     }

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -263,8 +263,8 @@ module Plottable {
         this.anchor(selection);
       }
       if (this._element == null) {
-        throw new Error("If a Component has never been rendered before, then renderTo must be given a node to render to, \
-          or a d3.Selection, or a selector string");
+        throw new Error("If a Component has never been rendered before, then renderTo must be given a node to render to, " +
+          "or a d3.Selection, or a selector string");
       }
       this.computeLayout();
       this.render();
@@ -390,6 +390,18 @@ module Plottable {
         }
         return this;
       }
+    }
+
+    public addClass(cssClass) {
+      return this;
+    }
+
+    public removeClass(cssClass) {
+      return this;
+    }
+
+    public hasClass(cssClass) {
+      return this;
     }
 
     /**

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -392,16 +392,48 @@ module Plottable {
       }
     }
 
-    public addClass(cssClass) {
+    public addClass(cssClass: string) {
+      if (cssClass == null) {
+        return this;
+      }
+
+      if (this._element == null) {
+        var classIndex = this._cssClasses.indexOf(cssClass);
+        if (classIndex === -1) {
+          this._cssClasses.push(cssClass);
+        }
+      } else {
+        this._element.classed(cssClass, true);
+      }
+
       return this;
     }
 
-    public removeClass(cssClass) {
+    public removeClass(cssClass: string) {
+      if (cssClass == null) {
+        return this;
+      }
+
+      if (this._element == null) {
+        var classIndex = this._cssClasses.indexOf(cssClass);
+        if (classIndex !== -1) {
+          this._cssClasses.splice(classIndex, 1);
+        }
+      } else {
+        this._element.classed(cssClass, false);
+      }
+
       return this;
     }
 
-    public hasClass(cssClass) {
-      return this;
+    public hasClass(cssClass: string) {
+      if (cssClass == null) {
+        return false;
+      } else if (this._element == null) {
+        return (this._cssClasses.indexOf(cssClass) !== -1);
+      } else {
+        return this._element.classed(cssClass);
+      }
     }
 
     /**

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -351,47 +351,11 @@ module Plottable {
       this._addBox("clip-rect", clipPathParent);
     }
 
-    // /**
-    //  * Checks if the Component has a given CSS class.
-    //  *
-    //  * @param {string} cssClass The CSS class to check for.
-    //  */
-    // public classed(cssClass: string): boolean;
-    // /**
-    //  * Adds/removes a given CSS class to/from the Component.
-    //  *
-    //  * @param {string} cssClass The CSS class to add or remove.
-    //  * @param {boolean} addClass If true, adds the provided CSS class; otherwise, removes it.
-    //  * @returns {Component} The calling Component.
-    //  */
-    // public classed(cssClass: string, addClass: boolean): Component;
-    // public classed(cssClass: string, addClass?: boolean): any {
-    //   if (addClass == null) {
-    //     if (cssClass == null) {
-    //       return false;
-    //     } else if (this._element == null) {
-    //       return (this._cssClasses.indexOf(cssClass) !== -1);
-    //     } else {
-    //       return this._element.classed(cssClass);
-    //     }
-    //   } else {
-    //     if (cssClass == null) {
-    //       return this;
-    //     }
-    //     if (this._element == null) {
-    //       var classIndex = this._cssClasses.indexOf(cssClass);
-    //       if (addClass && classIndex === -1) {
-    //         this._cssClasses.push(cssClass);
-    //       } else if (!addClass && classIndex !== -1) {
-    //         this._cssClasses.splice(classIndex, 1);
-    //       }
-    //     } else {
-    //       this._element.classed(cssClass, addClass);
-    //     }
-    //     return this;
-    //   }
-    // }
-
+    /**
+     * Checks if the Component has a given CSS class.
+     *
+     * @param {string} cssClass The CSS class to check for.
+     */
     public hasClass(cssClass: string) {
       if (cssClass == null) {
         return false;
@@ -402,6 +366,12 @@ module Plottable {
       }
     }
 
+    /**
+     * Adds a given CSS class to the Component.
+     *
+     * @param {string} cssClass The CSS class to add.
+     * @returns {Component} The calling Component.
+     */
     public addClass(cssClass: string) {
       if (cssClass == null) {
         return this;
@@ -419,6 +389,12 @@ module Plottable {
       return this;
     }
 
+    /**
+     * Removes a given CSS class from the Component.
+     *
+     * @param {string} cssClass The CSS class to remove.
+     * @returns {Component} The calling Component.
+     */
     public removeClass(cssClass: string) {
       if (cssClass == null) {
         return this;

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -392,6 +392,16 @@ module Plottable {
       }
     }
 
+    public hasClass(cssClass: string) {
+      if (cssClass == null) {
+        return false;
+      } else if (this._element == null) {
+        return (this._cssClasses.indexOf(cssClass) !== -1);
+      } else {
+        return this._element.classed(cssClass);
+      }
+    }
+
     public addClass(cssClass: string) {
       if (cssClass == null) {
         return this;
@@ -424,16 +434,6 @@ module Plottable {
       }
 
       return this;
-    }
-
-    public hasClass(cssClass: string) {
-      if (cssClass == null) {
-        return false;
-      } else if (this._element == null) {
-        return (this._cssClasses.indexOf(cssClass) !== -1);
-      } else {
-        return this._element.classed(cssClass);
-      }
     }
 
     /**

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -351,46 +351,46 @@ module Plottable {
       this._addBox("clip-rect", clipPathParent);
     }
 
-    /**
-     * Checks if the Component has a given CSS class.
-     *
-     * @param {string} cssClass The CSS class to check for.
-     */
-    public classed(cssClass: string): boolean;
-    /**
-     * Adds/removes a given CSS class to/from the Component.
-     *
-     * @param {string} cssClass The CSS class to add or remove.
-     * @param {boolean} addClass If true, adds the provided CSS class; otherwise, removes it.
-     * @returns {Component} The calling Component.
-     */
-    public classed(cssClass: string, addClass: boolean): Component;
-    public classed(cssClass: string, addClass?: boolean): any {
-      if (addClass == null) {
-        if (cssClass == null) {
-          return false;
-        } else if (this._element == null) {
-          return (this._cssClasses.indexOf(cssClass) !== -1);
-        } else {
-          return this._element.classed(cssClass);
-        }
-      } else {
-        if (cssClass == null) {
-          return this;
-        }
-        if (this._element == null) {
-          var classIndex = this._cssClasses.indexOf(cssClass);
-          if (addClass && classIndex === -1) {
-            this._cssClasses.push(cssClass);
-          } else if (!addClass && classIndex !== -1) {
-            this._cssClasses.splice(classIndex, 1);
-          }
-        } else {
-          this._element.classed(cssClass, addClass);
-        }
-        return this;
-      }
-    }
+    // /**
+    //  * Checks if the Component has a given CSS class.
+    //  *
+    //  * @param {string} cssClass The CSS class to check for.
+    //  */
+    // public classed(cssClass: string): boolean;
+    // /**
+    //  * Adds/removes a given CSS class to/from the Component.
+    //  *
+    //  * @param {string} cssClass The CSS class to add or remove.
+    //  * @param {boolean} addClass If true, adds the provided CSS class; otherwise, removes it.
+    //  * @returns {Component} The calling Component.
+    //  */
+    // public classed(cssClass: string, addClass: boolean): Component;
+    // public classed(cssClass: string, addClass?: boolean): any {
+    //   if (addClass == null) {
+    //     if (cssClass == null) {
+    //       return false;
+    //     } else if (this._element == null) {
+    //       return (this._cssClasses.indexOf(cssClass) !== -1);
+    //     } else {
+    //       return this._element.classed(cssClass);
+    //     }
+    //   } else {
+    //     if (cssClass == null) {
+    //       return this;
+    //     }
+    //     if (this._element == null) {
+    //       var classIndex = this._cssClasses.indexOf(cssClass);
+    //       if (addClass && classIndex === -1) {
+    //         this._cssClasses.push(cssClass);
+    //       } else if (!addClass && classIndex !== -1) {
+    //         this._cssClasses.splice(classIndex, 1);
+    //       }
+    //     } else {
+    //       this._element.classed(cssClass, addClass);
+    //     }
+    //     return this;
+    //   }
+    // }
 
     public hasClass(cssClass: string) {
       if (cssClass == null) {

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -49,7 +49,6 @@ module Plottable {
     private _onAnchorCallbacks = new Utils.CallbackSet<ComponentCallback>();
     private _onDetachCallbacks = new Utils.CallbackSet<ComponentCallback>();
 
-
     public constructor() {
       this._cssClasses.add("component");
     }
@@ -364,7 +363,9 @@ module Plottable {
     public hasClass(cssClass: string) {
       if (cssClass == null) {
         return false;
-      } else if (this._element == null) {
+      }
+
+      if (this._element == null) {
         return this._cssClasses.has(cssClass);
       } else {
         return this._element.classed(cssClass);

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -44,10 +44,15 @@ module Plottable {
     private _isTopLevelComponent = false;
     private _width: number; // Width and height of the Component. Used to size the hitbox, bounding box, etc
     private _height: number;
-    private _cssClasses: string[] = ["component"];
+    private _cssClasses = new Utils.Set<string>();
     private _destroyed = false;
     private _onAnchorCallbacks = new Utils.CallbackSet<ComponentCallback>();
     private _onDetachCallbacks = new Utils.CallbackSet<ComponentCallback>();
+
+
+    public constructor() {
+      this._cssClasses.add("component");
+    }
 
     /**
      * Attaches the Component as a child of a given d3 Selection.
@@ -120,7 +125,7 @@ module Plottable {
       this._cssClasses.forEach((cssClass: string) => {
         this._element.classed(cssClass, true);
       });
-      this._cssClasses = null;
+      this._cssClasses = new Utils.Set<string>();
 
       this._backgroundContainer = this._element.append("g").classed("background-container", true);
       this._addBox("background-fill", this._backgroundContainer);
@@ -360,7 +365,7 @@ module Plottable {
       if (cssClass == null) {
         return false;
       } else if (this._element == null) {
-        return (this._cssClasses.indexOf(cssClass) !== -1);
+        return this._cssClasses.has(cssClass);
       } else {
         return this._element.classed(cssClass);
       }
@@ -378,10 +383,7 @@ module Plottable {
       }
 
       if (this._element == null) {
-        var classIndex = this._cssClasses.indexOf(cssClass);
-        if (classIndex === -1) {
-          this._cssClasses.push(cssClass);
-        }
+        this._cssClasses.add(cssClass);
       } else {
         this._element.classed(cssClass, true);
       }
@@ -401,10 +403,7 @@ module Plottable {
       }
 
       if (this._element == null) {
-        var classIndex = this._cssClasses.indexOf(cssClass);
-        if (classIndex !== -1) {
-          this._cssClasses.splice(classIndex, 1);
-        }
+        this._cssClasses.delete(cssClass);
       } else {
         this._element.classed(cssClass, false);
       }

--- a/src/components/dragBoxLayer.ts
+++ b/src/components/dragBoxLayer.ts
@@ -49,7 +49,7 @@ export module Components {
        * wouldn't be able to grab the edges or corners for resizing.
        */
       this._clipPathEnabled = true;
-      this.classed("drag-box-layer", true);
+      this.addClass("drag-box-layer");
 
       this._dragInteraction = new Interactions.Drag();
       this._setUpCallbacks();
@@ -263,8 +263,13 @@ export module Components {
 
     // Sets resizable classes. Overridden by subclasses that only resize in one dimension.
     protected _setResizableClasses(canResize: boolean) {
-      this.classed("x-resizable", canResize);
-      this.classed("y-resizable", canResize);
+      if (canResize) {
+        this.addClass("x-resizable");
+        this.addClass("y-resizable");
+      } else {
+        this.removeClass("x-resizable");
+        this.removeClass("y-resizable");
+      }
     }
 
     /**

--- a/src/components/gridlines.ts
+++ b/src/components/gridlines.ts
@@ -23,7 +23,7 @@ export module Components {
         throw new Error("yScale needs to inherit from Scale.QuantitativeScale");
       }
       super();
-      this.classed("gridlines", true);
+      this.addClass("gridlines");
       this._xScale = xScale;
       this._yScale = yScale;
       this._renderCallback = (scale) => this.render();

--- a/src/components/group.ts
+++ b/src/components/group.ts
@@ -16,7 +16,7 @@ export module Components {
      */
     constructor(components: Component[] = []) {
       super();
-      this.classed("component-group", true);
+      this.addClass("component-group");
       components.forEach((c: Component) => this.append(c));
     }
 

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -44,7 +44,8 @@ export module Components {
       this._formatter = Formatters.general();
       this._orientation = "horizontal";
 
-      this.classed("legend", true).classed("interpolated-color-legend", true);
+      this.addClass("legend");
+      this.addClass("interpolated-color-legend");
     }
 
     public destroy() {

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -20,7 +20,7 @@ export module Components {
      */
     constructor(displayText = "", angle = 0) {
       super();
-      this.classed("label", true);
+      this.addClass("label");
       this.text(displayText);
       this.angle(angle);
       this.xAlignment("center").yAlignment("center");
@@ -162,7 +162,7 @@ export module Components {
      */
     constructor(text?: string, angle?: number) {
       super(text, angle);
-      this.classed(TitleLabel.TITLE_LABEL_CLASS, true);
+      this.addClass(TitleLabel.TITLE_LABEL_CLASS);
     }
   }
 
@@ -175,7 +175,7 @@ export module Components {
      */
     constructor(text?: string, angle?: number) {
       super(text, angle);
-      this.classed(AxisLabel.AXIS_LABEL_CLASS, true);
+      this.addClass(AxisLabel.AXIS_LABEL_CLASS);
     }
   }
 }

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -34,7 +34,7 @@ export module Components {
      */
     constructor(colorScale: Scales.Color) {
       super();
-      this.classed("legend", true);
+      this.addClass("legend");
       this.maxEntriesPerRow(1);
 
       if (colorScale == null ) {
@@ -206,9 +206,9 @@ export module Components {
     }
 
     /**
-     * Gets the Entities (representing Legend entries) at a particular point. 
+     * Gets the Entities (representing Legend entries) at a particular point.
      * Returns an empty array if no Entities are present at that location.
-     * 
+     *
      * @param {Point} p
      * @returns {Entity<Legend>[]}
      */

--- a/src/components/plots/areaPlot.ts
+++ b/src/components/plots/areaPlot.ts
@@ -16,7 +16,7 @@ export module Plots {
      */
     constructor() {
       super();
-      this.classed("area-plot", true);
+      this.addClass("area-plot");
       this.y0(0); // default
       this.attr("fill-opacity", 0.25);
       this.attr("fill", new Scales.Color().range()[0]);

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -35,7 +35,7 @@ export module Plots {
      */
     constructor(orientation = Bar.ORIENTATION_VERTICAL) {
       super();
-      this.classed("bar-plot", true);
+      this.addClass("bar-plot");
       if (orientation !== Bar.ORIENTATION_VERTICAL && orientation !== Bar.ORIENTATION_HORIZONTAL) {
         throw new Error(orientation + " is not a valid orientation for Plots.Bar");
       }

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -11,7 +11,7 @@ export module Plots {
      */
     constructor() {
       super();
-      this.classed("line-plot", true);
+      this.addClass("line-plot");
       var animator = new Animators.Easing();
       animator.stepDuration(Plot.ANIMATION_MAX_DURATION);
       animator.easingMode("exp-in-out");

--- a/src/components/plots/piePlot.ts
+++ b/src/components/plots/piePlot.ts
@@ -17,7 +17,7 @@ export module Plots {
       super();
       this.innerRadius(0);
       this.outerRadius(() => Math.min(this.width(), this.height()) / 2);
-      this.classed("pie-plot", true);
+      this.addClass("pie-plot");
       this.attr("fill", (d, i) => String(i), new Scales.Color());
     }
 

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -46,7 +46,7 @@ module Plottable {
     constructor() {
       super();
       this._clipPathEnabled = true;
-      this.classed("plot", true);
+      this.addClass("plot");
       this._datasetToDrawer = new Utils.Map<Dataset, Drawer>();
       this._attrBindings = d3.map<Plots.AccessorScaleBinding<any, any>>();
       this._attrExtents = d3.map<any[]>();

--- a/src/components/plots/rectanglePlot.ts
+++ b/src/components/plots/rectanglePlot.ts
@@ -21,7 +21,7 @@ export module Plots {
       super();
 
       this.animator("rectangles", new Animators.Null());
-      this.classed("rectangle-plot", true);
+      this.addClass("rectangle-plot");
     }
 
     protected _getDrawer(dataset: Dataset) {

--- a/src/components/plots/scatterPlot.ts
+++ b/src/components/plots/scatterPlot.ts
@@ -15,7 +15,7 @@ export module Plots {
      */
     constructor() {
       super();
-      this.classed("scatter-plot", true);
+      this.addClass("scatter-plot");
       var animator = new Animators.Easing();
       animator.startDelay(5);
       animator.stepDuration(250);

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -17,7 +17,7 @@ export module Plots {
      */
     constructor() {
       super();
-      this.classed("stacked-area-plot", true);
+      this.addClass("stacked-area-plot");
       this.attr("fill-opacity", 1);
       this._stackOffsets = new Utils.Map<Dataset, d3.Map<number>>();
       this._stackedExtent = [];

--- a/src/components/plots/stackedBarPlot.ts
+++ b/src/components/plots/stackedBarPlot.ts
@@ -18,7 +18,7 @@ export module Plots {
      */
     constructor(orientation = Bar.ORIENTATION_VERTICAL) {
       super(orientation);
-      this.classed("stacked-bar-plot", true);
+      this.addClass("stacked-bar-plot");
       this._stackOffsets = new Utils.Map<Dataset, d3.Map<number>>();
       this._stackedExtent = [];
     }

--- a/src/components/plots/xyPlot.ts
+++ b/src/components/plots/xyPlot.ts
@@ -18,7 +18,7 @@ module Plottable {
      */
     constructor() {
       super();
-      this.classed("xy-plot", true);
+      this.addClass("xy-plot");
 
       this._adjustYDomainOnChangeFromXCallback = (scale) => this._adjustYDomainOnChangeFromX();
       this._adjustXDomainOnChangeFromYCallback = (scale) => this._adjustXDomainOnChangeFromY();

--- a/src/components/selectionBoxLayer.ts
+++ b/src/components/selectionBoxLayer.ts
@@ -13,7 +13,7 @@ export module Components {
 
     constructor() {
       super();
-      this.classed("selection-box-layer", true);
+      this.addClass("selection-box-layer");
     }
 
     protected _setup() {

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -46,7 +46,7 @@ export module Components {
      */
     constructor(rows: Component[][] = []) {
       super();
-      this.classed("table", true);
+      this.addClass("table");
       rows.forEach((row, rowIndex) => {
         row.forEach((component, colIndex) => {
           if (component != null) {

--- a/src/components/xDragBoxLayer.ts
+++ b/src/components/xDragBoxLayer.ts
@@ -11,7 +11,7 @@ export module Components {
      */
     constructor() {
       super();
-      this.classed("x-drag-box-layer", true);
+      this.addClass("x-drag-box-layer");
       this._hasCorners = false;
     }
 
@@ -29,7 +29,11 @@ export module Components {
     }
 
     protected _setResizableClasses(canResize: boolean) {
-      this.classed("x-resizable", canResize);
+      if (canResize) {
+        this.addClass("x-resizable");
+      } else {
+        this.removeClass("x-resizable");
+      }
     }
   }
 }

--- a/src/components/yDragBoxLayer.ts
+++ b/src/components/yDragBoxLayer.ts
@@ -11,7 +11,7 @@ export module Components {
      */
     constructor() {
       super();
-      this.classed("y-drag-box-layer", true);
+      this.addClass("y-drag-box-layer");
       this._hasCorners = false;
     }
 
@@ -29,7 +29,11 @@ export module Components {
     }
 
     protected _setResizableClasses(canResize: boolean) {
-      this.classed("y-resizable", canResize);
+      if (canResize) {
+        this.addClass("y-resizable");
+      } else {
+        this.removeClass("y-resizable");
+      }
     }
   }
 }

--- a/test/core/componentGroupTests.ts
+++ b/test/core/componentGroupTests.ts
@@ -152,8 +152,8 @@ describe("ComponentGroups", () => {
   });
 
   it("detach()", () => {
-    var c1 = new Plottable.Component().classed("component-1", true);
-    var c2 = new Plottable.Component().classed("component-2", true);
+    var c1 = new Plottable.Component().addClass("component-1");
+    var c2 = new Plottable.Component().addClass("component-2");
     var cg = new Plottable.Components.Group([c1, c2]);
 
     var svg = TestMethods.generateSVG(200, 200);

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -298,24 +298,24 @@ describe("Component behavior", () => {
   });
 
   it("css classing works as expected", () => {
-    assert.isFalse(c.classed("CSS-PREANCHOR-KEEP"));
-    c.classed("CSS-PREANCHOR-KEEP", true);
-    assert.isTrue(c.classed("CSS-PREANCHOR-KEEP"));
-    c.classed("CSS-PREANCHOR-REMOVE", true);
-    assert.isTrue(c.classed("CSS-PREANCHOR-REMOVE"));
-    c.classed("CSS-PREANCHOR-REMOVE", false);
-    assert.isFalse(c.classed("CSS-PREANCHOR-REMOVE"));
+    assert.isFalse(c.hasClass("CSS-PREANCHOR-KEEP"));
+    c.addClass("CSS-PREANCHOR-KEEP");
+    assert.isTrue(c.hasClass("CSS-PREANCHOR-KEEP"));
+    c.addClass("CSS-PREANCHOR-REMOVE");
+    assert.isTrue(c.hasClass("CSS-PREANCHOR-REMOVE"));
+    c.removeClass("CSS-PREANCHOR-REMOVE");
+    assert.isFalse(c.hasClass("CSS-PREANCHOR-REMOVE"));
 
     c.anchor(svg);
-    assert.isTrue(c.classed("CSS-PREANCHOR-KEEP"));
-    assert.isFalse(c.classed("CSS-PREANCHOR-REMOVE"));
-    assert.isFalse(c.classed("CSS-POSTANCHOR"));
-    c.classed("CSS-POSTANCHOR", true);
-    assert.isTrue(c.classed("CSS-POSTANCHOR"));
-    c.classed("CSS-POSTANCHOR", false);
-    assert.isFalse(c.classed("CSS-POSTANCHOR"));
-    assert.isFalse(c.classed(undefined), "returns false when classed called w/ undefined");
-    assert.strictEqual(c.classed(undefined, true), c, "returns this when classed called w/ undefined and true");
+    assert.isTrue(c.hasClass("CSS-PREANCHOR-KEEP"));
+    assert.isFalse(c.hasClass("CSS-PREANCHOR-REMOVE"));
+    assert.isFalse(c.hasClass("CSS-POSTANCHOR"));
+    c.addClass("CSS-POSTANCHOR");
+    assert.isTrue(c.hasClass("CSS-POSTANCHOR"));
+    c.removeClass("CSS-POSTANCHOR");
+    assert.isFalse(c.hasClass("CSS-POSTANCHOR"));
+    assert.isFalse(c.hasClass(undefined), "returns false when classed called w/ undefined");
+    assert.strictEqual(c.addClass(undefined), c, "returns this when classed called w/ undefined and true");
     svg.remove();
   });
 

--- a/test/core/componentTests.ts
+++ b/test/core/componentTests.ts
@@ -314,8 +314,8 @@ describe("Component behavior", () => {
     assert.isTrue(c.hasClass("CSS-POSTANCHOR"));
     c.removeClass("CSS-POSTANCHOR");
     assert.isFalse(c.hasClass("CSS-POSTANCHOR"));
-    assert.isFalse(c.hasClass(undefined), "returns false when classed called w/ undefined");
-    assert.strictEqual(c.addClass(undefined), c, "returns this when classed called w/ undefined and true");
+    assert.isFalse(c.hasClass(undefined), "returns false when hasClass called w/ undefined");
+    assert.strictEqual(c.addClass(undefined), c, "returns this when hasClass called w/ undefined and true");
     svg.remove();
   });
 

--- a/test/core/tableTests.ts
+++ b/test/core/tableTests.ts
@@ -20,7 +20,7 @@ function generateBasicTable(nRows: number, nCols: number) {
 describe("Tables", () => {
   it("tables are classed properly", () => {
     var table = new Plottable.Components.Table();
-    assert.isTrue(table.classed("table"));
+    assert.isTrue(table.hasClass("table"));
   });
 
   it("padTableToSize works properly", () => {

--- a/test/tests.js
+++ b/test/tests.js
@@ -6545,8 +6545,8 @@ describe("Component behavior", function () {
         assert.isTrue(c.hasClass("CSS-POSTANCHOR"));
         c.removeClass("CSS-POSTANCHOR");
         assert.isFalse(c.hasClass("CSS-POSTANCHOR"));
-        assert.isFalse(c.hasClass(undefined), "returns false when classed called w/ undefined");
-        assert.strictEqual(c.addClass(undefined), c, "returns this when classed called w/ undefined and true");
+        assert.isFalse(c.hasClass(undefined), "returns false when hasClass called w/ undefined");
+        assert.strictEqual(c.addClass(undefined), c, "returns this when hasClass called w/ undefined and true");
         svg.remove();
     });
     it("can't reuse component if it's been destroy()-ed", function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -6199,8 +6199,8 @@ describe("ComponentGroups", function () {
         svg.remove();
     });
     it("detach()", function () {
-        var c1 = new Plottable.Component().classed("component-1", true);
-        var c2 = new Plottable.Component().classed("component-2", true);
+        var c1 = new Plottable.Component().addClass("component-1");
+        var c2 = new Plottable.Component().addClass("component-2");
         var cg = new Plottable.Components.Group([c1, c2]);
         var svg = TestMethods.generateSVG(200, 200);
         cg.renderTo(svg);
@@ -6530,23 +6530,23 @@ describe("Component behavior", function () {
         svg.remove();
     });
     it("css classing works as expected", function () {
-        assert.isFalse(c.classed("CSS-PREANCHOR-KEEP"));
-        c.classed("CSS-PREANCHOR-KEEP", true);
-        assert.isTrue(c.classed("CSS-PREANCHOR-KEEP"));
-        c.classed("CSS-PREANCHOR-REMOVE", true);
-        assert.isTrue(c.classed("CSS-PREANCHOR-REMOVE"));
-        c.classed("CSS-PREANCHOR-REMOVE", false);
-        assert.isFalse(c.classed("CSS-PREANCHOR-REMOVE"));
+        assert.isFalse(c.hasClass("CSS-PREANCHOR-KEEP"));
+        c.addClass("CSS-PREANCHOR-KEEP");
+        assert.isTrue(c.hasClass("CSS-PREANCHOR-KEEP"));
+        c.addClass("CSS-PREANCHOR-REMOVE");
+        assert.isTrue(c.hasClass("CSS-PREANCHOR-REMOVE"));
+        c.removeClass("CSS-PREANCHOR-REMOVE");
+        assert.isFalse(c.hasClass("CSS-PREANCHOR-REMOVE"));
         c.anchor(svg);
-        assert.isTrue(c.classed("CSS-PREANCHOR-KEEP"));
-        assert.isFalse(c.classed("CSS-PREANCHOR-REMOVE"));
-        assert.isFalse(c.classed("CSS-POSTANCHOR"));
-        c.classed("CSS-POSTANCHOR", true);
-        assert.isTrue(c.classed("CSS-POSTANCHOR"));
-        c.classed("CSS-POSTANCHOR", false);
-        assert.isFalse(c.classed("CSS-POSTANCHOR"));
-        assert.isFalse(c.classed(undefined), "returns false when classed called w/ undefined");
-        assert.strictEqual(c.classed(undefined, true), c, "returns this when classed called w/ undefined and true");
+        assert.isTrue(c.hasClass("CSS-PREANCHOR-KEEP"));
+        assert.isFalse(c.hasClass("CSS-PREANCHOR-REMOVE"));
+        assert.isFalse(c.hasClass("CSS-POSTANCHOR"));
+        c.addClass("CSS-POSTANCHOR");
+        assert.isTrue(c.hasClass("CSS-POSTANCHOR"));
+        c.removeClass("CSS-POSTANCHOR");
+        assert.isFalse(c.hasClass("CSS-POSTANCHOR"));
+        assert.isFalse(c.hasClass(undefined), "returns false when classed called w/ undefined");
+        assert.strictEqual(c.addClass(undefined), c, "returns this when classed called w/ undefined and true");
         svg.remove();
     });
     it("can't reuse component if it's been destroy()-ed", function () {
@@ -6789,7 +6789,7 @@ function generateBasicTable(nRows, nCols) {
 describe("Tables", function () {
     it("tables are classed properly", function () {
         var table = new Plottable.Components.Table();
-        assert.isTrue(table.classed("table"));
+        assert.isTrue(table.hasClass("table"));
     });
     it("padTableToSize works properly", function () {
         var t = new Plottable.Components.Table();


### PR DESCRIPTION
Closes #2219 

> Currently the CSS classes on a Component are queried and set using the classed() method:
> 
> component.classed("foo"); // does the Component have the class "foo"?
> component.classed("foo", true); // adds the class "foo" to the Component
> component.classed("foo", false); // removes the class "foo" from the Component
> 
> This mirrors the D3 method of the same name (although with more limited functionality). However, the boolean parameter leads to mistakes because it effectively functions as a trinary parameter (true/false/undefined to switch between "add"/"remove"/"query"):
> 
> component.classed("foo"); // sounds like it might add the class "foo", but doesn't
> 
> Our proposed alternative is to use separate methods for each part of the functionality:
> 
> component.hasClass("foo");
> component.addClass("foo");
> component.removeClass("foo");
> 
> While this is less consistent with D3, we think it will cut down on confusion. Thoughts?