### PR TITLE
Bar plot perf

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2871,7 +2871,7 @@ declare module Plottable {
              *   from https://github.com/mbostock/d3/wiki/Ordinal-Scales#ordinal_rangePoints, the max barPixelWidth is step * padding
              * If the position scale of the plot is a QuantitativeScale, then _getMinimumDataWidth is scaled to compute the barPixelWidth
              */
-            protected _updateBarPixelWidth(): number;
+            protected _getBarPixelWidth(): number;
             entities(datasets?: Dataset[]): PlotEntity[];
             protected _pixelPoint(datum: any, index: number, dataset: Dataset): {
                 x: any;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2805,8 +2805,8 @@ declare module Plottable {
              * @returns {Bar} The calling Bar Plot.
              */
             baselineValue(value: X | Y): Bar<X, Y>;
-            addDataset(dataset: Dataset): Plot;
-            removeDataset(dataset: Dataset): Plot;
+            addDataset(dataset: Dataset): Bar<X, Y>;
+            removeDataset(dataset: Dataset): Bar<X, Y>;
             /**
              * Get whether bar labels are enabled.
              *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -300,6 +300,16 @@ declare module Plottable {
              */
             function stackedExtent(stackingResult: StackingResult, keyAccessor: Accessor<any>, filter: Accessor<boolean>): number[];
             /**
+             * Given an array of Datasets and the accessor function for the key, computes the
+             * set reunion (no duplicates) of the domain of each Dataset. The keys are stringified
+             * before being returned.
+             *
+             * @param {Dataset[]} datasets The Datasets for which we extract the domain keys
+             * @param {Accessor<any>} keyAccessor The accessor for the key of the data
+             * @return {string[]} An array of stringified keys
+             */
+            function domainKeys(datasets: Dataset[], keyAccessor: Accessor<any>): string[];
+            /**
              * Normalizes a key used for stacking
              *
              * @param {any} key The key to be normalized
@@ -2795,6 +2805,8 @@ declare module Plottable {
              * @returns {Bar} The calling Bar Plot.
              */
             baselineValue(value: X | Y): Bar<X, Y>;
+            addDataset(dataset: Dataset): Plot;
+            removeDataset(dataset: Dataset): Plot;
             /**
              * Get whether bar labels are enabled.
              *
@@ -2874,6 +2886,7 @@ declare module Plottable {
                 x: any;
                 y: any;
             };
+            protected _uninstallScaleForKey(scale: Scale<any, number>, key: string): void;
             protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
         }
     }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2881,7 +2881,7 @@ declare module Plottable {
              *   from https://github.com/mbostock/d3/wiki/Ordinal-Scales#ordinal_rangePoints, the max barPixelWidth is step * padding
              * If the position scale of the plot is a QuantitativeScale, then _getMinimumDataWidth is scaled to compute the barPixelWidth
              */
-            protected _getBarPixelWidth(): number;
+            protected _updateBarPixelWidth(): number;
             entities(datasets?: Dataset[]): PlotEntity[];
             protected _pixelPoint(datum: any, index: number, dataset: Dataset): {
                 x: any;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -66,6 +66,7 @@ declare module Plottable {
          * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
          */
         class Map<K, V> {
+            constructor();
             set(key: K, value: V): Map<K, V>;
             get(key: K): V;
             has(key: K): boolean;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -300,16 +300,6 @@ declare module Plottable {
              */
             function stackedExtent(stackingResult: StackingResult, keyAccessor: Accessor<any>, filter: Accessor<boolean>): number[];
             /**
-             * Given an array of Datasets and the accessor function for the key, computes the
-             * set reunion (no duplicates) of the domain of each Dataset. The keys are stringified
-             * before being returned.
-             *
-             * @param {Dataset[]} datasets The Datasets for which we extract the domain keys
-             * @param {Accessor<any>} keyAccessor The accessor for the key of the data
-             * @return {string[]} An array of stringified keys
-             */
-            function domainKeys(datasets: Dataset[], keyAccessor: Accessor<any>): string[];
-            /**
              * Normalizes a key used for stacking
              *
              * @param {any} key The key to be normalized

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2788,6 +2788,7 @@ declare module Plottable {
              * @return "vertical" | "horizontal"
              */
             orientation(): string;
+            render(): Bar<X, Y>;
             protected _createDrawer(dataset: Dataset): Drawers.Rectangle;
             protected _setup(): void;
             /**

--- a/plottable.js
+++ b/plottable.js
@@ -7355,7 +7355,7 @@ var Plottable;
              *   from https://github.com/mbostock/d3/wiki/Ordinal-Scales#ordinal_rangePoints, the max barPixelWidth is step * padding
              * If the position scale of the plot is a QuantitativeScale, then _getMinimumDataWidth is scaled to compute the barPixelWidth
              */
-            Bar.prototype._updateBarPixelWidth = function () {
+            Bar.prototype._getBarPixelWidth = function () {
                 if (!this._projectorsReady()) {
                     return 0;
                 }
@@ -7387,7 +7387,10 @@ var Plottable;
                     }
                     barPixelWidth *= Bar._BAR_WIDTH_RATIO;
                 }
-                this._barPixelWidth = barPixelWidth;
+                return barPixelWidth;
+            };
+            Bar.prototype._updateBarPixelWidth = function () {
+                this._barPixelWidth = this._getBarPixelWidth();
             };
             Bar.prototype.entities = function (datasets) {
                 var _this = this;

--- a/plottable.js
+++ b/plottable.js
@@ -7395,6 +7395,15 @@ var Plottable;
                     barPixelWidth = Plottable.Utils.Math.min(barAccessorDataPairs, function (pair, i) {
                         return Math.abs(pair[1] - pair[0]);
                     }, barWidthDimension * Bar._SINGLE_BAR_DIMENSION_RATIO);
+                    var minScaledDatum = Plottable.Utils.Math.min(scaledData, 0);
+                    if (minScaledDatum > 0) {
+                        barPixelWidth = Math.min(barPixelWidth, minScaledDatum * 2);
+                    }
+                    var maxScaledDatum = Plottable.Utils.Math.max(scaledData, 0);
+                    if (maxScaledDatum < barWidthDimension) {
+                        var margin = barWidthDimension - maxScaledDatum;
+                        barPixelWidth = Math.min(barPixelWidth, margin * 2);
+                    }
                     barPixelWidth *= Bar._BAR_WIDTH_RATIO;
                 }
                 this._barPixelWidth = barPixelWidth;

--- a/plottable.js
+++ b/plottable.js
@@ -217,30 +217,30 @@ var Plottable;
                 else {
                     this._values = [];
                 }
-                this._updateSize();
+                this.size = 0;
             }
             Set.prototype.add = function (value) {
                 if (this._es6Set != null) {
                     this._es6Set.add(value);
+                    this.size = this._es6Set.size;
+                    return this;
                 }
-                else {
-                    if (!this.has(value)) {
-                        this._values.push(value);
-                    }
+                if (!this.has(value)) {
+                    this._values.push(value);
+                    this.size = this._values.length;
                 }
-                this._updateSize();
                 return this;
             };
             Set.prototype.delete = function (value) {
                 if (this._es6Set != null) {
                     var deleted = this._es6Set.delete(value);
-                    this._updateSize();
+                    this.size = this._es6Set.size;
                     return deleted;
                 }
                 var index = this._values.indexOf(value);
                 if (index !== -1) {
                     this._values.splice(index, 1);
-                    this._updateSize();
+                    this.size = this._values.length;
                     return true;
                 }
                 return false;
@@ -260,21 +260,6 @@ var Plottable;
                 this._values.forEach(function (value) {
                     callback.call(thisArg, value, value, _this);
                 });
-            };
-            /**
-             * Updates the value of the read-only parameter size
-             */
-            Set.prototype._updateSize = function () {
-                if (this._es6Set != null) {
-                    this.size = this._es6Set.size;
-                }
-                else {
-                    this.size = this._values.length;
-                }
-                // Object.defineProperty(this, "size", {
-                //   value: newSize,
-                //   configurable: true
-                // });
             };
             return Set;
         })();

--- a/plottable.js
+++ b/plottable.js
@@ -126,11 +126,20 @@ var Plottable;
          */
         var Map = (function () {
             function Map() {
-                this._keyValuePairs = [];
+                if (typeof window.Map === "function") {
+                    this._es6Map = new window.Map();
+                }
+                else {
+                    this._keyValuePairs = [];
+                }
             }
             Map.prototype.set = function (key, value) {
                 if (Utils.Math.isNaN(key)) {
                     throw new Error("NaN may not be used as a key to the Map");
+                }
+                if (this._es6Map != null) {
+                    this._es6Map.set(key, value);
+                    return this;
                 }
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
                     if (this._keyValuePairs[i].key === key) {
@@ -142,6 +151,9 @@ var Plottable;
                 return this;
             };
             Map.prototype.get = function (key) {
+                if (this._es6Map != null) {
+                    return this._es6Map.get(key);
+                }
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
                     if (this._keyValuePairs[i].key === key) {
                         return this._keyValuePairs[i].value;
@@ -150,6 +162,9 @@ var Plottable;
                 return undefined;
             };
             Map.prototype.has = function (key) {
+                if (this._es6Map != null) {
+                    return this._es6Map.has(key);
+                }
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
                     if (this._keyValuePairs[i].key === key) {
                         return true;
@@ -159,11 +174,18 @@ var Plottable;
             };
             Map.prototype.forEach = function (callbackFn, thisArg) {
                 var _this = this;
+                if (this._es6Map != null) {
+                    this._es6Map.forEach(callbackFn, thisArg);
+                    return;
+                }
                 this._keyValuePairs.forEach(function (keyValuePair) {
                     callbackFn.call(thisArg, keyValuePair.value, keyValuePair.key, _this);
                 });
             };
             Map.prototype.delete = function (key) {
+                if (this._es6Map != null) {
+                    return this._es6Map.delete(key);
+                }
                 for (var i = 0; i < this._keyValuePairs.length; i++) {
                     if (this._keyValuePairs[i].key === key) {
                         this._keyValuePairs.splice(i, 1);

--- a/plottable.js
+++ b/plottable.js
@@ -7052,6 +7052,11 @@ var Plottable;
             Bar.prototype.orientation = function () {
                 return this._isVertical ? Bar.ORIENTATION_VERTICAL : Bar.ORIENTATION_HORIZONTAL;
             };
+            Bar.prototype.render = function () {
+                _super.prototype.render.call(this);
+                this._getBarPixelWidth();
+                return this;
+            };
             Bar.prototype._createDrawer = function (dataset) {
                 return new Plottable.Drawers.Rectangle(dataset);
             };
@@ -7380,8 +7385,6 @@ var Plottable;
                 }
                 else {
                     var barAccessor = this._isVertical ? this.x().accessor : this.y().accessor;
-                    // var tmp: string[] = Plottable.Utils.Stacking.domainKeys(this.datasets(), barAccessor);
-                    // return 14;
                     var numberBarAccessorData = d3.set(Plottable.Utils.Array.flatten(this.datasets().map(function (dataset) {
                         return dataset.data().map(function (d, i) { return barAccessor(d, i, dataset); }).filter(function (d) { return d != null; }).map(function (d) { return d.valueOf(); });
                     }))).values().map(function (value) { return +value; });

--- a/plottable.js
+++ b/plottable.js
@@ -211,17 +211,32 @@ var Plottable;
          */
         var Set = (function () {
             function Set() {
-                this._values = [];
+                if (typeof window.Set === "function") {
+                    this._es6Set = new window.Set();
+                }
+                else {
+                    this._values = [];
+                }
                 this._updateSize();
             }
             Set.prototype.add = function (value) {
-                if (!this.has(value)) {
-                    this._values.push(value);
-                    this._updateSize();
+                if (this._es6Set != null) {
+                    this._es6Set.add(value);
                 }
+                else {
+                    if (!this.has(value)) {
+                        this._values.push(value);
+                    }
+                }
+                this._updateSize();
                 return this;
             };
             Set.prototype.delete = function (value) {
+                if (this._es6Set != null) {
+                    var deleted = this._es6Set.delete(value);
+                    this._updateSize();
+                    return deleted;
+                }
                 var index = this._values.indexOf(value);
                 if (index !== -1) {
                     this._values.splice(index, 1);
@@ -231,10 +246,17 @@ var Plottable;
                 return false;
             };
             Set.prototype.has = function (value) {
+                if (this._es6Set != null) {
+                    return this._es6Set.has(value);
+                }
                 return this._values.indexOf(value) !== -1;
             };
             Set.prototype.forEach = function (callback, thisArg) {
                 var _this = this;
+                if (this._es6Set != null) {
+                    this._es6Set.forEach(callback, thisArg);
+                    return;
+                }
                 this._values.forEach(function (value) {
                     callback.call(thisArg, value, value, _this);
                 });
@@ -243,8 +265,15 @@ var Plottable;
              * Updates the value of the read-only parameter size
              */
             Set.prototype._updateSize = function () {
+                var newSize = 0;
+                if (this._es6Set != null) {
+                    newSize = this._es6Set.size;
+                }
+                else {
+                    newSize = this._values.length;
+                }
                 Object.defineProperty(this, "size", {
-                    value: this._values.length,
+                    value: newSize,
                     configurable: true
                 });
             };

--- a/plottable.js
+++ b/plottable.js
@@ -7014,7 +7014,7 @@ var Plottable;
                 this.attr("width", function () { return _this._barPixelWidth; });
                 this._labelConfig = new Plottable.Utils.Map();
                 this._baselineValueProvider = function () { return [_this.baselineValue()]; };
-                this._getBarPixelWidthCallback = function () { return _this._getBarPixelWidth(); };
+                this._updateBarPixelWidthCallback = function () { return _this._updateBarPixelWidth(); };
             }
             Bar.prototype.x = function (x, xScale) {
                 if (x == null) {
@@ -7025,7 +7025,7 @@ var Plottable;
                 }
                 else {
                     _super.prototype.x.call(this, x, xScale);
-                    xScale.onUpdate(this._getBarPixelWidthCallback);
+                    xScale.onUpdate(this._updateBarPixelWidthCallback);
                 }
                 this._updateValueScale();
                 return this;
@@ -7039,7 +7039,7 @@ var Plottable;
                 }
                 else {
                     _super.prototype.y.call(this, y, yScale);
-                    yScale.onUpdate(this._getBarPixelWidthCallback);
+                    yScale.onUpdate(this._updateBarPixelWidthCallback);
                 }
                 this._updateValueScale();
                 return this;
@@ -7054,7 +7054,7 @@ var Plottable;
             };
             Bar.prototype.render = function () {
                 _super.prototype.render.call(this);
-                this._getBarPixelWidth();
+                this._updateBarPixelWidth();
                 return this;
             };
             Bar.prototype._createDrawer = function (dataset) {
@@ -7087,15 +7087,15 @@ var Plottable;
                 return this;
             };
             Bar.prototype.addDataset = function (dataset) {
-                dataset.onUpdate(this._getBarPixelWidthCallback);
+                dataset.onUpdate(this._updateBarPixelWidthCallback);
                 _super.prototype.addDataset.call(this, dataset);
-                this._getBarPixelWidth();
+                this._updateBarPixelWidth();
                 return this;
             };
             Bar.prototype.removeDataset = function (dataset) {
-                dataset.offUpdate(this._getBarPixelWidthCallback);
+                dataset.offUpdate(this._updateBarPixelWidthCallback);
                 _super.prototype.removeDataset.call(this, dataset);
-                this._getBarPixelWidth();
+                this._updateBarPixelWidth();
                 return this;
             };
             Bar.prototype.labelsEnabled = function (enabled) {
@@ -7374,7 +7374,7 @@ var Plottable;
              *   from https://github.com/mbostock/d3/wiki/Ordinal-Scales#ordinal_rangePoints, the max barPixelWidth is step * padding
              * If the position scale of the plot is a QuantitativeScale, then _getMinimumDataWidth is scaled to compute the barPixelWidth
              */
-            Bar.prototype._getBarPixelWidth = function () {
+            Bar.prototype._updateBarPixelWidth = function () {
                 if (!this._projectorsReady()) {
                     return 0;
                 }
@@ -7407,7 +7407,6 @@ var Plottable;
                     barPixelWidth *= Bar._BAR_WIDTH_RATIO;
                 }
                 this._barPixelWidth = barPixelWidth;
-                return barPixelWidth;
             };
             Bar.prototype.entities = function (datasets) {
                 var _this = this;
@@ -7446,7 +7445,7 @@ var Plottable;
                 return { x: x, y: y };
             };
             Bar.prototype._uninstallScaleForKey = function (scale, key) {
-                scale.offUpdate(this._getBarPixelWidthCallback);
+                scale.offUpdate(this._updateBarPixelWidthCallback);
                 _super.prototype._uninstallScaleForKey.call(this, scale, key);
             };
             Bar.prototype._getDataToDraw = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -710,25 +710,6 @@ var Plottable;
             }
             Stacking.stackedExtent = stackedExtent;
             /**
-             * Given an array of Datasets and the accessor function for the key, computes the
-             * set reunion (no duplicates) of the domain of each Dataset. The keys are stringified
-             * before being returned.
-             *
-             * @param {Dataset[]} datasets The Datasets for which we extract the domain keys
-             * @param {Accessor<any>} keyAccessor The accessor for the key of the data
-             * @return {string[]} An array of stringified keys
-             */
-            function domainKeys(datasets, keyAccessor) {
-                var domainKeys = d3.set();
-                datasets.forEach(function (dataset) {
-                    dataset.data().forEach(function (datum, index) {
-                        domainKeys.add(keyAccessor(datum, index, dataset));
-                    });
-                });
-                return domainKeys.values();
-            }
-            Stacking.domainKeys = domainKeys;
-            /**
              * Normalizes a key used for stacking
              *
              * @param {any} key The key to be normalized

--- a/plottable.js
+++ b/plottable.js
@@ -710,6 +710,25 @@ var Plottable;
             }
             Stacking.stackedExtent = stackedExtent;
             /**
+             * Given an array of Datasets and the accessor function for the key, computes the
+             * set reunion (no duplicates) of the domain of each Dataset. The keys are stringified
+             * before being returned.
+             *
+             * @param {Dataset[]} datasets The Datasets for which we extract the domain keys
+             * @param {Accessor<any>} keyAccessor The accessor for the key of the data
+             * @return {string[]} An array of stringified keys
+             */
+            function domainKeys(datasets, keyAccessor) {
+                var domainKeys = d3.set();
+                datasets.forEach(function (dataset) {
+                    dataset.data().forEach(function (datum, index) {
+                        domainKeys.add(keyAccessor(datum, index, dataset));
+                    });
+                });
+                return domainKeys.values();
+            }
+            Stacking.domainKeys = domainKeys;
+            /**
              * Normalizes a key used for stacking
              *
              * @param {any} key The key to be normalized
@@ -6984,6 +7003,7 @@ var Plottable;
                 this._labelFormatter = Plottable.Formatters.identity();
                 this._labelsEnabled = false;
                 this._hideBarsIfAnyAreTooWide = true;
+                this._barPixelWidth = 0;
                 this.addClass("bar-plot");
                 if (orientation !== Bar.ORIENTATION_VERTICAL && orientation !== Bar.ORIENTATION_HORIZONTAL) {
                     throw new Error(orientation + " is not a valid orientation for Plots.Bar");
@@ -6991,9 +7011,10 @@ var Plottable;
                 this._isVertical = orientation === Bar.ORIENTATION_VERTICAL;
                 this.animator("baseline", new Plottable.Animators.Null());
                 this.attr("fill", new Plottable.Scales.Color().range()[0]);
-                this.attr("width", function () { return _this._getBarPixelWidth(); });
+                this.attr("width", function () { return _this._barPixelWidth; });
                 this._labelConfig = new Plottable.Utils.Map();
                 this._baselineValueProvider = function () { return [_this.baselineValue()]; };
+                this._getBarPixelWidthCallback = function () { return _this._getBarPixelWidth(); };
             }
             Bar.prototype.x = function (x, xScale) {
                 if (x == null) {
@@ -7004,6 +7025,7 @@ var Plottable;
                 }
                 else {
                     _super.prototype.x.call(this, x, xScale);
+                    xScale.onUpdate(this._getBarPixelWidthCallback);
                 }
                 this._updateValueScale();
                 return this;
@@ -7017,6 +7039,7 @@ var Plottable;
                 }
                 else {
                     _super.prototype.y.call(this, y, yScale);
+                    yScale.onUpdate(this._getBarPixelWidthCallback);
                 }
                 this._updateValueScale();
                 return this;
@@ -7057,6 +7080,16 @@ var Plottable;
                 this._updateValueScale();
                 this.render();
                 return this;
+            };
+            Bar.prototype.addDataset = function (dataset) {
+                dataset.onUpdate(this._getBarPixelWidthCallback);
+                this._getBarPixelWidth();
+                return _super.prototype.addDataset.call(this, dataset);
+            };
+            Bar.prototype.removeDataset = function (dataset) {
+                dataset.offUpdate(this._getBarPixelWidthCallback);
+                this._getBarPixelWidth();
+                return _super.prototype.removeDataset.call(this, dataset);
             };
             Bar.prototype.labelsEnabled = function (enabled) {
                 if (enabled === undefined) {
@@ -7345,9 +7378,13 @@ var Plottable;
                 }
                 else {
                     var barAccessor = this._isVertical ? this.x().accessor : this.y().accessor;
+                    // var tmp: string[] = Plottable.Utils.Stacking.domainKeys(this.datasets(), barAccessor);
+                    // return 14;
                     var numberBarAccessorData = d3.set(Plottable.Utils.Array.flatten(this.datasets().map(function (dataset) {
                         return dataset.data().map(function (d, i) { return barAccessor(d, i, dataset); }).filter(function (d) { return d != null; }).map(function (d) { return d.valueOf(); });
                     }))).values().map(function (value) { return +value; });
+                    // console.log(tmp);
+                    // var numberBarAccessorData: number[] = tmp.map((v) => +v);
                     numberBarAccessorData.sort(function (a, b) { return a - b; });
                     var barAccessorDataPairs = d3.pairs(numberBarAccessorData);
                     var barWidthDimension = this._isVertical ? this.width() : this.height();
@@ -7366,6 +7403,7 @@ var Plottable;
                     }
                     barPixelWidth *= Bar._BAR_WIDTH_RATIO;
                 }
+                this._barPixelWidth = barPixelWidth;
                 return barPixelWidth;
             };
             Bar.prototype.entities = function (datasets) {
@@ -7403,6 +7441,10 @@ var Plottable;
                 var x = this._isVertical ? rectX + rectWidth / 2 : rectX + rectWidth;
                 var y = this._isVertical ? rectY : rectY + rectHeight / 2;
                 return { x: x, y: y };
+            };
+            Bar.prototype._uninstallScaleForKey = function (scale, key) {
+                scale.offUpdate(this._getBarPixelWidthCallback);
+                _super.prototype._uninstallScaleForKey.call(this, scale, key);
             };
             Bar.prototype._getDataToDraw = function () {
                 var dataToDraw = new Plottable.Utils.Map();

--- a/plottable.js
+++ b/plottable.js
@@ -7083,13 +7083,15 @@ var Plottable;
             };
             Bar.prototype.addDataset = function (dataset) {
                 dataset.onUpdate(this._getBarPixelWidthCallback);
+                _super.prototype.addDataset.call(this, dataset);
                 this._getBarPixelWidth();
-                return _super.prototype.addDataset.call(this, dataset);
+                return this;
             };
             Bar.prototype.removeDataset = function (dataset) {
                 dataset.offUpdate(this._getBarPixelWidthCallback);
+                _super.prototype.removeDataset.call(this, dataset);
                 this._getBarPixelWidth();
-                return _super.prototype.removeDataset.call(this, dataset);
+                return this;
             };
             Bar.prototype.labelsEnabled = function (enabled) {
                 if (enabled === undefined) {
@@ -7383,24 +7385,13 @@ var Plottable;
                     var numberBarAccessorData = d3.set(Plottable.Utils.Array.flatten(this.datasets().map(function (dataset) {
                         return dataset.data().map(function (d, i) { return barAccessor(d, i, dataset); }).filter(function (d) { return d != null; }).map(function (d) { return d.valueOf(); });
                     }))).values().map(function (value) { return +value; });
-                    // console.log(tmp);
-                    // var numberBarAccessorData: number[] = tmp.map((v) => +v);
                     numberBarAccessorData.sort(function (a, b) { return a - b; });
-                    var barAccessorDataPairs = d3.pairs(numberBarAccessorData);
+                    var scaledData = numberBarAccessorData.map(function (datum) { return barScale.scale(datum); });
+                    var barAccessorDataPairs = d3.pairs(scaledData);
                     var barWidthDimension = this._isVertical ? this.width() : this.height();
                     barPixelWidth = Plottable.Utils.Math.min(barAccessorDataPairs, function (pair, i) {
-                        return Math.abs(barScale.scale(pair[1]) - barScale.scale(pair[0]));
+                        return Math.abs(pair[1] - pair[0]);
                     }, barWidthDimension * Bar._SINGLE_BAR_DIMENSION_RATIO);
-                    var scaledData = numberBarAccessorData.map(function (datum) { return barScale.scale(datum); });
-                    var minScaledDatum = Plottable.Utils.Math.min(scaledData, 0);
-                    if (minScaledDatum > 0) {
-                        barPixelWidth = Math.min(barPixelWidth, minScaledDatum * 2);
-                    }
-                    var maxScaledDatum = Plottable.Utils.Math.max(scaledData, 0);
-                    if (maxScaledDatum < barWidthDimension) {
-                        var margin = barWidthDimension - maxScaledDatum;
-                        barPixelWidth = Math.min(barPixelWidth, margin * 2);
-                    }
                     barPixelWidth *= Bar._BAR_WIDTH_RATIO;
                 }
                 this._barPixelWidth = barPixelWidth;

--- a/plottable.js
+++ b/plottable.js
@@ -265,17 +265,16 @@ var Plottable;
              * Updates the value of the read-only parameter size
              */
             Set.prototype._updateSize = function () {
-                var newSize = 0;
                 if (this._es6Set != null) {
-                    newSize = this._es6Set.size;
+                    this.size = this._es6Set.size;
                 }
                 else {
-                    newSize = this._values.length;
+                    this.size = this._values.length;
                 }
-                Object.defineProperty(this, "size", {
-                    value: newSize,
-                    configurable: true
-                });
+                // Object.defineProperty(this, "size", {
+                //   value: newSize,
+                //   configurable: true
+                // });
             };
             return Set;
         })();

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -149,14 +149,16 @@ export module Plots {
 
     public addDataset(dataset: Dataset) {
       dataset.onUpdate(this._getBarPixelWidthCallback);
+      super.addDataset(dataset);
       this._getBarPixelWidth();
-      return super.addDataset(dataset);
+      return this;
     }
 
     public removeDataset(dataset: Dataset) {
       dataset.offUpdate(this._getBarPixelWidthCallback);
+      super.removeDataset(dataset);
       this._getBarPixelWidth();
-      return super.removeDataset(dataset);
+      return this;
     }
 
     /**
@@ -516,33 +518,21 @@ export module Plots {
                                .map((d) => d.valueOf());
         }))).values().map((value) => +value);
 
-        // console.log(tmp);
-
-        // var numberBarAccessorData: number[] = tmp.map((v) => +v);
 
         numberBarAccessorData.sort((a, b) => a - b);
 
-        var barAccessorDataPairs = d3.pairs(numberBarAccessorData);
+        var scaledData = numberBarAccessorData.map((datum: number) => barScale.scale(datum));
+        var barAccessorDataPairs = d3.pairs(scaledData);
         var barWidthDimension = this._isVertical ? this.width() : this.height();
 
         barPixelWidth = Utils.Math.min(barAccessorDataPairs, (pair: any[], i: number) => {
-          return Math.abs(barScale.scale(pair[1]) - barScale.scale(pair[0]));
+          return Math.abs(pair[1] - pair[0]);
         }, barWidthDimension * Bar._SINGLE_BAR_DIMENSION_RATIO);
-
-        var scaledData = numberBarAccessorData.map((datum: number) => barScale.scale(datum));
-        var minScaledDatum = Utils.Math.min(scaledData, 0);
-        if (minScaledDatum > 0) {
-          barPixelWidth = Math.min(barPixelWidth, minScaledDatum * 2);
-        }
-        var maxScaledDatum = Utils.Math.max(scaledData, 0);
-        if ( maxScaledDatum < barWidthDimension) {
-          var margin = barWidthDimension - maxScaledDatum;
-          barPixelWidth = Math.min(barPixelWidth, margin * 2);
-        }
 
         barPixelWidth *= Bar._BAR_WIDTH_RATIO;
       }
       this._barPixelWidth = barPixelWidth;
+
       return barPixelWidth;
     }
 

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -28,7 +28,7 @@ export module Plots {
     private _baselineValueProvider: () => (X|Y)[];
 
     private _barPixelWidth = 0;
-    private _getBarPixelWidthCallback: (() => void);
+    private _updateBarPixelWidthCallback: (() => void);
 
     /**
      * A Bar Plot draws bars growing out from a baseline to some value
@@ -48,7 +48,7 @@ export module Plots {
       this.attr("width", () => this._barPixelWidth);
       this._labelConfig = new Utils.Map<Dataset, LabelConfig>();
       this._baselineValueProvider = () => [this.baselineValue()];
-      this._getBarPixelWidthCallback = () => this._getBarPixelWidth();
+      this._updateBarPixelWidthCallback = () => this._updateBarPixelWidth();
     }
 
     public x(): Plots.AccessorScaleBinding<X, number>;
@@ -63,7 +63,7 @@ export module Plots {
         super.x(<number | Accessor<number>>x);
       } else {
         super.x(< X | Accessor<X>>x, xScale);
-        xScale.onUpdate(this._getBarPixelWidthCallback);
+        xScale.onUpdate(this._updateBarPixelWidthCallback);
       }
 
       this._updateValueScale();
@@ -82,7 +82,7 @@ export module Plots {
         super.y(<number | Accessor<number>>y);
       } else {
         super.y(<Y | Accessor<Y>>y, yScale);
-        yScale.onUpdate(this._getBarPixelWidthCallback);
+        yScale.onUpdate(this._updateBarPixelWidthCallback);
       }
 
       this._updateValueScale();
@@ -100,7 +100,7 @@ export module Plots {
 
     public render() {
       super.render();
-      this._getBarPixelWidth();
+      this._updateBarPixelWidth();
       return this;
     }
 
@@ -154,16 +154,16 @@ export module Plots {
     }
 
     public addDataset(dataset: Dataset) {
-      dataset.onUpdate(this._getBarPixelWidthCallback);
+      dataset.onUpdate(this._updateBarPixelWidthCallback);
       super.addDataset(dataset);
-      this._getBarPixelWidth();
+      this._updateBarPixelWidth();
       return this;
     }
 
     public removeDataset(dataset: Dataset) {
-      dataset.offUpdate(this._getBarPixelWidthCallback);
+      dataset.offUpdate(this._updateBarPixelWidthCallback);
       super.removeDataset(dataset);
-      this._getBarPixelWidth();
+      this._updateBarPixelWidth();
       return this;
     }
 
@@ -504,7 +504,7 @@ export module Plots {
      *   from https://github.com/mbostock/d3/wiki/Ordinal-Scales#ordinal_rangePoints, the max barPixelWidth is step * padding
      * If the position scale of the plot is a QuantitativeScale, then _getMinimumDataWidth is scaled to compute the barPixelWidth
      */
-    protected _getBarPixelWidth(): number {
+    protected _updateBarPixelWidth(): number {
 
       if (!this._projectorsReady()) { return 0; }
       var barPixelWidth: number;
@@ -543,8 +543,6 @@ export module Plots {
         barPixelWidth *= Bar._BAR_WIDTH_RATIO;
       }
       this._barPixelWidth = barPixelWidth;
-
-      return barPixelWidth;
     }
 
     public entities(datasets = this.datasets()): PlotEntity[] {
@@ -583,7 +581,7 @@ export module Plots {
     }
 
   protected _uninstallScaleForKey(scale: Scale<any, number>, key: string) {
-    scale.offUpdate(this._getBarPixelWidthCallback);
+    scale.offUpdate(this._updateBarPixelWidthCallback);
     super._uninstallScaleForKey(scale, key);
   }
 

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -98,6 +98,12 @@ export module Plots {
       return this._isVertical ? Bar.ORIENTATION_VERTICAL : Bar.ORIENTATION_HORIZONTAL;
     }
 
+    public render() {
+      super.render();
+      this._getBarPixelWidth();
+      return this;
+    }
+
     protected _createDrawer(dataset: Dataset) {
       return new Plottable.Drawers.Rectangle(dataset);
     }
@@ -508,16 +514,11 @@ export module Plots {
       } else {
         var barAccessor = this._isVertical ? this.x().accessor : this.y().accessor;
 
-        // var tmp: string[] = Plottable.Utils.Stacking.domainKeys(this.datasets(), barAccessor);
-        // return 14;
-
-
         var numberBarAccessorData = d3.set(Utils.Array.flatten(this.datasets().map((dataset) => {
           return dataset.data().map((d, i) => barAccessor(d, i, dataset))
                                .filter((d) => d != null)
                                .map((d) => d.valueOf());
         }))).values().map((value) => +value);
-
 
         numberBarAccessorData.sort((a, b) => a - b);
 

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -530,6 +530,16 @@ export module Plots {
           return Math.abs(pair[1] - pair[0]);
         }, barWidthDimension * Bar._SINGLE_BAR_DIMENSION_RATIO);
 
+        var minScaledDatum = Utils.Math.min(scaledData, 0);
+        if (minScaledDatum > 0) {
+          barPixelWidth = Math.min(barPixelWidth, minScaledDatum * 2);
+        }
+        var maxScaledDatum = Utils.Math.max(scaledData, 0);
+        if ( maxScaledDatum < barWidthDimension) {
+          var margin = barWidthDimension - maxScaledDatum;
+          barPixelWidth = Math.min(barPixelWidth, margin * 2);
+        }
+
         barPixelWidth *= Bar._BAR_WIDTH_RATIO;
       }
       this._barPixelWidth = barPixelWidth;

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -504,7 +504,7 @@ export module Plots {
      *   from https://github.com/mbostock/d3/wiki/Ordinal-Scales#ordinal_rangePoints, the max barPixelWidth is step * padding
      * If the position scale of the plot is a QuantitativeScale, then _getMinimumDataWidth is scaled to compute the barPixelWidth
      */
-    protected _updateBarPixelWidth(): number {
+    protected _getBarPixelWidth(): number {
 
       if (!this._projectorsReady()) { return 0; }
       var barPixelWidth: number;
@@ -542,7 +542,11 @@ export module Plots {
 
         barPixelWidth *= Bar._BAR_WIDTH_RATIO;
       }
-      this._barPixelWidth = barPixelWidth;
+      return barPixelWidth;
+    }
+
+    private _updateBarPixelWidth() {
+      this._barPixelWidth = this._getBarPixelWidth();
     }
 
     public entities(datasets = this.datasets()): PlotEntity[] {

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -38,9 +38,9 @@ export module Utils {
       return this;
     }
 
-    public get(key: K): V {
+    public get(key: K) {
       if (this._es6Map != null) {
-        return this._es6Map.get(key);
+        return <V>this._es6Map.get(key);
       }
 
       for (var i = 0; i < this._keyValuePairs.length; i++) {
@@ -51,9 +51,9 @@ export module Utils {
       return undefined;
     }
 
-    public has(key: K): boolean {
+    public has(key: K) {
       if (this._es6Map != null) {
-        return this._es6Map.has(key);
+        return <boolean>this._es6Map.has(key);
       }
 
       for (var i = 0; i < this._keyValuePairs.length; i++) {
@@ -75,9 +75,9 @@ export module Utils {
       });
     }
 
-    public delete(key: K): boolean {
+    public delete(key: K) {
       if (this._es6Map != null) {
-        return this._es6Map.delete(key);
+        return <boolean>this._es6Map.delete(key);
       }
 
       for (var i = 0; i < this._keyValuePairs.length; i++) {

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -7,12 +7,27 @@ export module Utils {
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
    */
   export class Map<K, V> {
-    private _keyValuePairs: { key: K; value: V; }[] = [];
+    private _keyValuePairs: { key: K; value: V; }[];
+    private _es6Map: any;
+
+    public constructor() {
+      if (typeof (<any>window).Map === "function") {
+        this._es6Map = new (<any>window).Map();
+      } else {
+        this._keyValuePairs = [];
+      }
+    }
 
     public set(key: K, value: V) {
       if (Utils.Math.isNaN(key)) {
         throw new Error("NaN may not be used as a key to the Map");
       }
+
+      if (this._es6Map != null) {
+        this._es6Map.set(key, value);
+        return this;
+      }
+
       for (var i = 0; i < this._keyValuePairs.length; i++) {
         if (this._keyValuePairs[i].key === key) {
           this._keyValuePairs[i].value = value;
@@ -23,7 +38,11 @@ export module Utils {
       return this;
     }
 
-    public get(key: K) {
+    public get(key: K): V {
+      if (this._es6Map != null) {
+        return this._es6Map.get(key);
+      }
+
       for (var i = 0; i < this._keyValuePairs.length; i++) {
         if (this._keyValuePairs[i].key === key) {
           return this._keyValuePairs[i].value;
@@ -32,7 +51,11 @@ export module Utils {
       return undefined;
     }
 
-    public has(key: K) {
+    public has(key: K): boolean {
+      if (this._es6Map != null) {
+        return this._es6Map.has(key);
+      }
+
       for (var i = 0; i < this._keyValuePairs.length; i++) {
         if (this._keyValuePairs[i].key === key) {
           return true;
@@ -42,12 +65,21 @@ export module Utils {
     }
 
     public forEach(callbackFn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any) {
+      if (this._es6Map != null) {
+        this._es6Map.forEach(callbackFn, thisArg);
+        return;
+      }
+
       this._keyValuePairs.forEach((keyValuePair) => {
         callbackFn.call(thisArg, keyValuePair.value, keyValuePair.key, this);
       });
     }
 
-    public delete(key: K) {
+    public delete(key: K): boolean {
+      if (this._es6Map != null) {
+        return this._es6Map.delete(key);
+      }
+
       for (var i = 0; i < this._keyValuePairs.length; i++) {
         if (this._keyValuePairs[i].key === key) {
           this._keyValuePairs.splice(i, 1);

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -18,33 +18,34 @@ export module Utils {
       } else {
         this._values = [];
       }
-      this._updateSize();
+      this.size = 0;
     }
 
     public add(value: T) {
       if (this._es6Set != null) {
         this._es6Set.add(value);
-      } else {
-        if (!this.has(value)) {
-          this._values.push(value);
-        }
+        this.size = this._es6Set.size;
+        return this;
       }
 
-      this._updateSize();
+      if (!this.has(value)) {
+        this._values.push(value);
+        this.size = this._values.length;
+      }
       return this;
     }
 
     public delete(value: T): boolean {
       if (this._es6Set != null) {
         var deleted = this._es6Set.delete(value);
-        this._updateSize();
+        this.size = this._es6Set.size;
         return deleted;
       }
 
       var index = this._values.indexOf(value);
       if (index !== -1) {
         this._values.splice(index, 1);
-        this._updateSize();
+        this.size = this._values.length;
         return true;
       }
       return false;
@@ -69,20 +70,6 @@ export module Utils {
       });
     }
 
-    /**
-     * Updates the value of the read-only parameter size
-     */
-    private _updateSize() {
-      if (this._es6Set != null) {
-        this.size = this._es6Set.size;
-      } else {
-        this.size = this._values.length;
-      }
-      // Object.defineProperty(this, "size", {
-      //   value: newSize,
-      //   configurable: true
-      // });
-    }
   }
 }
 }

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -73,16 +73,15 @@ export module Utils {
      * Updates the value of the read-only parameter size
      */
     private _updateSize() {
-      var newSize = 0;
       if (this._es6Set != null) {
-        newSize = this._es6Set.size;
+        this.size = this._es6Set.size;
       } else {
-        newSize = this._values.length;
+        this.size = this._values.length;
       }
-      Object.defineProperty(this, "size", {
-        value: newSize,
-        configurable: true
-      });
+      // Object.defineProperty(this, "size", {
+      //   value: newSize,
+      //   configurable: true
+      // });
     }
   }
 }

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -35,9 +35,9 @@ export module Utils {
       return this;
     }
 
-    public delete(value: T): boolean {
+    public delete(value: T) {
       if (this._es6Set != null) {
-        var deleted = this._es6Set.delete(value);
+        var deleted = <boolean>this._es6Set.delete(value);
         this.size = this._es6Set.size;
         return deleted;
       }
@@ -51,9 +51,9 @@ export module Utils {
       return false;
     }
 
-    public has(value: T): boolean {
+    public has(value: T) {
       if (this._es6Set != null) {
-        return this._es6Set.has(value);
+        return <boolean>this._es6Set.has(value);
       }
 
       return this._values.indexOf(value) !== -1;

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -10,21 +10,37 @@ export module Utils {
     public size: number;
 
     private _values: T[];
+    private _es6Set: any;
 
     constructor() {
-      this._values = [];
+      if (typeof (<any>window).Set === "function") {
+        this._es6Set = new (<any>window).Set();
+      } else {
+        this._values = [];
+      }
       this._updateSize();
     }
 
     public add(value: T) {
-      if (!this.has(value)) {
-        this._values.push(value);
-        this._updateSize();
+      if (this._es6Set != null) {
+        this._es6Set.add(value);
+      } else {
+        if (!this.has(value)) {
+          this._values.push(value);
+        }
       }
+
+      this._updateSize();
       return this;
     }
 
-    public delete(value: T) {
+    public delete(value: T): boolean {
+      if (this._es6Set != null) {
+        var deleted = this._es6Set.delete(value);
+        this._updateSize();
+        return deleted;
+      }
+
       var index = this._values.indexOf(value);
       if (index !== -1) {
         this._values.splice(index, 1);
@@ -34,11 +50,20 @@ export module Utils {
       return false;
     }
 
-    public has(value: T) {
+    public has(value: T): boolean {
+      if (this._es6Set != null) {
+        return this._es6Set.has(value);
+      }
+
       return this._values.indexOf(value) !== -1;
     }
 
     public forEach(callback: (value: T, value2: T, set: Set<T>) => void, thisArg?: any) {
+      if (this._es6Set != null) {
+        this._es6Set.forEach(callback, thisArg);
+        return;
+      }
+
       this._values.forEach((value: T) => {
         callback.call(thisArg, value, value, this);
       });
@@ -48,8 +73,14 @@ export module Utils {
      * Updates the value of the read-only parameter size
      */
     private _updateSize() {
+      var newSize = 0;
+      if (this._es6Set != null) {
+        newSize = this._es6Set.size;
+      } else {
+        newSize = this._values.length;
+      }
       Object.defineProperty(this, "size", {
-        value: this._values.length,
+        value: newSize,
         configurable: true
       });
     }

--- a/src/utils/stackingUtils.ts
+++ b/src/utils/stackingUtils.ts
@@ -76,6 +76,26 @@ export module Utils {
     }
 
     /**
+     * Given an array of Datasets and the accessor function for the key, computes the
+     * set reunion (no duplicates) of the domain of each Dataset. The keys are stringified
+     * before being returned.
+     *
+     * @param {Dataset[]} datasets The Datasets for which we extract the domain keys
+     * @param {Accessor<any>} keyAccessor The accessor for the key of the data
+     * @return {string[]} An array of stringified keys
+     */
+    export function domainKeys(datasets: Dataset[], keyAccessor: Accessor<any>) {
+      var domainKeys = d3.set();
+      datasets.forEach((dataset) => {
+        dataset.data().forEach((datum, index) => {
+          domainKeys.add(keyAccessor(datum, index, dataset));
+        });
+      });
+
+      return domainKeys.values();
+    }
+
+    /**
      * Normalizes a key used for stacking
      *
      * @param {any} key The key to be normalized

--- a/src/utils/stackingUtils.ts
+++ b/src/utils/stackingUtils.ts
@@ -76,26 +76,6 @@ export module Utils {
     }
 
     /**
-     * Given an array of Datasets and the accessor function for the key, computes the
-     * set reunion (no duplicates) of the domain of each Dataset. The keys are stringified
-     * before being returned.
-     *
-     * @param {Dataset[]} datasets The Datasets for which we extract the domain keys
-     * @param {Accessor<any>} keyAccessor The accessor for the key of the data
-     * @return {string[]} An array of stringified keys
-     */
-    export function domainKeys(datasets: Dataset[], keyAccessor: Accessor<any>) {
-      var domainKeys = d3.set();
-      datasets.forEach((dataset) => {
-        dataset.data().forEach((datum, index) => {
-          domainKeys.add(keyAccessor(datum, index, dataset));
-        });
-      });
-
-      return domainKeys.values();
-    }
-
-    /**
      * Normalizes a key used for stacking
      *
      * @param {any} key The key to be normalized

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -291,7 +291,7 @@ describe("Plots", () => {
       });
 
       it("barPixelWidth calculated appropriately", () => {
-        assert.strictEqual((<any> barPlot)._getBarPixelWidth(), xScale.scale(2) * 2 * 0.95);
+        assert.strictEqual((<any> barPlot)._barPixelWidth, xScale.scale(2) * 2 * 0.95);
         svg.remove();
       });
 
@@ -300,7 +300,7 @@ describe("Plots", () => {
         var bars = renderArea.selectAll("rect");
         assert.lengthOf(bars[0], 3, "One bar was created per data point");
 
-        var barPixelWidth = (<any> barPlot)._getBarPixelWidth();
+        var barPixelWidth = (<any> barPlot)._barPixelWidth;
         var bar0 = d3.select(bars[0][0]);
         var bar1 = d3.select(bars[0][1]);
         var bar2 = d3.select(bars[0][2]);
@@ -345,7 +345,7 @@ describe("Plots", () => {
       });
 
       it("bar width takes an appropriate value", () => {
-        assert.strictEqual((<any> barPlot)._getBarPixelWidth(), (xScale.scale(10) - xScale.scale(2)) * 0.95);
+        assert.strictEqual((<any> barPlot)._barPixelWidth, (xScale.scale(10) - xScale.scale(2)) * 0.95);
         svg.remove();
       });
 
@@ -354,7 +354,7 @@ describe("Plots", () => {
         var bars = renderArea.selectAll("rect");
         assert.lengthOf(bars[0], 3, "One bar was created per data point");
 
-        var barPixelWidth = (<any> barPlot)._getBarPixelWidth();
+        var barPixelWidth = (<any> barPlot)._barPixelWidth;
         var bar0 = d3.select(bars[0][0]);
         var bar1 = d3.select(bars[0][1]);
         var bar2 = d3.select(bars[0][2]);
@@ -367,14 +367,14 @@ describe("Plots", () => {
       it("sensible bar width one datum", () => {
         barPlot.removeDataset(dataset);
         barPlot.addDataset(new Plottable.Dataset([{x: 10, y: 2}]));
-        assert.closeTo((<any> barPlot)._getBarPixelWidth(), 228, 0.1, "sensible bar width for only one datum");
+        assert.closeTo((<any> barPlot)._barPixelWidth, 228, 0.1, "sensible bar width for only one datum");
         svg.remove();
       });
 
       it("sensible bar width same datum", () => {
         barPlot.removeDataset(dataset);
         barPlot.addDataset(new Plottable.Dataset([{x: 10, y: 2}, {x: 10, y: 2}]));
-        assert.closeTo((<any> barPlot)._getBarPixelWidth(), 228, 0.1, "uses the width sensible for one datum");
+        assert.closeTo((<any> barPlot)._barPixelWidth, 228, 0.1, "uses the width sensible for one datum");
         svg.remove();
       });
 
@@ -382,7 +382,7 @@ describe("Plots", () => {
         barPlot.removeDataset(dataset);
         barPlot.addDataset(new Plottable.Dataset([{x: 2, y: 2}, {x: 20, y: 2}, {x: 5, y: 2}]));
         var expectedBarPixelWidth = (xScale.scale(5) - xScale.scale(2)) * 0.95;
-        assert.closeTo((<any> barPlot)._getBarPixelWidth(), expectedBarPixelWidth, 0.1, "bar width uses closest sorted x values");
+        assert.closeTo((<any> barPlot)._barPixelWidth, expectedBarPixelWidth, 0.1, "bar width uses closest sorted x values");
         svg.remove();
       });
     });
@@ -412,7 +412,7 @@ describe("Plots", () => {
       it("bar width takes an appropriate value", () => {
         var timeFormatter = d3.time.format("%m/%d/%y");
         var expectedBarWidth = (xScale.scale(timeFormatter.parse("12/01/94")) - xScale.scale(timeFormatter.parse("12/01/93"))) * 0.95;
-        assert.closeTo((<any> barPlot)._getBarPixelWidth(), expectedBarWidth, 0.1, "width is difference between two dates");
+        assert.closeTo((<any> barPlot)._barPixelWidth, expectedBarWidth, 0.1, "width is difference between two dates");
         svg.remove();
       });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -8240,7 +8240,12 @@ describe("Map", function () {
         map.forEach(function (value, key, mp) {
             assert.strictEqual(value, values[index], "Value " + index + " is the expected one");
             assert.strictEqual(key, keys[index], "Key " + index + " is the expected one");
-            assert.strictEqual(mp, map, "The correct map is passed as the third argument");
+            if (map._es6Map != null) {
+                assert.strictEqual(mp, map._es6Map, "The correct map is passed as the third argument (ES6)");
+            }
+            else {
+                assert.strictEqual(mp, map, "The correct map is passed as the third argument (non ES6)");
+            }
             index++;
         });
         assert.strictEqual(index, keys.length, "The expected number of iterations executed in the forEach");
@@ -8327,7 +8332,12 @@ describe("Utils", function () {
             set.forEach(function (value1, value2, passedSet) {
                 assert.strictEqual(value1, value2, "The two value arguments passed to the callback are the same");
                 assert.strictEqual(value1, values[index], "Value " + index + " is the expected one");
-                assert.strictEqual(passedSet, set, "The correct Set is passed as the third argument");
+                if (set._es6Set != null) {
+                    assert.strictEqual(passedSet, set._es6Set, "The correct Set is passed as the third argument (ES6)");
+                }
+                else {
+                    assert.strictEqual(passedSet, set, "The correct Set is passed as the third argument (non ES6)");
+                }
                 index++;
             });
             assert.strictEqual(index, values.length, "The expected number of iterations executed in the forEach");

--- a/test/tests.js
+++ b/test/tests.js
@@ -4609,14 +4609,14 @@ describe("Plots", function () {
                 barPlot.renderTo(svg);
             });
             it("barPixelWidth calculated appropriately", function () {
-                assert.strictEqual(barPlot._getBarPixelWidth(), xScale.scale(2) * 2 * 0.95);
+                assert.strictEqual(barPlot._barPixelWidth, xScale.scale(2) * 2 * 0.95);
                 svg.remove();
             });
             it("bar widths are equal to barPixelWidth", function () {
                 var renderArea = barPlot._renderArea;
                 var bars = renderArea.selectAll("rect");
                 assert.lengthOf(bars[0], 3, "One bar was created per data point");
-                var barPixelWidth = barPlot._getBarPixelWidth();
+                var barPixelWidth = barPlot._barPixelWidth;
                 var bar0 = d3.select(bars[0][0]);
                 var bar1 = d3.select(bars[0][1]);
                 var bar2 = d3.select(bars[0][2]);
@@ -4657,14 +4657,14 @@ describe("Plots", function () {
                 svg.remove();
             });
             it("bar width takes an appropriate value", function () {
-                assert.strictEqual(barPlot._getBarPixelWidth(), (xScale.scale(10) - xScale.scale(2)) * 0.95);
+                assert.strictEqual(barPlot._barPixelWidth, (xScale.scale(10) - xScale.scale(2)) * 0.95);
                 svg.remove();
             });
             it("bar widths are equal to barPixelWidth", function () {
                 var renderArea = barPlot._renderArea;
                 var bars = renderArea.selectAll("rect");
                 assert.lengthOf(bars[0], 3, "One bar was created per data point");
-                var barPixelWidth = barPlot._getBarPixelWidth();
+                var barPixelWidth = barPlot._barPixelWidth;
                 var bar0 = d3.select(bars[0][0]);
                 var bar1 = d3.select(bars[0][1]);
                 var bar2 = d3.select(bars[0][2]);
@@ -4676,20 +4676,20 @@ describe("Plots", function () {
             it("sensible bar width one datum", function () {
                 barPlot.removeDataset(dataset);
                 barPlot.addDataset(new Plottable.Dataset([{ x: 10, y: 2 }]));
-                assert.closeTo(barPlot._getBarPixelWidth(), 228, 0.1, "sensible bar width for only one datum");
+                assert.closeTo(barPlot._barPixelWidth, 228, 0.1, "sensible bar width for only one datum");
                 svg.remove();
             });
             it("sensible bar width same datum", function () {
                 barPlot.removeDataset(dataset);
                 barPlot.addDataset(new Plottable.Dataset([{ x: 10, y: 2 }, { x: 10, y: 2 }]));
-                assert.closeTo(barPlot._getBarPixelWidth(), 228, 0.1, "uses the width sensible for one datum");
+                assert.closeTo(barPlot._barPixelWidth, 228, 0.1, "uses the width sensible for one datum");
                 svg.remove();
             });
             it("sensible bar width unsorted data", function () {
                 barPlot.removeDataset(dataset);
                 barPlot.addDataset(new Plottable.Dataset([{ x: 2, y: 2 }, { x: 20, y: 2 }, { x: 5, y: 2 }]));
                 var expectedBarPixelWidth = (xScale.scale(5) - xScale.scale(2)) * 0.95;
-                assert.closeTo(barPlot._getBarPixelWidth(), expectedBarPixelWidth, 0.1, "bar width uses closest sorted x values");
+                assert.closeTo(barPlot._barPixelWidth, expectedBarPixelWidth, 0.1, "bar width uses closest sorted x values");
                 svg.remove();
             });
         });
@@ -4709,7 +4709,7 @@ describe("Plots", function () {
             it("bar width takes an appropriate value", function () {
                 var timeFormatter = d3.time.format("%m/%d/%y");
                 var expectedBarWidth = (xScale.scale(timeFormatter.parse("12/01/94")) - xScale.scale(timeFormatter.parse("12/01/93"))) * 0.95;
-                assert.closeTo(barPlot._getBarPixelWidth(), expectedBarWidth, 0.1, "width is difference between two dates");
+                assert.closeTo(barPlot._barPixelWidth, expectedBarWidth, 0.1, "width is difference between two dates");
                 svg.remove();
             });
         });

--- a/test/tests.js
+++ b/test/tests.js
@@ -8280,15 +8280,21 @@ describe("Utils", function () {
             var value1 = { value: "one" };
             set.add(value1);
             assert.strictEqual(set.size, 1, "set contains one value");
-            assert.strictEqual(set._values[0], value1, "the value was added to the set");
+            if (set._values != null) {
+                assert.strictEqual(set._values[0], value1, "the value was added to the set");
+            }
             set.add(value1);
             assert.strictEqual(set.size, 1, "same value is not added twice");
-            assert.strictEqual(set._values[0], value1, "list still contains the value");
+            if (set._values != null) {
+                assert.strictEqual(set._values[0], value1, "list still contains the value");
+            }
             var value2 = { value: "two" };
             set.add(value2);
             assert.strictEqual(set.size, 2, "set now contains two values");
-            assert.strictEqual(set._values[0], value1, "set contains value 1");
-            assert.strictEqual(set._values[1], value2, "set contains value 2");
+            if (set._values != null) {
+                assert.strictEqual(set._values[0], value1, "set contains value 1");
+                assert.strictEqual(set._values[1], value2, "set contains value 2");
+            }
         });
         it("delete()", function () {
             var set = new Plottable.Utils.Set();

--- a/test/utils/mapTests.ts
+++ b/test/utils/mapTests.ts
@@ -44,7 +44,11 @@ describe("Map", () => {
     map.forEach((value: number, key: string, mp: Plottable.Utils.Map<string, number>) => {
       assert.strictEqual(value, values[index], "Value " + index + " is the expected one");
       assert.strictEqual(key, keys[index], "Key " + index + " is the expected one");
-      assert.strictEqual(mp, map, "The correct map is passed as the third argument");
+      if ((<any>map)._es6Map != null) {
+        assert.strictEqual(mp, (<any>map)._es6Map, "The correct map is passed as the third argument (ES6)");
+      } else {
+        assert.strictEqual(mp, map, "The correct map is passed as the third argument (non ES6)");
+      }
       index++;
     });
     assert.strictEqual(index, keys.length, "The expected number of iterations executed in the forEach");

--- a/test/utils/setTests.ts
+++ b/test/utils/setTests.ts
@@ -67,7 +67,11 @@ describe("Utils", () => {
       set.forEach((value1: any, value2: any, passedSet: Plottable.Utils.Set<any>) => {
         assert.strictEqual(value1, value2, "The two value arguments passed to the callback are the same");
         assert.strictEqual(value1, values[index], "Value " + index + " is the expected one");
-        assert.strictEqual(passedSet, set, "The correct Set is passed as the third argument");
+        if ((<any>set)._es6Set != null) {
+            assert.strictEqual(passedSet, (<any>set)._es6Set, "The correct Set is passed as the third argument (ES6)");
+          } else {
+            assert.strictEqual(passedSet, set, "The correct Set is passed as the third argument (non ES6)");
+          }
         index++;
       });
       assert.strictEqual(index, values.length, "The expected number of iterations executed in the forEach");

--- a/test/utils/setTests.ts
+++ b/test/utils/setTests.ts
@@ -10,17 +10,23 @@ describe("Utils", () => {
       var value1 = { value: "one" };
       set.add(value1);
       assert.strictEqual(set.size, 1, "set contains one value");
-      assert.strictEqual((<any>set)._values[0], value1, "the value was added to the set");
+      if ((<any>set)._values != null) {
+        assert.strictEqual((<any>set)._values[0], value1, "the value was added to the set");
+      }
 
       set.add(value1);
       assert.strictEqual(set.size, 1, "same value is not added twice");
-      assert.strictEqual((<any>set)._values[0], value1, "list still contains the value");
+      if ((<any>set)._values != null) {
+        assert.strictEqual((<any>set)._values[0], value1, "list still contains the value");
+      }
 
       var value2 = { value: "two" };
       set.add(value2);
       assert.strictEqual(set.size, 2, "set now contains two values");
-      assert.strictEqual((<any>set)._values[0], value1, "set contains value 1");
-      assert.strictEqual((<any>set)._values[1], value2, "set contains value 2");
+      if ((<any>set)._values != null) {
+        assert.strictEqual((<any>set)._values[0], value1, "set contains value 1");
+        assert.strictEqual((<any>set)._values[1], value2, "set contains value 2");
+      }
     });
 
     it("delete()", () => {


### PR DESCRIPTION
Closes #1289

Improved the call of `flush()` from `132 ms` down to `10 ms` by caching the result of `_getBarPixelWidth()`