### PR TITLE
[Tslint] - adding variable-name rule

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -5783,8 +5783,8 @@ var Plottable;
             };
             Table._fixedSpace = function (componentGroup, fixityAccessor) {
                 var all = function (bools) { return bools.reduce(function (a, b) { return a && b; }, true); };
-                var group_isFixed = function (components) { return all(components.map(fixityAccessor)); };
-                return all(componentGroup.map(group_isFixed));
+                var groupIsFixed = function (components) { return all(components.map(fixityAccessor)); };
+                return all(componentGroup.map(groupIsFixed));
             };
             return Table;
         })(Plottable.ComponentContainer);

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -471,8 +471,8 @@ export module Components {
 
     private static _fixedSpace(componentGroup: Component[][], fixityAccessor: (c: Component) => boolean) {
       var all = (bools: boolean[]) => bools.reduce((a, b) => a && b, true);
-      var group_isFixed = (components: Component[]) => all(components.map(fixityAccessor));
-      return all(componentGroup.map(group_isFixed));
+      var groupIsFixed = (components: Component[]) => all(components.map(fixityAccessor));
+      return all(componentGroup.map(groupIsFixed));
     }
   }
 }

--- a/test/plots/linePlotTests.ts
+++ b/test/plots/linePlotTests.ts
@@ -131,15 +131,15 @@ describe("Plots", () => {
       ];
       simpleDataset.data(lineData);
       var linePath = renderArea.select(".line");
-      var d_original = TestMethods.normalizePath(linePath.attr("d"));
+      var dOriginal = TestMethods.normalizePath(linePath.attr("d"));
 
       function assertCorrectPathSplitting(msgPrefix: string) {
         var d = TestMethods.normalizePath(linePath.attr("d"));
         var pathSegements = d.split("M").filter((segment) => segment !== "");
         assert.lengthOf(pathSegements, 2, msgPrefix + " split path into two segments");
-        var firstSegmentContained = d_original.indexOf(pathSegements[0]) >= 0;
+        var firstSegmentContained = dOriginal.indexOf(pathSegements[0]) >= 0;
         assert.isTrue(firstSegmentContained, "first path segment is a subpath of the original path");
-        var secondSegmentContained = d_original.indexOf(pathSegements[1]) >= 0;
+        var secondSegmentContained = dOriginal.indexOf(pathSegements[1]) >= 0;
         assert.isTrue(secondSegmentContained, "second path segment is a subpath of the original path");
       }
 

--- a/test/plots/stackedPlotTests.ts
+++ b/test/plots/stackedPlotTests.ts
@@ -369,7 +369,7 @@ describe("Plots", () => {
         { key: "a", value: 3 },
         { key: "b", value: -4 }
       ];
-      var data2_b = [
+      var data2B = [
         { key: "a", value: 1 },
         { key: "b", value: -2 }
       ];
@@ -382,7 +382,7 @@ describe("Plots", () => {
       assert.closeTo(yScale.domain()[0], -6, 1, "min stacked extent is as normal");
       assert.closeTo(yScale.domain()[1], 4, 1, "max stacked extent is as normal");
 
-      dataset2.data(data2_b);
+      dataset2.data(data2B);
 
       assert.closeTo(yScale.domain()[0], -4, 1, "min stacked extent decreases in magnitude");
       assert.closeTo(yScale.domain()[1], 2, 1, "max stacked extent decreases in magnitude");

--- a/test/tests.js
+++ b/test/tests.js
@@ -4047,14 +4047,14 @@ describe("Plots", function () {
             ];
             simpleDataset.data(lineData);
             var linePath = renderArea.select(".line");
-            var d_original = TestMethods.normalizePath(linePath.attr("d"));
+            var dOriginal = TestMethods.normalizePath(linePath.attr("d"));
             function assertCorrectPathSplitting(msgPrefix) {
                 var d = TestMethods.normalizePath(linePath.attr("d"));
                 var pathSegements = d.split("M").filter(function (segment) { return segment !== ""; });
                 assert.lengthOf(pathSegements, 2, msgPrefix + " split path into two segments");
-                var firstSegmentContained = d_original.indexOf(pathSegements[0]) >= 0;
+                var firstSegmentContained = dOriginal.indexOf(pathSegements[0]) >= 0;
                 assert.isTrue(firstSegmentContained, "first path segment is a subpath of the original path");
-                var secondSegmentContained = d_original.indexOf(pathSegements[1]) >= 0;
+                var secondSegmentContained = dOriginal.indexOf(pathSegements[1]) >= 0;
                 assert.isTrue(secondSegmentContained, "second path segment is a subpath of the original path");
             }
             var dataWithNaN = lineData.slice();
@@ -5823,7 +5823,7 @@ describe("Plots", function () {
                 { key: "a", value: 3 },
                 { key: "b", value: -4 }
             ];
-            var data2_b = [
+            var data2B = [
                 { key: "a", value: 1 },
                 { key: "b", value: -2 }
             ];
@@ -5833,7 +5833,7 @@ describe("Plots", function () {
             stackedBarPlot.addDataset(dataset2);
             assert.closeTo(yScale.domain()[0], -6, 1, "min stacked extent is as normal");
             assert.closeTo(yScale.domain()[1], 4, 1, "max stacked extent is as normal");
-            dataset2.data(data2_b);
+            dataset2.data(data2B);
             assert.closeTo(yScale.domain()[0], -4, 1, "min stacked extent decreases in magnitude");
             assert.closeTo(yScale.domain()[1], 2, 1, "max stacked extent decreases in magnitude");
         });

--- a/tslint.json
+++ b/tslint.json
@@ -62,7 +62,7 @@
         "property-declaration": "nospace",
         "variable-declaration": "nospace"
     }],
-    "variable-name": false,
+    "variable-name": [true, "allow-leading-underscore"],
     "whitespace": [true,
         "check-branch",
         "check-decl",


### PR DESCRIPTION
Putting more enforcement through tslint.  The rule enforces that variables are either camelCased or UPPER_CASED.  Mainly to keep to a consistent style that Typescript variables are normally under the above heuristic.

Invalid:
```typescript
var one_two_three;
```

Valid:
```typescript
var oneTwoThree;
```