### PR TITLE
Safari test fix. ES6 Set forEach() badly implemented in Safari

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -8341,7 +8341,7 @@ describe("Utils", function () {
             set.add(values[1]);
             var index = 0;
             set.forEach(function (value1, value2, passedSet) {
-                // HACKHACK: Safari does not pass a duplicate value as the second argument, as the spec suggests.
+                // HACKHACK: Safari bug #21489317: Safari passes undefined instead of a duplicate value for value2.
                 if (value2 !== undefined) {
                     assert.strictEqual(value1, value2, "The two value arguments passed to the callback are the same");
                 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -8341,7 +8341,10 @@ describe("Utils", function () {
             set.add(values[1]);
             var index = 0;
             set.forEach(function (value1, value2, passedSet) {
-                assert.strictEqual(value1, value2, "The two value arguments passed to the callback are the same");
+                // HACKHACK: Safari does not pass a duplicate value as the second argument, as the spec suggests.
+                if (value2 !== undefined) {
+                    assert.strictEqual(value1, value2, "The two value arguments passed to the callback are the same");
+                }
                 assert.strictEqual(value1, values[index], "Value " + index + " is the expected one");
                 assert.strictEqual(passedSet, set, "The correct Set is passed as the third argument");
                 index++;

--- a/test/utils/setTests.ts
+++ b/test/utils/setTests.ts
@@ -55,7 +55,10 @@ describe("Utils", () => {
       set.add(values[1]);
       var index = 0;
       set.forEach((value1: any, value2: any, passedSet: Plottable.Utils.Set<any>) => {
-        assert.strictEqual(value1, value2, "The two value arguments passed to the callback are the same");
+        // HACKHACK: Safari does not pass a duplicate value as the second argument, as the spec suggests.
+        if (value2 !== undefined) {
+          assert.strictEqual(value1, value2, "The two value arguments passed to the callback are the same");
+        }
         assert.strictEqual(value1, values[index], "Value " + index + " is the expected one");
         assert.strictEqual(passedSet, set, "The correct Set is passed as the third argument");
         index++;

--- a/test/utils/setTests.ts
+++ b/test/utils/setTests.ts
@@ -55,7 +55,7 @@ describe("Utils", () => {
       set.add(values[1]);
       var index = 0;
       set.forEach((value1: any, value2: any, passedSet: Plottable.Utils.Set<any>) => {
-        // HACKHACK: Safari does not pass a duplicate value as the second argument, as the spec suggests.
+        // HACKHACK: Safari bug #21489317: Safari passes undefined instead of a duplicate value for value2.
         if (value2 !== undefined) {
           assert.strictEqual(value1, value2, "The two value arguments passed to the callback are the same");
         }


### PR DESCRIPTION
Closes #2353

As [this](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/forEach) suggests, the second argument for the `forEach()` method is the same as the first argument. However, Safari is not following the spec, so had to add a HackHack for the test to pass.