### PR TITLE
[Plot] - _isVisibleOnPlot -> _visibleOnPlot

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2350,7 +2350,7 @@ declare module Plottable {
          * @returns {Plots.PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
          */
         entityNearest(queryPoint: Point): Plots.PlotEntity;
-        protected _isVisibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
+        protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
         protected _uninstallScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _installScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _propertyProjectors(): AttributeToProjector;
@@ -2644,7 +2644,7 @@ declare module Plottable {
             symbol(): AccessorScaleBinding<any, any>;
             symbol(symbol: Accessor<SymbolFactory>): Plots.Scatter<X, Y>;
             protected _generateDrawSteps(): Drawers.DrawStep[];
-            protected _isVisibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
+            protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
             protected _propertyProjectors(): AttributeToProjector;
         }
     }
@@ -2730,7 +2730,7 @@ declare module Plottable {
              * @returns {PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
              */
             entityNearest(queryPoint: Point): PlotEntity;
-            protected _isVisibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
+            protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
             /**
              * Gets the Entities at a particular Point.
              *

--- a/plottable.js
+++ b/plottable.js
@@ -6295,7 +6295,7 @@ var Plottable;
             var closestDistanceSquared = Infinity;
             var closest;
             this.entities().forEach(function (entity) {
-                if (!_this._isVisibleOnPlot(entity.datum, entity.position, entity.selection)) {
+                if (!_this._visibleOnPlot(entity.datum, entity.position, entity.selection)) {
                     return;
                 }
                 var distanceSquared = Plottable.Utils.Math.distanceSquared(entity.position, queryPoint);
@@ -6306,7 +6306,7 @@ var Plottable;
             });
             return closest;
         };
-        Plot.prototype._isVisibleOnPlot = function (datum, pixelPoint, selection) {
+        Plot.prototype._visibleOnPlot = function (datum, pixelPoint, selection) {
             return !(pixelPoint.x < 0 || pixelPoint.y < 0 || pixelPoint.x > this.width() || pixelPoint.y > this.height());
         };
         Plot.prototype._uninstallScaleForKey = function (scale, key) {
@@ -6956,7 +6956,7 @@ var Plottable;
                 drawSteps.push({ attrToProjector: this._generateAttrToProjector(), animator: this._getAnimator(Plots.Animator.MAIN) });
                 return drawSteps;
             };
-            Scatter.prototype._isVisibleOnPlot = function (datum, pixelPoint, selection) {
+            Scatter.prototype._visibleOnPlot = function (datum, pixelPoint, selection) {
                 var xRange = { min: 0, max: this.width() };
                 var yRange = { min: 0, max: this.height() };
                 var translation = d3.transform(selection.attr("transform")).translate;
@@ -7146,7 +7146,7 @@ var Plottable;
                 var tolerance = 0.5;
                 var closest;
                 this.entities().forEach(function (entity) {
-                    if (!_this._isVisibleOnPlot(entity.datum, entity.position, entity.selection)) {
+                    if (!_this._visibleOnPlot(entity.datum, entity.position, entity.selection)) {
                         return;
                     }
                     var primaryDist = 0;
@@ -7178,7 +7178,7 @@ var Plottable;
                 });
                 return closest;
             };
-            Bar.prototype._isVisibleOnPlot = function (datum, pixelPoint, selection) {
+            Bar.prototype._visibleOnPlot = function (datum, pixelPoint, selection) {
                 var xRange = { min: 0, max: this.width() };
                 var yRange = { min: 0, max: this.height() };
                 var barBBox = Plottable.Utils.DOM.elementBBox(selection);
@@ -7532,7 +7532,7 @@ var Plottable;
                 var minYDist = Infinity;
                 var closest;
                 this.entities().forEach(function (entity) {
-                    if (!_this._isVisibleOnPlot(entity.datum, entity.position, entity.selection)) {
+                    if (!_this._visibleOnPlot(entity.datum, entity.position, entity.selection)) {
                         return;
                     }
                     var xDist = Math.abs(queryPoint.x - entity.position.x);

--- a/src/components/plots/barPlot.ts
+++ b/src/components/plots/barPlot.ts
@@ -228,7 +228,7 @@ export module Plots {
 
       var closest: PlotEntity;
       this.entities().forEach((entity) => {
-        if (!this._isVisibleOnPlot(entity.datum, entity.position, entity.selection)) {
+        if (!this._visibleOnPlot(entity.datum, entity.position, entity.selection)) {
           return;
         }
         var primaryDist = 0;
@@ -264,7 +264,7 @@ export module Plots {
       return closest;
     }
 
-    protected _isVisibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean {
+    protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean {
       var xRange = { min: 0, max: this.width() };
       var yRange = { min: 0, max: this.height() };
       var barBBox = Utils.DOM.elementBBox(selection);

--- a/src/components/plots/linePlot.ts
+++ b/src/components/plots/linePlot.ts
@@ -73,7 +73,7 @@ export module Plots {
       var minYDist = Infinity;
       var closest: PlotEntity;
       this.entities().forEach((entity) => {
-        if (!this._isVisibleOnPlot(entity.datum, entity.position, entity.selection)) {
+        if (!this._visibleOnPlot(entity.datum, entity.position, entity.selection)) {
           return;
         }
         var xDist = Math.abs(queryPoint.x - entity.position.x);

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -482,7 +482,7 @@ module Plottable {
       var closestDistanceSquared = Infinity;
       var closest: Plots.PlotEntity;
       this.entities().forEach((entity) => {
-        if (!this._isVisibleOnPlot(entity.datum, entity.position, entity.selection)) {
+        if (!this._visibleOnPlot(entity.datum, entity.position, entity.selection)) {
           return;
         }
 
@@ -496,7 +496,7 @@ module Plottable {
       return closest;
     }
 
-    protected _isVisibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean {
+    protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean {
       return !(pixelPoint.x < 0 || pixelPoint.y < 0 ||
         pixelPoint.x > this.width() || pixelPoint.y > this.height());
     }

--- a/src/components/plots/scatterPlot.ts
+++ b/src/components/plots/scatterPlot.ts
@@ -67,7 +67,7 @@ export module Plots {
       return drawSteps;
     }
 
-    protected _isVisibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean {
+    protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean {
       var xRange = { min: 0, max: this.width() };
       var yRange = { min: 0, max: this.height() };
 


### PR DESCRIPTION
We're currently consistent on trying to shorten our variable/function names where applicable (removing "get" / "set" / "is" in front where we can).  Since I think `_visibleOnPlot()` conveys the meaning of `_isVisibleOnPlot()` and it's more consistent with our vocabulary in our codebase, we should change the name.

API Changes:
* `plot._isVisibleOnPlot()` -> `plot._visibleOnPlot()`

QE: Protected function rename.  Should not require QE