### PR TITLE
[ESLint] - allowing for default usage of comma-dangle

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,6 @@
     "space-infix-ops": 0,
     "no-mixed-spaces-and-tabs": 0,
     "semi-spacing": 0,
-    "comma-dangle": 0,
     "no-use-before-define": 0,
     "strict": 0,
     "no-underscore-dangle": 0,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,27 +72,27 @@ module.exports = function(grunt) {
     private_definitions: {
       pattern: jsdoc + prefixMatch + "private " + varNameMatch + finalMatch,
       replacement: "",
-      path: "build/plottable.d.ts",
+      path: "build/plottable.d.ts"
     },
     plottable_multifile: {
       pattern: '/// *<reference path="([^."]*).ts" */>',
       replacement: 'synchronousRequire("/build/src/$1.js");',
-      path: "plottable_multifile.js",
+      path: "plottable_multifile.js"
     },
     definitions: {
       pattern: '/// *<reference path=[\'"].*[\'"] */>',
       replacement: "",
-      path: "build/plottable.d.ts",
+      path: "build/plottable.d.ts"
     },
     tests_multifile: {
       pattern: '/// *<reference path="([^."]*).ts" */>',
       replacement: 'synchronousRequire("/build/test/$1.js");',
-      path: "test/tests_multifile.js",
+      path: "test/tests_multifile.js"
     },
     sublime: {
       pattern: "(.*\\.ts)",
       replacement: '/// <reference path="../$1" />',
-      path: "build/sublime.d.ts",
+      path: "build/sublime.d.ts"
     },
     version_number: {
       pattern: "@VERSION",
@@ -151,44 +151,44 @@ module.exports = function(grunt) {
       all: {
         src: "plottable.js", 
         template: "unit",
-        objectToExport: "Plottable",
+        objectToExport: "Plottable"
       }
     },
     concat: {
       header: {
         src: ["license_header.txt", "plottable.js"],
-        dest: "plottable.js",
+        dest: "plottable.js"
       },
       plottable_multifile: {
         src: ["synchronousRequire.js", "src/reference.ts"],
-        dest: "plottable_multifile.js",
+        dest: "plottable_multifile.js"
       },
       tests_multifile: {
         src: ["synchronousRequire.js", "test/testReference.ts"],
-        dest: "test/tests_multifile.js",
+        dest: "test/tests_multifile.js"
       },
       plottable: {
         src: tsFiles.map(function(s) {
               return "build/src/" + s.replace(".ts", ".js");
           }),
-        dest: "plottable.js",
+        dest: "plottable.js"
       },
       tests: {
         src: testTsFiles.map(function(s) {
               return "build/test/" + s.replace(".ts", ".js");
           }),
-        dest: "test/tests.js",
+        dest: "test/tests.js"
       },
       definitions: {
         src: tsFiles.map(function(s) {
               return "build/src/" + s.replace(".ts", ".d.ts");
           }),
-        dest: "build/plottable.d.ts",
+        dest: "build/plottable.d.ts"
       },
       svgtypewriter: {
         src: ["plottable.js", "bower_components/svg-typewriter/svgtypewriter.js"],
-        dest: "plottable.js",
-      },
+        dest: "plottable.js"
+      }
     },
     ts: tsJSON,
     tslint: {
@@ -298,8 +298,8 @@ module.exports = function(grunt) {
     },
     shell: {
       sublime: {
-        command: "(echo 'src/reference.ts'; find typings -name '*.d.ts') > build/sublime.d.ts",
-      },
+        command: "(echo 'src/reference.ts'; find typings -name '*.d.ts') > build/sublime.d.ts"
+      }
     },
     'saucelabs-mocha': {
       all: {
@@ -329,7 +329,7 @@ module.exports = function(grunt) {
                                   "ts:test",
                                   "concat:tests_multifile",
                                   "sed:tests_multifile",
-                                  "concat:tests",
+                                  "concat:tests"
                                   ]);
   grunt.registerTask("default", "launch");
   var compile_task = [
@@ -382,7 +382,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask("sublime", [
                                   "shell:sublime",
-                                  "sed:sublime",
+                                  "sed:sublime"
                                   ]);
 
   var updateQuickTestsJSON = function() {

--- a/quicktests/color/main.js
+++ b/quicktests/color/main.js
@@ -14,10 +14,10 @@ function expandSidebar(){
       left: '0%'
     });
     content.animate({
-      left: '20%',
+      left: '20%'
     });
     controls.animate({
-      width: '80%',
+      width: '80%'
     });
   }
   else{
@@ -30,7 +30,7 @@ function expandSidebar(){
       sidebar.css("visibility", "hidden");
     });
     controls.animate({
-      width: '100%',
+      width: '100%'
     });
   }
 }

--- a/quicktests/overlaying/overlaying.js
+++ b/quicktests/overlaying/overlaying.js
@@ -17,13 +17,13 @@ function toggleSidebar(){
       left: '0%'
     });
     content.animate({
-      left: '20%',
+      left: '20%'
     });
     controls.animate({
-      width: '80%',
+      width: '80%'
     });
     sizeControls.animate({
-      width: '80%',
+      width: '80%'
     });
   }
   else{
@@ -36,10 +36,10 @@ function toggleSidebar(){
       sidebar.css("visibility", "hidden");
     });
     controls.animate({
-      width: '100%',
+      width: '100%'
     });
     sizeControls.animate({
-      width: '100%',
+      width: '100%'
     });
   }
 }

--- a/quicktests/overlaying/tests/realistic/animals.js
+++ b/quicktests/overlaying/tests/realistic/animals.js
@@ -59,7 +59,7 @@ function makeData() {
 	type1: "invertebrate",
 	type2: "insect",
 	type3: "pterygota"
-  },
+  }
   ];
 
   return [d];

--- a/quicktests/overlaying/tests/realistic/basic_pie_real.js
+++ b/quicktests/overlaying/tests/realistic/basic_pie_real.js
@@ -58,7 +58,7 @@ function run(svg, data, Plottable) {
 
   var productPlots = new Plottable.Components.Table([
       [AGroup],
-      [BGroup],
+      [BGroup]
   ]);
 
   var allPlots = new Plottable.Components.Table([

--- a/quicktests/overlaying/tests/realistic/category_grid.js
+++ b/quicktests/overlaying/tests/realistic/category_grid.js
@@ -47,7 +47,7 @@ function makeData() {
           {hospital: "no", hour: "2 AM", percent: 5.0},
           {hospital: "no", hour: "3 AM", percent: 5.2},
           {hospital: "no", hour: "4 AM", percent: 5.2},
-          {hospital: "no", hour: "5 AM", percent: 4.9},
+          {hospital: "no", hour: "5 AM", percent: 4.9}
          ];
 }
 

--- a/quicktests/overlaying/tests/realistic/scatter_bar.js
+++ b/quicktests/overlaying/tests/realistic/scatter_bar.js
@@ -6,7 +6,7 @@ function makeData() {
           {company: "Google", overall: 0.30, leadership: 0.21}, 
           {company: "Intel", overall: 0.24, leadership: 0.16}, 
           {company: "Microsoft", overall: 0.29, leadership: 0.17},
-          {company: "Twitter", overall: 0.30, leadership: 0.21}, ];
+          {company: "Twitter", overall: 0.30, leadership: 0.21}];
 }
 
 function run(svg, data, Plottable) {


### PR DESCRIPTION
Default usage is where commas cannot be dangling at the end.

Invalid:
[ {foo: "bar"},
  {foo: "baz"}, ]

Valid:
[ {foo: "bar"},
  {foo: "baz"} ]