### PR TITLE
Bar plot performance

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2880,7 +2880,7 @@ declare module Plottable {
              *   from https://github.com/mbostock/d3/wiki/Ordinal-Scales#ordinal_rangePoints, the max barPixelWidth is step * padding
              * If the position scale of the plot is a QuantitativeScale, then _getMinimumDataWidth is scaled to compute the barPixelWidth
              */
-            protected _getBarPixelWidth(): number;
+            protected _updateBarPixelWidth(): number;
             entities(datasets?: Dataset[]): PlotEntity[];
             protected _pixelPoint(datum: any, index: number, dataset: Dataset): {
                 x: any;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -299,16 +299,6 @@ declare module Plottable {
              */
             function stackedExtent(stackingResult: StackingResult, keyAccessor: Accessor<any>, filter: Accessor<boolean>): number[];
             /**
-             * Given an array of Datasets and the accessor function for the key, computes the
-             * set reunion (no duplicates) of the domain of each Dataset. The keys are stringified
-             * before being returned.
-             *
-             * @param {Dataset[]} datasets The Datasets for which we extract the domain keys
-             * @param {Accessor<any>} keyAccessor The accessor for the key of the data
-             * @return {string[]} An array of stringified keys
-             */
-            function domainKeys(datasets: Dataset[], keyAccessor: Accessor<any>): string[];
-            /**
              * Normalizes a key used for stacking
              *
              * @param {any} key The key to be normalized

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2787,6 +2787,7 @@ declare module Plottable {
              * @return "vertical" | "horizontal"
              */
             orientation(): string;
+            render(): Bar<X, Y>;
             protected _createDrawer(dataset: Dataset): Drawers.Rectangle;
             protected _setup(): void;
             /**

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -299,6 +299,16 @@ declare module Plottable {
              */
             function stackedExtent(stackingResult: StackingResult, keyAccessor: Accessor<any>, filter: Accessor<boolean>): number[];
             /**
+             * Given an array of Datasets and the accessor function for the key, computes the
+             * set reunion (no duplicates) of the domain of each Dataset. The keys are stringified
+             * before being returned.
+             *
+             * @param {Dataset[]} datasets The Datasets for which we extract the domain keys
+             * @param {Accessor<any>} keyAccessor The accessor for the key of the data
+             * @return {string[]} An array of stringified keys
+             */
+            function domainKeys(datasets: Dataset[], keyAccessor: Accessor<any>): string[];
+            /**
              * Normalizes a key used for stacking
              *
              * @param {any} key The key to be normalized
@@ -2794,6 +2804,8 @@ declare module Plottable {
              * @returns {Bar} The calling Bar Plot.
              */
             baselineValue(value: X | Y): Bar<X, Y>;
+            addDataset(dataset: Dataset): Plot;
+            removeDataset(dataset: Dataset): Plot;
             /**
              * Get whether bar labels are enabled.
              *
@@ -2873,6 +2885,7 @@ declare module Plottable {
                 x: any;
                 y: any;
             };
+            protected _uninstallScaleForKey(scale: Scale<any, number>, key: string): void;
             protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
         }
     }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2804,8 +2804,8 @@ declare module Plottable {
              * @returns {Bar} The calling Bar Plot.
              */
             baselineValue(value: X | Y): Bar<X, Y>;
-            addDataset(dataset: Dataset): Plot;
-            removeDataset(dataset: Dataset): Plot;
+            addDataset(dataset: Dataset): Bar<X, Y>;
+            removeDataset(dataset: Dataset): Bar<X, Y>;
             /**
              * Get whether bar labels are enabled.
              *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2870,7 +2870,7 @@ declare module Plottable {
              *   from https://github.com/mbostock/d3/wiki/Ordinal-Scales#ordinal_rangePoints, the max barPixelWidth is step * padding
              * If the position scale of the plot is a QuantitativeScale, then _getMinimumDataWidth is scaled to compute the barPixelWidth
              */
-            protected _updateBarPixelWidth(): number;
+            protected _getBarPixelWidth(): number;
             entities(datasets?: Dataset[]): PlotEntity[];
             protected _pixelPoint(datum: any, index: number, dataset: Dataset): {
                 x: any;

--- a/plottable.js
+++ b/plottable.js
@@ -7320,7 +7320,7 @@ var Plottable;
              *   from https://github.com/mbostock/d3/wiki/Ordinal-Scales#ordinal_rangePoints, the max barPixelWidth is step * padding
              * If the position scale of the plot is a QuantitativeScale, then _getMinimumDataWidth is scaled to compute the barPixelWidth
              */
-            Bar.prototype._updateBarPixelWidth = function () {
+            Bar.prototype._getBarPixelWidth = function () {
                 if (!this._projectorsReady()) {
                     return 0;
                 }
@@ -7352,7 +7352,10 @@ var Plottable;
                     }
                     barPixelWidth *= Bar._BAR_WIDTH_RATIO;
                 }
-                this._barPixelWidth = barPixelWidth;
+                return barPixelWidth;
+            };
+            Bar.prototype._updateBarPixelWidth = function () {
+                this._barPixelWidth = this._getBarPixelWidth();
             };
             Bar.prototype.entities = function (datasets) {
                 var _this = this;

--- a/plottable.js
+++ b/plottable.js
@@ -7048,13 +7048,15 @@ var Plottable;
             };
             Bar.prototype.addDataset = function (dataset) {
                 dataset.onUpdate(this._getBarPixelWidthCallback);
+                _super.prototype.addDataset.call(this, dataset);
                 this._getBarPixelWidth();
-                return _super.prototype.addDataset.call(this, dataset);
+                return this;
             };
             Bar.prototype.removeDataset = function (dataset) {
                 dataset.offUpdate(this._getBarPixelWidthCallback);
+                _super.prototype.removeDataset.call(this, dataset);
                 this._getBarPixelWidth();
-                return _super.prototype.removeDataset.call(this, dataset);
+                return this;
             };
             Bar.prototype.labelsEnabled = function (enabled) {
                 if (enabled === undefined) {
@@ -7348,24 +7350,13 @@ var Plottable;
                     var numberBarAccessorData = d3.set(Plottable.Utils.Array.flatten(this.datasets().map(function (dataset) {
                         return dataset.data().map(function (d, i) { return barAccessor(d, i, dataset); }).filter(function (d) { return d != null; }).map(function (d) { return d.valueOf(); });
                     }))).values().map(function (value) { return +value; });
-                    // console.log(tmp);
-                    // var numberBarAccessorData: number[] = tmp.map((v) => +v);
                     numberBarAccessorData.sort(function (a, b) { return a - b; });
-                    var barAccessorDataPairs = d3.pairs(numberBarAccessorData);
+                    var scaledData = numberBarAccessorData.map(function (datum) { return barScale.scale(datum); });
+                    var barAccessorDataPairs = d3.pairs(scaledData);
                     var barWidthDimension = this._isVertical ? this.width() : this.height();
                     barPixelWidth = Plottable.Utils.Math.min(barAccessorDataPairs, function (pair, i) {
-                        return Math.abs(barScale.scale(pair[1]) - barScale.scale(pair[0]));
+                        return Math.abs(pair[1] - pair[0]);
                     }, barWidthDimension * Bar._SINGLE_BAR_DIMENSION_RATIO);
-                    var scaledData = numberBarAccessorData.map(function (datum) { return barScale.scale(datum); });
-                    var minScaledDatum = Plottable.Utils.Math.min(scaledData, 0);
-                    if (minScaledDatum > 0) {
-                        barPixelWidth = Math.min(barPixelWidth, minScaledDatum * 2);
-                    }
-                    var maxScaledDatum = Plottable.Utils.Math.max(scaledData, 0);
-                    if (maxScaledDatum < barWidthDimension) {
-                        var margin = barWidthDimension - maxScaledDatum;
-                        barPixelWidth = Math.min(barPixelWidth, margin * 2);
-                    }
                     barPixelWidth *= Bar._BAR_WIDTH_RATIO;
                 }
                 this._barPixelWidth = barPixelWidth;

--- a/plottable.js
+++ b/plottable.js
@@ -6979,7 +6979,7 @@ var Plottable;
                 this.attr("width", function () { return _this._barPixelWidth; });
                 this._labelConfig = new Plottable.Utils.Map();
                 this._baselineValueProvider = function () { return [_this.baselineValue()]; };
-                this._getBarPixelWidthCallback = function () { return _this._getBarPixelWidth(); };
+                this._updateBarPixelWidthCallback = function () { return _this._updateBarPixelWidth(); };
             }
             Bar.prototype.x = function (x, xScale) {
                 if (x == null) {
@@ -6990,7 +6990,7 @@ var Plottable;
                 }
                 else {
                     _super.prototype.x.call(this, x, xScale);
-                    xScale.onUpdate(this._getBarPixelWidthCallback);
+                    xScale.onUpdate(this._updateBarPixelWidthCallback);
                 }
                 this._updateValueScale();
                 return this;
@@ -7004,7 +7004,7 @@ var Plottable;
                 }
                 else {
                     _super.prototype.y.call(this, y, yScale);
-                    yScale.onUpdate(this._getBarPixelWidthCallback);
+                    yScale.onUpdate(this._updateBarPixelWidthCallback);
                 }
                 this._updateValueScale();
                 return this;
@@ -7019,7 +7019,7 @@ var Plottable;
             };
             Bar.prototype.render = function () {
                 _super.prototype.render.call(this);
-                this._getBarPixelWidth();
+                this._updateBarPixelWidth();
                 return this;
             };
             Bar.prototype._createDrawer = function (dataset) {
@@ -7052,15 +7052,15 @@ var Plottable;
                 return this;
             };
             Bar.prototype.addDataset = function (dataset) {
-                dataset.onUpdate(this._getBarPixelWidthCallback);
+                dataset.onUpdate(this._updateBarPixelWidthCallback);
                 _super.prototype.addDataset.call(this, dataset);
-                this._getBarPixelWidth();
+                this._updateBarPixelWidth();
                 return this;
             };
             Bar.prototype.removeDataset = function (dataset) {
-                dataset.offUpdate(this._getBarPixelWidthCallback);
+                dataset.offUpdate(this._updateBarPixelWidthCallback);
                 _super.prototype.removeDataset.call(this, dataset);
-                this._getBarPixelWidth();
+                this._updateBarPixelWidth();
                 return this;
             };
             Bar.prototype.labelsEnabled = function (enabled) {
@@ -7339,7 +7339,7 @@ var Plottable;
              *   from https://github.com/mbostock/d3/wiki/Ordinal-Scales#ordinal_rangePoints, the max barPixelWidth is step * padding
              * If the position scale of the plot is a QuantitativeScale, then _getMinimumDataWidth is scaled to compute the barPixelWidth
              */
-            Bar.prototype._getBarPixelWidth = function () {
+            Bar.prototype._updateBarPixelWidth = function () {
                 if (!this._projectorsReady()) {
                     return 0;
                 }
@@ -7372,7 +7372,6 @@ var Plottable;
                     barPixelWidth *= Bar._BAR_WIDTH_RATIO;
                 }
                 this._barPixelWidth = barPixelWidth;
-                return barPixelWidth;
             };
             Bar.prototype.entities = function (datasets) {
                 var _this = this;
@@ -7411,7 +7410,7 @@ var Plottable;
                 return { x: x, y: y };
             };
             Bar.prototype._uninstallScaleForKey = function (scale, key) {
-                scale.offUpdate(this._getBarPixelWidthCallback);
+                scale.offUpdate(this._updateBarPixelWidthCallback);
                 _super.prototype._uninstallScaleForKey.call(this, scale, key);
             };
             Bar.prototype._getDataToDraw = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -675,25 +675,6 @@ var Plottable;
             }
             Stacking.stackedExtent = stackedExtent;
             /**
-             * Given an array of Datasets and the accessor function for the key, computes the
-             * set reunion (no duplicates) of the domain of each Dataset. The keys are stringified
-             * before being returned.
-             *
-             * @param {Dataset[]} datasets The Datasets for which we extract the domain keys
-             * @param {Accessor<any>} keyAccessor The accessor for the key of the data
-             * @return {string[]} An array of stringified keys
-             */
-            function domainKeys(datasets, keyAccessor) {
-                var domainKeys = d3.set();
-                datasets.forEach(function (dataset) {
-                    dataset.data().forEach(function (datum, index) {
-                        domainKeys.add(keyAccessor(datum, index, dataset));
-                    });
-                });
-                return domainKeys.values();
-            }
-            Stacking.domainKeys = domainKeys;
-            /**
              * Normalizes a key used for stacking
              *
              * @param {any} key The key to be normalized

--- a/plottable.js
+++ b/plottable.js
@@ -7017,6 +7017,11 @@ var Plottable;
             Bar.prototype.orientation = function () {
                 return this._isVertical ? Bar.ORIENTATION_VERTICAL : Bar.ORIENTATION_HORIZONTAL;
             };
+            Bar.prototype.render = function () {
+                _super.prototype.render.call(this);
+                this._getBarPixelWidth();
+                return this;
+            };
             Bar.prototype._createDrawer = function (dataset) {
                 return new Plottable.Drawers.Rectangle(dataset);
             };
@@ -7345,8 +7350,6 @@ var Plottable;
                 }
                 else {
                     var barAccessor = this._isVertical ? this.x().accessor : this.y().accessor;
-                    // var tmp: string[] = Plottable.Utils.Stacking.domainKeys(this.datasets(), barAccessor);
-                    // return 14;
                     var numberBarAccessorData = d3.set(Plottable.Utils.Array.flatten(this.datasets().map(function (dataset) {
                         return dataset.data().map(function (d, i) { return barAccessor(d, i, dataset); }).filter(function (d) { return d != null; }).map(function (d) { return d.valueOf(); });
                     }))).values().map(function (value) { return +value; });

--- a/plottable.js
+++ b/plottable.js
@@ -7360,6 +7360,15 @@ var Plottable;
                     barPixelWidth = Plottable.Utils.Math.min(barAccessorDataPairs, function (pair, i) {
                         return Math.abs(pair[1] - pair[0]);
                     }, barWidthDimension * Bar._SINGLE_BAR_DIMENSION_RATIO);
+                    var minScaledDatum = Plottable.Utils.Math.min(scaledData, 0);
+                    if (minScaledDatum > 0) {
+                        barPixelWidth = Math.min(barPixelWidth, minScaledDatum * 2);
+                    }
+                    var maxScaledDatum = Plottable.Utils.Math.max(scaledData, 0);
+                    if (maxScaledDatum < barWidthDimension) {
+                        var margin = barWidthDimension - maxScaledDatum;
+                        barPixelWidth = Math.min(barPixelWidth, margin * 2);
+                    }
                     barPixelWidth *= Bar._BAR_WIDTH_RATIO;
                 }
                 this._barPixelWidth = barPixelWidth;

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -149,14 +149,16 @@ export module Plots {
 
     public addDataset(dataset: Dataset) {
       dataset.onUpdate(this._getBarPixelWidthCallback);
+      super.addDataset(dataset);
       this._getBarPixelWidth();
-      return super.addDataset(dataset);
+      return this;
     }
 
     public removeDataset(dataset: Dataset) {
       dataset.offUpdate(this._getBarPixelWidthCallback);
+      super.removeDataset(dataset);
       this._getBarPixelWidth();
-      return super.removeDataset(dataset);
+      return this;
     }
 
     /**
@@ -516,33 +518,21 @@ export module Plots {
                                .map((d) => d.valueOf());
         }))).values().map((value) => +value);
 
-        // console.log(tmp);
-
-        // var numberBarAccessorData: number[] = tmp.map((v) => +v);
 
         numberBarAccessorData.sort((a, b) => a - b);
 
-        var barAccessorDataPairs = d3.pairs(numberBarAccessorData);
+        var scaledData = numberBarAccessorData.map((datum: number) => barScale.scale(datum));
+        var barAccessorDataPairs = d3.pairs(scaledData);
         var barWidthDimension = this._isVertical ? this.width() : this.height();
 
         barPixelWidth = Utils.Math.min(barAccessorDataPairs, (pair: any[], i: number) => {
-          return Math.abs(barScale.scale(pair[1]) - barScale.scale(pair[0]));
+          return Math.abs(pair[1] - pair[0]);
         }, barWidthDimension * Bar._SINGLE_BAR_DIMENSION_RATIO);
-
-        var scaledData = numberBarAccessorData.map((datum: number) => barScale.scale(datum));
-        var minScaledDatum = Utils.Math.min(scaledData, 0);
-        if (minScaledDatum > 0) {
-          barPixelWidth = Math.min(barPixelWidth, minScaledDatum * 2);
-        }
-        var maxScaledDatum = Utils.Math.max(scaledData, 0);
-        if ( maxScaledDatum < barWidthDimension) {
-          var margin = barWidthDimension - maxScaledDatum;
-          barPixelWidth = Math.min(barPixelWidth, margin * 2);
-        }
 
         barPixelWidth *= Bar._BAR_WIDTH_RATIO;
       }
       this._barPixelWidth = barPixelWidth;
+
       return barPixelWidth;
     }
 

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -28,7 +28,7 @@ export module Plots {
     private _baselineValueProvider: () => (X|Y)[];
 
     private _barPixelWidth = 0;
-    private _updateBarPixelWidthCallback: (() => void);
+    private _updateBarPixelWidthCallback: () => void;
 
     /**
      * A Bar Plot draws bars growing out from a baseline to some value
@@ -505,7 +505,6 @@ export module Plots {
      * If the position scale of the plot is a QuantitativeScale, then _getMinimumDataWidth is scaled to compute the barPixelWidth
      */
     protected _getBarPixelWidth(): number {
-
       if (!this._projectorsReady()) { return 0; }
       var barPixelWidth: number;
       var barScale: Scale<any, number> = this._isVertical ? this.x().scale : this.y().scale;
@@ -522,7 +521,7 @@ export module Plots {
 
         numberBarAccessorData.sort((a, b) => a - b);
 
-        var scaledData = numberBarAccessorData.map((datum: number) => barScale.scale(datum));
+        var scaledData = numberBarAccessorData.map((datum) => barScale.scale(datum));
         var barAccessorDataPairs = d3.pairs(scaledData);
         var barWidthDimension = this._isVertical ? this.width() : this.height();
 
@@ -584,10 +583,10 @@ export module Plots {
       return { x: x, y: y };
     }
 
-  protected _uninstallScaleForKey(scale: Scale<any, number>, key: string) {
-    scale.offUpdate(this._updateBarPixelWidthCallback);
-    super._uninstallScaleForKey(scale, key);
-  }
+    protected _uninstallScaleForKey(scale: Scale<any, number>, key: string) {
+      scale.offUpdate(this._updateBarPixelWidthCallback);
+      super._uninstallScaleForKey(scale, key);
+    }
 
     protected _getDataToDraw() {
       var dataToDraw = new Utils.Map<Dataset, any[]>();

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -28,7 +28,7 @@ export module Plots {
     private _baselineValueProvider: () => (X|Y)[];
 
     private _barPixelWidth = 0;
-    private _getBarPixelWidthCallback: (() => void);
+    private _updateBarPixelWidthCallback: (() => void);
 
     /**
      * A Bar Plot draws bars growing out from a baseline to some value
@@ -48,7 +48,7 @@ export module Plots {
       this.attr("width", () => this._barPixelWidth);
       this._labelConfig = new Utils.Map<Dataset, LabelConfig>();
       this._baselineValueProvider = () => [this.baselineValue()];
-      this._getBarPixelWidthCallback = () => this._getBarPixelWidth();
+      this._updateBarPixelWidthCallback = () => this._updateBarPixelWidth();
     }
 
     public x(): Plots.AccessorScaleBinding<X, number>;
@@ -63,7 +63,7 @@ export module Plots {
         super.x(<number | Accessor<number>>x);
       } else {
         super.x(< X | Accessor<X>>x, xScale);
-        xScale.onUpdate(this._getBarPixelWidthCallback);
+        xScale.onUpdate(this._updateBarPixelWidthCallback);
       }
 
       this._updateValueScale();
@@ -82,7 +82,7 @@ export module Plots {
         super.y(<number | Accessor<number>>y);
       } else {
         super.y(<Y | Accessor<Y>>y, yScale);
-        yScale.onUpdate(this._getBarPixelWidthCallback);
+        yScale.onUpdate(this._updateBarPixelWidthCallback);
       }
 
       this._updateValueScale();
@@ -100,7 +100,7 @@ export module Plots {
 
     public render() {
       super.render();
-      this._getBarPixelWidth();
+      this._updateBarPixelWidth();
       return this;
     }
 
@@ -154,16 +154,16 @@ export module Plots {
     }
 
     public addDataset(dataset: Dataset) {
-      dataset.onUpdate(this._getBarPixelWidthCallback);
+      dataset.onUpdate(this._updateBarPixelWidthCallback);
       super.addDataset(dataset);
-      this._getBarPixelWidth();
+      this._updateBarPixelWidth();
       return this;
     }
 
     public removeDataset(dataset: Dataset) {
-      dataset.offUpdate(this._getBarPixelWidthCallback);
+      dataset.offUpdate(this._updateBarPixelWidthCallback);
       super.removeDataset(dataset);
-      this._getBarPixelWidth();
+      this._updateBarPixelWidth();
       return this;
     }
 
@@ -504,7 +504,7 @@ export module Plots {
      *   from https://github.com/mbostock/d3/wiki/Ordinal-Scales#ordinal_rangePoints, the max barPixelWidth is step * padding
      * If the position scale of the plot is a QuantitativeScale, then _getMinimumDataWidth is scaled to compute the barPixelWidth
      */
-    protected _getBarPixelWidth(): number {
+    protected _updateBarPixelWidth(): number {
 
       if (!this._projectorsReady()) { return 0; }
       var barPixelWidth: number;
@@ -543,8 +543,6 @@ export module Plots {
         barPixelWidth *= Bar._BAR_WIDTH_RATIO;
       }
       this._barPixelWidth = barPixelWidth;
-
-      return barPixelWidth;
     }
 
     public entities(datasets = this.datasets()): PlotEntity[] {
@@ -583,7 +581,7 @@ export module Plots {
     }
 
   protected _uninstallScaleForKey(scale: Scale<any, number>, key: string) {
-    scale.offUpdate(this._getBarPixelWidthCallback);
+    scale.offUpdate(this._updateBarPixelWidthCallback);
     super._uninstallScaleForKey(scale, key);
   }
 

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -98,6 +98,12 @@ export module Plots {
       return this._isVertical ? Bar.ORIENTATION_VERTICAL : Bar.ORIENTATION_HORIZONTAL;
     }
 
+    public render() {
+      super.render();
+      this._getBarPixelWidth();
+      return this;
+    }
+
     protected _createDrawer(dataset: Dataset) {
       return new Plottable.Drawers.Rectangle(dataset);
     }
@@ -508,16 +514,11 @@ export module Plots {
       } else {
         var barAccessor = this._isVertical ? this.x().accessor : this.y().accessor;
 
-        // var tmp: string[] = Plottable.Utils.Stacking.domainKeys(this.datasets(), barAccessor);
-        // return 14;
-
-
         var numberBarAccessorData = d3.set(Utils.Array.flatten(this.datasets().map((dataset) => {
           return dataset.data().map((d, i) => barAccessor(d, i, dataset))
                                .filter((d) => d != null)
                                .map((d) => d.valueOf());
         }))).values().map((value) => +value);
-
 
         numberBarAccessorData.sort((a, b) => a - b);
 

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -530,6 +530,16 @@ export module Plots {
           return Math.abs(pair[1] - pair[0]);
         }, barWidthDimension * Bar._SINGLE_BAR_DIMENSION_RATIO);
 
+        var minScaledDatum = Utils.Math.min(scaledData, 0);
+        if (minScaledDatum > 0) {
+          barPixelWidth = Math.min(barPixelWidth, minScaledDatum * 2);
+        }
+        var maxScaledDatum = Utils.Math.max(scaledData, 0);
+        if ( maxScaledDatum < barWidthDimension) {
+          var margin = barWidthDimension - maxScaledDatum;
+          barPixelWidth = Math.min(barPixelWidth, margin * 2);
+        }
+
         barPixelWidth *= Bar._BAR_WIDTH_RATIO;
       }
       this._barPixelWidth = barPixelWidth;

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -504,7 +504,7 @@ export module Plots {
      *   from https://github.com/mbostock/d3/wiki/Ordinal-Scales#ordinal_rangePoints, the max barPixelWidth is step * padding
      * If the position scale of the plot is a QuantitativeScale, then _getMinimumDataWidth is scaled to compute the barPixelWidth
      */
-    protected _updateBarPixelWidth(): number {
+    protected _getBarPixelWidth(): number {
 
       if (!this._projectorsReady()) { return 0; }
       var barPixelWidth: number;
@@ -542,7 +542,11 @@ export module Plots {
 
         barPixelWidth *= Bar._BAR_WIDTH_RATIO;
       }
-      this._barPixelWidth = barPixelWidth;
+      return barPixelWidth;
+    }
+
+    private _updateBarPixelWidth() {
+      this._barPixelWidth = this._getBarPixelWidth();
     }
 
     public entities(datasets = this.datasets()): PlotEntity[] {

--- a/src/utils/stackingUtils.ts
+++ b/src/utils/stackingUtils.ts
@@ -76,6 +76,26 @@ export module Utils {
     }
 
     /**
+     * Given an array of Datasets and the accessor function for the key, computes the
+     * set reunion (no duplicates) of the domain of each Dataset. The keys are stringified
+     * before being returned.
+     *
+     * @param {Dataset[]} datasets The Datasets for which we extract the domain keys
+     * @param {Accessor<any>} keyAccessor The accessor for the key of the data
+     * @return {string[]} An array of stringified keys
+     */
+    export function domainKeys(datasets: Dataset[], keyAccessor: Accessor<any>) {
+      var domainKeys = d3.set();
+      datasets.forEach((dataset) => {
+        dataset.data().forEach((datum, index) => {
+          domainKeys.add(keyAccessor(datum, index, dataset));
+        });
+      });
+
+      return domainKeys.values();
+    }
+
+    /**
      * Normalizes a key used for stacking
      *
      * @param {any} key The key to be normalized

--- a/src/utils/stackingUtils.ts
+++ b/src/utils/stackingUtils.ts
@@ -76,26 +76,6 @@ export module Utils {
     }
 
     /**
-     * Given an array of Datasets and the accessor function for the key, computes the
-     * set reunion (no duplicates) of the domain of each Dataset. The keys are stringified
-     * before being returned.
-     *
-     * @param {Dataset[]} datasets The Datasets for which we extract the domain keys
-     * @param {Accessor<any>} keyAccessor The accessor for the key of the data
-     * @return {string[]} An array of stringified keys
-     */
-    export function domainKeys(datasets: Dataset[], keyAccessor: Accessor<any>) {
-      var domainKeys = d3.set();
-      datasets.forEach((dataset) => {
-        dataset.data().forEach((datum, index) => {
-          domainKeys.add(keyAccessor(datum, index, dataset));
-        });
-      });
-
-      return domainKeys.values();
-    }
-
-    /**
      * Normalizes a key used for stacking
      *
      * @param {any} key The key to be normalized

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -291,7 +291,7 @@ describe("Plots", () => {
       });
 
       it("barPixelWidth calculated appropriately", () => {
-        assert.strictEqual((<any> barPlot)._getBarPixelWidth(), xScale.scale(2) * 2 * 0.95);
+        assert.strictEqual((<any> barPlot)._barPixelWidth, xScale.scale(2) * 2 * 0.95);
         svg.remove();
       });
 
@@ -300,7 +300,7 @@ describe("Plots", () => {
         var bars = renderArea.selectAll("rect");
         assert.lengthOf(bars[0], 3, "One bar was created per data point");
 
-        var barPixelWidth = (<any> barPlot)._getBarPixelWidth();
+        var barPixelWidth = (<any> barPlot)._barPixelWidth;
         var bar0 = d3.select(bars[0][0]);
         var bar1 = d3.select(bars[0][1]);
         var bar2 = d3.select(bars[0][2]);
@@ -345,7 +345,7 @@ describe("Plots", () => {
       });
 
       it("bar width takes an appropriate value", () => {
-        assert.strictEqual((<any> barPlot)._getBarPixelWidth(), (xScale.scale(10) - xScale.scale(2)) * 0.95);
+        assert.strictEqual((<any> barPlot)._barPixelWidth, (xScale.scale(10) - xScale.scale(2)) * 0.95);
         svg.remove();
       });
 
@@ -354,7 +354,7 @@ describe("Plots", () => {
         var bars = renderArea.selectAll("rect");
         assert.lengthOf(bars[0], 3, "One bar was created per data point");
 
-        var barPixelWidth = (<any> barPlot)._getBarPixelWidth();
+        var barPixelWidth = (<any> barPlot)._barPixelWidth;
         var bar0 = d3.select(bars[0][0]);
         var bar1 = d3.select(bars[0][1]);
         var bar2 = d3.select(bars[0][2]);
@@ -367,14 +367,14 @@ describe("Plots", () => {
       it("sensible bar width one datum", () => {
         barPlot.removeDataset(dataset);
         barPlot.addDataset(new Plottable.Dataset([{x: 10, y: 2}]));
-        assert.closeTo((<any> barPlot)._getBarPixelWidth(), 228, 0.1, "sensible bar width for only one datum");
+        assert.closeTo((<any> barPlot)._barPixelWidth, 228, 0.1, "sensible bar width for only one datum");
         svg.remove();
       });
 
       it("sensible bar width same datum", () => {
         barPlot.removeDataset(dataset);
         barPlot.addDataset(new Plottable.Dataset([{x: 10, y: 2}, {x: 10, y: 2}]));
-        assert.closeTo((<any> barPlot)._getBarPixelWidth(), 228, 0.1, "uses the width sensible for one datum");
+        assert.closeTo((<any> barPlot)._barPixelWidth, 228, 0.1, "uses the width sensible for one datum");
         svg.remove();
       });
 
@@ -382,7 +382,7 @@ describe("Plots", () => {
         barPlot.removeDataset(dataset);
         barPlot.addDataset(new Plottable.Dataset([{x: 2, y: 2}, {x: 20, y: 2}, {x: 5, y: 2}]));
         var expectedBarPixelWidth = (xScale.scale(5) - xScale.scale(2)) * 0.95;
-        assert.closeTo((<any> barPlot)._getBarPixelWidth(), expectedBarPixelWidth, 0.1, "bar width uses closest sorted x values");
+        assert.closeTo((<any> barPlot)._barPixelWidth, expectedBarPixelWidth, 0.1, "bar width uses closest sorted x values");
         svg.remove();
       });
     });
@@ -412,7 +412,7 @@ describe("Plots", () => {
       it("bar width takes an appropriate value", () => {
         var timeFormatter = d3.time.format("%m/%d/%y");
         var expectedBarWidth = (xScale.scale(timeFormatter.parse("12/01/94")) - xScale.scale(timeFormatter.parse("12/01/93"))) * 0.95;
-        assert.closeTo((<any> barPlot)._getBarPixelWidth(), expectedBarWidth, 0.1, "width is difference between two dates");
+        assert.closeTo((<any> barPlot)._barPixelWidth, expectedBarWidth, 0.1, "width is difference between two dates");
         svg.remove();
       });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -4609,14 +4609,14 @@ describe("Plots", function () {
                 barPlot.renderTo(svg);
             });
             it("barPixelWidth calculated appropriately", function () {
-                assert.strictEqual(barPlot._getBarPixelWidth(), xScale.scale(2) * 2 * 0.95);
+                assert.strictEqual(barPlot._barPixelWidth, xScale.scale(2) * 2 * 0.95);
                 svg.remove();
             });
             it("bar widths are equal to barPixelWidth", function () {
                 var renderArea = barPlot._renderArea;
                 var bars = renderArea.selectAll("rect");
                 assert.lengthOf(bars[0], 3, "One bar was created per data point");
-                var barPixelWidth = barPlot._getBarPixelWidth();
+                var barPixelWidth = barPlot._barPixelWidth;
                 var bar0 = d3.select(bars[0][0]);
                 var bar1 = d3.select(bars[0][1]);
                 var bar2 = d3.select(bars[0][2]);
@@ -4657,14 +4657,14 @@ describe("Plots", function () {
                 svg.remove();
             });
             it("bar width takes an appropriate value", function () {
-                assert.strictEqual(barPlot._getBarPixelWidth(), (xScale.scale(10) - xScale.scale(2)) * 0.95);
+                assert.strictEqual(barPlot._barPixelWidth, (xScale.scale(10) - xScale.scale(2)) * 0.95);
                 svg.remove();
             });
             it("bar widths are equal to barPixelWidth", function () {
                 var renderArea = barPlot._renderArea;
                 var bars = renderArea.selectAll("rect");
                 assert.lengthOf(bars[0], 3, "One bar was created per data point");
-                var barPixelWidth = barPlot._getBarPixelWidth();
+                var barPixelWidth = barPlot._barPixelWidth;
                 var bar0 = d3.select(bars[0][0]);
                 var bar1 = d3.select(bars[0][1]);
                 var bar2 = d3.select(bars[0][2]);
@@ -4676,20 +4676,20 @@ describe("Plots", function () {
             it("sensible bar width one datum", function () {
                 barPlot.removeDataset(dataset);
                 barPlot.addDataset(new Plottable.Dataset([{ x: 10, y: 2 }]));
-                assert.closeTo(barPlot._getBarPixelWidth(), 228, 0.1, "sensible bar width for only one datum");
+                assert.closeTo(barPlot._barPixelWidth, 228, 0.1, "sensible bar width for only one datum");
                 svg.remove();
             });
             it("sensible bar width same datum", function () {
                 barPlot.removeDataset(dataset);
                 barPlot.addDataset(new Plottable.Dataset([{ x: 10, y: 2 }, { x: 10, y: 2 }]));
-                assert.closeTo(barPlot._getBarPixelWidth(), 228, 0.1, "uses the width sensible for one datum");
+                assert.closeTo(barPlot._barPixelWidth, 228, 0.1, "uses the width sensible for one datum");
                 svg.remove();
             });
             it("sensible bar width unsorted data", function () {
                 barPlot.removeDataset(dataset);
                 barPlot.addDataset(new Plottable.Dataset([{ x: 2, y: 2 }, { x: 20, y: 2 }, { x: 5, y: 2 }]));
                 var expectedBarPixelWidth = (xScale.scale(5) - xScale.scale(2)) * 0.95;
-                assert.closeTo(barPlot._getBarPixelWidth(), expectedBarPixelWidth, 0.1, "bar width uses closest sorted x values");
+                assert.closeTo(barPlot._barPixelWidth, expectedBarPixelWidth, 0.1, "bar width uses closest sorted x values");
                 svg.remove();
             });
         });
@@ -4709,7 +4709,7 @@ describe("Plots", function () {
             it("bar width takes an appropriate value", function () {
                 var timeFormatter = d3.time.format("%m/%d/%y");
                 var expectedBarWidth = (xScale.scale(timeFormatter.parse("12/01/94")) - xScale.scale(timeFormatter.parse("12/01/93"))) * 0.95;
-                assert.closeTo(barPlot._getBarPixelWidth(), expectedBarWidth, 0.1, "width is difference between two dates");
+                assert.closeTo(barPlot._barPixelWidth, expectedBarWidth, 0.1, "width is difference between two dates");
                 svg.remove();
             });
         });


### PR DESCRIPTION
Closes https://github.com/palantir/plottable/issues/1284

Improved the call of `flush()` from `132 ms` down to `10 ms` by caching the result of `_getBarPixelWidth()`

Historic Before: http://jsfiddle.net/aycxz2ap/4/
Before: http://jsfiddle.net/aycxz2ap/1/
After: http://jsfiddle.net/aycxz2ap/3/

**QE Notes:** Bar Plot should behave the same. In particular the width of the bars should not behave weirdly. Also The main performance boost is in the PanZoom animation effect (as can be seen in the fiddle) 