### PR TITLE
[ESLint] - applying default usage of no-mixed-spaces-and-tabs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,6 @@
     "comma-spacing": 0,
     "key-spacing": 0,
     "space-infix-ops": 0,
-    "no-mixed-spaces-and-tabs": 0,
     "semi-spacing": 0,
     "comma-dangle": 0,
     "no-use-before-define": 0,

--- a/quicktests/overlaying/tests/realistic/animals.js
+++ b/quicktests/overlaying/tests/realistic/animals.js
@@ -80,9 +80,9 @@ function run(svg, data, Plottable){
 
   var csType3 = new Plottable.Scales.Color();
   csType3.domain(["odd-toed hoofed", "insectivore", "marsupial", 
-  				  "squamata", "chelonia", "malacostraca", "pterygota"]);
+                  "squamata", "chelonia", "malacostraca", "pterygota"]);
   csType3.range(["#d8b2d8", "#bf7fbf", "#b266b2", "#800080", 
-  				"#4c004c", "#ffb6c1", "#cc919a"]);
+                 "#4c004c", "#ffb6c1", "#cc919a"]);
 
   var legend1 = new Plottable.Components.Legend(csType1).xAlignment("left");
   var legend2 = new Plottable.Components.Legend(csType2).xAlignment("left");
@@ -91,28 +91,28 @@ function run(svg, data, Plottable){
   var innerPie = new Plottable.Plots.Pie();
   innerPie.addDataset(dataset);
   innerPie.sectorValue(function(){ return 0.1;})
-  		  .innerRadius(25)
-  		  .outerRadius(50)
-  		  .attr("fill", function(d){ return d.type1;}, csType1);
+          .innerRadius(25)
+          .outerRadius(50)
+          .attr("fill", function(d){ return d.type1;}, csType1);
 
   var midPie = new Plottable.Plots.Pie();
   midPie.addDataset(dataset);
   midPie.sectorValue(function(){ return 0.1;})
-  		  .innerRadius(50)
-  		  .outerRadius(75)
-  		  .attr("fill", function(d){ return d.type2;}, csType2);  		
+        .innerRadius(50)
+        .outerRadius(75)
+        .attr("fill", function(d){ return d.type2;}, csType2);  		
 
   var outerPie = new Plottable.Plots.Pie();
   outerPie.addDataset(dataset);
   outerPie.sectorValue(function(){ return 0.1;})
-  		  .innerRadius(75)
-  		  .outerRadius(100)
-  		  .attr("fill", function(d){ return d.type3;}, csType3);  		    
+          .innerRadius(75)
+          .outerRadius(100)
+          .attr("fill", function(d){ return d.type3;}, csType3);  		    
 
   var pies = new Plottable.Components.Group([innerPie, midPie, outerPie]);
   var legendTable = new Plottable.Components.Table([[legend1],
-  													[legend2],
-  													[legend3]]);
+                                                    [legend2],
+                                                    [legend3]]);
   var table = new Plottable.Components.Table([[pies, legendTable]]);
   table.renderTo(svg);  
 }

--- a/quicktests/overlaying/tests/realistic/numeric_grid.js
+++ b/quicktests/overlaying/tests/realistic/numeric_grid.js
@@ -1,15 +1,15 @@
 function makeData() {
   "use strict";
   return [{fill: "#FFFFFF",	x:0, x2:13, y:0, y2:7},
- 		  {fill: "#FF0000",	x:0, x2:13, y:7, y2:20},
-  		  {fill: "#0000FF",	x:13, x2:20, y:0, y2:7},
-  		  {fill: "#FFFFFF",	x:13, x2:20, y:7, y2:13},
-  		  {fill: "#FFFF00",	x:13, x2:20, y:13, y2:20},
-  		  {fill: "#FFFF00",	x:20, x2:30, y:0, y2:10},
-  		  {fill: "#0000FF",	x:20, x2:27, y:10, y2:13},
-   		  {fill: "#FFFFFF",	x:27, x2:30, y:10, y2:17},
-   		  {fill: "#FFFFFF",	x:20, x2:27, y:13, y2:20},
-   		  {fill: "#FF0000",	x:27, x2:30, y:17, y2:20}
+          {fill: "#FF0000",	x:0, x2:13, y:7, y2:20},
+          {fill: "#0000FF",	x:13, x2:20, y:0, y2:7},
+          {fill: "#FFFFFF",	x:13, x2:20, y:7, y2:13},
+          {fill: "#FFFF00",	x:13, x2:20, y:13, y2:20},
+          {fill: "#FFFF00",	x:20, x2:30, y:0, y2:10},
+          {fill: "#0000FF",	x:20, x2:27, y:10, y2:13},
+          {fill: "#FFFFFF",	x:27, x2:30, y:10, y2:17},
+          {fill: "#FFFFFF",	x:20, x2:27, y:13, y2:20},
+          {fill: "#FF0000",	x:27, x2:30, y:17, y2:20}
          ];
 }
 
@@ -27,9 +27,9 @@ function run(svg, data, Plottable) {
       .y(function(d) { return d.y; }, yScale)
       .x2(function(d){ return d.x2; }, xScale)
       .y2(function(d) { return d.y2; }, yScale)
-  	  .attr("fill", function(d) { return d.fill; })
-  	  .attr("stroke", function(){ return "#000000";})
-  	  .attr("stroke-width", function(){ return 4;});
+      .attr("fill", function(d) { return d.fill; })
+      .attr("stroke", function(){ return "#000000";})
+      .attr("stroke-width", function(){ return 4;});
 
   plot.renderTo(svg);
 }


### PR DESCRIPTION
Tab characters in general should not be used.  Only spaces for alignment.

Using {\t} as a tab character

Invalid:
```javascript
{\t}{\t}var foo = "bar;
```

Valid:
```javascript
  var foo = "bar";
```