### PR TITLE
[ESLint] - applying default usage of no-undef

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,18 @@
 {
+  "env": {
+    "browser": true,
+    "jquery": true,
+    "node": true
+  },
+  "globals": {
+    "d3": true,
+    "Plottable": true,
+    "makeRandomData": true,
+    "deep_copy": true
+  },
   "rules": {
     "no-eval": 0,
     "no-return-assign": 0,
-    "no-undef": 0,
     "no-shadow": 0,
     "no-trailing-spaces": 0,
     "quotes": 0,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,9 +1,6 @@
 module.exports = function(grunt) {
   "use strict";
 
-  var path = require("path");
-  var cwd = process.cwd();
-
   var tsJSON = {
     dev: {
       src: ["src/**/*.ts", "typings/**/*.d.ts"],

--- a/quicktests/overlaying/overlaying.js
+++ b/quicktests/overlaying/overlaying.js
@@ -323,7 +323,7 @@ function loadPlottableBranches(category, branchList){
       });
     }
     else if(textStatus === "error"){
-      console.log("could not retrieve Plottable branch, check if branch name " + branch + " is correct!");
+      console.log("could not retrieve Plottable branch, check if url " + listOfUrl[0] + " is correct!");
     }
   });
 }


### PR DESCRIPTION
The rule disallows the usage of variables before they are defined

Invalid:
```javascript
function foo() {
  doStuff(a);
}
```

Valid:
```javascript
function foo() {
  var a = ...;
  doStuff(a);
}
```