### PR TITLE
[Plot] - split animated() to enableAnimation()/disableAnimation()/willAnimate()

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2302,13 +2302,23 @@ declare module Plottable {
         protected _generateAttrToProjector(): AttributeToProjector;
         renderImmediately(): Plot;
         /**
-         * Returns whether the plot will be animated.
+         * Enables animation on the plot.
+         *
+         * @returns {Plot} The calling Plot.
          */
-        animated(): boolean;
+        enableAnimation(): Plot;
         /**
-         * Enables or disables animation.
+         * Disables animation on the plot.
+         *
+         * @returns {Plot} The calling Plot.
          */
-        animated(willAnimate: boolean): Plot;
+        disableAnimation(): Plot;
+        /**
+         * Gets if the plot will animate
+         *
+         * @returns {boolean} If the plot will animate.
+         */
+        willAnimate(): boolean;
         detach(): Plot;
         /**
          * Updates the extents associated with each attribute, then autodomains all scales the Plot uses.

--- a/plottable.js
+++ b/plottable.js
@@ -6049,12 +6049,31 @@ var Plottable;
             }
             return this;
         };
-        Plot.prototype.animated = function (willAnimate) {
-            if (willAnimate == null) {
-                return this._animate;
-            }
-            this._animate = willAnimate;
+        /**
+         * Enables animation on the plot.
+         *
+         * @returns {Plot} The calling Plot.
+         */
+        Plot.prototype.enableAnimation = function () {
+            this._animate = true;
             return this;
+        };
+        /**
+         * Disables animation on the plot.
+         *
+         * @returns {Plot} The calling Plot.
+         */
+        Plot.prototype.disableAnimation = function () {
+            this._animate = false;
+            return this;
+        };
+        /**
+         * Gets if the plot will animate
+         *
+         * @returns {boolean} If the plot will animate.
+         */
+        Plot.prototype.willAnimate = function () {
+            return this._animate;
         };
         Plot.prototype.detach = function () {
             _super.prototype.detach.call(this);

--- a/src/components/plots/plot.ts
+++ b/src/components/plots/plot.ts
@@ -210,20 +210,32 @@ module Plottable {
     }
 
     /**
-     * Returns whether the plot will be animated.
+     * Enables animation on the plot.
+     * 
+     * @returns {Plot} The calling Plot.
      */
-    public animated(): boolean;
-    /**
-     * Enables or disables animation.
-     */
-    public animated(willAnimate: boolean): Plot;
-    public animated(willAnimate?: boolean): any {
-      if (willAnimate == null) {
-        return this._animate;
-      }
-
-      this._animate = willAnimate;
+    public enableAnimation() {
+      this._animate = true;
       return this;
+    }
+
+    /**
+     * Disables animation on the plot.
+     * 
+     * @returns {Plot} The calling Plot.
+     */
+    public disableAnimation() {
+      this._animate = false;
+      return this;
+    }
+
+    /**
+     * Gets if the plot will animate
+     * 
+     * @returns {boolean} If the plot will animate.
+     */
+    public willAnimate() {
+      return this._animate;
     }
 
     public detach() {

--- a/test/components/plots/barPlotTests.ts
+++ b/test/components/plots/barPlotTests.ts
@@ -55,7 +55,7 @@ describe("Plots", () => {
         dataset = new Plottable.Dataset(data);
         barPlot = new Plottable.Plots.Bar<string, number>();
         barPlot.addDataset(dataset);
-        barPlot.animated(false);
+        barPlot.disableAnimation();
         barPlot.baselineValue(0);
         yScale.domain([-2, 2]);
         barPlot.x((d) => d.x, xScale);
@@ -282,7 +282,7 @@ describe("Plots", () => {
         dataset = new Plottable.Dataset(data);
         barPlot = new Plottable.Plots.Bar<number, number>();
         barPlot.addDataset(dataset);
-        barPlot.animated(false);
+        barPlot.disableAnimation();
         barPlot.baselineValue(0);
         yScale.domain([-2, 2]);
         barPlot.x((d) => d.x, xScale);
@@ -440,7 +440,7 @@ describe("Plots", () => {
         dataset = new Plottable.Dataset(data);
         barPlot = new Plottable.Plots.Bar<number, string>(Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
         barPlot.addDataset(dataset);
-        barPlot.animated(false);
+        barPlot.disableAnimation();
         barPlot.baselineValue(0);
         barPlot.x((d) => d.x, xScale);
         barPlot.y((d) => d.y, yScale);

--- a/test/components/plots/plotTests.ts
+++ b/test/components/plots/plotTests.ts
@@ -482,7 +482,7 @@ describe("Plots", () => {
       var x = new Plottable.Scales.Linear();
       var y = new Plottable.Scales.Linear();
       var plot = new Plottable.Plots.Bar();
-      plot.addDataset(new Plottable.Dataset([])).animated(true);
+      plot.addDataset(new Plottable.Dataset([])).enableAnimation();
       var recordedTime: number = -1;
       var additionalPaint = (x: number) => {
         recordedTime = Math.max(x, recordedTime);
@@ -516,11 +516,11 @@ describe("Plots", () => {
 
     it("animated() getter", () => {
       var plot = new Plottable.Plot();
-      assert.strictEqual(plot.animated(), false, "by default the plot is not animated");
-      assert.strictEqual(plot.animated(true), plot, "toggling animation returns the plot");
-      assert.strictEqual(plot.animated(), true, "animated toggled on");
-      plot.animated(false);
-      assert.strictEqual(plot.animated(), false, "animated toggled off");
+      assert.strictEqual(plot.willAnimate(), false, "by default the plot is not animated");
+      assert.strictEqual(plot.enableAnimation(), plot, "toggling animation returns the plot");
+      assert.strictEqual(plot.willAnimate(), true, "animated toggled on");
+      plot.disableAnimation();
+      assert.strictEqual(plot.willAnimate(), false, "animated toggled off");
     });
   });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -2623,7 +2623,7 @@ describe("Plots", function () {
             var x = new Plottable.Scales.Linear();
             var y = new Plottable.Scales.Linear();
             var plot = new Plottable.Plots.Bar();
-            plot.addDataset(new Plottable.Dataset([])).animated(true);
+            plot.addDataset(new Plottable.Dataset([])).enableAnimation();
             var recordedTime = -1;
             var additionalPaint = function (x) {
                 recordedTime = Math.max(x, recordedTime);
@@ -2653,11 +2653,11 @@ describe("Plots", function () {
         });
         it("animated() getter", function () {
             var plot = new Plottable.Plot();
-            assert.strictEqual(plot.animated(), false, "by default the plot is not animated");
-            assert.strictEqual(plot.animated(true), plot, "toggling animation returns the plot");
-            assert.strictEqual(plot.animated(), true, "animated toggled on");
-            plot.animated(false);
-            assert.strictEqual(plot.animated(), false, "animated toggled off");
+            assert.strictEqual(plot.willAnimate(), false, "by default the plot is not animated");
+            assert.strictEqual(plot.enableAnimation(), plot, "toggling animation returns the plot");
+            assert.strictEqual(plot.willAnimate(), true, "animated toggled on");
+            plot.disableAnimation();
+            assert.strictEqual(plot.willAnimate(), false, "animated toggled off");
         });
     });
 });
@@ -3470,7 +3470,7 @@ describe("Plots", function () {
                 dataset = new Plottable.Dataset(data);
                 barPlot = new Plottable.Plots.Bar();
                 barPlot.addDataset(dataset);
-                barPlot.animated(false);
+                barPlot.disableAnimation();
                 barPlot.baselineValue(0);
                 yScale.domain([-2, 2]);
                 barPlot.x(function (d) { return d.x; }, xScale);
@@ -3662,7 +3662,7 @@ describe("Plots", function () {
                 dataset = new Plottable.Dataset(data);
                 barPlot = new Plottable.Plots.Bar();
                 barPlot.addDataset(dataset);
-                barPlot.animated(false);
+                barPlot.disableAnimation();
                 barPlot.baselineValue(0);
                 yScale.domain([-2, 2]);
                 barPlot.x(function (d) { return d.x; }, xScale);
@@ -3795,7 +3795,7 @@ describe("Plots", function () {
                 dataset = new Plottable.Dataset(data);
                 barPlot = new Plottable.Plots.Bar(Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
                 barPlot.addDataset(dataset);
-                barPlot.animated(false);
+                barPlot.disableAnimation();
                 barPlot.baselineValue(0);
                 barPlot.x(function (d) { return d.x; }, xScale);
                 barPlot.y(function (d) { return d.y; }, yScale);


### PR DESCRIPTION
Functions that take in boolean parameters usually can be reworked so that it is significantly more readable / easier to use.

API Changes:
* `plot.animated()` has been removed in favor of the following API endpoints.
* `plot.enableAnimation()` has been added to enable animation on plots.
* `plot.disableAnimation()` has been added to disable animation on plots.
* `plot.willAnimate()` has been added to allow checking if the plot will animate.