### PR TITLE
[Plots.Pie] Add labels to slices

### DIFF
--- a/plottable.css
+++ b/plottable.css
@@ -63,6 +63,11 @@ svg.plottable {
   font-size: 14px;
 }
 
+.plottable .label-area text {
+  font-family: "Helvetica Neue", sans-serif;
+  fill: #32313F;
+}
+
 .plottable .light-label text {
   fill: white;
 }

--- a/plottable.css
+++ b/plottable.css
@@ -64,8 +64,9 @@ svg.plottable {
 }
 
 .plottable .label-area text {
-  font-family: "Helvetica Neue", sans-serif;
   fill: #32313F;
+  font-family: "Helvetica Neue", sans-serif;
+  font-size: 14px;
 }
 
 .plottable .light-label text {

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2509,12 +2509,26 @@ declare module Plottable {
              * @returns {Pie} The calling Pie Plot.
              */
             outerRadius<R>(outerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Pie;
+            /**
+             * Get whether slice labels are enabled.
+             *
+             * @returns {boolean} Whether slices should display labels or not.
+             */
+            labelsEnabled(): boolean;
+            /**
+             * Sets whether labels are enabled.
+             *
+             * @param {boolean} labelsEnabled
+             * @returns {Pie} The calling Pie Plot.
+             */
+            labelsEnabled(enabled: boolean): Pie;
             protected _propertyProjectors(): AttributeToProjector;
             protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
             protected _pixelPoint(datum: any, index: number, dataset: Dataset): {
                 x: number;
                 y: number;
             };
+            protected _additionalPaint(time: number): void;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2511,7 +2511,6 @@ declare module Plottable {
              */
             outerRadius<R>(outerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Pie;
             /**
-        <<<<<<< HEAD
              * Get whether slice labels are enabled.
              *
              * @returns {boolean} Whether slices should display labels or not.

--- a/plottable.js
+++ b/plottable.js
@@ -6500,7 +6500,7 @@ var Plottable;
                     Plottable.Utils.Window.setTimeout(function () { return _this._drawLabels(); }, time);
                 }
             };
-            Pie.prototype._getSliceIndexForPoint = function (p) {
+            Pie.prototype._sliceIndexForPoint = function (p) {
                 var pointRadius = Math.sqrt(Math.pow(p.x, 2) + Math.pow(p.y, 2));
                 var pointAngle = Math.acos(-p.y / (1 + pointRadius));
                 if (p.x < 0) {
@@ -6546,18 +6546,16 @@ var Plottable;
                     var labelRadius = (outerRadius + innerRadius) / 2;
                     var x = Math.sin(theta) * labelRadius - measurement.width / 2;
                     var y = -Math.cos(theta) * labelRadius - measurement.height / 2;
-                    // Hide the label if it is outside of the slice area
                     var corners = [
                         { x: x, y: y },
                         { x: x, y: y + measurement.height },
                         { x: x + measurement.width, y: y },
                         { x: x + measurement.width, y: y + measurement.height }
                     ];
-                    // We use the first entity as a point of comparison
                     var showLabel = true;
-                    var index = this._getSliceIndexForPoint(corners[0]);
+                    var index = this._sliceIndexForPoint(corners[0]);
                     for (var j = 1; j < corners.length; j++) {
-                        var sliceIndex = this._getSliceIndexForPoint(corners[j]);
+                        var sliceIndex = this._sliceIndexForPoint(corners[j]);
                         if (sliceIndex == null || sliceIndex !== index || sliceIndex !== i) {
                             showLabel = false;
                         }

--- a/plottable.js
+++ b/plottable.js
@@ -6442,7 +6442,6 @@ var Plottable;
                 this.entities().forEach(function (entity) {
                     var value = "" + _this.sectorValue().accessor(entity.datum, entity.index, entity.dataset);
                     var measurement = measurer.measure(value);
-                    var center = _this._center();
                     var theta = (_this._endAngles[entity.index] + _this._startAngles[entity.index]) / 2;
                     var outerRadius = _this.outerRadius().accessor(entity.datum, entity.index, entity.dataset);
                     if (_this.outerRadius().scale) {

--- a/plottable.js
+++ b/plottable.js
@@ -6500,8 +6500,31 @@ var Plottable;
                     Plottable.Utils.Window.setTimeout(function () { return _this._drawLabels(); }, time);
                 }
             };
+            Pie.prototype._getSliceIndexForPoint = function (p) {
+                var pointRadius = Math.sqrt(Math.pow(p.x, 2) + Math.pow(p.y, 2));
+                var pointAngle = Math.acos(-p.y / (1 + pointRadius));
+                if (p.x < 0) {
+                    pointAngle = Math.PI * 2 - pointAngle;
+                }
+                var index;
+                for (var i = 0; i < this._startAngles.length; i++) {
+                    if (this._startAngles[i] < pointAngle && this._endAngles[i] > pointAngle) {
+                        index = i;
+                        break;
+                    }
+                }
+                if (index !== undefined) {
+                    var dataset = this.datasets()[0];
+                    var datum = dataset.data()[i];
+                    var innerRadius = this.innerRadius().accessor(datum, index, dataset);
+                    var outerRadius = this.outerRadius().accessor(datum, index, dataset);
+                    if (pointRadius > innerRadius && pointRadius < outerRadius) {
+                        return index;
+                    }
+                }
+                return null;
+            };
             Pie.prototype._drawLabels = function () {
-                var _this = this;
                 var attrToProjector = this._generateAttrToProjector();
                 var labelArea = this._renderArea.append("g").classed("label-area", true);
                 var measurer = new SVGTypewriter.Measurers.Measurer(labelArea);
@@ -6524,26 +6547,21 @@ var Plottable;
                     var x = Math.sin(theta) * labelRadius - measurement.width / 2;
                     var y = -Math.cos(theta) * labelRadius - measurement.height / 2;
                     // Hide the label if it is outside of the slice area
-                    var svgX = x + this.width() / 2;
-                    var svgY = y + this.height() / 2;
                     var corners = [
-                        { x: svgX, y: svgY },
-                        { x: svgX + measurement.width, y: svgY },
-                        { x: svgX + measurement.width, y: svgY + measurement.height },
-                        { x: svgX, y: svgY + measurement.height }
+                        { x: x, y: y },
+                        { x: x, y: y + measurement.height },
+                        { x: x + measurement.width, y: y },
+                        { x: x + measurement.width, y: y + measurement.height }
                     ];
+                    // We use the first entity as a point of comparison
                     var showLabel = true;
-                    corners.forEach(function (corner) {
-                        var entities = _this.entitiesAt(corner);
-                        if (entities.length < 1) {
+                    var index = this._getSliceIndexForPoint(corners[0]);
+                    for (var j = 1; j < corners.length; j++) {
+                        var sliceIndex = this._getSliceIndexForPoint(corners[j]);
+                        if (sliceIndex == null || sliceIndex !== index || sliceIndex !== i) {
                             showLabel = false;
                         }
-                        else {
-                            if (entities[0].index !== i) {
-                                showLabel = false;
-                            }
-                        }
-                    });
+                    }
                     var color = attrToProjector["fill"](datum, i, dataset);
                     var dark = Plottable.Utils.Color.contrast("white", color) * 1.6 < Plottable.Utils.Color.contrast("black", color);
                     var g = labelArea.append("g").attr("transform", "translate(" + x + "," + y + ")");

--- a/plottable.js
+++ b/plottable.js
@@ -6467,9 +6467,6 @@ var Plottable;
                     });
                 });
             };
-            Pie.prototype._center = function () {
-                return { x: this.width() / 2, y: this.height() / 2 };
-            };
             Pie._INNER_RADIUS_KEY = "inner-radius";
             Pie._OUTER_RADIUS_KEY = "outer-radius";
             Pie._SECTOR_VALUE_KEY = "sector-value";

--- a/plottable.js
+++ b/plottable.js
@@ -6560,7 +6560,7 @@ var Plottable;
                     var g = labelArea.append("g").attr("transform", "translate(" + x + "," + y + ")");
                     var className = dark ? "dark-label" : "light-label";
                     g.classed(className, true);
-                    g.style("display", showLabel ? "block" : "none");
+                    g.style("visibility", showLabel ? "inherit" : "hidden");
                     writer.write(value, measurement.width, measurement.height, {
                         selection: g,
                         xAlign: "center",

--- a/plottable.js
+++ b/plottable.js
@@ -6515,7 +6515,7 @@ var Plottable;
                 }
                 if (index !== undefined) {
                     var dataset = this.datasets()[0];
-                    var datum = dataset.data()[i];
+                    var datum = dataset.data()[index];
                     var innerRadius = this.innerRadius().accessor(datum, index, dataset);
                     var outerRadius = this.outerRadius().accessor(datum, index, dataset);
                     if (pointRadius > innerRadius && pointRadius < outerRadius) {
@@ -6525,6 +6525,7 @@ var Plottable;
                 return null;
             };
             Pie.prototype._drawLabels = function () {
+                var _this = this;
                 var attrToProjector = this._generateAttrToProjector();
                 var labelArea = this._renderArea.append("g").classed("label-area", true);
                 var measurer = new SVGTypewriter.Measurers.Measurer(labelArea);
@@ -6552,14 +6553,8 @@ var Plottable;
                         { x: x + measurement.width, y: y },
                         { x: x + measurement.width, y: y + measurement.height }
                     ];
-                    var showLabel = true;
-                    var index = this._sliceIndexForPoint(corners[0]);
-                    for (var j = 1; j < corners.length; j++) {
-                        var sliceIndex = this._sliceIndexForPoint(corners[j]);
-                        if (sliceIndex == null || sliceIndex !== index || sliceIndex !== i) {
-                            showLabel = false;
-                        }
-                    }
+                    var sliceIndices = corners.map(function (corner) { return _this._sliceIndexForPoint(corner); });
+                    var showLabel = sliceIndices.every(function (index) { return (index != null && index === sliceIndices[0]); });
                     var color = attrToProjector["fill"](datum, i, dataset);
                     var dark = Plottable.Utils.Color.contrast("white", color) * 1.6 < Plottable.Utils.Color.contrast("black", color);
                     var g = labelArea.append("g").attr("transform", "translate(" + x + "," + y + ")");

--- a/plottable.js
+++ b/plottable.js
@@ -6554,7 +6554,7 @@ var Plottable;
                         { x: x + measurement.width, y: y + measurement.height }
                     ];
                     var sliceIndices = corners.map(function (corner) { return _this._sliceIndexForPoint(corner); });
-                    var showLabel = sliceIndices.every(function (index) { return (index != null && index === sliceIndices[0]); });
+                    var showLabel = sliceIndices.every(function (index) { return (index != null && index === i); });
                     var color = attrToProjector["fill"](datum, i, dataset);
                     var dark = Plottable.Utils.Color.contrast("white", color) * 1.6 < Plottable.Utils.Color.contrast("black", color);
                     var g = labelArea.append("g").attr("transform", "translate(" + x + "," + y + ")");

--- a/plottable.js
+++ b/plottable.js
@@ -6506,24 +6506,26 @@ var Plottable;
                 var labelArea = this._renderArea.append("g").classed("label-area", true);
                 var measurer = new SVGTypewriter.Measurers.Measurer(labelArea);
                 var writer = new SVGTypewriter.Writers.Writer(measurer);
-                this.entities().forEach(function (entity) {
-                    var value = "" + _this.sectorValue().accessor(entity.datum, entity.index, entity.dataset);
+                var dataset = this.datasets()[0];
+                for (var i = 0; i < dataset.data().length; i++) {
+                    var datum = dataset.data()[i];
+                    var value = "" + this.sectorValue().accessor(datum, i, dataset);
                     var measurement = measurer.measure(value);
-                    var theta = (_this._endAngles[entity.index] + _this._startAngles[entity.index]) / 2;
-                    var outerRadius = _this.outerRadius().accessor(entity.datum, entity.index, entity.dataset);
-                    if (_this.outerRadius().scale) {
-                        outerRadius = _this.outerRadius().scale.scale(outerRadius);
+                    var theta = (this._endAngles[i] + this._startAngles[i]) / 2;
+                    var outerRadius = this.outerRadius().accessor(datum, i, dataset);
+                    if (this.outerRadius().scale) {
+                        outerRadius = this.outerRadius().scale.scale(outerRadius);
                     }
-                    var innerRadius = _this.innerRadius().accessor(entity.datum, entity.index, entity.dataset);
-                    if (_this.innerRadius().scale) {
-                        innerRadius = _this.innerRadius().scale.scale(innerRadius);
+                    var innerRadius = this.innerRadius().accessor(datum, i, dataset);
+                    if (this.innerRadius().scale) {
+                        innerRadius = this.innerRadius().scale.scale(innerRadius);
                     }
                     var labelRadius = (outerRadius + innerRadius) / 2;
                     var x = Math.sin(theta) * labelRadius - measurement.width / 2;
                     var y = -Math.cos(theta) * labelRadius - measurement.height / 2;
                     // Hide the label if it is outside of the slice area
-                    var svgX = x + _this.width() / 2;
-                    var svgY = y + _this.height() / 2;
+                    var svgX = x + this.width() / 2;
+                    var svgY = y + this.height() / 2;
                     var corners = [
                         { x: svgX, y: svgY },
                         { x: svgX + measurement.width, y: svgY },
@@ -6537,12 +6539,12 @@ var Plottable;
                             showLabel = false;
                         }
                         else {
-                            if (entities[0].index != entity.index) {
+                            if (entities[0].index !== i) {
                                 showLabel = false;
                             }
                         }
                     });
-                    var color = attrToProjector["fill"](entity.datum, entity.index, entity.dataset);
+                    var color = attrToProjector["fill"](datum, i, dataset);
                     var dark = Plottable.Utils.Color.contrast("white", color) * 1.6 < Plottable.Utils.Color.contrast("black", color);
                     var g = labelArea.append("g").attr("transform", "translate(" + x + "," + y + ")");
                     var className = dark ? "dark-label" : "light-label";
@@ -6554,7 +6556,7 @@ var Plottable;
                         yAlign: "center",
                         textRotation: 0
                     });
-                });
+                }
             };
             Pie._INNER_RADIUS_KEY = "inner-radius";
             Pie._OUTER_RADIUS_KEY = "outer-radius";

--- a/plottable.js
+++ b/plottable.js
@@ -6531,16 +6531,16 @@ var Plottable;
                 var measurer = new SVGTypewriter.Measurers.Measurer(labelArea);
                 var writer = new SVGTypewriter.Writers.Writer(measurer);
                 var dataset = this.datasets()[0];
-                for (var i = 0; i < dataset.data().length; i++) {
-                    var datum = dataset.data()[i];
-                    var value = "" + this.sectorValue().accessor(datum, i, dataset);
+                for (var datumIndex = 0; datumIndex < dataset.data().length; datumIndex++) {
+                    var datum = dataset.data()[datumIndex];
+                    var value = "" + this.sectorValue().accessor(datum, datumIndex, dataset);
                     var measurement = measurer.measure(value);
-                    var theta = (this._endAngles[i] + this._startAngles[i]) / 2;
-                    var outerRadius = this.outerRadius().accessor(datum, i, dataset);
+                    var theta = (this._endAngles[datumIndex] + this._startAngles[datumIndex]) / 2;
+                    var outerRadius = this.outerRadius().accessor(datum, datumIndex, dataset);
                     if (this.outerRadius().scale) {
                         outerRadius = this.outerRadius().scale.scale(outerRadius);
                     }
-                    var innerRadius = this.innerRadius().accessor(datum, i, dataset);
+                    var innerRadius = this.innerRadius().accessor(datum, datumIndex, dataset);
                     if (this.innerRadius().scale) {
                         innerRadius = this.innerRadius().scale.scale(innerRadius);
                     }
@@ -6554,8 +6554,8 @@ var Plottable;
                         { x: x + measurement.width, y: y + measurement.height }
                     ];
                     var sliceIndices = corners.map(function (corner) { return _this._sliceIndexForPoint(corner); });
-                    var showLabel = sliceIndices.every(function (index) { return (index != null && index === i); });
-                    var color = attrToProjector["fill"](datum, i, dataset);
+                    var showLabel = sliceIndices.every(function (index) { return index === datumIndex; });
+                    var color = attrToProjector["fill"](datum, datumIndex, dataset);
                     var dark = Plottable.Utils.Color.contrast("white", color) * 1.6 < Plottable.Utils.Color.contrast("black", color);
                     var g = labelArea.append("g").attr("transform", "translate(" + x + "," + y + ")");
                     var className = dark ? "dark-label" : "light-label";

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -306,17 +306,17 @@ export module Plots {
       var writer = new SVGTypewriter.Writers.Writer(measurer);
       var dataset = this.datasets()[0];
 
-      for (var i = 0; i < dataset.data().length; i++) {
-        var datum = dataset.data()[i];
-        var value = "" + this.sectorValue().accessor(datum, i, dataset);
+      for (var datumIndex = 0; datumIndex < dataset.data().length; datumIndex++) {
+        var datum = dataset.data()[datumIndex];
+        var value = "" + this.sectorValue().accessor(datum, datumIndex, dataset);
         var measurement = measurer.measure(value);
 
-        var theta = (this._endAngles[i] + this._startAngles[i]) / 2;
-        var outerRadius = this.outerRadius().accessor(datum, i, dataset);
+        var theta = (this._endAngles[datumIndex] + this._startAngles[datumIndex]) / 2;
+        var outerRadius = this.outerRadius().accessor(datum, datumIndex, dataset);
         if (this.outerRadius().scale) {
           outerRadius = this.outerRadius().scale.scale(outerRadius);
         }
-        var innerRadius = this.innerRadius().accessor(datum, i, dataset);
+        var innerRadius = this.innerRadius().accessor(datum, datumIndex, dataset);
         if (this.innerRadius().scale) {
           innerRadius = this.innerRadius().scale.scale(innerRadius);
         }
@@ -333,9 +333,9 @@ export module Plots {
         ];
 
         var sliceIndices = corners.map((corner) => this._sliceIndexForPoint(corner));
-        var showLabel = sliceIndices.every((index) => (index != null && index === i));
+        var showLabel = sliceIndices.every((index) => index === datumIndex);
 
-        var color = attrToProjector["fill"](datum, i, dataset);
+        var color = attrToProjector["fill"](datum, datumIndex, dataset);
         var dark = Utils.Color.contrast("white", color) * 1.6 < Utils.Color.contrast("black", color);
         var g = labelArea.append("g").attr("transform", "translate(" + x + "," + y + ")");
         var className = dark ? "dark-label" : "light-label";

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -249,7 +249,6 @@ export module Plots {
         var value = "" + this.sectorValue().accessor(entity.datum, entity.index, entity.dataset);
         var measurement = measurer.measure(value);
 
-        var center = this._center();
         var theta = (this._endAngles[entity.index] + this._startAngles[entity.index]) / 2;
         var outerRadius = this.outerRadius().accessor(entity.datum, entity.index, entity.dataset);
         if (this.outerRadius().scale) {

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -277,10 +277,6 @@ export module Plots {
         });
       });
     }
-
-    private _center() {
-      return { x: this.width() / 2, y: this.height() / 2 };
-    }
   }
 }
 }

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -279,16 +279,19 @@ export module Plots {
       var labelArea = this._renderArea.append("g").classed("label-area", true);
       var measurer = new SVGTypewriter.Measurers.Measurer(labelArea);
       var writer = new SVGTypewriter.Writers.Writer(measurer);
-      this.entities().forEach((entity) => {
-        var value = "" + this.sectorValue().accessor(entity.datum, entity.index, entity.dataset);
+      var dataset = this.datasets()[0];
+
+      for (var i = 0; i < dataset.data().length; i++) {
+        var datum = dataset.data()[i];
+        var value = "" + this.sectorValue().accessor(datum, i, dataset);
         var measurement = measurer.measure(value);
 
-        var theta = (this._endAngles[entity.index] + this._startAngles[entity.index]) / 2;
-        var outerRadius = this.outerRadius().accessor(entity.datum, entity.index, entity.dataset);
+        var theta = (this._endAngles[i] + this._startAngles[i]) / 2;
+        var outerRadius = this.outerRadius().accessor(datum, i, dataset);
         if (this.outerRadius().scale) {
           outerRadius = this.outerRadius().scale.scale(outerRadius);
         }
-        var innerRadius = this.innerRadius().accessor(entity.datum, entity.index, entity.dataset);
+        var innerRadius = this.innerRadius().accessor(datum, i, dataset);
         if (this.innerRadius().scale) {
           innerRadius = this.innerRadius().scale.scale(innerRadius);
         }
@@ -313,13 +316,13 @@ export module Plots {
           if (entities.length < 1) {
             showLabel = false;
           } else {
-            if (entities[0].index != entity.index) {
+            if (entities[0].index !== i) {
               showLabel = false;
-            }            
+            }
           }
-        });        
+        });
 
-        var color = attrToProjector["fill"](entity.datum, entity.index, entity.dataset);
+        var color = attrToProjector["fill"](datum, i, dataset);
         var dark = Utils.Color.contrast("white", color) * 1.6 < Utils.Color.contrast("black", color);
         var g = labelArea.append("g").attr("transform", "translate(" + x + "," + y + ")");
         var className = dark ? "dark-label" : "light-label";
@@ -332,7 +335,7 @@ export module Plots {
           yAlign: "center",
           textRotation: 0
         });
-      });
+      }
     }
   }
 }

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -340,7 +340,7 @@ export module Plots {
         var g = labelArea.append("g").attr("transform", "translate(" + x + "," + y + ")");
         var className = dark ? "dark-label" : "light-label";
         g.classed(className, true);
-        g.style("display", showLabel ? "block" : "none");
+        g.style("visibility", showLabel ? "inherit" : "hidden");
 
         writer.write(value, measurement.width, measurement.height, {
           selection: g,

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -331,7 +331,7 @@ export module Plots {
           { x: x + measurement.width, y: y },
           { x: x + measurement.width, y: y + measurement.height }
         ];
-        
+
         var sliceIndices = corners.map((corner) => this._sliceIndexForPoint(corner));
         var showLabel = sliceIndices.every((index) => (index != null && index === sliceIndices[0]));
 

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -289,7 +289,7 @@ export module Plots {
       }
       if (index !== undefined) {
         var dataset = this.datasets()[0];
-        var datum = dataset.data()[i];
+        var datum = dataset.data()[index];
         var innerRadius = this.innerRadius().accessor(datum, index, dataset);
         var outerRadius = this.outerRadius().accessor(datum, index, dataset);
         if (pointRadius > innerRadius && pointRadius < outerRadius) {
@@ -331,15 +331,9 @@ export module Plots {
           { x: x + measurement.width, y: y },
           { x: x + measurement.width, y: y + measurement.height }
         ];
-
-        var showLabel = true;
-        var index = this._sliceIndexForPoint(corners[0]);
-        for (var j = 1; j < corners.length; j++) {
-          var sliceIndex = this._sliceIndexForPoint(corners[j]);
-          if (sliceIndex == null || sliceIndex !== index || sliceIndex !== i) {
-            showLabel = false;
-          }
-        }
+        
+        var sliceIndices = corners.map((corner) => this._sliceIndexForPoint(corner));
+        var showLabel = sliceIndices.every((index) => (index != null && index === sliceIndices[0]));
 
         var color = attrToProjector["fill"](datum, i, dataset);
         var dark = Utils.Color.contrast("white", color) * 1.6 < Utils.Color.contrast("black", color);

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -333,7 +333,7 @@ export module Plots {
         ];
 
         var sliceIndices = corners.map((corner) => this._sliceIndexForPoint(corner));
-        var showLabel = sliceIndices.every((index) => (index != null && index === sliceIndices[0]));
+        var showLabel = sliceIndices.every((index) => (index != null && index === i));
 
         var color = attrToProjector["fill"](datum, i, dataset);
         var dark = Utils.Color.contrast("white", color) * 1.6 < Utils.Color.contrast("black", color);

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -159,7 +159,6 @@ export module Plots {
     }
 
     /**
-<<<<<<< HEAD
      * Get whether slice labels are enabled.
      *
      * @returns {boolean} Whether slices should display labels or not.
@@ -278,7 +277,7 @@ export module Plots {
     private _drawLabels() {
       var attrToProjector = this._generateAttrToProjector();
       var labelArea = this._renderArea.append("g").classed("label-area", true);
-      var measurer = new SVGTypewriter.Measurers.CacheCharacterMeasurer(labelArea);
+      var measurer = new SVGTypewriter.Measurers.Measurer(labelArea);
       var writer = new SVGTypewriter.Writers.Writer(measurer);
       this.entities().forEach((entity) => {
         var value = "" + this.sectorValue().accessor(entity.datum, entity.index, entity.dataset);
@@ -298,11 +297,34 @@ export module Plots {
         var x = Math.sin(theta) * labelRadius - measurement.width / 2;
         var y = -Math.cos(theta) * labelRadius - measurement.height / 2;
 
+        // Hide the label if it is outside of the slice area
+        var svgX = x + this.width() / 2;
+        var svgY = y + this.height() / 2;
+        var corners = [
+          { x: svgX, y: svgY },
+          { x: svgX + measurement.width, y: svgY },
+          { x: svgX + measurement.width, y: svgY + measurement.height },
+          { x: svgX, y: svgY + measurement.height}
+        ];
+
+        var showLabel = true;
+        corners.forEach((corner) => {
+          var entities = this.entitiesAt(corner);
+          if (entities.length < 1) {
+            showLabel = false;
+          } else {
+            if (entities[0].index != entity.index) {
+              showLabel = false;
+            }            
+          }
+        });        
+
         var color = attrToProjector["fill"](entity.datum, entity.index, entity.dataset);
         var dark = Utils.Color.contrast("white", color) * 1.6 < Utils.Color.contrast("black", color);
         var g = labelArea.append("g").attr("transform", "translate(" + x + "," + y + ")");
         var className = dark ? "dark-label" : "light-label";
         g.classed(className, true);
+        g.style("display", showLabel ? "block" : "none");
 
         writer.write(value, measurement.width, measurement.height, {
           selection: g,

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -274,7 +274,7 @@ export module Plots {
       }
     }
 
-    private _getSliceIndexForPoint(p: Point) {
+    private _sliceIndexForPoint(p: Point) {
       var pointRadius = Math.sqrt(Math.pow(p.x, 2) + Math.pow(p.y, 2));
       var pointAngle = Math.acos(-p.y / (1 + pointRadius));
       if (p.x < 0) {
@@ -325,7 +325,6 @@ export module Plots {
         var x = Math.sin(theta) * labelRadius - measurement.width / 2;
         var y = -Math.cos(theta) * labelRadius - measurement.height / 2;
 
-        // Hide the label if it is outside of the slice area
         var corners = [
           { x: x, y: y },
           { x: x, y: y + measurement.height},
@@ -333,11 +332,10 @@ export module Plots {
           { x: x + measurement.width, y: y + measurement.height }
         ];
 
-        // We use the first entity as a point of comparison
         var showLabel = true;
-        var index = this._getSliceIndexForPoint(corners[0]);
+        var index = this._sliceIndexForPoint(corners[0]);
         for (var j = 1; j < corners.length; j++) {
-          var sliceIndex = this._getSliceIndexForPoint(corners[j]);
+          var sliceIndex = this._sliceIndexForPoint(corners[j]);
           if (sliceIndex == null || sliceIndex !== index || sliceIndex !== i) {
             showLabel = false;
           }

--- a/test/plots/piePlotTests.ts
+++ b/test/plots/piePlotTests.ts
@@ -257,9 +257,9 @@ describe("Plots", () => {
         piePlot.addDataset(dataset).labelsEnabled(true);
         $(".label-area").children("g").each(function(i) {
           if (i % 2 === 0) {
-            assert.strictEqual($(this).css("display"), "none", "label hidden when slice is too small");
+            assert.strictEqual($(this).css("visibility"), "hidden", "label hidden when slice is too small");
           } else {
-            assert.strictEqual($(this).css("display"), "block", "label shown when slice is appropriately sized");
+            assert.strictEqual($(this).css("visibility"), "visible", "label shown when slice is appropriately sized");
           }
         });
         svg.remove();

--- a/test/plots/piePlotTests.ts
+++ b/test/plots/piePlotTests.ts
@@ -244,6 +244,27 @@ describe("Plots", () => {
       Plottable.Utils.Window.warn = oldWarn;
       svg.remove();
     });
+
+    describe("Labels", () => {
+      it("labels are shown and hidden appropriately", () => {
+        piePlot.removeDataset(simpleDataset);
+        var data = [
+          { key: "A", value: 1 }, { key: "B", value: 50 },
+          { key: "C", value: 1 }, { key: "D", value: 50 },
+          { key: "E", value: 1 }, { key: "F", value: 50 }
+        ];
+        var dataset = new Plottable.Dataset(data);
+        piePlot.addDataset(dataset).labelsEnabled(true);
+        $(".label-area").children("g").each(function(i) {
+          if (i % 2 === 0) {
+            assert.strictEqual($(this).css("display"), "none", "label hidden when slice is too small");
+          } else {
+            assert.strictEqual($(this).css("display"), "block", "label shown when slice is appropriately sized");
+          }
+        });
+        svg.remove();
+      });
+    });
   });
 
   describe("fail safe tests", () => {

--- a/test/plots/piePlotTests.ts
+++ b/test/plots/piePlotTests.ts
@@ -259,7 +259,7 @@ describe("Plots", () => {
           if (i % 2 === 0) {
             assert.strictEqual($(this).css("visibility"), "hidden", "label hidden when slice is too small");
           } else {
-            assert.strictEqual($(this).css("visibility"), "visible", "label shown when slice is appropriately sized");
+            assert.include(["visible", "inherit"], $(this).css("visibility"), "label shown when slice is appropriately sized");
           }
         });
         svg.remove();

--- a/test/tests.js
+++ b/test/tests.js
@@ -3926,7 +3926,7 @@ describe("Plots", function () {
                         assert.strictEqual($(this).css("visibility"), "hidden", "label hidden when slice is too small");
                     }
                     else {
-                        assert.strictEqual($(this).css("visibility"), "visible", "label shown when slice is appropriately sized");
+                        assert.include(["visible", "inherit"], $(this).css("visibility"), "label shown when slice is appropriately sized");
                     }
                 });
                 svg.remove();

--- a/test/tests.js
+++ b/test/tests.js
@@ -3923,10 +3923,10 @@ describe("Plots", function () {
                 piePlot.addDataset(dataset).labelsEnabled(true);
                 $(".label-area").children("g").each(function (i) {
                     if (i % 2 === 0) {
-                        assert.strictEqual($(this).css("display"), "none", "label hidden when slice is too small");
+                        assert.strictEqual($(this).css("visibility"), "hidden", "label hidden when slice is too small");
                     }
                     else {
-                        assert.strictEqual($(this).css("display"), "block", "label shown when slice is appropriately sized");
+                        assert.strictEqual($(this).css("visibility"), "visible", "label shown when slice is appropriately sized");
                     }
                 });
                 svg.remove();

--- a/test/tests.js
+++ b/test/tests.js
@@ -3908,6 +3908,30 @@ describe("Plots", function () {
             Plottable.Utils.Window.warn = oldWarn;
             svg.remove();
         });
+        describe("Labels", function () {
+            it("labels are shown and hidden appropriately", function () {
+                piePlot.removeDataset(simpleDataset);
+                var data = [
+                    { key: "A", value: 1 },
+                    { key: "B", value: 50 },
+                    { key: "C", value: 1 },
+                    { key: "D", value: 50 },
+                    { key: "E", value: 1 },
+                    { key: "F", value: 50 }
+                ];
+                var dataset = new Plottable.Dataset(data);
+                piePlot.addDataset(dataset).labelsEnabled(true);
+                $(".label-area").children("g").each(function (i) {
+                    if (i % 2 === 0) {
+                        assert.strictEqual($(this).css("display"), "none", "label hidden when slice is too small");
+                    }
+                    else {
+                        assert.strictEqual($(this).css("display"), "block", "label shown when slice is appropriately sized");
+                    }
+                });
+                svg.remove();
+            });
+        });
     });
     describe("fail safe tests", function () {
         it("undefined, NaN and non-numeric strings not be represented in a Pie Chart", function () {


### PR DESCRIPTION
Turns out that I can't use `arc.centroid()` directly here from d3, but I've implemented an identical technique as a substitute.

![image](https://cloud.githubusercontent.com/assets/1175041/8221851/7a504a5e-1518-11e5-93ad-77e1708f4c87.png)

Fixes #1970 

Fiddle: http://jsfiddle.net/2z4pckh8/1/