### PR TITLE
[Legend] - rename symbolFactoryAccessor -> symbol

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1964,20 +1964,18 @@ declare module Plottable {
             entitiesAt(p: Point): Entity<Legend>[];
             renderImmediately(): Legend;
             /**
-             * Gets the SymbolFactory accessor of the Legend.
-             * The accessor determines the symbol for each entry.
+             * Gets the function determining the symbols of the Legend.
              *
              * @returns {(datum: any, index: number) => symbolFactory}
              */
-            symbolFactoryAccessor(): (datum: any, index: number) => SymbolFactory;
+            symbol(): (datum: any, index: number) => SymbolFactory;
             /**
-             * Sets the SymbolFactory accessor of the Legend.
-             * The accessor determines the symbol for each entry.
+             * Sets the function determining the symbols of the Legend.
              *
-             * @param {(datum: any, index: number) => symbolFactory} symbolFactoryAccessor
+             * @param {(datum: any, index: number) => SymbolFactory} symbol
              * @returns {Legend} The calling Legend
              */
-            symbolFactoryAccessor(symbolFactoryAccessor: (datum: any, index: number) => SymbolFactory): Legend;
+            symbol(symbol: (datum: any, index: number) => SymbolFactory): Legend;
             fixedWidth(): boolean;
             fixedHeight(): boolean;
         }

--- a/plottable.js
+++ b/plottable.js
@@ -5094,7 +5094,7 @@ var Plottable;
                         return translateString;
                     });
                 });
-                entries.select("path").attr("d", function (d, i) { return _this.symbolFactoryAccessor()(d, i)(layout.textHeight * 0.6); }).attr("transform", "translate(" + (layout.textHeight / 2) + "," + layout.textHeight / 2 + ")").attr("fill", function (value) { return _this._colorScale.scale(value); }).classed(Legend.LEGEND_SYMBOL_CLASS, true);
+                entries.select("path").attr("d", function (d, i) { return _this.symbol()(d, i)(layout.textHeight * 0.6); }).attr("transform", "translate(" + (layout.textHeight / 2) + "," + layout.textHeight / 2 + ")").attr("fill", function (value) { return _this._colorScale.scale(value); }).classed(Legend.LEGEND_SYMBOL_CLASS, true);
                 var padding = this._padding;
                 var textContainers = entries.select("g.text-container");
                 textContainers.text(""); // clear out previous results
@@ -5113,12 +5113,12 @@ var Plottable;
                 });
                 return this;
             };
-            Legend.prototype.symbolFactoryAccessor = function (symbolFactoryAccessor) {
-                if (symbolFactoryAccessor == null) {
+            Legend.prototype.symbol = function (symbol) {
+                if (symbol == null) {
                     return this._symbolFactoryAccessor;
                 }
                 else {
-                    this._symbolFactoryAccessor = symbolFactoryAccessor;
+                    this._symbolFactoryAccessor = symbol;
                     this.render();
                     return this;
                 }

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -277,7 +277,7 @@ export module Components {
         });
       });
 
-      entries.select("path").attr("d", (d: any, i: number) => this.symbolFactoryAccessor()(d, i)(layout.textHeight * 0.6))
+      entries.select("path").attr("d", (d: any, i: number) => this.symbol()(d, i)(layout.textHeight * 0.6))
                             .attr("transform", "translate(" + (layout.textHeight / 2) + "," + layout.textHeight / 2 + ")")
                             .attr("fill", (value: string) => this._colorScale.scale(value) )
                             .classed(Legend.LEGEND_SYMBOL_CLASS, true);
@@ -304,25 +304,23 @@ export module Components {
     }
 
     /**
-     * Gets the SymbolFactory accessor of the Legend.
-     * The accessor determines the symbol for each entry.
+     * Gets the function determining the symbols of the Legend.
      *
      * @returns {(datum: any, index: number) => symbolFactory}
      */
-    public symbolFactoryAccessor(): (datum: any, index: number) => SymbolFactory;
+    public symbol(): (datum: any, index: number) => SymbolFactory;
     /**
-     * Sets the SymbolFactory accessor of the Legend.
-     * The accessor determines the symbol for each entry.
+     * Sets the function determining the symbols of the Legend.
      *
-     * @param {(datum: any, index: number) => symbolFactory} symbolFactoryAccessor
+     * @param {(datum: any, index: number) => SymbolFactory} symbol
      * @returns {Legend} The calling Legend
      */
-    public symbolFactoryAccessor(symbolFactoryAccessor: (datum: any, index: number) => SymbolFactory): Legend;
-    public symbolFactoryAccessor(symbolFactoryAccessor?: (datum: any, index: number) => SymbolFactory): any {
-      if (symbolFactoryAccessor == null) {
+    public symbol(symbol: (datum: any, index: number) => SymbolFactory): Legend;
+    public symbol(symbol?: (datum: any, index: number) => SymbolFactory): any {
+      if (symbol == null) {
         return this._symbolFactoryAccessor;
       } else {
-        this._symbolFactoryAccessor = symbolFactoryAccessor;
+        this._symbolFactoryAccessor = symbol;
         this.render();
         return this;
       }


### PR DESCRIPTION
API Changes:
* `legend.symbolFactoryAccessor()` has been renamed to `legend.symbol()`

QE: Simple rename.  Should not need QE.