### PR TITLE
Gridlines on Scales.Category

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2120,10 +2120,10 @@ declare module Plottable {
         class Gridlines extends Component {
             /**
              * @constructor
-             * @param {QuantitativeScale} xScale The scale to base the x gridlines on. Pass null if no gridlines are desired.
-             * @param {QuantitativeScale} yScale The scale to base the y gridlines on. Pass null if no gridlines are desired.
+             * @param {Scale<any, number>} xScale The scale to base the x gridlines on. Pass null if no gridlines are desired.
+             * @param {Scale<any, number>} yScale The scale to base the y gridlines on. Pass null if no gridlines are desired.
              */
-            constructor(xScale: Scale<any, any>, yScale: Scale<any, any>);
+            constructor(xScale: Scale<any, number>, yScale: Scale<any, number>);
             destroy(): Gridlines;
             protected _setup(): void;
             renderImmediately(): Gridlines;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -798,6 +798,12 @@ declare module Plottable {
          * @returns {Scale} The calling Scale.
          */
         removeIncludedValuesProvider(provider: Scales.IncludedValuesProvider<D>): Scale<D, R>;
+        /**
+         * Gets an array of tick values spanning the domain.
+         *
+         * @returns {D[]}
+         */
+        ticks(): D[];
     }
 }
 
@@ -2117,7 +2123,7 @@ declare module Plottable {
              * @param {QuantitativeScale} xScale The scale to base the x gridlines on. Pass null if no gridlines are desired.
              * @param {QuantitativeScale} yScale The scale to base the y gridlines on. Pass null if no gridlines are desired.
              */
-            constructor(xScale: QuantitativeScale<any>, yScale: QuantitativeScale<any>);
+            constructor(xScale: Scale<any, any>, yScale: Scale<any, any>);
             destroy(): Gridlines;
             protected _setup(): void;
             renderImmediately(): Gridlines;

--- a/plottable.js
+++ b/plottable.js
@@ -1449,6 +1449,14 @@ var Plottable;
             this._autoDomainIfAutomaticMode();
             return this;
         };
+        /**
+         * Gets an array of tick values spanning the domain.
+         *
+         * @returns {D[]}
+         */
+        Scale.prototype.ticks = function () {
+            return this.domain();
+        };
         return Scale;
     })();
     Plottable.Scale = Scale;
@@ -5329,12 +5337,12 @@ var Plottable;
              */
             function Gridlines(xScale, yScale) {
                 var _this = this;
-                if (xScale != null && !(Plottable.QuantitativeScale.prototype.isPrototypeOf(xScale))) {
-                    throw new Error("xScale needs to inherit from Scale.QuantitativeScale");
-                }
-                if (yScale != null && !(Plottable.QuantitativeScale.prototype.isPrototypeOf(yScale))) {
-                    throw new Error("yScale needs to inherit from Scale.QuantitativeScale");
-                }
+                // if (xScale != null && !(QuantitativeScale.prototype.isPrototypeOf(xScale))) {
+                //   throw new Error("xScale needs to inherit from Scale.QuantitativeScale");
+                // }
+                // if (yScale != null && !(QuantitativeScale.prototype.isPrototypeOf(yScale))) {
+                //   throw new Error("yScale needs to inherit from Scale.QuantitativeScale");
+                // }
                 _super.call(this);
                 this.addClass("gridlines");
                 this._xScale = xScale;

--- a/plottable.js
+++ b/plottable.js
@@ -5332,17 +5332,11 @@ var Plottable;
             __extends(Gridlines, _super);
             /**
              * @constructor
-             * @param {QuantitativeScale} xScale The scale to base the x gridlines on. Pass null if no gridlines are desired.
-             * @param {QuantitativeScale} yScale The scale to base the y gridlines on. Pass null if no gridlines are desired.
+             * @param {Scale<any, number>} xScale The scale to base the x gridlines on. Pass null if no gridlines are desired.
+             * @param {Scale<any, number>} yScale The scale to base the y gridlines on. Pass null if no gridlines are desired.
              */
             function Gridlines(xScale, yScale) {
                 var _this = this;
-                // if (xScale != null && !(QuantitativeScale.prototype.isPrototypeOf(xScale))) {
-                //   throw new Error("xScale needs to inherit from Scale.QuantitativeScale");
-                // }
-                // if (yScale != null && !(QuantitativeScale.prototype.isPrototypeOf(yScale))) {
-                //   throw new Error("yScale needs to inherit from Scale.QuantitativeScale");
-                // }
                 _super.call(this);
                 this.addClass("gridlines");
                 this._xScale = xScale;

--- a/src/components/gridlines.ts
+++ b/src/components/gridlines.ts
@@ -3,8 +3,8 @@
 module Plottable {
 export module Components {
   export class Gridlines extends Component {
-    private _xScale: QuantitativeScale<any>;
-    private _yScale: QuantitativeScale<any>;
+    private _xScale: Scale<any, any>;
+    private _yScale: Scale<any, any>;
     private _xLinesContainer: d3.Selection<void>;
     private _yLinesContainer: d3.Selection<void>;
 
@@ -15,13 +15,13 @@ export module Components {
      * @param {QuantitativeScale} xScale The scale to base the x gridlines on. Pass null if no gridlines are desired.
      * @param {QuantitativeScale} yScale The scale to base the y gridlines on. Pass null if no gridlines are desired.
      */
-    constructor(xScale: QuantitativeScale<any>, yScale: QuantitativeScale<any>) {
-      if (xScale != null && !(QuantitativeScale.prototype.isPrototypeOf(xScale))) {
-        throw new Error("xScale needs to inherit from Scale.QuantitativeScale");
-      }
-      if (yScale != null && !(QuantitativeScale.prototype.isPrototypeOf(yScale))) {
-        throw new Error("yScale needs to inherit from Scale.QuantitativeScale");
-      }
+    constructor(xScale: Scale<any, any>, yScale: Scale<any, any>) {
+      // if (xScale != null && !(QuantitativeScale.prototype.isPrototypeOf(xScale))) {
+      //   throw new Error("xScale needs to inherit from Scale.QuantitativeScale");
+      // }
+      // if (yScale != null && !(QuantitativeScale.prototype.isPrototypeOf(yScale))) {
+      //   throw new Error("yScale needs to inherit from Scale.QuantitativeScale");
+      // }
       super();
       this.addClass("gridlines");
       this._xScale = xScale;

--- a/src/components/gridlines.ts
+++ b/src/components/gridlines.ts
@@ -3,8 +3,8 @@
 module Plottable {
 export module Components {
   export class Gridlines extends Component {
-    private _xScale: Scale<any, any>;
-    private _yScale: Scale<any, any>;
+    private _xScale: Scale<any, number>;
+    private _yScale: Scale<any, number>;
     private _xLinesContainer: d3.Selection<void>;
     private _yLinesContainer: d3.Selection<void>;
 
@@ -12,16 +12,10 @@ export module Components {
 
     /**
      * @constructor
-     * @param {QuantitativeScale} xScale The scale to base the x gridlines on. Pass null if no gridlines are desired.
-     * @param {QuantitativeScale} yScale The scale to base the y gridlines on. Pass null if no gridlines are desired.
+     * @param {Scale<any, number>} xScale The scale to base the x gridlines on. Pass null if no gridlines are desired.
+     * @param {Scale<any, number>} yScale The scale to base the y gridlines on. Pass null if no gridlines are desired.
      */
-    constructor(xScale: Scale<any, any>, yScale: Scale<any, any>) {
-      // if (xScale != null && !(QuantitativeScale.prototype.isPrototypeOf(xScale))) {
-      //   throw new Error("xScale needs to inherit from Scale.QuantitativeScale");
-      // }
-      // if (yScale != null && !(QuantitativeScale.prototype.isPrototypeOf(yScale))) {
-      //   throw new Error("yScale needs to inherit from Scale.QuantitativeScale");
-      // }
+    constructor(xScale: Scale<any, number>, yScale: Scale<any, number>) {
       super();
       this.addClass("gridlines");
       this._xScale = xScale;

--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -159,6 +159,7 @@ export module Scales {
     protected _setRange(values: number[]) {
       this._d3Scale.range(values);
     }
+
   }
 }
 }

--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -159,7 +159,6 @@ export module Scales {
     protected _setRange(values: number[]) {
       this._d3Scale.range(values);
     }
-
   }
 }
 }

--- a/src/scales/scale.ts
+++ b/src/scales/scale.ts
@@ -215,5 +215,15 @@ module Plottable {
       this._autoDomainIfAutomaticMode();
       return this;
     }
+
+   /**
+    * Gets an array of tick values spanning the domain.
+    *
+    * @returns {D[]}
+    */
+    public ticks(): D[] {
+      return this.domain();
+    }
+
   }
 }


### PR DESCRIPTION
Closes #1289

Consider the scenario of scatter plot + gridlines on category scale. It should be valid IMO. 

**Fiddle**: http://jsfiddle.net/haku8pmk/1/
**QE Notes:** Before, using gridlines with a Category Scale, just threw an error (watch console). Now it should work as expected. 