### PR TITLE
[Interactions.PanZoom] - Usage on multiple scales

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3573,13 +3573,53 @@ declare module Plottable {
             constructor(xScale?: QuantitativeScale<any>, yScale?: QuantitativeScale<any>);
             protected _anchor(component: Component): void;
             protected _unanchor(): void;
+            /**
+             * Gets the x scales for this PanZoom Interaction.
+             */
             xScales(): QuantitativeScale<any>[];
+            /**
+             * Sets the x scales for this PanZoom Interaction.
+             *
+             * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+             */
             xScales(xScales: QuantitativeScale<any>[]): Interactions.PanZoom;
+            /**
+             * Gets the y scales for this PanZoom Interaction.
+             */
             yScales(): QuantitativeScale<any>[];
+            /**
+             * Sets the y scales for this PanZoom Interaction.
+             *
+             * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+             */
             yScales(yScales: QuantitativeScale<any>[]): Interactions.PanZoom;
+            /**
+             * Adds an x scale to use for this PanZoom Interaction
+             *
+             * @param {QuantitativeScale<any>} An x scale to add
+             * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+             */
             addXScale(xScale: QuantitativeScale<any>): PanZoom;
+            /**
+             * Removes an x scale that would have been used for this PanZoom Interaction
+             *
+             * @param {QuantitativeScale<any>} An x scale to add
+             * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+             */
             removeXScale(xScale: QuantitativeScale<any>): PanZoom;
+            /**
+             * Adds a y scale to use for this PanZoom Interaction
+             *
+             * @param {QuantitativeScale<any>} An y scale to add
+             * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+             */
             addYScale(yScale: QuantitativeScale<any>): PanZoom;
+            /**
+             * Removes a y scale that would have been used for this PanZoom Interaction
+             *
+             * @param {QuantitativeScale<any>} An y scale to add
+             * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+             */
             removeYScale(yScale: QuantitativeScale<any>): PanZoom;
         }
     }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3573,6 +3573,14 @@ declare module Plottable {
             constructor(xScale?: QuantitativeScale<any>, yScale?: QuantitativeScale<any>);
             protected _anchor(component: Component): void;
             protected _unanchor(): void;
+            xScales(): QuantitativeScale<any>[];
+            xScales(xScales: QuantitativeScale<any>[]): Interactions.PanZoom;
+            yScales(): QuantitativeScale<any>[];
+            yScales(xScales: QuantitativeScale<any>[]): Interactions.PanZoom;
+            addXScale(xScale: QuantitativeScale<any>): PanZoom;
+            removeXScale(yScale: QuantitativeScale<any>): PanZoom;
+            addYScale(xScale: QuantitativeScale<any>): PanZoom;
+            removeYScale(yScale: QuantitativeScale<any>): PanZoom;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3576,7 +3576,7 @@ declare module Plottable {
             xScales(): QuantitativeScale<any>[];
             xScales(xScales: QuantitativeScale<any>[]): Interactions.PanZoom;
             yScales(): QuantitativeScale<any>[];
-            yScales(xScales: QuantitativeScale<any>[]): Interactions.PanZoom;
+            yScales(yScales: QuantitativeScale<any>[]): Interactions.PanZoom;
             addXScale(xScale: QuantitativeScale<any>): PanZoom;
             removeXScale(yScale: QuantitativeScale<any>): PanZoom;
             addYScale(xScale: QuantitativeScale<any>): PanZoom;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3594,30 +3594,30 @@ declare module Plottable {
              */
             yScales(yScales: QuantitativeScale<any>[]): Interactions.PanZoom;
             /**
-             * Adds an x scale to use for this PanZoom Interaction
+             * Adds an x scale to this PanZoom Interaction
              *
              * @param {QuantitativeScale<any>} An x scale to add
              * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
              */
             addXScale(xScale: QuantitativeScale<any>): PanZoom;
             /**
-             * Removes an x scale that would have been used for this PanZoom Interaction
+             * Removes an x scale from this PanZoom Interaction
              *
-             * @param {QuantitativeScale<any>} An x scale to add
+             * @param {QuantitativeScale<any>} An x scale to remove
              * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
              */
             removeXScale(xScale: QuantitativeScale<any>): PanZoom;
             /**
-             * Adds a y scale to use for this PanZoom Interaction
+             * Adds a y scale to this PanZoom Interaction
              *
-             * @param {QuantitativeScale<any>} An y scale to add
+             * @param {QuantitativeScale<any>} A y scale to add
              * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
              */
             addYScale(yScale: QuantitativeScale<any>): PanZoom;
             /**
-             * Removes a y scale that would have been used for this PanZoom Interaction
+             * Removes a y scale from this PanZoom Interaction
              *
-             * @param {QuantitativeScale<any>} An y scale to add
+             * @param {QuantitativeScale<any>} A y scale to remove
              * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
              */
             removeYScale(yScale: QuantitativeScale<any>): PanZoom;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3578,8 +3578,8 @@ declare module Plottable {
             yScales(): QuantitativeScale<any>[];
             yScales(yScales: QuantitativeScale<any>[]): Interactions.PanZoom;
             addXScale(xScale: QuantitativeScale<any>): PanZoom;
-            removeXScale(yScale: QuantitativeScale<any>): PanZoom;
-            addYScale(xScale: QuantitativeScale<any>): PanZoom;
+            removeXScale(xScale: QuantitativeScale<any>): PanZoom;
+            addYScale(yScale: QuantitativeScale<any>): PanZoom;
             removeYScale(yScale: QuantitativeScale<any>): PanZoom;
         }
     }

--- a/plottable.js
+++ b/plottable.js
@@ -9094,8 +9094,14 @@ var Plottable;
                 this._touchMoveCallback = function (ids, idToPoint, e) { return _this._handlePinch(ids, idToPoint, e); };
                 this._touchEndCallback = function (ids, idToPoint, e) { return _this._handleTouchEnd(ids, idToPoint, e); };
                 this._touchCancelCallback = function (ids, idToPoint, e) { return _this._handleTouchEnd(ids, idToPoint, e); };
-                this._xScales = xScale == null ? [] : [xScale];
-                this._yScales = yScale == null ? [] : [yScale];
+                this._xScales = new Plottable.Utils.Set();
+                if (xScale != null) {
+                    this._xScales.add(xScale);
+                }
+                this._yScales = new Plottable.Utils.Set();
+                if (yScale != null) {
+                    this._yScales.add(yScale);
+                }
                 this._dragInteraction = new Interactions.Drag();
                 this._setupDragInteraction();
                 this._touchIds = d3.map();

--- a/plottable.js
+++ b/plottable.js
@@ -9094,8 +9094,8 @@ var Plottable;
                 this._touchMoveCallback = function (ids, idToPoint, e) { return _this._handlePinch(ids, idToPoint, e); };
                 this._touchEndCallback = function (ids, idToPoint, e) { return _this._handleTouchEnd(ids, idToPoint, e); };
                 this._touchCancelCallback = function (ids, idToPoint, e) { return _this._handleTouchEnd(ids, idToPoint, e); };
-                this._xScale = xScale;
-                this._yScale = yScale;
+                this._xScales = xScale == null ? [] : [xScale];
+                this._yScales = yScale == null ? [] : [yScale];
                 this._dragInteraction = new Interactions.Drag();
                 this._setupDragInteraction();
                 this._touchIds = d3.map();
@@ -9142,13 +9142,17 @@ var Plottable;
                 });
                 var newCenterPoint = this._centerPoint();
                 var newCornerDistance = this._cornerDistance();
-                if (this._xScale != null && newCornerDistance !== 0 && oldCornerDistance !== 0) {
-                    PanZoom._magnifyScale(this._xScale, oldCornerDistance / newCornerDistance, oldCenterPoint.x);
-                    PanZoom._translateScale(this._xScale, oldCenterPoint.x - newCenterPoint.x);
+                if (newCornerDistance !== 0 && oldCornerDistance !== 0) {
+                    this._xScales.forEach(function (xScale) {
+                        PanZoom._magnifyScale(xScale, oldCornerDistance / newCornerDistance, oldCenterPoint.x);
+                        PanZoom._translateScale(xScale, oldCenterPoint.x - newCenterPoint.x);
+                    });
                 }
-                if (this._yScale != null && newCornerDistance !== 0 && oldCornerDistance !== 0) {
-                    PanZoom._magnifyScale(this._yScale, oldCornerDistance / newCornerDistance, oldCenterPoint.y);
-                    PanZoom._translateScale(this._yScale, oldCenterPoint.y - newCenterPoint.y);
+                if (newCornerDistance !== 0 && oldCornerDistance !== 0) {
+                    this._yScales.forEach(function (yScale) {
+                        PanZoom._magnifyScale(yScale, oldCornerDistance / newCornerDistance, oldCenterPoint.y);
+                        PanZoom._translateScale(yScale, oldCenterPoint.y - newCenterPoint.y);
+                    });
                 }
             };
             PanZoom.prototype._centerPoint = function () {
@@ -9191,12 +9195,12 @@ var Plottable;
                     e.preventDefault();
                     var deltaPixelAmount = e.deltaY * (e.deltaMode ? PanZoom._PIXELS_PER_LINE : 1);
                     var zoomAmount = Math.pow(2, deltaPixelAmount * .002);
-                    if (this._xScale != null) {
-                        PanZoom._magnifyScale(this._xScale, zoomAmount, translatedP.x);
-                    }
-                    if (this._yScale != null) {
-                        PanZoom._magnifyScale(this._yScale, zoomAmount, translatedP.y);
-                    }
+                    this._xScales.forEach(function (xScale) {
+                        PanZoom._magnifyScale(xScale, zoomAmount, translatedP.x);
+                    });
+                    this._yScales.forEach(function (yScale) {
+                        PanZoom._magnifyScale(yScale, zoomAmount, translatedP.y);
+                    });
                 }
             };
             PanZoom.prototype._setupDragInteraction = function () {
@@ -9208,14 +9212,14 @@ var Plottable;
                     if (_this._touchIds.size() >= 2) {
                         return;
                     }
-                    if (_this._xScale != null) {
+                    _this._xScales.forEach(function (xScale) {
                         var dragAmountX = endPoint.x - (lastDragPoint == null ? startPoint.x : lastDragPoint.x);
-                        PanZoom._translateScale(_this._xScale, -dragAmountX);
-                    }
-                    if (_this._yScale != null) {
+                        PanZoom._translateScale(xScale, -dragAmountX);
+                    });
+                    _this._yScales.forEach(function (yScale) {
                         var dragAmountY = endPoint.y - (lastDragPoint == null ? startPoint.y : lastDragPoint.y);
-                        PanZoom._translateScale(_this._yScale, -dragAmountY);
-                    }
+                        PanZoom._translateScale(yScale, -dragAmountY);
+                    });
                     lastDragPoint = endPoint;
                 });
             };

--- a/plottable.js
+++ b/plottable.js
@@ -9244,7 +9244,7 @@ var Plottable;
              * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
              */
             PanZoom.prototype.addXScale = function (xScale) {
-                if (this.xScales().indexOf(xScale) === -1) {
+                if (this.xScales().indexOf(xScale) != -1) {
                     return this;
                 }
                 this._xScales.push(xScale);
@@ -9271,7 +9271,7 @@ var Plottable;
              * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
              */
             PanZoom.prototype.addYScale = function (yScale) {
-                if (this.yScales().indexOf(yScale) === -1) {
+                if (this.yScales().indexOf(yScale) != -1) {
                     return this;
                 }
                 this._yScales.push(yScale);

--- a/plottable.js
+++ b/plottable.js
@@ -9219,6 +9219,24 @@ var Plottable;
                     lastDragPoint = endPoint;
                 });
             };
+            PanZoom.prototype.xScales = function (xScales) {
+                // TODO: Implement this.
+            };
+            PanZoom.prototype.yScales = function (xScales) {
+                // TODO: Implement this.
+            };
+            PanZoom.prototype.addXScale = function (xScale) {
+                return this;
+            };
+            PanZoom.prototype.removeXScale = function (yScale) {
+                return this;
+            };
+            PanZoom.prototype.addYScale = function (xScale) {
+                return this;
+            };
+            PanZoom.prototype.removeYScale = function (yScale) {
+                return this;
+            };
             /**
              * The number of pixels occupied in a line.
              */

--- a/plottable.js
+++ b/plottable.js
@@ -9244,7 +9244,7 @@ var Plottable;
              * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
              */
             PanZoom.prototype.addXScale = function (xScale) {
-                if (this.xScales().indexOf(xScale) != -1) {
+                if (this.xScales().indexOf(xScale) !== -1) {
                     return this;
                 }
                 this._xScales.push(xScale);
@@ -9271,7 +9271,7 @@ var Plottable;
              * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
              */
             PanZoom.prototype.addYScale = function (yScale) {
-                if (this.yScales().indexOf(yScale) != -1) {
+                if (this.yScales().indexOf(yScale) !== -1) {
                     return this;
                 }
                 this._yScales.push(yScale);

--- a/plottable.js
+++ b/plottable.js
@@ -9143,13 +9143,13 @@ var Plottable;
                 var newCenterPoint = this._centerPoint();
                 var newCornerDistance = this._cornerDistance();
                 if (newCornerDistance !== 0 && oldCornerDistance !== 0) {
-                    this._xScales.forEach(function (xScale) {
+                    this.yScales().forEach(function (xScale) {
                         PanZoom._magnifyScale(xScale, oldCornerDistance / newCornerDistance, oldCenterPoint.x);
                         PanZoom._translateScale(xScale, oldCenterPoint.x - newCenterPoint.x);
                     });
                 }
                 if (newCornerDistance !== 0 && oldCornerDistance !== 0) {
-                    this._yScales.forEach(function (yScale) {
+                    this.yScales().forEach(function (yScale) {
                         PanZoom._magnifyScale(yScale, oldCornerDistance / newCornerDistance, oldCenterPoint.y);
                         PanZoom._translateScale(yScale, oldCenterPoint.y - newCenterPoint.y);
                     });
@@ -9195,10 +9195,10 @@ var Plottable;
                     e.preventDefault();
                     var deltaPixelAmount = e.deltaY * (e.deltaMode ? PanZoom._PIXELS_PER_LINE : 1);
                     var zoomAmount = Math.pow(2, deltaPixelAmount * .002);
-                    this._xScales.forEach(function (xScale) {
+                    this.xScales().forEach(function (xScale) {
                         PanZoom._magnifyScale(xScale, zoomAmount, translatedP.x);
                     });
-                    this._yScales.forEach(function (yScale) {
+                    this.yScales().forEach(function (yScale) {
                         PanZoom._magnifyScale(yScale, zoomAmount, translatedP.y);
                     });
                 }
@@ -9212,11 +9212,11 @@ var Plottable;
                     if (_this._touchIds.size() >= 2) {
                         return;
                     }
-                    _this._xScales.forEach(function (xScale) {
+                    _this.xScales().forEach(function (xScale) {
                         var dragAmountX = endPoint.x - (lastDragPoint == null ? startPoint.x : lastDragPoint.x);
                         PanZoom._translateScale(xScale, -dragAmountX);
                     });
-                    _this._yScales.forEach(function (yScale) {
+                    _this.yScales().forEach(function (yScale) {
                         var dragAmountY = endPoint.y - (lastDragPoint == null ? startPoint.y : lastDragPoint.y);
                         PanZoom._translateScale(yScale, -dragAmountY);
                     });
@@ -9224,10 +9224,18 @@ var Plottable;
                 });
             };
             PanZoom.prototype.xScales = function (xScales) {
-                // TODO: Implement this.
+                if (xScales == null) {
+                    return this._xScales;
+                }
+                this._xScales = xScales;
+                return this;
             };
-            PanZoom.prototype.yScales = function (xScales) {
-                // TODO: Implement this.
+            PanZoom.prototype.yScales = function (yScales) {
+                if (yScales == null) {
+                    return this._yScales;
+                }
+                this._yScales = yScales;
+                return this;
             };
             PanZoom.prototype.addXScale = function (xScale) {
                 return this;

--- a/plottable.js
+++ b/plottable.js
@@ -9143,7 +9143,7 @@ var Plottable;
                 var newCenterPoint = this._centerPoint();
                 var newCornerDistance = this._cornerDistance();
                 if (newCornerDistance !== 0 && oldCornerDistance !== 0) {
-                    this.yScales().forEach(function (xScale) {
+                    this.xScales().forEach(function (xScale) {
                         PanZoom._magnifyScale(xScale, oldCornerDistance / newCornerDistance, oldCenterPoint.x);
                         PanZoom._translateScale(xScale, oldCenterPoint.x - newCenterPoint.x);
                     });

--- a/plottable.js
+++ b/plottable.js
@@ -9094,8 +9094,14 @@ var Plottable;
                 this._touchMoveCallback = function (ids, idToPoint, e) { return _this._handlePinch(ids, idToPoint, e); };
                 this._touchEndCallback = function (ids, idToPoint, e) { return _this._handleTouchEnd(ids, idToPoint, e); };
                 this._touchCancelCallback = function (ids, idToPoint, e) { return _this._handleTouchEnd(ids, idToPoint, e); };
-                this._xScales = xScale == null ? [] : [xScale];
-                this._yScales = yScale == null ? [] : [yScale];
+                this._xScales = new Plottable.Utils.Set();
+                if (xScale != null) {
+                    this._xScales.add(xScale);
+                }
+                this._yScales = new Plottable.Utils.Set();
+                if (yScale != null) {
+                    this._yScales.add(yScale);
+                }
                 this._dragInteraction = new Interactions.Drag();
                 this._setupDragInteraction();
                 this._touchIds = d3.map();
@@ -9224,17 +9230,33 @@ var Plottable;
                 });
             };
             PanZoom.prototype.xScales = function (xScales) {
+                var _this = this;
                 if (xScales == null) {
-                    return this._xScales;
+                    var scales = [];
+                    this._xScales.forEach(function (xScale) {
+                        scales.push(xScale);
+                    });
+                    return scales;
                 }
-                this._xScales = xScales;
+                this._xScales = new Plottable.Utils.Set();
+                xScales.forEach(function (xScale) {
+                    _this.addXScale(xScale);
+                });
                 return this;
             };
             PanZoom.prototype.yScales = function (yScales) {
+                var _this = this;
                 if (yScales == null) {
-                    return this._yScales;
+                    var scales = [];
+                    this._yScales.forEach(function (yScale) {
+                        scales.push(yScale);
+                    });
+                    return scales;
                 }
-                this._yScales = yScales;
+                this._yScales = new Plottable.Utils.Set();
+                yScales.forEach(function (yScale) {
+                    _this.addYScale(yScale);
+                });
                 return this;
             };
             /**
@@ -9244,10 +9266,7 @@ var Plottable;
              * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
              */
             PanZoom.prototype.addXScale = function (xScale) {
-                if (this.xScales().indexOf(xScale) !== -1) {
-                    return this;
-                }
-                this._xScales.push(xScale);
+                this._xScales.add(xScale);
                 return this;
             };
             /**
@@ -9257,11 +9276,7 @@ var Plottable;
              * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
              */
             PanZoom.prototype.removeXScale = function (xScale) {
-                var xScaleIndex = this.xScales().indexOf(xScale);
-                if (xScaleIndex === -1) {
-                    return this;
-                }
-                this._xScales.splice(xScaleIndex, 1);
+                this._xScales.delete(xScale);
                 return this;
             };
             /**
@@ -9271,10 +9286,7 @@ var Plottable;
              * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
              */
             PanZoom.prototype.addYScale = function (yScale) {
-                if (this.yScales().indexOf(yScale) !== -1) {
-                    return this;
-                }
-                this._yScales.push(yScale);
+                this._yScales.add(yScale);
                 return this;
             };
             /**
@@ -9284,11 +9296,7 @@ var Plottable;
              * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
              */
             PanZoom.prototype.removeYScale = function (yScale) {
-                var yScaleIndex = this.yScales().indexOf(yScale);
-                if (yScaleIndex === -1) {
-                    return this;
-                }
-                this._yScales.splice(yScaleIndex, 1);
+                this._yScales.delete(yScale);
                 return this;
             };
             /**

--- a/plottable.js
+++ b/plottable.js
@@ -9238,15 +9238,33 @@ var Plottable;
                 return this;
             };
             PanZoom.prototype.addXScale = function (xScale) {
+                if (this.xScales().indexOf(xScale) === -1) {
+                    return this;
+                }
+                this._xScales.push(xScale);
                 return this;
             };
-            PanZoom.prototype.removeXScale = function (yScale) {
+            PanZoom.prototype.removeXScale = function (xScale) {
+                var xScaleIndex = this.xScales().indexOf(xScale);
+                if (xScaleIndex === -1) {
+                    return this;
+                }
+                this._xScales.splice(xScaleIndex, 1);
                 return this;
             };
-            PanZoom.prototype.addYScale = function (xScale) {
+            PanZoom.prototype.addYScale = function (yScale) {
+                if (this.yScales().indexOf(yScale) === -1) {
+                    return this;
+                }
+                this._yScales.push(yScale);
                 return this;
             };
             PanZoom.prototype.removeYScale = function (yScale) {
+                var yScaleIndex = this.yScales().indexOf(yScale);
+                if (yScaleIndex === -1) {
+                    return this;
+                }
+                this._yScales.splice(yScaleIndex, 1);
                 return this;
             };
             /**

--- a/plottable.js
+++ b/plottable.js
@@ -9094,14 +9094,8 @@ var Plottable;
                 this._touchMoveCallback = function (ids, idToPoint, e) { return _this._handlePinch(ids, idToPoint, e); };
                 this._touchEndCallback = function (ids, idToPoint, e) { return _this._handleTouchEnd(ids, idToPoint, e); };
                 this._touchCancelCallback = function (ids, idToPoint, e) { return _this._handleTouchEnd(ids, idToPoint, e); };
-                this._xScales = new Plottable.Utils.Set();
-                if (xScale != null) {
-                    this._xScales.add(xScale);
-                }
-                this._yScales = new Plottable.Utils.Set();
-                if (yScale != null) {
-                    this._yScales.add(yScale);
-                }
+                this._xScales = xScale == null ? [] : [xScale];
+                this._yScales = yScale == null ? [] : [yScale];
                 this._dragInteraction = new Interactions.Drag();
                 this._setupDragInteraction();
                 this._touchIds = d3.map();

--- a/plottable.js
+++ b/plottable.js
@@ -9238,7 +9238,7 @@ var Plottable;
                 return this;
             };
             /**
-             * Adds an x scale to use for this PanZoom Interaction
+             * Adds an x scale to this PanZoom Interaction
              *
              * @param {QuantitativeScale<any>} An x scale to add
              * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
@@ -9251,9 +9251,9 @@ var Plottable;
                 return this;
             };
             /**
-             * Removes an x scale that would have been used for this PanZoom Interaction
+             * Removes an x scale from this PanZoom Interaction
              *
-             * @param {QuantitativeScale<any>} An x scale to add
+             * @param {QuantitativeScale<any>} An x scale to remove
              * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
              */
             PanZoom.prototype.removeXScale = function (xScale) {
@@ -9265,9 +9265,9 @@ var Plottable;
                 return this;
             };
             /**
-             * Adds a y scale to use for this PanZoom Interaction
+             * Adds a y scale to this PanZoom Interaction
              *
-             * @param {QuantitativeScale<any>} An y scale to add
+             * @param {QuantitativeScale<any>} A y scale to add
              * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
              */
             PanZoom.prototype.addYScale = function (yScale) {
@@ -9278,9 +9278,9 @@ var Plottable;
                 return this;
             };
             /**
-             * Removes a y scale that would have been used for this PanZoom Interaction
+             * Removes a y scale from this PanZoom Interaction
              *
-             * @param {QuantitativeScale<any>} An y scale to add
+             * @param {QuantitativeScale<any>} A y scale to remove
              * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
              */
             PanZoom.prototype.removeYScale = function (yScale) {

--- a/plottable.js
+++ b/plottable.js
@@ -9237,6 +9237,12 @@ var Plottable;
                 this._yScales = yScales;
                 return this;
             };
+            /**
+             * Adds an x scale to use for this PanZoom Interaction
+             *
+             * @param {QuantitativeScale<any>} An x scale to add
+             * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+             */
             PanZoom.prototype.addXScale = function (xScale) {
                 if (this.xScales().indexOf(xScale) === -1) {
                     return this;
@@ -9244,6 +9250,12 @@ var Plottable;
                 this._xScales.push(xScale);
                 return this;
             };
+            /**
+             * Removes an x scale that would have been used for this PanZoom Interaction
+             *
+             * @param {QuantitativeScale<any>} An x scale to add
+             * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+             */
             PanZoom.prototype.removeXScale = function (xScale) {
                 var xScaleIndex = this.xScales().indexOf(xScale);
                 if (xScaleIndex === -1) {
@@ -9252,6 +9264,12 @@ var Plottable;
                 this._xScales.splice(xScaleIndex, 1);
                 return this;
             };
+            /**
+             * Adds a y scale to use for this PanZoom Interaction
+             *
+             * @param {QuantitativeScale<any>} An y scale to add
+             * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+             */
             PanZoom.prototype.addYScale = function (yScale) {
                 if (this.yScales().indexOf(yScale) === -1) {
                     return this;
@@ -9259,6 +9277,12 @@ var Plottable;
                 this._yScales.push(yScale);
                 return this;
             };
+            /**
+             * Removes a y scale that would have been used for this PanZoom Interaction
+             *
+             * @param {QuantitativeScale<any>} An y scale to add
+             * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+             */
             PanZoom.prototype.removeYScale = function (yScale) {
                 var yScaleIndex = this.yScales().indexOf(yScale);
                 if (yScaleIndex === -1) {

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -185,7 +185,15 @@ export module Interactions {
       });
     }
 
+    /**
+     * Gets the x scales for this PanZoom Interaction.
+     */
     public xScales(): QuantitativeScale<any>[];
+    /**
+     * Sets the x scales for this PanZoom Interaction.
+     * 
+     * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+     */
     public xScales(xScales: QuantitativeScale<any>[]): Interactions.PanZoom;
     public xScales(xScales?: QuantitativeScale<any>[]): any {
       if (xScales == null) {
@@ -195,7 +203,15 @@ export module Interactions {
       return this;
     }
 
+    /**
+     * Gets the y scales for this PanZoom Interaction.
+     */
     public yScales(): QuantitativeScale<any>[];
+    /**
+     * Sets the y scales for this PanZoom Interaction.
+     * 
+     * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+     */
     public yScales(yScales: QuantitativeScale<any>[]): Interactions.PanZoom;
     public yScales(yScales?: QuantitativeScale<any>[]): any {
       if (yScales == null) {
@@ -205,6 +221,12 @@ export module Interactions {
       return this;
     }
 
+    /**
+     * Adds an x scale to use for this PanZoom Interaction
+     * 
+     * @param {QuantitativeScale<any>} An x scale to add
+     * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+     */
     public addXScale(xScale: QuantitativeScale<any>) {
       if (this.xScales().indexOf(xScale) === -1) {
         return this;
@@ -213,6 +235,12 @@ export module Interactions {
       return this;
     }
 
+    /**
+     * Removes an x scale that would have been used for this PanZoom Interaction
+     * 
+     * @param {QuantitativeScale<any>} An x scale to add
+     * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+     */
     public removeXScale(xScale: QuantitativeScale<any>) {
       var xScaleIndex = this.xScales().indexOf(xScale);
       if (xScaleIndex === -1) {
@@ -222,6 +250,12 @@ export module Interactions {
       return this;
     }
 
+    /**
+     * Adds a y scale to use for this PanZoom Interaction
+     * 
+     * @param {QuantitativeScale<any>} An y scale to add
+     * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+     */
     public addYScale(yScale: QuantitativeScale<any>) {
       if (this.yScales().indexOf(yScale) === -1) {
         return this;
@@ -230,6 +264,12 @@ export module Interactions {
       return this;
     }
 
+    /**
+     * Removes a y scale that would have been used for this PanZoom Interaction
+     * 
+     * @param {QuantitativeScale<any>} An y scale to add
+     * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+     */
     public removeYScale(yScale: QuantitativeScale<any>) {
       var yScaleIndex = this.yScales().indexOf(yScale);
       if (yScaleIndex === -1) {

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -8,8 +8,8 @@ export module Interactions {
      */
     private static _PIXELS_PER_LINE = 120;
 
-    private _xScales: QuantitativeScale<any>[];
-    private _yScales: QuantitativeScale<any>[];
+    private _xScales: Utils.Set<QuantitativeScale<any>>;
+    private _yScales: Utils.Set<QuantitativeScale<any>>;
     private _dragInteraction: Interactions.Drag;
     private _mouseDispatcher: Dispatchers.Mouse;
     private _touchDispatcher: Dispatchers.Touch;
@@ -32,8 +32,14 @@ export module Interactions {
      */
     constructor(xScale?: QuantitativeScale<any>, yScale?: QuantitativeScale<any>) {
       super();
-      this._xScales = xScale == null ? [] : [xScale];
-      this._yScales = yScale == null ? [] : [yScale];
+      this._xScales = new Utils.Set<QuantitativeScale<any>>();
+      if (xScale != null) {
+        this._xScales.add(xScale);
+      }
+      this._yScales = new Utils.Set<QuantitativeScale<any>>();
+      if (yScale != null) {
+        this._yScales.add(yScale);
+      }
 
       this._dragInteraction = new Interactions.Drag();
       this._setupDragInteraction();
@@ -197,9 +203,16 @@ export module Interactions {
     public xScales(xScales: QuantitativeScale<any>[]): Interactions.PanZoom;
     public xScales(xScales?: QuantitativeScale<any>[]): any {
       if (xScales == null) {
-        return this._xScales;
+        var scales: QuantitativeScale<any>[] = [];
+        this._xScales.forEach((xScale) => {
+          scales.push(xScale);
+        });
+        return scales;
       }
-      this._xScales = xScales;
+      this._xScales = new Utils.Set<QuantitativeScale<any>>();
+      xScales.forEach((xScale) => {
+        this.addXScale(xScale);
+      });
       return this;
     }
 
@@ -215,9 +228,16 @@ export module Interactions {
     public yScales(yScales: QuantitativeScale<any>[]): Interactions.PanZoom;
     public yScales(yScales?: QuantitativeScale<any>[]): any {
       if (yScales == null) {
-        return this._yScales;
+        var scales: QuantitativeScale<any>[] = [];
+        this._yScales.forEach((yScale) => {
+          scales.push(yScale);
+        });
+        return scales;
       }
-      this._yScales = yScales;
+      this._yScales = new Utils.Set<QuantitativeScale<any>>();
+      yScales.forEach((yScale) => {
+        this.addYScale(yScale);
+      });
       return this;
     }
 
@@ -228,10 +248,7 @@ export module Interactions {
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
     public addXScale(xScale: QuantitativeScale<any>) {
-      if (this.xScales().indexOf(xScale) !== -1) {
-        return this;
-      }
-      this._xScales.push(xScale);
+      this._xScales.add(xScale);
       return this;
     }
 
@@ -242,11 +259,7 @@ export module Interactions {
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
     public removeXScale(xScale: QuantitativeScale<any>) {
-      var xScaleIndex = this.xScales().indexOf(xScale);
-      if (xScaleIndex === -1) {
-        return this;
-      }
-      this._xScales.splice(xScaleIndex, 1);
+      this._xScales.delete(xScale);
       return this;
     }
 
@@ -257,10 +270,7 @@ export module Interactions {
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
     public addYScale(yScale: QuantitativeScale<any>) {
-      if (this.yScales().indexOf(yScale) !== -1) {
-        return this;
-      }
-      this._yScales.push(yScale);
+      this._yScales.add(yScale);
       return this;
     }
 
@@ -271,11 +281,7 @@ export module Interactions {
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
     public removeYScale(yScale: QuantitativeScale<any>) {
-      var yScaleIndex = this.yScales().indexOf(yScale);
-      if (yScaleIndex === -1) {
-        return this;
-      }
-      this._yScales.splice(yScaleIndex, 1);
+      this._yScales.delete(yScale);
       return this;
     }
   }

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -228,7 +228,7 @@ export module Interactions {
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
     public addXScale(xScale: QuantitativeScale<any>) {
-      if (this.xScales().indexOf(xScale) === -1) {
+      if (this.xScales().indexOf(xScale) != -1) {
         return this;
       }
       this._xScales.push(xScale);
@@ -257,7 +257,7 @@ export module Interactions {
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
     public addYScale(yScale: QuantitativeScale<any>) {
-      if (this.yScales().indexOf(yScale) === -1) {
+      if (this.yScales().indexOf(yScale) != -1) {
         return this;
       }
       this._yScales.push(yScale);

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -228,7 +228,7 @@ export module Interactions {
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
     public addXScale(xScale: QuantitativeScale<any>) {
-      if (this.xScales().indexOf(xScale) != -1) {
+      if (this.xScales().indexOf(xScale) !== -1) {
         return this;
       }
       this._xScales.push(xScale);
@@ -257,7 +257,7 @@ export module Interactions {
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
     public addYScale(yScale: QuantitativeScale<any>) {
-      if (this.yScales().indexOf(yScale) != -1) {
+      if (this.yScales().indexOf(yScale) !== -1) {
         return this;
       }
       this._yScales.push(yScale);

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -8,8 +8,8 @@ export module Interactions {
      */
     private static _PIXELS_PER_LINE = 120;
 
-    private _xScales: Utils.Set<QuantitativeScale<any>>;
-    private _yScales: Utils.Set<QuantitativeScale<any>>;
+    private _xScales: QuantitativeScale<any>[];
+    private _yScales: QuantitativeScale<any>[];
     private _dragInteraction: Interactions.Drag;
     private _mouseDispatcher: Dispatchers.Mouse;
     private _touchDispatcher: Dispatchers.Touch;
@@ -32,14 +32,8 @@ export module Interactions {
      */
     constructor(xScale?: QuantitativeScale<any>, yScale?: QuantitativeScale<any>) {
       super();
-      this._xScales = new Utils.Set<QuantitativeScale<any>>();
-      if (xScale != null) {
-        this._xScales.add(xScale);
-      }
-      this._yScales = new Utils.Set<QuantitativeScale<any>>();
-      if (yScale != null) {
-        this._yScales.add(yScale);
-      }
+      this._xScales = xScale == null ? [] : [xScale];
+      this._yScales = yScale == null ? [] : [yScale];
 
       this._dragInteraction = new Interactions.Drag();
       this._setupDragInteraction();

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -206,18 +206,36 @@ export module Interactions {
     }
 
     public addXScale(xScale: QuantitativeScale<any>) {
+      if (this.xScales().indexOf(xScale) === -1) {
+        return this;
+      }
+      this._xScales.push(xScale);
       return this;
     }
 
-    public removeXScale(yScale: QuantitativeScale<any>) {
+    public removeXScale(xScale: QuantitativeScale<any>) {
+      var xScaleIndex = this.xScales().indexOf(xScale);
+      if (xScaleIndex === -1) {
+        return this;
+      }
+      this._xScales.splice(xScaleIndex, 1);
       return this;
     }
 
-    public addYScale(xScale: QuantitativeScale<any>) {
+    public addYScale(yScale: QuantitativeScale<any>) {
+      if (this.yScales().indexOf(yScale) === -1) {
+        return this;
+      }
+      this._yScales.push(yScale);
       return this;
     }
 
     public removeYScale(yScale: QuantitativeScale<any>) {
+      var yScaleIndex = this.yScales().indexOf(yScale);
+      if (yScaleIndex === -1) {
+        return this;
+      }
+      this._yScales.splice(yScaleIndex, 1);
       return this;
     }
   }

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -8,8 +8,8 @@ export module Interactions {
      */
     private static _PIXELS_PER_LINE = 120;
 
-    private _xScales: QuantitativeScale<any>[];
-    private _yScales: QuantitativeScale<any>[];
+    private _xScales: Utils.Set<QuantitativeScale<any>>;
+    private _yScales: Utils.Set<QuantitativeScale<any>>;
     private _dragInteraction: Interactions.Drag;
     private _mouseDispatcher: Dispatchers.Mouse;
     private _touchDispatcher: Dispatchers.Touch;
@@ -32,8 +32,14 @@ export module Interactions {
      */
     constructor(xScale?: QuantitativeScale<any>, yScale?: QuantitativeScale<any>) {
       super();
-      this._xScales = xScale == null ? [] : [xScale];
-      this._yScales = yScale == null ? [] : [yScale];
+      this._xScales = new Utils.Set<QuantitativeScale<any>>();
+      if (xScale != null) {
+        this._xScales.add(xScale);
+      }
+      this._yScales = new Utils.Set<QuantitativeScale<any>>();
+      if (yScale != null) {
+        this._yScales.add(yScale);
+      }
 
       this._dragInteraction = new Interactions.Drag();
       this._setupDragInteraction();

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -93,7 +93,7 @@ export module Interactions {
       var newCornerDistance = this._cornerDistance();
 
       if (newCornerDistance !== 0 && oldCornerDistance !== 0) {
-        this.yScales().forEach((xScale) => {
+        this.xScales().forEach((xScale) => {
           PanZoom._magnifyScale(xScale, oldCornerDistance / newCornerDistance, oldCenterPoint.x);
           PanZoom._translateScale(xScale, oldCenterPoint.x - newCenterPoint.x);
         });

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -181,6 +181,33 @@ export module Interactions {
       });
     }
 
+    public xScales(): QuantitativeScale<any>[];
+    public xScales(xScales: QuantitativeScale<any>[]): Interactions.PanZoom;
+    public xScales(xScales?: QuantitativeScale<any>[]): any {
+      // TODO: Implement this.
+    }
+
+    public yScales(): QuantitativeScale<any>[];
+    public yScales(xScales: QuantitativeScale<any>[]): Interactions.PanZoom;
+    public yScales(xScales?: QuantitativeScale<any>[]): any {
+      // TODO: Implement this.
+    }
+
+    public addXScale(xScale: QuantitativeScale<any>) {
+      return this;
+    }
+
+    public removeXScale(yScale: QuantitativeScale<any>) {
+      return this;
+    }
+
+    public addYScale(xScale: QuantitativeScale<any>) {
+      return this;
+    }
+
+    public removeYScale(yScale: QuantitativeScale<any>) {
+      return this;
+    }
   }
 }
 }

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -93,13 +93,13 @@ export module Interactions {
       var newCornerDistance = this._cornerDistance();
 
       if (newCornerDistance !== 0 && oldCornerDistance !== 0) {
-        this._xScales.forEach((xScale) => {
+        this.yScales().forEach((xScale) => {
           PanZoom._magnifyScale(xScale, oldCornerDistance / newCornerDistance, oldCenterPoint.x);
           PanZoom._translateScale(xScale, oldCenterPoint.x - newCenterPoint.x);
         });
       }
       if (newCornerDistance !== 0 && oldCornerDistance !== 0) {
-        this._yScales.forEach((yScale) => {
+        this.yScales().forEach((yScale) => {
           PanZoom._magnifyScale(yScale, oldCornerDistance / newCornerDistance, oldCenterPoint.y);
           PanZoom._translateScale(yScale, oldCenterPoint.y - newCenterPoint.y);
         });
@@ -155,10 +155,10 @@ export module Interactions {
 
         var deltaPixelAmount = e.deltaY * (e.deltaMode ? PanZoom._PIXELS_PER_LINE : 1);
         var zoomAmount = Math.pow(2, deltaPixelAmount * .002);
-        this._xScales.forEach((xScale) => {
+        this.xScales().forEach((xScale) => {
           PanZoom._magnifyScale(xScale, zoomAmount, translatedP.x);
         });
-        this._yScales.forEach((yScale) => {
+        this.yScales().forEach((yScale) => {
           PanZoom._magnifyScale(yScale, zoomAmount, translatedP.y);
         });
       }
@@ -173,11 +173,11 @@ export module Interactions {
         if (this._touchIds.size() >= 2) {
           return;
         }
-        this._xScales.forEach((xScale) => {
+        this.xScales().forEach((xScale) => {
           var dragAmountX = endPoint.x - (lastDragPoint == null ? startPoint.x : lastDragPoint.x);
           PanZoom._translateScale(xScale, -dragAmountX);
         });
-        this._yScales.forEach((yScale) => {
+        this.yScales().forEach((yScale) => {
           var dragAmountY = endPoint.y - (lastDragPoint == null ? startPoint.y : lastDragPoint.y);
           PanZoom._translateScale(yScale, -dragAmountY);
         });
@@ -188,13 +188,21 @@ export module Interactions {
     public xScales(): QuantitativeScale<any>[];
     public xScales(xScales: QuantitativeScale<any>[]): Interactions.PanZoom;
     public xScales(xScales?: QuantitativeScale<any>[]): any {
-      // TODO: Implement this.
+      if (xScales == null) {
+        return this._xScales;
+      }
+      this._xScales = xScales;
+      return this;
     }
 
     public yScales(): QuantitativeScale<any>[];
-    public yScales(xScales: QuantitativeScale<any>[]): Interactions.PanZoom;
-    public yScales(xScales?: QuantitativeScale<any>[]): any {
-      // TODO: Implement this.
+    public yScales(yScales: QuantitativeScale<any>[]): Interactions.PanZoom;
+    public yScales(yScales?: QuantitativeScale<any>[]): any {
+      if (yScales == null) {
+        return this._yScales;
+      }
+      this._yScales = yScales;
+      return this;
     }
 
     public addXScale(xScale: QuantitativeScale<any>) {

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -222,7 +222,7 @@ export module Interactions {
     }
 
     /**
-     * Adds an x scale to use for this PanZoom Interaction
+     * Adds an x scale to this PanZoom Interaction
      * 
      * @param {QuantitativeScale<any>} An x scale to add
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
@@ -236,9 +236,9 @@ export module Interactions {
     }
 
     /**
-     * Removes an x scale that would have been used for this PanZoom Interaction
+     * Removes an x scale from this PanZoom Interaction
      * 
-     * @param {QuantitativeScale<any>} An x scale to add
+     * @param {QuantitativeScale<any>} An x scale to remove
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
     public removeXScale(xScale: QuantitativeScale<any>) {
@@ -251,9 +251,9 @@ export module Interactions {
     }
 
     /**
-     * Adds a y scale to use for this PanZoom Interaction
+     * Adds a y scale to this PanZoom Interaction
      * 
-     * @param {QuantitativeScale<any>} An y scale to add
+     * @param {QuantitativeScale<any>} A y scale to add
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
     public addYScale(yScale: QuantitativeScale<any>) {
@@ -265,9 +265,9 @@ export module Interactions {
     }
 
     /**
-     * Removes a y scale that would have been used for this PanZoom Interaction
+     * Removes a y scale from this PanZoom Interaction
      * 
-     * @param {QuantitativeScale<any>} An y scale to add
+     * @param {QuantitativeScale<any>} A y scale to remove
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
     public removeYScale(yScale: QuantitativeScale<any>) {

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -8,8 +8,8 @@ export module Interactions {
      */
     private static _PIXELS_PER_LINE = 120;
 
-    private _xScale: QuantitativeScale<any>;
-    private _yScale: QuantitativeScale<any>;
+    private _xScales: QuantitativeScale<any>[];
+    private _yScales: QuantitativeScale<any>[];
     private _dragInteraction: Interactions.Drag;
     private _mouseDispatcher: Dispatchers.Mouse;
     private _touchDispatcher: Dispatchers.Touch;
@@ -32,8 +32,8 @@ export module Interactions {
      */
     constructor(xScale?: QuantitativeScale<any>, yScale?: QuantitativeScale<any>) {
       super();
-      this._xScale = xScale;
-      this._yScale = yScale;
+      this._xScales = xScale == null ? [] : [xScale];
+      this._yScales = yScale == null ? [] : [yScale];
 
       this._dragInteraction = new Interactions.Drag();
       this._setupDragInteraction();
@@ -92,13 +92,17 @@ export module Interactions {
       var newCenterPoint = this._centerPoint();
       var newCornerDistance = this._cornerDistance();
 
-      if (this._xScale != null && newCornerDistance !== 0 && oldCornerDistance !== 0) {
-        PanZoom._magnifyScale(this._xScale, oldCornerDistance / newCornerDistance, oldCenterPoint.x);
-        PanZoom._translateScale(this._xScale, oldCenterPoint.x - newCenterPoint.x);
+      if (newCornerDistance !== 0 && oldCornerDistance !== 0) {
+        this._xScales.forEach((xScale) => {
+          PanZoom._magnifyScale(xScale, oldCornerDistance / newCornerDistance, oldCenterPoint.x);
+          PanZoom._translateScale(xScale, oldCenterPoint.x - newCenterPoint.x);
+        });
       }
-      if (this._yScale != null && newCornerDistance !== 0 && oldCornerDistance !== 0) {
-        PanZoom._magnifyScale(this._yScale, oldCornerDistance / newCornerDistance, oldCenterPoint.y);
-        PanZoom._translateScale(this._yScale, oldCenterPoint.y - newCenterPoint.y);
+      if (newCornerDistance !== 0 && oldCornerDistance !== 0) {
+        this._yScales.forEach((yScale) => {
+          PanZoom._magnifyScale(yScale, oldCornerDistance / newCornerDistance, oldCenterPoint.y);
+          PanZoom._translateScale(yScale, oldCenterPoint.y - newCenterPoint.y);
+        });
       }
     }
 
@@ -151,12 +155,12 @@ export module Interactions {
 
         var deltaPixelAmount = e.deltaY * (e.deltaMode ? PanZoom._PIXELS_PER_LINE : 1);
         var zoomAmount = Math.pow(2, deltaPixelAmount * .002);
-        if (this._xScale != null) {
-          PanZoom._magnifyScale(this._xScale, zoomAmount, translatedP.x);
-        }
-        if (this._yScale != null) {
-          PanZoom._magnifyScale(this._yScale, zoomAmount, translatedP.y);
-        }
+        this._xScales.forEach((xScale) => {
+          PanZoom._magnifyScale(xScale, zoomAmount, translatedP.x);
+        });
+        this._yScales.forEach((yScale) => {
+          PanZoom._magnifyScale(yScale, zoomAmount, translatedP.y);
+        });
       }
     }
 
@@ -169,14 +173,14 @@ export module Interactions {
         if (this._touchIds.size() >= 2) {
           return;
         }
-        if (this._xScale != null) {
+        this._xScales.forEach((xScale) => {
           var dragAmountX = endPoint.x - (lastDragPoint == null ? startPoint.x : lastDragPoint.x);
-          PanZoom._translateScale(this._xScale, -dragAmountX);
-        }
-        if (this._yScale != null) {
+          PanZoom._translateScale(xScale, -dragAmountX);
+        });
+        this._yScales.forEach((yScale) => {
           var dragAmountY = endPoint.y - (lastDragPoint == null ? startPoint.y : lastDragPoint.y);
-          PanZoom._translateScale(this._yScale, -dragAmountY);
-        }
+          PanZoom._translateScale(yScale, -dragAmountY);
+        });
         lastDragPoint = endPoint;
       });
     }

--- a/test/interactions/panZoomInteractionTests.ts
+++ b/test/interactions/panZoomInteractionTests.ts
@@ -215,5 +215,19 @@ describe("Interactions", () => {
       svg.remove();
     });
 
+    it("Adding an already existent xScale does nothing", () => {
+      var oldXScaleNumber = panZoomInteraction.xScales().length;
+      panZoomInteraction.addXScale(panZoomInteraction.xScales()[0]);
+      assert.lengthOf(panZoomInteraction.xScales(), oldXScaleNumber, "Number of x scales is maintained");
+      svg.remove();
+    });
+
+    it("Adding an already existent yScale does nothing", () => {
+      var oldYScaleNumber = panZoomInteraction.yScales().length;
+      panZoomInteraction.addYScale(panZoomInteraction.yScales()[0]);
+      assert.lengthOf(panZoomInteraction.yScales(), oldYScaleNumber, "Number of y scales is maintained");
+      svg.remove();
+    });
+
   });
 });

--- a/test/interactions/panZoomInteractionTests.ts
+++ b/test/interactions/panZoomInteractionTests.ts
@@ -133,6 +133,27 @@ describe("Interactions", () => {
       svg.remove();
     });
 
+    it("mousewheeling a certain amount will magnify multiple scales correctly", () => {
+      // HACKHACK PhantomJS doesn't implement fake creation of WheelEvents
+      // https://github.com/ariya/phantomjs/issues/11289
+      if ( window.PHANTOMJS ) {
+        svg.remove();
+        return;
+      }
+      var xScale2 = new Plottable.Scales.Linear();
+      xScale2.domain([0, 2 * SVG_WIDTH]).range([0, SVG_WIDTH]);
+      panZoomInteraction.addXScale(xScale2);
+
+      var scrollPoint = { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 };
+      var deltaY = 500;
+
+      TestMethods.triggerFakeWheelEvent( "wheel", svg, scrollPoint.x, scrollPoint.y, deltaY );
+
+      assert.deepEqual(xScale.domain(), [-SVG_WIDTH / 8, SVG_WIDTH * 7 / 8], "xScale zooms to the correct domain via scroll");
+      assert.deepEqual(xScale2.domain(), [-SVG_WIDTH / 8, SVG_WIDTH * 7 / 8], "xScale2 zooms to the correct domain via scroll");
+      svg.remove();
+    });
+
     it("pinching a certain amount will magnify the scale correctly", () => {
       // HACKHACK PhantomJS doesn't implement fake creation of WheelEvents
       // https://github.com/ariya/phantomjs/issues/11289
@@ -150,6 +171,29 @@ describe("Interactions", () => {
       TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint], [1] );
       assert.deepEqual(xScale.domain(), [SVG_WIDTH / 16, SVG_WIDTH * 5 / 16], "xScale transforms to the correct domain via pinch");
       assert.deepEqual(yScale.domain(), [SVG_HEIGHT / 16, SVG_HEIGHT * 5 / 16], "yScale transforms to the correct domain via pinch");
+      svg.remove();
+    });
+
+    it("pinching a certain amount will magnify multiple scales correctly", () => {
+      // HACKHACK PhantomJS doesn't implement fake creation of WheelEvents
+      // https://github.com/ariya/phantomjs/issues/11289
+      if ( window.PHANTOMJS ) {
+        svg.remove();
+        return;
+      }
+
+      var xScale2 = new Plottable.Scales.Linear();
+      xScale2.domain([0, 2 * SVG_WIDTH]).range([0, SVG_WIDTH]);
+      panZoomInteraction.addXScale(xScale2);
+      var startPoint = { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 };
+      var startPoint2 = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
+      TestMethods.triggerFakeTouchEvent( "touchstart", eventTarget, [startPoint, startPoint2], [0, 1] );
+
+      var endPoint = { x: SVG_WIDTH * 3 / 4, y: SVG_HEIGHT * 3 / 4 };
+      TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint], [1] );
+      TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint], [1] );
+      assert.deepEqual(xScale.domain(), [SVG_WIDTH / 16, SVG_WIDTH * 5 / 16], "xScale transforms to the correct domain via pinch");
+      assert.deepEqual(xScale2.domain(), [SVG_WIDTH / 16, SVG_WIDTH * 5 / 16], "xScale2 transforms to the correct domain via pinch");
       svg.remove();
     });
 

--- a/test/interactions/panZoomInteractionTests.ts
+++ b/test/interactions/panZoomInteractionTests.ts
@@ -12,6 +12,7 @@ describe("Interactions", () => {
 
     var xScale: Plottable.QuantitativeScale<number>;
     var yScale: Plottable.QuantitativeScale<number>;
+    var panZoomInteraction: Plottable.Interactions.PanZoom;
 
     beforeEach(() => {
       svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
@@ -23,7 +24,10 @@ describe("Interactions", () => {
       xScale.domain([0, SVG_WIDTH / 2]).range([0, SVG_WIDTH]);
       yScale = new Plottable.Scales.Linear();
       yScale.domain([0, SVG_HEIGHT / 2]).range([0, SVG_HEIGHT]);
-      (new Plottable.Interactions.PanZoom(xScale, yScale)).attachTo(component);
+      panZoomInteraction = new Plottable.Interactions.PanZoom();
+      panZoomInteraction.addXScale(xScale);
+      panZoomInteraction.addYScale(yScale);
+      panZoomInteraction.attachTo(component);
 
       eventTarget = component.background();
     });
@@ -49,6 +53,20 @@ describe("Interactions", () => {
         TestMethods.triggerFakeMouseEvent("mouseend", eventTarget, endPoint.x, endPoint.y);
         assert.deepEqual(xScale.domain(), [SVG_WIDTH / 2, SVG_WIDTH], "xScale pans to the correct domain via drag (mouse)");
         assert.deepEqual(yScale.domain(), [SVG_HEIGHT / 2, SVG_HEIGHT], "yScale pans to the correct domain via drag (mouse)");
+        svg.remove();
+      });
+
+      it("dragging a certain amount will translate multiple scales correctly (mouse)", () => {
+        var xScale2 = new Plottable.Scales.Linear();
+        xScale2.domain([0, 2 * SVG_WIDTH]).range([0, SVG_WIDTH]);
+        panZoomInteraction.addXScale(xScale2);
+        var startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
+        var endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
+        TestMethods.triggerFakeMouseEvent("mousedown", eventTarget, startPoint.x, startPoint.y);
+        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, endPoint.x, endPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseend", eventTarget, endPoint.x, endPoint.y);
+        assert.deepEqual(xScale.domain(), [SVG_WIDTH / 2, SVG_WIDTH], "xScale pans to the correct domain via drag (mouse)");
+        assert.deepEqual(xScale2.domain(), [SVG_WIDTH * 2, SVG_WIDTH * 4], "xScale2 pans to the correct domain via drag (mouse)");
         svg.remove();
       });
 
@@ -78,6 +96,20 @@ describe("Interactions", () => {
         TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint]);
         assert.deepEqual(xScale.domain(), [SVG_WIDTH / 2, SVG_WIDTH], "xScale pans to the correct domain via drag (touch)");
         assert.deepEqual(yScale.domain(), [SVG_HEIGHT / 2, SVG_HEIGHT], "yScale pans to the correct domain via drag (touch)");
+        svg.remove();
+      });
+
+      it("dragging a certain amount will translate multiple scales correctly (touch)", () => {
+        var xScale2 = new Plottable.Scales.Linear();
+        xScale2.domain([0, 2 * SVG_WIDTH]).range([0, SVG_WIDTH]);
+        panZoomInteraction.addXScale(xScale2);
+        var startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
+        var endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
+        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint]);
+        TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint]);
+        TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint]);
+        assert.deepEqual(xScale.domain(), [SVG_WIDTH / 2, SVG_WIDTH], "xScale pans to the correct domain via drag (touch)");
+        assert.deepEqual(xScale2.domain(), [SVG_WIDTH * 2, SVG_WIDTH * 4], "xScale2 pans to the correct domain via drag (touch)");
         svg.remove();
       });
 

--- a/test/interactions/panZoomInteractionTests.ts
+++ b/test/interactions/panZoomInteractionTests.ts
@@ -150,7 +150,7 @@ describe("Interactions", () => {
       TestMethods.triggerFakeWheelEvent( "wheel", svg, scrollPoint.x, scrollPoint.y, deltaY );
 
       assert.deepEqual(xScale.domain(), [-SVG_WIDTH / 8, SVG_WIDTH * 7 / 8], "xScale zooms to the correct domain via scroll");
-      assert.deepEqual(xScale2.domain(), [-SVG_WIDTH / 8, SVG_WIDTH * 7 / 8], "xScale2 zooms to the correct domain via scroll");
+      assert.deepEqual(xScale2.domain(), [-SVG_WIDTH / 2, SVG_WIDTH * 7 / 2], "xScale2 zooms to the correct domain via scroll");
       svg.remove();
     });
 
@@ -193,7 +193,7 @@ describe("Interactions", () => {
       TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint], [1] );
       TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint], [1] );
       assert.deepEqual(xScale.domain(), [SVG_WIDTH / 16, SVG_WIDTH * 5 / 16], "xScale transforms to the correct domain via pinch");
-      assert.deepEqual(xScale2.domain(), [SVG_WIDTH / 16, SVG_WIDTH * 5 / 16], "xScale2 transforms to the correct domain via pinch");
+      assert.deepEqual(xScale2.domain(), [SVG_WIDTH / 4, SVG_WIDTH * 5 / 4], "xScale2 transforms to the correct domain via pinch");
       svg.remove();
     });
 

--- a/test/interactions/panZoomInteractionTests.ts
+++ b/test/interactions/panZoomInteractionTests.ts
@@ -197,5 +197,23 @@ describe("Interactions", () => {
       svg.remove();
     });
 
+    it("Setting the xScales in batch is the same as adding one at a time", () => {
+      var xScale2 = new Plottable.Scales.Linear();
+      panZoomInteraction.addXScale(xScale2);
+      var xScales = panZoomInteraction.xScales();
+      panZoomInteraction.xScales([xScale, xScale2]);
+      assert.deepEqual(xScales, panZoomInteraction.xScales(), "Setting and adding x scales result in the same behavior");
+      svg.remove();
+    });
+
+    it("Setting the yScales in batch is the same as adding one at a time", () => {
+      var yScale2 = new Plottable.Scales.Linear();
+      panZoomInteraction.addYScale(yScale2);
+      var yScales = panZoomInteraction.yScales();
+      panZoomInteraction.yScales([yScale, yScale2]);
+      assert.deepEqual(yScales, panZoomInteraction.yScales(), "Setting and adding y scales result in the same behavior");
+      svg.remove();
+    });
+
   });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -9789,6 +9789,18 @@ describe("Interactions", function () {
             assert.deepEqual(yScales, panZoomInteraction.yScales(), "Setting and adding y scales result in the same behavior");
             svg.remove();
         });
+        it("Adding an already existent xScale does nothing", function () {
+            var oldXScaleNumber = panZoomInteraction.xScales().length;
+            panZoomInteraction.addXScale(panZoomInteraction.xScales()[0]);
+            assert.lengthOf(panZoomInteraction.xScales(), oldXScaleNumber, "Number of x scales is maintained");
+            svg.remove();
+        });
+        it("Adding an already existent yScale does nothing", function () {
+            var oldYScaleNumber = panZoomInteraction.yScales().length;
+            panZoomInteraction.addYScale(panZoomInteraction.yScales()[0]);
+            assert.lengthOf(panZoomInteraction.yScales(), oldYScaleNumber, "Number of y scales is maintained");
+            svg.remove();
+        });
     });
 });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -9616,6 +9616,7 @@ describe("Interactions", function () {
         var eventTarget;
         var xScale;
         var yScale;
+        var panZoomInteraction;
         beforeEach(function () {
             svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
             var component = new Plottable.Component();
@@ -9624,7 +9625,10 @@ describe("Interactions", function () {
             xScale.domain([0, SVG_WIDTH / 2]).range([0, SVG_WIDTH]);
             yScale = new Plottable.Scales.Linear();
             yScale.domain([0, SVG_HEIGHT / 2]).range([0, SVG_HEIGHT]);
-            (new Plottable.Interactions.PanZoom(xScale, yScale)).attachTo(component);
+            panZoomInteraction = new Plottable.Interactions.PanZoom();
+            panZoomInteraction.addXScale(xScale);
+            panZoomInteraction.addYScale(yScale);
+            panZoomInteraction.attachTo(component);
             eventTarget = component.background();
         });
         describe("Panning", function () {
@@ -9646,6 +9650,19 @@ describe("Interactions", function () {
                 TestMethods.triggerFakeMouseEvent("mouseend", eventTarget, endPoint.x, endPoint.y);
                 assert.deepEqual(xScale.domain(), [SVG_WIDTH / 2, SVG_WIDTH], "xScale pans to the correct domain via drag (mouse)");
                 assert.deepEqual(yScale.domain(), [SVG_HEIGHT / 2, SVG_HEIGHT], "yScale pans to the correct domain via drag (mouse)");
+                svg.remove();
+            });
+            it("dragging a certain amount will translate multiple scales correctly (mouse)", function () {
+                var xScale2 = new Plottable.Scales.Linear();
+                xScale2.domain([0, 2 * SVG_WIDTH]).range([0, SVG_WIDTH]);
+                panZoomInteraction.addXScale(xScale2);
+                var startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
+                var endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
+                TestMethods.triggerFakeMouseEvent("mousedown", eventTarget, startPoint.x, startPoint.y);
+                TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, endPoint.x, endPoint.y);
+                TestMethods.triggerFakeMouseEvent("mouseend", eventTarget, endPoint.x, endPoint.y);
+                assert.deepEqual(xScale.domain(), [SVG_WIDTH / 2, SVG_WIDTH], "xScale pans to the correct domain via drag (mouse)");
+                assert.deepEqual(xScale2.domain(), [SVG_WIDTH * 2, SVG_WIDTH * 4], "xScale2 pans to the correct domain via drag (mouse)");
                 svg.remove();
             });
             it("dragging a certain amount will translate the scale correctly (touch)", function () {
@@ -9672,6 +9689,19 @@ describe("Interactions", function () {
                 TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint]);
                 assert.deepEqual(xScale.domain(), [SVG_WIDTH / 2, SVG_WIDTH], "xScale pans to the correct domain via drag (touch)");
                 assert.deepEqual(yScale.domain(), [SVG_HEIGHT / 2, SVG_HEIGHT], "yScale pans to the correct domain via drag (touch)");
+                svg.remove();
+            });
+            it("dragging a certain amount will translate multiple scales correctly (touch)", function () {
+                var xScale2 = new Plottable.Scales.Linear();
+                xScale2.domain([0, 2 * SVG_WIDTH]).range([0, SVG_WIDTH]);
+                panZoomInteraction.addXScale(xScale2);
+                var startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
+                var endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
+                TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint]);
+                TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint]);
+                TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint]);
+                assert.deepEqual(xScale.domain(), [SVG_WIDTH / 2, SVG_WIDTH], "xScale pans to the correct domain via drag (touch)");
+                assert.deepEqual(xScale2.domain(), [SVG_WIDTH * 2, SVG_WIDTH * 4], "xScale2 pans to the correct domain via drag (touch)");
                 svg.remove();
             });
         });

--- a/test/tests.js
+++ b/test/tests.js
@@ -9773,6 +9773,22 @@ describe("Interactions", function () {
             assert.deepEqual(xScale2.domain(), [SVG_WIDTH / 16, SVG_WIDTH * 5 / 16], "xScale2 transforms to the correct domain via pinch");
             svg.remove();
         });
+        it("Setting the xScales in batch is the same as adding one at a time", function () {
+            var xScale2 = new Plottable.Scales.Linear();
+            panZoomInteraction.addXScale(xScale2);
+            var xScales = panZoomInteraction.xScales();
+            panZoomInteraction.xScales([xScale, xScale2]);
+            assert.deepEqual(xScales, panZoomInteraction.xScales(), "Setting and adding x scales result in the same behavior");
+            svg.remove();
+        });
+        it("Setting the yScales in batch is the same as adding one at a time", function () {
+            var yScale2 = new Plottable.Scales.Linear();
+            panZoomInteraction.addYScale(yScale2);
+            var yScales = panZoomInteraction.yScales();
+            panZoomInteraction.yScales([yScale, yScale2]);
+            assert.deepEqual(yScales, panZoomInteraction.yScales(), "Setting and adding y scales result in the same behavior");
+            svg.remove();
+        });
     });
 });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -9733,7 +9733,7 @@ describe("Interactions", function () {
             var deltaY = 500;
             TestMethods.triggerFakeWheelEvent("wheel", svg, scrollPoint.x, scrollPoint.y, deltaY);
             assert.deepEqual(xScale.domain(), [-SVG_WIDTH / 8, SVG_WIDTH * 7 / 8], "xScale zooms to the correct domain via scroll");
-            assert.deepEqual(xScale2.domain(), [-SVG_WIDTH / 8, SVG_WIDTH * 7 / 8], "xScale2 zooms to the correct domain via scroll");
+            assert.deepEqual(xScale2.domain(), [-SVG_WIDTH / 2, SVG_WIDTH * 7 / 2], "xScale2 zooms to the correct domain via scroll");
             svg.remove();
         });
         it("pinching a certain amount will magnify the scale correctly", function () {
@@ -9770,7 +9770,7 @@ describe("Interactions", function () {
             TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint], [1]);
             TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint], [1]);
             assert.deepEqual(xScale.domain(), [SVG_WIDTH / 16, SVG_WIDTH * 5 / 16], "xScale transforms to the correct domain via pinch");
-            assert.deepEqual(xScale2.domain(), [SVG_WIDTH / 16, SVG_WIDTH * 5 / 16], "xScale2 transforms to the correct domain via pinch");
+            assert.deepEqual(xScale2.domain(), [SVG_WIDTH / 4, SVG_WIDTH * 5 / 4], "xScale2 transforms to the correct domain via pinch");
             svg.remove();
         });
         it("Setting the xScales in batch is the same as adding one at a time", function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -9719,6 +9719,23 @@ describe("Interactions", function () {
             assert.deepEqual(yScale.domain(), [-SVG_HEIGHT / 8, SVG_HEIGHT * 7 / 8], "yScale zooms to the correct domain via scroll");
             svg.remove();
         });
+        it("mousewheeling a certain amount will magnify multiple scales correctly", function () {
+            // HACKHACK PhantomJS doesn't implement fake creation of WheelEvents
+            // https://github.com/ariya/phantomjs/issues/11289
+            if (window.PHANTOMJS) {
+                svg.remove();
+                return;
+            }
+            var xScale2 = new Plottable.Scales.Linear();
+            xScale2.domain([0, 2 * SVG_WIDTH]).range([0, SVG_WIDTH]);
+            panZoomInteraction.addXScale(xScale2);
+            var scrollPoint = { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 };
+            var deltaY = 500;
+            TestMethods.triggerFakeWheelEvent("wheel", svg, scrollPoint.x, scrollPoint.y, deltaY);
+            assert.deepEqual(xScale.domain(), [-SVG_WIDTH / 8, SVG_WIDTH * 7 / 8], "xScale zooms to the correct domain via scroll");
+            assert.deepEqual(xScale2.domain(), [-SVG_WIDTH / 8, SVG_WIDTH * 7 / 8], "xScale2 zooms to the correct domain via scroll");
+            svg.remove();
+        });
         it("pinching a certain amount will magnify the scale correctly", function () {
             // HACKHACK PhantomJS doesn't implement fake creation of WheelEvents
             // https://github.com/ariya/phantomjs/issues/11289
@@ -9734,6 +9751,26 @@ describe("Interactions", function () {
             TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint], [1]);
             assert.deepEqual(xScale.domain(), [SVG_WIDTH / 16, SVG_WIDTH * 5 / 16], "xScale transforms to the correct domain via pinch");
             assert.deepEqual(yScale.domain(), [SVG_HEIGHT / 16, SVG_HEIGHT * 5 / 16], "yScale transforms to the correct domain via pinch");
+            svg.remove();
+        });
+        it("pinching a certain amount will magnify multiple scales correctly", function () {
+            // HACKHACK PhantomJS doesn't implement fake creation of WheelEvents
+            // https://github.com/ariya/phantomjs/issues/11289
+            if (window.PHANTOMJS) {
+                svg.remove();
+                return;
+            }
+            var xScale2 = new Plottable.Scales.Linear();
+            xScale2.domain([0, 2 * SVG_WIDTH]).range([0, SVG_WIDTH]);
+            panZoomInteraction.addXScale(xScale2);
+            var startPoint = { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 };
+            var startPoint2 = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
+            TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint, startPoint2], [0, 1]);
+            var endPoint = { x: SVG_WIDTH * 3 / 4, y: SVG_HEIGHT * 3 / 4 };
+            TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint], [1]);
+            TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint], [1]);
+            assert.deepEqual(xScale.domain(), [SVG_WIDTH / 16, SVG_WIDTH * 5 / 16], "xScale transforms to the correct domain via pinch");
+            assert.deepEqual(xScale2.domain(), [SVG_WIDTH / 16, SVG_WIDTH * 5 / 16], "xScale2 transforms to the correct domain via pinch");
             svg.remove();
         });
     });


### PR DESCRIPTION
Allowing usage of `Interactions.PanZoom` on multiple scales.  Through the usage of either of the `addXScale()` / `addYScale()` / `xScales()` / `yScales()`, users can install multiple scales to use for the interaction.  In consequence, a panning or zooming will occur on all installed scales at once.

API Changes:
* `panZoomInteraction.addXScale()` has been added to add an x scale to the interaction.
* `panZoomInteraction.addYScale()` has been added to add a y scale to the interaction.
* `panZoomInteraction.removeXScale()` has been added to from an x scale from the interaction.
* `panZoomInteraction.removeYScale()` has been added to from an y scale from the interaction.
* `pandZoomInteraction.xScales()` has been added to get/set the x scales for the interaction.
* `pandZoomInteraction.yScales()` has been added to get/set the y scales for the interaction.

Example JSFiddle:
http://jsfiddle.net/bluong63/j8fgxw0o/2/