### PR TITLE
Compress computeStackOffsets() down into a single method.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -292,6 +292,7 @@ declare module Plottable {
                 value: number;
                 offset?: number;
             };
+            function normalizeKey(key: any): string;
             function computeStackOffsets(datasets: Dataset[], keyAccessor: Accessor<any>, valueAccessor: Accessor<number>): Map<Dataset, Map<string, {
                 value: number;
                 offset?: number;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -298,13 +298,7 @@ declare module Plottable {
                 value: number;
                 offset?: number;
             }>>;
-            /**
-             * Calculates an extent across all datasets. The extent is a <number> interval that
-             * accounts for the fact that Utils.stacked bits have to be added together when calculating the extent
-             *
-             * @return {[number]} The extent that spans all the Utils.stacked data
-             */
-            function computeStackExtent(stackOffsets: Utils.Map<Dataset, Utils.Map<string, StackedDatum>>, filter: (value: string) => boolean): number[];
+            function computeStackExtent(stackOffsets: Utils.Map<Dataset, Utils.Map<string, StackedDatum>>, keyAccessor: Accessor<any>, filter: Accessor<boolean>): number[];
             /**
              * Given an array of datasets and the accessor function for the key, computes the
              * set reunion (no duplicates) of the domain of each dataset.
@@ -2522,7 +2516,6 @@ declare module Plottable {
          */
         y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): XYPlot<X, Y>;
         protected _filterForProperty(property: string): (datum: any, index: number, dataset: Dataset) => boolean;
-        protected _valueFilterForProperty(property: string): (value: string) => boolean;
         protected _uninstallScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _installScaleForKey(scale: Scale<any, any>, key: string): void;
         destroy(): XYPlot<X, Y>;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -293,12 +293,6 @@ declare module Plottable {
                 value: number;
                 offset?: number;
             };
-            /**
-             * Calculates the offset of each piece of data, in each dataset, relative to the baseline,
-             * for drawing purposes.
-             *
-             * @return {Utils.Map<Dataset, d3.Map<number>>} A map from each dataset to the offset of each datapoint
-             */
             function computeStackOffsets(datasets: Dataset[], keyAccessor: Accessor<any>, valueAccessor: Accessor<number>): Map<Dataset, Map<string, {
                 key: any;
                 value: number;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -289,12 +289,10 @@ declare module Plottable {
     module Utils {
         module Stacked {
             type StackedDatum = {
-                key: any;
                 value: number;
                 offset?: number;
             };
             function computeStackOffsets(datasets: Dataset[], keyAccessor: Accessor<any>, valueAccessor: Accessor<number>): Map<Dataset, Map<string, {
-                key: any;
                 value: number;
                 offset?: number;
             }>>;

--- a/plottable.js
+++ b/plottable.js
@@ -647,7 +647,6 @@ var Plottable;
                             offsetMap.set(key, value);
                         }
                         keyToStackedDatum.set(key, {
-                            key: key,
                             value: value,
                             offset: offset
                         });

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -143,11 +143,13 @@ export module Plots {
       var propertyToProjectors = super._propertyProjectors();
       var yAccessor = this.y().accessor;
       var xAccessor = this.x().accessor;
-
+      var normalizedXAccessor = (datum: any, index: number, dataset: Dataset) => {
+        return Utils.Stacked.normalizeKey(xAccessor(datum, index, dataset));
+      };
       var stackYProjector = (d: any, i: number, dataset: Dataset) =>
-        this.y().scale.scale(+yAccessor(d, i, dataset) + this._stackOffsets.get(dataset).get(String(xAccessor(d, i, dataset))).offset);
+        this.y().scale.scale(+yAccessor(d, i, dataset) + this._stackOffsets.get(dataset).get(normalizedXAccessor(d, i, dataset)).offset);
       var stackY0Projector = (d: any, i: number, dataset: Dataset) =>
-        this.y().scale.scale(this._stackOffsets.get(dataset).get(String(xAccessor(d, i, dataset))).offset);
+        this.y().scale.scale(this._stackOffsets.get(dataset).get(normalizedXAccessor(d, i, dataset)).offset);
 
       propertyToProjectors["d"] = this._constructAreaProjector(Plot._scaledAccessor(this.x()), stackYProjector, stackY0Projector);
       return propertyToProjectors;
@@ -157,7 +159,7 @@ export module Plots {
       var pixelPoint = super._pixelPoint(datum, index, dataset);
       var xValue = this.x().accessor(datum, index, dataset);
       var yValue = this.y().accessor(datum, index, dataset);
-      var scaledYValue = this.y().scale.scale(+yValue + this._stackOffsets.get(dataset).get(String(xValue)).offset);
+      var scaledYValue = this.y().scale.scale(+yValue + this._stackOffsets.get(dataset).get(Utils.Stacked.normalizeKey(xValue)).offset);
       return { x: pixelPoint.x, y: scaledYValue };
     }
 

--- a/src/components/plots/stackedAreaPlot.ts
+++ b/src/components/plots/stackedAreaPlot.ts
@@ -121,11 +121,11 @@ export module Plots {
       var datasets = this.datasets();
       var keyAccessor = this.x().accessor;
       var valueAccessor = this.y().accessor;
-      var filter = this._valueFilterForProperty("y");
+      var filter = this._filterForProperty("y");
 
       this._checkSameDomain(datasets, keyAccessor);
       this._stackOffsets = Utils.Stacked.computeStackOffsets(datasets, keyAccessor, valueAccessor);
-      this._stackedExtent = Utils.Stacked.computeStackExtent(this._stackOffsets, filter);
+      this._stackedExtent = Utils.Stacked.computeStackExtent(this._stackOffsets, keyAccessor, filter);
     }
 
     private _checkSameDomain(datasets: Dataset[], keyAccessor: Accessor<any>) {

--- a/src/components/plots/stackedBarPlot.ts
+++ b/src/components/plots/stackedBarPlot.ts
@@ -65,11 +65,14 @@ export module Plots {
       var primaryScale: Scale<any, number> = this._isVertical ? this.y().scale : this.x().scale;
       var primaryAccessor = this._propertyBindings.get(valueAttr).accessor;
       var keyAccessor = this._propertyBindings.get(keyAttr).accessor;
+      var normalizedKeyAccessor = (datum: any, index: number, dataset: Dataset) => {
+        return Utils.Stacked.normalizeKey(keyAccessor(datum, index, dataset));
+      };
       var getStart = (d: any, i: number, dataset: Dataset) =>
-        primaryScale.scale(this._stackOffsets.get(dataset).get(String(keyAccessor(d, i, dataset))).offset);
+        primaryScale.scale(this._stackOffsets.get(dataset).get(normalizedKeyAccessor(d, i, dataset)).offset);
       var getEnd = (d: any, i: number, dataset: Dataset) =>
         primaryScale.scale(+primaryAccessor(d, i, dataset) +
-          this._stackOffsets.get(dataset).get(String(keyAccessor(d, i, dataset))).offset);
+          this._stackOffsets.get(dataset).get(normalizedKeyAccessor(d, i, dataset)).offset);
 
       var heightF = (d: any, i: number, dataset: Dataset) => {
         return Math.abs(getEnd(d, i, dataset) - getStart(d, i, dataset));

--- a/src/components/plots/stackedBarPlot.ts
+++ b/src/components/plots/stackedBarPlot.ts
@@ -112,10 +112,10 @@ export module Plots {
       var datasets = this.datasets();
       var keyAccessor = this._isVertical ? this.x().accessor : this.y().accessor;
       var valueAccessor = this._isVertical ? this.y().accessor : this.x().accessor;
-      var filter = this._valueFilterForProperty(this._isVertical ? "y" : "x");
+      var filter = this._filterForProperty(this._isVertical ? "y" : "x");
 
       this._stackOffsets = Utils.Stacked.computeStackOffsets(datasets, keyAccessor, valueAccessor);
-      this._stackedExtent = Utils.Stacked.computeStackExtent(this._stackOffsets, filter);
+      this._stackedExtent = Utils.Stacked.computeStackExtent(this._stackOffsets, keyAccessor, filter);
     }
   }
 }

--- a/src/components/plots/xyPlot.ts
+++ b/src/components/plots/xyPlot.ts
@@ -108,29 +108,6 @@ module Plottable {
       return null;
     }
 
-    protected _valueFilterForProperty(property: string) {
-      if (property === "x" && !this._autoAdjustXScaleDomain) {
-        return null;
-      }
-
-      if (property === "y" && !this._autoAdjustYScaleDomain) {
-        return null;
-      }
-
-      var binding = this._propertyBindings.get(property === "x" ? "y" : "x");
-      if (binding == null) {
-        return null;
-      }
-      var scale = binding.scale;
-      if (scale == null) {
-        return null;
-      }
-      return (value: string) => {
-        var range = scale.range();
-        return Utils.Math.inRange(scale.scale(value), range[0], range[1]);
-      };
-    }
-
     private _makeFilterByProperty(property: string) {
       var binding = this._propertyBindings.get(property);
       if (binding != null) {

--- a/src/utils/stackedUtils.ts
+++ b/src/utils/stackedUtils.ts
@@ -46,23 +46,24 @@ module Plottable {
         return datasetToKeyToStackedDatum;
       }
 
-      /**
-       * Calculates an extent across all datasets. The extent is a <number> interval that
-       * accounts for the fact that Utils.stacked bits have to be added together when calculating the extent
-       *
-       * @return {[number]} The extent that spans all the Utils.stacked data
-       */
       export function computeStackExtent(
           stackOffsets: Utils.Map<Dataset, Utils.Map<string, StackedDatum>>,
-          filter: (value: string) => boolean) {
+          keyAccessor: Accessor<any>,
+          filter: Accessor<boolean>) {
+
+        var getKey = (datum: any, index: number, dataset: Dataset) => {
+          return String(keyAccessor(datum, index, dataset));
+        };
+
         var extents: number[] = [];
         stackOffsets.forEach((stackedDatumMap: Utils.Map<string, StackedDatum>, dataset: Dataset) => {
-          stackedDatumMap.forEach((stackedDatum: StackedDatum) => {
-            if (filter != null && !filter(stackedDatum.key)) {
+          dataset.data().forEach((datum, index) => {
+            if (filter != null && !filter(datum, index, dataset)) {
               return;
             }
+            var stackedDatum = stackedDatumMap.get(getKey(datum, index, dataset));
             extents.push(stackedDatum.value + stackedDatum.offset);
-          });
+          })
         });
         var maxStackExtent = Utils.Math.max(extents, 0);
         var minStackExtent = Utils.Math.min(extents, 0);

--- a/src/utils/stackedUtils.ts
+++ b/src/utils/stackedUtils.ts
@@ -5,7 +5,6 @@ module Plottable {
     export module Stacked {
 
       export type StackedDatum = {
-        key: any;
         value: number;
         offset?: number;
       };
@@ -36,7 +35,6 @@ module Plottable {
               offsetMap.set(key, value);
             }
             keyToStackedDatum.set(key, {
-              key: key,
               value: value,
               offset: offset
             });

--- a/src/utils/stackedUtils.ts
+++ b/src/utils/stackedUtils.ts
@@ -11,11 +11,11 @@ module Plottable {
 
       var nativeMath: Math = (<any>window).Math;
 
-      export function computeStackOffsets(datasets: Dataset[], keyAccessor: Accessor<any>, valueAccessor: Accessor<number>) {
-        var getKey = (datum: any, index: number, dataset: Dataset) => {
-          return String(keyAccessor(datum, index, dataset));
-        };
+      export function normalizeKey(key: any) {
+        return String(key);
+      }
 
+      export function computeStackOffsets(datasets: Dataset[], keyAccessor: Accessor<any>, valueAccessor: Accessor<number>) {
         var positiveOffsets = d3.map<number>();
         var negativeOffsets = d3.map<number>();
         var datasetToKeyToStackedDatum = new Utils.Map<Dataset, Utils.Map<string, StackedDatum>>();
@@ -23,7 +23,7 @@ module Plottable {
         datasets.forEach((dataset) => {
           var keyToStackedDatum = new Utils.Map<string, StackedDatum>();
           dataset.data().forEach((datum, index) => {
-            var key = getKey(datum, index, dataset);
+            var key = normalizeKey(keyAccessor(datum, index, dataset));
             var value = +valueAccessor(datum, index, dataset);
             var offset: number;
             var offsetMap = (value >= 0) ? positiveOffsets : negativeOffsets;
@@ -48,18 +48,13 @@ module Plottable {
           stackOffsets: Utils.Map<Dataset, Utils.Map<string, StackedDatum>>,
           keyAccessor: Accessor<any>,
           filter: Accessor<boolean>) {
-
-        var getKey = (datum: any, index: number, dataset: Dataset) => {
-          return String(keyAccessor(datum, index, dataset));
-        };
-
         var extents: number[] = [];
         stackOffsets.forEach((stackedDatumMap: Utils.Map<string, StackedDatum>, dataset: Dataset) => {
           dataset.data().forEach((datum, index) => {
             if (filter != null && !filter(datum, index, dataset)) {
               return;
             }
-            var stackedDatum = stackedDatumMap.get(getKey(datum, index, dataset));
+            var stackedDatum = stackedDatumMap.get(normalizeKey(keyAccessor(datum, index, dataset)));
             extents.push(stackedDatum.value + stackedDatum.offset);
           })
         });

--- a/src/utils/stackedUtils.ts
+++ b/src/utils/stackedUtils.ts
@@ -56,7 +56,7 @@ module Plottable {
             }
             var stackedDatum = stackedDatumMap.get(normalizeKey(keyAccessor(datum, index, dataset)));
             extents.push(stackedDatum.value + stackedDatum.offset);
-          })
+          });
         });
         var maxStackExtent = Utils.Math.max(extents, 0);
         var minStackExtent = Utils.Math.min(extents, 0);

--- a/test/tests.js
+++ b/test/tests.js
@@ -8681,6 +8681,27 @@ describe("Utils", function () {
             assert.deepEqual(stackExtents[0], expectedStackExtents[0], "Barney has the smallest minimum stack (-50)");
             assert.deepEqual(stackExtents[1], expectedStackExtents[1], "Fred has the largest maximum stack (100)");
         });
+        it("computeStackExtent() works with filter", function () {
+            var data1 = [
+                { key: "Fred", value: 100 },
+                { key: "Barney", value: 15 }
+            ];
+            var data2 = [
+                { key: "Fred", value: -5 },
+                { key: "Barney", value: -50 }
+            ];
+            var data3 = [
+                { key: "Fred", value: 0 },
+                { key: "Barney", value: 0 }
+            ];
+            var datasets = createDatasets([data1, data2, data3]);
+            var stackOffsets = Plottable.Utils.Stacked.computeStackOffsets(datasets, keyAccessor, valueAccessor);
+            filter = function (datum) { return datum.key === "Fred"; };
+            var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, keyAccessor, filter);
+            var expectedStackExtents = [-5, 100];
+            assert.deepEqual(stackExtents[0], expectedStackExtents[0], "Fred has the smallest minimum stack");
+            assert.deepEqual(stackExtents[1], expectedStackExtents[1], "Fred has the largest maximum stack");
+        });
     });
 });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -8632,7 +8632,7 @@ describe("Utils", function () {
             var datasets = createDatasets([data1, data2, data3, data4]);
             var stackOffsets = Plottable.Utils.Stacked.computeStackOffsets(datasets, keyAccessor, valueAccessor);
             filter = null;
-            var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, filter);
+            var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, keyAccessor, filter);
             var expectedStackExtents = [0, 303];
             assert.deepEqual(stackExtents, expectedStackExtents, "all datasets stack up and the sum of their values is 303");
         });
@@ -8643,7 +8643,7 @@ describe("Utils", function () {
             var datasets = createDatasets([data1, data2, data3]);
             var stackOffsets = Plottable.Utils.Stacked.computeStackOffsets(datasets, keyAccessor, valueAccessor);
             filter = null;
-            var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, filter);
+            var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, keyAccessor, filter);
             var expectedStackExtents = [-301, 0];
             assert.deepEqual(stackExtents, expectedStackExtents, "all datasets stack down and the sum of their values is -301");
         });
@@ -8656,7 +8656,7 @@ describe("Utils", function () {
             var datasets = createDatasets([data1, data2, data3, data4, data5]);
             var stackOffsets = Plottable.Utils.Stacked.computeStackOffsets(datasets, keyAccessor, valueAccessor);
             filter = null;
-            var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, filter);
+            var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, keyAccessor, filter);
             var expectedStackExtents = [-10, 120];
             assert.deepEqual(stackExtents, expectedStackExtents, "all datasets stack down and the sum of their values is -301");
         });
@@ -8676,7 +8676,7 @@ describe("Utils", function () {
             var datasets = createDatasets([data1, data2, data3]);
             var stackOffsets = Plottable.Utils.Stacked.computeStackOffsets(datasets, keyAccessor, valueAccessor);
             filter = null;
-            var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, filter);
+            var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, keyAccessor, filter);
             var expectedStackExtents = [-50, 100];
             assert.deepEqual(stackExtents[0], expectedStackExtents[0], "Barney has the smallest minimum stack (-50)");
             assert.deepEqual(stackExtents[1], expectedStackExtents[1], "Fred has the largest maximum stack (100)");

--- a/test/utils/stackedUtilsTests.ts
+++ b/test/utils/stackedUtilsTests.ts
@@ -175,5 +175,31 @@ describe("Utils", () => {
       assert.deepEqual(stackExtents[0], expectedStackExtents[0], "Barney has the smallest minimum stack (-50)");
       assert.deepEqual(stackExtents[1], expectedStackExtents[1], "Fred has the largest maximum stack (100)");
     });
+
+    it("computeStackExtent() works with filter", () => {
+      var data1 = [
+        {key: "Fred", value: 100},
+        {key: "Barney", value: 15}
+      ];
+      var data2 = [
+        {key: "Fred", value: -5},
+        {key: "Barney", value: -50}
+      ];
+      var data3 = [
+        {key: "Fred", value: 0},
+        {key: "Barney", value: 0}
+      ];
+
+      var datasets = createDatasets([data1, data2, data3]);
+
+      var stackOffsets = Plottable.Utils.Stacked.computeStackOffsets(datasets, keyAccessor, valueAccessor);
+      filter = (datum: any) => datum.key === "Fred";
+
+      var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, keyAccessor, filter);
+      var expectedStackExtents = [-5, 100];
+
+      assert.deepEqual(stackExtents[0], expectedStackExtents[0], "Fred has the smallest minimum stack");
+      assert.deepEqual(stackExtents[1], expectedStackExtents[1], "Fred has the largest maximum stack");
+    });
   });
 });

--- a/test/utils/stackedUtilsTests.ts
+++ b/test/utils/stackedUtilsTests.ts
@@ -110,7 +110,7 @@ describe("Utils", () => {
       var stackOffsets = Plottable.Utils.Stacked.computeStackOffsets(datasets, keyAccessor, valueAccessor);
       filter = null;
 
-      var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, filter);
+      var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, keyAccessor, filter);
       var expectedStackExtents = [0, 303];
 
       assert.deepEqual(stackExtents, expectedStackExtents, "all datasets stack up and the sum of their values is 303");
@@ -126,7 +126,7 @@ describe("Utils", () => {
       var stackOffsets = Plottable.Utils.Stacked.computeStackOffsets(datasets, keyAccessor, valueAccessor);
       filter = null;
 
-      var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, filter);
+      var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, keyAccessor, filter);
       var expectedStackExtents = [-301, 0];
 
       assert.deepEqual(stackExtents, expectedStackExtents, "all datasets stack down and the sum of their values is -301");
@@ -144,7 +144,7 @@ describe("Utils", () => {
       var stackOffsets = Plottable.Utils.Stacked.computeStackOffsets(datasets, keyAccessor, valueAccessor);
       filter = null;
 
-      var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, filter);
+      var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, keyAccessor, filter);
       var expectedStackExtents = [-10, 120];
 
       assert.deepEqual(stackExtents, expectedStackExtents, "all datasets stack down and the sum of their values is -301");
@@ -169,7 +169,7 @@ describe("Utils", () => {
       var stackOffsets = Plottable.Utils.Stacked.computeStackOffsets(datasets, keyAccessor, valueAccessor);
       filter = null;
 
-      var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, filter);
+      var stackExtents = Plottable.Utils.Stacked.computeStackExtent(stackOffsets, keyAccessor, filter);
       var expectedStackExtents = [-50, 100];
 
       assert.deepEqual(stackExtents[0], expectedStackExtents[0], "Barney has the smallest minimum stack (-50)");


### PR DESCRIPTION
A whole bunch of shimming was being done to satisfy d3's stack layout,
but we didn't even need all its power.

**[-2]**-ing myself since this is a demo for @aicioara. @aicioara, you can merge this if you want to pick up my changes.