### PR TITLE
Map and Set performance improvements

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -66,6 +66,7 @@ declare module Plottable {
          * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
          */
         class Map<K, V> {
+            constructor();
             set(key: K, value: V): Map<K, V>;
             get(key: K): V;
             has(key: K): boolean;

--- a/plottable.js
+++ b/plottable.js
@@ -217,30 +217,30 @@ var Plottable;
                 else {
                     this._values = [];
                 }
-                this._updateSize();
+                this.size = 0;
             }
             Set.prototype.add = function (value) {
                 if (this._es6Set != null) {
                     this._es6Set.add(value);
+                    this.size = this._es6Set.size;
+                    return this;
                 }
-                else {
-                    if (!this.has(value)) {
-                        this._values.push(value);
-                    }
+                if (!this.has(value)) {
+                    this._values.push(value);
+                    this.size = this._values.length;
                 }
-                this._updateSize();
                 return this;
             };
             Set.prototype.delete = function (value) {
                 if (this._es6Set != null) {
                     var deleted = this._es6Set.delete(value);
-                    this._updateSize();
+                    this.size = this._es6Set.size;
                     return deleted;
                 }
                 var index = this._values.indexOf(value);
                 if (index !== -1) {
                     this._values.splice(index, 1);
-                    this._updateSize();
+                    this.size = this._values.length;
                     return true;
                 }
                 return false;
@@ -260,21 +260,6 @@ var Plottable;
                 this._values.forEach(function (value) {
                     callback.call(thisArg, value, value, _this);
                 });
-            };
-            /**
-             * Updates the value of the read-only parameter size
-             */
-            Set.prototype._updateSize = function () {
-                if (this._es6Set != null) {
-                    this.size = this._es6Set.size;
-                }
-                else {
-                    this.size = this._values.length;
-                }
-                // Object.defineProperty(this, "size", {
-                //   value: newSize,
-                //   configurable: true
-                // });
             };
             return Set;
         })();

--- a/plottable.js
+++ b/plottable.js
@@ -126,11 +126,20 @@ var Plottable;
          */
         var Map = (function () {
             function Map() {
-                this._keyValuePairs = [];
+                if (typeof window.Map === "function") {
+                    this._es6Map = new window.Map();
+                }
+                else {
+                    this._keyValuePairs = [];
+                }
             }
             Map.prototype.set = function (key, value) {
                 if (Utils.Math.isNaN(key)) {
                     throw new Error("NaN may not be used as a key to the Map");
+                }
+                if (this._es6Map != null) {
+                    this._es6Map.set(key, value);
+                    return this;
                 }
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
                     if (this._keyValuePairs[i].key === key) {
@@ -142,6 +151,9 @@ var Plottable;
                 return this;
             };
             Map.prototype.get = function (key) {
+                if (this._es6Map != null) {
+                    return this._es6Map.get(key);
+                }
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
                     if (this._keyValuePairs[i].key === key) {
                         return this._keyValuePairs[i].value;
@@ -150,6 +162,9 @@ var Plottable;
                 return undefined;
             };
             Map.prototype.has = function (key) {
+                if (this._es6Map != null) {
+                    return this._es6Map.has(key);
+                }
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
                     if (this._keyValuePairs[i].key === key) {
                         return true;
@@ -159,11 +174,18 @@ var Plottable;
             };
             Map.prototype.forEach = function (callbackFn, thisArg) {
                 var _this = this;
+                if (this._es6Map != null) {
+                    this._es6Map.forEach(callbackFn, thisArg);
+                    return;
+                }
                 this._keyValuePairs.forEach(function (keyValuePair) {
                     callbackFn.call(thisArg, keyValuePair.value, keyValuePair.key, _this);
                 });
             };
             Map.prototype.delete = function (key) {
+                if (this._es6Map != null) {
+                    return this._es6Map.delete(key);
+                }
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
                     if (this._keyValuePairs[i].key === key) {
                         this._keyValuePairs.splice(i, 1);

--- a/plottable.js
+++ b/plottable.js
@@ -211,17 +211,32 @@ var Plottable;
          */
         var Set = (function () {
             function Set() {
-                this._values = [];
+                if (typeof window.Set === "function") {
+                    this._es6Set = new window.Set();
+                }
+                else {
+                    this._values = [];
+                }
                 this._updateSize();
             }
             Set.prototype.add = function (value) {
-                if (!this.has(value)) {
-                    this._values.push(value);
-                    this._updateSize();
+                if (this._es6Set != null) {
+                    this._es6Set.add(value);
                 }
+                else {
+                    if (!this.has(value)) {
+                        this._values.push(value);
+                    }
+                }
+                this._updateSize();
                 return this;
             };
             Set.prototype.delete = function (value) {
+                if (this._es6Set != null) {
+                    var deleted = this._es6Set.delete(value);
+                    this._updateSize();
+                    return deleted;
+                }
                 var index = this._values.indexOf(value);
                 if (index !== -1) {
                     this._values.splice(index, 1);
@@ -231,10 +246,17 @@ var Plottable;
                 return false;
             };
             Set.prototype.has = function (value) {
+                if (this._es6Set != null) {
+                    return this._es6Set.has(value);
+                }
                 return this._values.indexOf(value) !== -1;
             };
             Set.prototype.forEach = function (callback, thisArg) {
                 var _this = this;
+                if (this._es6Set != null) {
+                    this._es6Set.forEach(callback, thisArg);
+                    return;
+                }
                 this._values.forEach(function (value) {
                     callback.call(thisArg, value, value, _this);
                 });
@@ -243,8 +265,15 @@ var Plottable;
              * Updates the value of the read-only parameter size
              */
             Set.prototype._updateSize = function () {
+                var newSize = 0;
+                if (this._es6Set != null) {
+                    newSize = this._es6Set.size;
+                }
+                else {
+                    newSize = this._values.length;
+                }
                 Object.defineProperty(this, "size", {
-                    value: this._values.length,
+                    value: newSize,
                     configurable: true
                 });
             };

--- a/plottable.js
+++ b/plottable.js
@@ -175,7 +175,8 @@ var Plottable;
             Map.prototype.forEach = function (callbackFn, thisArg) {
                 var _this = this;
                 if (this._es6Map != null) {
-                    this._es6Map.forEach(callbackFn, thisArg);
+                    var callbackWrapper = function (value, key) { return callbackFn.call(thisArg, value, key, _this); };
+                    this._es6Map.forEach(callbackWrapper, thisArg);
                     return;
                 }
                 this._keyValuePairs.forEach(function (keyValuePair) {
@@ -254,7 +255,8 @@ var Plottable;
             Set.prototype.forEach = function (callback, thisArg) {
                 var _this = this;
                 if (this._es6Set != null) {
-                    this._es6Set.forEach(callback, thisArg);
+                    var callbackWrapper = function (value, value2) { return callback.call(thisArg, value, value2, _this); };
+                    this._es6Set.forEach(callbackWrapper, thisArg);
                     return;
                 }
                 this._values.forEach(function (value) {

--- a/plottable.js
+++ b/plottable.js
@@ -265,17 +265,16 @@ var Plottable;
              * Updates the value of the read-only parameter size
              */
             Set.prototype._updateSize = function () {
-                var newSize = 0;
                 if (this._es6Set != null) {
-                    newSize = this._es6Set.size;
+                    this.size = this._es6Set.size;
                 }
                 else {
-                    newSize = this._values.length;
+                    this.size = this._values.length;
                 }
-                Object.defineProperty(this, "size", {
-                    value: newSize,
-                    configurable: true
-                });
+                // Object.defineProperty(this, "size", {
+                //   value: newSize,
+                //   configurable: true
+                // });
             };
             return Set;
         })();

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -38,9 +38,9 @@ export module Utils {
       return this;
     }
 
-    public get(key: K): V {
+    public get(key: K) {
       if (this._es6Map != null) {
-        return this._es6Map.get(key);
+        return <V>this._es6Map.get(key);
       }
 
       for (var i = 0; i < this._keyValuePairs.length; i++) {
@@ -51,9 +51,9 @@ export module Utils {
       return undefined;
     }
 
-    public has(key: K): boolean {
+    public has(key: K) {
       if (this._es6Map != null) {
-        return this._es6Map.has(key);
+        return <boolean>this._es6Map.has(key);
       }
 
       for (var i = 0; i < this._keyValuePairs.length; i++) {
@@ -75,9 +75,9 @@ export module Utils {
       });
     }
 
-    public delete(key: K): boolean {
+    public delete(key: K) {
       if (this._es6Map != null) {
-        return this._es6Map.delete(key);
+        return <boolean>this._es6Map.delete(key);
       }
 
       for (var i = 0; i < this._keyValuePairs.length; i++) {

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -7,12 +7,27 @@ export module Utils {
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
    */
   export class Map<K, V> {
-    private _keyValuePairs: { key: K; value: V; }[] = [];
+    private _keyValuePairs: { key: K; value: V; }[];
+    private _es6Map: any;
+
+    public constructor() {
+      if (typeof (<any>window).Map === "function") {
+        this._es6Map = new (<any>window).Map();
+      } else {
+        this._keyValuePairs = [];
+      }
+    }
 
     public set(key: K, value: V) {
       if (Utils.Math.isNaN(key)) {
         throw new Error("NaN may not be used as a key to the Map");
       }
+
+      if (this._es6Map != null) {
+        this._es6Map.set(key, value);
+        return this;
+      }
+
       for (var i = 0; i < this._keyValuePairs.length; i++) {
         if (this._keyValuePairs[i].key === key) {
           this._keyValuePairs[i].value = value;
@@ -23,7 +38,11 @@ export module Utils {
       return this;
     }
 
-    public get(key: K) {
+    public get(key: K): V {
+      if (this._es6Map != null) {
+        return this._es6Map.get(key);
+      }
+
       for (var i = 0; i < this._keyValuePairs.length; i++) {
         if (this._keyValuePairs[i].key === key) {
           return this._keyValuePairs[i].value;
@@ -32,7 +51,11 @@ export module Utils {
       return undefined;
     }
 
-    public has(key: K) {
+    public has(key: K): boolean {
+      if (this._es6Map != null) {
+        return this._es6Map.has(key);
+      }
+
       for (var i = 0; i < this._keyValuePairs.length; i++) {
         if (this._keyValuePairs[i].key === key) {
           return true;
@@ -42,12 +65,21 @@ export module Utils {
     }
 
     public forEach(callbackFn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any) {
+      if (this._es6Map != null) {
+        this._es6Map.forEach(callbackFn, thisArg);
+        return;
+      }
+
       this._keyValuePairs.forEach((keyValuePair) => {
         callbackFn.call(thisArg, keyValuePair.value, keyValuePair.key, this);
       });
     }
 
-    public delete(key: K) {
+    public delete(key: K): boolean {
+      if (this._es6Map != null) {
+        return this._es6Map.delete(key);
+      }
+
       for (var i = 0; i < this._keyValuePairs.length; i++) {
         if (this._keyValuePairs[i].key === key) {
           this._keyValuePairs.splice(i, 1);

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -66,7 +66,8 @@ export module Utils {
 
     public forEach(callbackFn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any) {
       if (this._es6Map != null) {
-        this._es6Map.forEach(callbackFn, thisArg);
+        var callbackWrapper = (value: V, key: K) => callbackFn.call(thisArg, value, key, this);
+        this._es6Map.forEach(callbackWrapper, thisArg);
         return;
       }
 

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -18,33 +18,34 @@ export module Utils {
       } else {
         this._values = [];
       }
-      this._updateSize();
+      this.size = 0;
     }
 
     public add(value: T) {
       if (this._es6Set != null) {
         this._es6Set.add(value);
-      } else {
-        if (!this.has(value)) {
-          this._values.push(value);
-        }
+        this.size = this._es6Set.size;
+        return this;
       }
 
-      this._updateSize();
+      if (!this.has(value)) {
+        this._values.push(value);
+        this.size = this._values.length;
+      }
       return this;
     }
 
     public delete(value: T): boolean {
       if (this._es6Set != null) {
         var deleted = this._es6Set.delete(value);
-        this._updateSize();
+        this.size = this._es6Set.size;
         return deleted;
       }
 
       var index = this._values.indexOf(value);
       if (index !== -1) {
         this._values.splice(index, 1);
-        this._updateSize();
+        this.size = this._values.length;
         return true;
       }
       return false;
@@ -69,20 +70,6 @@ export module Utils {
       });
     }
 
-    /**
-     * Updates the value of the read-only parameter size
-     */
-    private _updateSize() {
-      if (this._es6Set != null) {
-        this.size = this._es6Set.size;
-      } else {
-        this.size = this._values.length;
-      }
-      // Object.defineProperty(this, "size", {
-      //   value: newSize,
-      //   configurable: true
-      // });
-    }
   }
 }
 }

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -61,7 +61,8 @@ export module Utils {
 
     public forEach(callback: (value: T, value2: T, set: Set<T>) => void, thisArg?: any) {
       if (this._es6Set != null) {
-        this._es6Set.forEach(callback, thisArg);
+        var callbackWrapper = (value: T, value2: T) => callback.call(thisArg, value, value2, this);
+        this._es6Set.forEach(callbackWrapper, thisArg);
         return;
       }
 

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -73,16 +73,15 @@ export module Utils {
      * Updates the value of the read-only parameter size
      */
     private _updateSize() {
-      var newSize = 0;
       if (this._es6Set != null) {
-        newSize = this._es6Set.size;
+        this.size = this._es6Set.size;
       } else {
-        newSize = this._values.length;
+        this.size = this._values.length;
       }
-      Object.defineProperty(this, "size", {
-        value: newSize,
-        configurable: true
-      });
+      // Object.defineProperty(this, "size", {
+      //   value: newSize,
+      //   configurable: true
+      // });
     }
   }
 }

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -35,9 +35,9 @@ export module Utils {
       return this;
     }
 
-    public delete(value: T): boolean {
+    public delete(value: T) {
       if (this._es6Set != null) {
-        var deleted = this._es6Set.delete(value);
+        var deleted = <boolean>this._es6Set.delete(value);
         this.size = this._es6Set.size;
         return deleted;
       }
@@ -51,9 +51,9 @@ export module Utils {
       return false;
     }
 
-    public has(value: T): boolean {
+    public has(value: T) {
       if (this._es6Set != null) {
-        return this._es6Set.has(value);
+        return <boolean>this._es6Set.has(value);
       }
 
       return this._values.indexOf(value) !== -1;

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -10,21 +10,37 @@ export module Utils {
     public size: number;
 
     private _values: T[];
+    private _es6Set: any;
 
     constructor() {
-      this._values = [];
+      if (typeof (<any>window).Set === "function") {
+        this._es6Set = new (<any>window).Set();
+      } else {
+        this._values = [];
+      }
       this._updateSize();
     }
 
     public add(value: T) {
-      if (!this.has(value)) {
-        this._values.push(value);
-        this._updateSize();
+      if (this._es6Set != null) {
+        this._es6Set.add(value);
+      } else {
+        if (!this.has(value)) {
+          this._values.push(value);
+        }
       }
+
+      this._updateSize();
       return this;
     }
 
-    public delete(value: T) {
+    public delete(value: T): boolean {
+      if (this._es6Set != null) {
+        var deleted = this._es6Set.delete(value);
+        this._updateSize();
+        return deleted;
+      }
+
       var index = this._values.indexOf(value);
       if (index !== -1) {
         this._values.splice(index, 1);
@@ -34,11 +50,20 @@ export module Utils {
       return false;
     }
 
-    public has(value: T) {
+    public has(value: T): boolean {
+      if (this._es6Set != null) {
+        return this._es6Set.has(value);
+      }
+
       return this._values.indexOf(value) !== -1;
     }
 
     public forEach(callback: (value: T, value2: T, set: Set<T>) => void, thisArg?: any) {
+      if (this._es6Set != null) {
+        this._es6Set.forEach(callback, thisArg);
+        return;
+      }
+
       this._values.forEach((value: T) => {
         callback.call(thisArg, value, value, this);
       });
@@ -48,8 +73,14 @@ export module Utils {
      * Updates the value of the read-only parameter size
      */
     private _updateSize() {
+      var newSize = 0;
+      if (this._es6Set != null) {
+        newSize = this._es6Set.size;
+      } else {
+        newSize = this._values.length;
+      }
       Object.defineProperty(this, "size", {
-        value: this._values.length,
+        value: newSize,
         configurable: true
       });
     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -8240,12 +8240,7 @@ describe("Map", function () {
         map.forEach(function (value, key, mp) {
             assert.strictEqual(value, values[index], "Value " + index + " is the expected one");
             assert.strictEqual(key, keys[index], "Key " + index + " is the expected one");
-            if (map._es6Map != null) {
-                assert.strictEqual(mp, map._es6Map, "The correct map is passed as the third argument (ES6)");
-            }
-            else {
-                assert.strictEqual(mp, map, "The correct map is passed as the third argument (non ES6)");
-            }
+            assert.strictEqual(mp, map, "The correct map is passed as the third argument");
             index++;
         });
         assert.strictEqual(index, keys.length, "The expected number of iterations executed in the forEach");
@@ -8285,21 +8280,15 @@ describe("Utils", function () {
             var value1 = { value: "one" };
             set.add(value1);
             assert.strictEqual(set.size, 1, "set contains one value");
-            if (set._values != null) {
-                assert.strictEqual(set._values[0], value1, "the value was added to the set");
-            }
+            assert.strictEqual(set._values[0], value1, "the value was added to the set");
             set.add(value1);
             assert.strictEqual(set.size, 1, "same value is not added twice");
-            if (set._values != null) {
-                assert.strictEqual(set._values[0], value1, "list still contains the value");
-            }
+            assert.strictEqual(set._values[0], value1, "list still contains the value");
             var value2 = { value: "two" };
             set.add(value2);
             assert.strictEqual(set.size, 2, "set now contains two values");
-            if (set._values != null) {
-                assert.strictEqual(set._values[0], value1, "set contains value 1");
-                assert.strictEqual(set._values[1], value2, "set contains value 2");
-            }
+            assert.strictEqual(set._values[0], value1, "set contains value 1");
+            assert.strictEqual(set._values[1], value2, "set contains value 2");
         });
         it("delete()", function () {
             var set = new Plottable.Utils.Set();
@@ -8332,12 +8321,7 @@ describe("Utils", function () {
             set.forEach(function (value1, value2, passedSet) {
                 assert.strictEqual(value1, value2, "The two value arguments passed to the callback are the same");
                 assert.strictEqual(value1, values[index], "Value " + index + " is the expected one");
-                if (set._es6Set != null) {
-                    assert.strictEqual(passedSet, set._es6Set, "The correct Set is passed as the third argument (ES6)");
-                }
-                else {
-                    assert.strictEqual(passedSet, set, "The correct Set is passed as the third argument (non ES6)");
-                }
+                assert.strictEqual(passedSet, set, "The correct Set is passed as the third argument");
                 index++;
             });
             assert.strictEqual(index, values.length, "The expected number of iterations executed in the forEach");

--- a/test/tests.js
+++ b/test/tests.js
@@ -8240,7 +8240,12 @@ describe("Map", function () {
         map.forEach(function (value, key, mp) {
             assert.strictEqual(value, values[index], "Value " + index + " is the expected one");
             assert.strictEqual(key, keys[index], "Key " + index + " is the expected one");
-            assert.strictEqual(mp, map, "The correct map is passed as the third argument");
+            if (map._es6Map != null) {
+                assert.strictEqual(mp, map._es6Map, "The correct map is passed as the third argument (ES6)");
+            }
+            else {
+                assert.strictEqual(mp, map, "The correct map is passed as the third argument (non ES6)");
+            }
             index++;
         });
         assert.strictEqual(index, keys.length, "The expected number of iterations executed in the forEach");
@@ -8327,7 +8332,12 @@ describe("Utils", function () {
             set.forEach(function (value1, value2, passedSet) {
                 assert.strictEqual(value1, value2, "The two value arguments passed to the callback are the same");
                 assert.strictEqual(value1, values[index], "Value " + index + " is the expected one");
-                assert.strictEqual(passedSet, set, "The correct Set is passed as the third argument");
+                if (set._es6Set != null) {
+                    assert.strictEqual(passedSet, set._es6Set, "The correct Set is passed as the third argument (ES6)");
+                }
+                else {
+                    assert.strictEqual(passedSet, set, "The correct Set is passed as the third argument (non ES6)");
+                }
                 index++;
             });
             assert.strictEqual(index, values.length, "The expected number of iterations executed in the forEach");

--- a/test/tests.js
+++ b/test/tests.js
@@ -8280,15 +8280,21 @@ describe("Utils", function () {
             var value1 = { value: "one" };
             set.add(value1);
             assert.strictEqual(set.size, 1, "set contains one value");
-            assert.strictEqual(set._values[0], value1, "the value was added to the set");
+            if (set._values != null) {
+                assert.strictEqual(set._values[0], value1, "the value was added to the set");
+            }
             set.add(value1);
             assert.strictEqual(set.size, 1, "same value is not added twice");
-            assert.strictEqual(set._values[0], value1, "list still contains the value");
+            if (set._values != null) {
+                assert.strictEqual(set._values[0], value1, "list still contains the value");
+            }
             var value2 = { value: "two" };
             set.add(value2);
             assert.strictEqual(set.size, 2, "set now contains two values");
-            assert.strictEqual(set._values[0], value1, "set contains value 1");
-            assert.strictEqual(set._values[1], value2, "set contains value 2");
+            if (set._values != null) {
+                assert.strictEqual(set._values[0], value1, "set contains value 1");
+                assert.strictEqual(set._values[1], value2, "set contains value 2");
+            }
         });
         it("delete()", function () {
             var set = new Plottable.Utils.Set();

--- a/test/tests.js
+++ b/test/tests.js
@@ -8280,21 +8280,11 @@ describe("Utils", function () {
             var value1 = { value: "one" };
             set.add(value1);
             assert.strictEqual(set.size, 1, "set contains one value");
-            if (set._values != null) {
-                assert.strictEqual(set._values[0], value1, "the value was added to the set");
-            }
             set.add(value1);
             assert.strictEqual(set.size, 1, "same value is not added twice");
-            if (set._values != null) {
-                assert.strictEqual(set._values[0], value1, "list still contains the value");
-            }
             var value2 = { value: "two" };
             set.add(value2);
             assert.strictEqual(set.size, 2, "set now contains two values");
-            if (set._values != null) {
-                assert.strictEqual(set._values[0], value1, "set contains value 1");
-                assert.strictEqual(set._values[1], value2, "set contains value 2");
-            }
         });
         it("delete()", function () {
             var set = new Plottable.Utils.Set();

--- a/test/utils/mapTests.ts
+++ b/test/utils/mapTests.ts
@@ -44,11 +44,7 @@ describe("Map", () => {
     map.forEach((value: number, key: string, mp: Plottable.Utils.Map<string, number>) => {
       assert.strictEqual(value, values[index], "Value " + index + " is the expected one");
       assert.strictEqual(key, keys[index], "Key " + index + " is the expected one");
-      if ((<any>map)._es6Map != null) {
-        assert.strictEqual(mp, (<any>map)._es6Map, "The correct map is passed as the third argument (ES6)");
-      } else {
-        assert.strictEqual(mp, map, "The correct map is passed as the third argument (non ES6)");
-      }
+      assert.strictEqual(mp, map, "The correct map is passed as the third argument");
       index++;
     });
     assert.strictEqual(index, keys.length, "The expected number of iterations executed in the forEach");

--- a/test/utils/mapTests.ts
+++ b/test/utils/mapTests.ts
@@ -44,7 +44,11 @@ describe("Map", () => {
     map.forEach((value: number, key: string, mp: Plottable.Utils.Map<string, number>) => {
       assert.strictEqual(value, values[index], "Value " + index + " is the expected one");
       assert.strictEqual(key, keys[index], "Key " + index + " is the expected one");
-      assert.strictEqual(mp, map, "The correct map is passed as the third argument");
+      if ((<any>map)._es6Map != null) {
+        assert.strictEqual(mp, (<any>map)._es6Map, "The correct map is passed as the third argument (ES6)");
+      } else {
+        assert.strictEqual(mp, map, "The correct map is passed as the third argument (non ES6)");
+      }
       index++;
     });
     assert.strictEqual(index, keys.length, "The expected number of iterations executed in the forEach");

--- a/test/utils/setTests.ts
+++ b/test/utils/setTests.ts
@@ -10,23 +10,17 @@ describe("Utils", () => {
       var value1 = { value: "one" };
       set.add(value1);
       assert.strictEqual(set.size, 1, "set contains one value");
-      if ((<any>set)._values != null) {
-        assert.strictEqual((<any>set)._values[0], value1, "the value was added to the set");
-      }
+      assert.strictEqual((<any>set)._values[0], value1, "the value was added to the set");
 
       set.add(value1);
       assert.strictEqual(set.size, 1, "same value is not added twice");
-      if ((<any>set)._values != null) {
-        assert.strictEqual((<any>set)._values[0], value1, "list still contains the value");
-      }
+      assert.strictEqual((<any>set)._values[0], value1, "list still contains the value");
 
       var value2 = { value: "two" };
       set.add(value2);
       assert.strictEqual(set.size, 2, "set now contains two values");
-      if ((<any>set)._values != null) {
-        assert.strictEqual((<any>set)._values[0], value1, "set contains value 1");
-        assert.strictEqual((<any>set)._values[1], value2, "set contains value 2");
-      }
+      assert.strictEqual((<any>set)._values[0], value1, "set contains value 1");
+      assert.strictEqual((<any>set)._values[1], value2, "set contains value 2");
     });
 
     it("delete()", () => {
@@ -67,11 +61,7 @@ describe("Utils", () => {
       set.forEach((value1: any, value2: any, passedSet: Plottable.Utils.Set<any>) => {
         assert.strictEqual(value1, value2, "The two value arguments passed to the callback are the same");
         assert.strictEqual(value1, values[index], "Value " + index + " is the expected one");
-        if ((<any>set)._es6Set != null) {
-            assert.strictEqual(passedSet, (<any>set)._es6Set, "The correct Set is passed as the third argument (ES6)");
-          } else {
-            assert.strictEqual(passedSet, set, "The correct Set is passed as the third argument (non ES6)");
-          }
+        assert.strictEqual(passedSet, set, "The correct Set is passed as the third argument");
         index++;
       });
       assert.strictEqual(index, values.length, "The expected number of iterations executed in the forEach");

--- a/test/utils/setTests.ts
+++ b/test/utils/setTests.ts
@@ -67,7 +67,11 @@ describe("Utils", () => {
       set.forEach((value1: any, value2: any, passedSet: Plottable.Utils.Set<any>) => {
         assert.strictEqual(value1, value2, "The two value arguments passed to the callback are the same");
         assert.strictEqual(value1, values[index], "Value " + index + " is the expected one");
-        assert.strictEqual(passedSet, set, "The correct Set is passed as the third argument");
+        if ((<any>set)._es6Set != null) {
+            assert.strictEqual(passedSet, (<any>set)._es6Set, "The correct Set is passed as the third argument (ES6)");
+          } else {
+            assert.strictEqual(passedSet, set, "The correct Set is passed as the third argument (non ES6)");
+          }
         index++;
       });
       assert.strictEqual(index, values.length, "The expected number of iterations executed in the forEach");

--- a/test/utils/setTests.ts
+++ b/test/utils/setTests.ts
@@ -10,17 +10,23 @@ describe("Utils", () => {
       var value1 = { value: "one" };
       set.add(value1);
       assert.strictEqual(set.size, 1, "set contains one value");
-      assert.strictEqual((<any>set)._values[0], value1, "the value was added to the set");
+      if ((<any>set)._values != null) {
+        assert.strictEqual((<any>set)._values[0], value1, "the value was added to the set");
+      }
 
       set.add(value1);
       assert.strictEqual(set.size, 1, "same value is not added twice");
-      assert.strictEqual((<any>set)._values[0], value1, "list still contains the value");
+      if ((<any>set)._values != null) {
+        assert.strictEqual((<any>set)._values[0], value1, "list still contains the value");
+      }
 
       var value2 = { value: "two" };
       set.add(value2);
       assert.strictEqual(set.size, 2, "set now contains two values");
-      assert.strictEqual((<any>set)._values[0], value1, "set contains value 1");
-      assert.strictEqual((<any>set)._values[1], value2, "set contains value 2");
+      if ((<any>set)._values != null) {
+        assert.strictEqual((<any>set)._values[0], value1, "set contains value 1");
+        assert.strictEqual((<any>set)._values[1], value2, "set contains value 2");
+      }
     });
 
     it("delete()", () => {

--- a/test/utils/setTests.ts
+++ b/test/utils/setTests.ts
@@ -10,23 +10,13 @@ describe("Utils", () => {
       var value1 = { value: "one" };
       set.add(value1);
       assert.strictEqual(set.size, 1, "set contains one value");
-      if ((<any>set)._values != null) {
-        assert.strictEqual((<any>set)._values[0], value1, "the value was added to the set");
-      }
 
       set.add(value1);
       assert.strictEqual(set.size, 1, "same value is not added twice");
-      if ((<any>set)._values != null) {
-        assert.strictEqual((<any>set)._values[0], value1, "list still contains the value");
-      }
 
       var value2 = { value: "two" };
       set.add(value2);
       assert.strictEqual(set.size, 2, "set now contains two values");
-      if ((<any>set)._values != null) {
-        assert.strictEqual((<any>set)._values[0], value1, "set contains value 1");
-        assert.strictEqual((<any>set)._values[1], value2, "set contains value 2");
-      }
     });
 
     it("delete()", () => {


### PR DESCRIPTION
As part of the API refactor, we introduced the ES6 shims for Map and Set. Also, we decided not to expose the d3 map/set anymore. The problem is that our Map and Set were not efficient.

However, Chrome and FF support ES6 Map / Set for quite a while, hence we can leverage their power and cut down O(n) to O(log n) / O(1).

[Browser Support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map):
```
Chrome: 38
Firefox: 25
IE: 11
Opera: 25
Safari: 7.1
```
For reference, [latest version](http://browsehappy.com/) of each browser at the time of writing is:
```
Chrome: 43
Firefox: 38
IE: 11
Opera: 30
Safari: 8
```

**Notice** The `size` field on the Set is no longer read-only. The reason for that is 25% time reduction (from 90-100 ms down to 15-25 ms) on the following test: http://jsfiddle.net/jto18oyh/2/. It is not excellent, but since a set is a core component and performance is important, I am in favor for this change

**Also:** Backward compatible 

---
#### Numbers
On the stacked plot test, the improvement is substantial. (if looking into the JSfiddle, I suggest open the console before clicking on the link)

Before http://jsfiddle.net/r44qLe06/2/
```
t: 11793.249ms
t: 12763.007ms
t: 13495.781ms
t: 14244.572ms
t: 14458.213ms
```
After http://jsfiddle.net/r44qLe06/1/
```
t: 1377.659ms
t: 1260.547ms
t: 1304.650ms
t: 1322.013ms
t: 1646.604ms
```


**QE Notes** Regression pass. IE should behave exactly the same. Firefox and Chrome should be faster everywhere as we improved the speed of our core Set and Map data structures. As a side note, stacking for stacked bar and stacked line should be improved by up to 10x