### PR TITLE
[ESLint] - applying default usage of no-return-assign

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,6 @@
 {
   "rules": {
     "no-eval": 0,
-    "no-return-assign": 0,
     "no-undef": 0,
     "no-shadow": 0,
     "no-trailing-spaces": 0,

--- a/quicktests/umd/lib/require.js
+++ b/quicktests/umd/lib/require.js
@@ -7,6 +7,7 @@
 //problems with requirejs.exec()/transpiler plugins that may not be strict.
 /*jslint regexp: true, nomen: true, sloppy: true */
 /*global window, navigator, document, importScripts, setTimeout, opera */
+/*eslint-disable */
 
 var requirejs, require, define;
 (function (global) {


### PR DESCRIPTION
Mainly by disabling the linter on require.js