### PR TITLE
Have selectionForIndex return d3.Selection<any>

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1250,7 +1250,7 @@ declare module Plottable {
         class Line extends Drawer {
             constructor(dataset: Dataset);
             protected _applyDefaultAttributes(selection: d3.Selection<any>): void;
-            selectionForIndex(index: number): d3.Selection<void>;
+            selectionForIndex(index: number): d3.Selection<any>;
         }
     }
 }
@@ -1261,7 +1261,7 @@ declare module Plottable {
         class Area extends Drawer {
             constructor(dataset: Dataset);
             protected _applyDefaultAttributes(selection: d3.Selection<any>): void;
-            selectionForIndex(index: number): d3.Selection<void>;
+            selectionForIndex(index: number): d3.Selection<any>;
         }
     }
 }

--- a/src/drawers/areaDrawer.ts
+++ b/src/drawers/areaDrawer.ts
@@ -15,7 +15,7 @@ export module Drawers {
       selection.style("stroke", "none");
     }
 
-    public selectionForIndex(index: number) {
+    public selectionForIndex(index: number): d3.Selection<any> {
       return this.renderArea().select(this.selector());
     }
   }

--- a/src/drawers/drawer.ts
+++ b/src/drawers/drawer.ts
@@ -169,7 +169,7 @@ export module Drawers {
     /**
      * Returns the D3 selection corresponding to the datum with the specified index.
      */
-    public selectionForIndex(index: number) {
+    public selectionForIndex(index: number): d3.Selection<any> {
       return d3.select(this._selection()[0][index]);
     }
 

--- a/src/drawers/lineDrawer.ts
+++ b/src/drawers/lineDrawer.ts
@@ -15,7 +15,7 @@ export module Drawers {
       selection.style("fill", "none");
     }
 
-    public selectionForIndex(index: number) {
+    public selectionForIndex(index: number): d3.Selection<any> {
       return this.renderArea().select(this.selector());
     }
   }


### PR DESCRIPTION
`Selection<any>` is the correct return type, since there is data bound to the `Selection`. The error was initially discovered in #2349.

[NOQE] because there are no JS or CSS changes.