### PR TITLE
[ESLint] - applying default usage of no-shadow

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,6 @@
     "no-eval": 0,
     "no-return-assign": 0,
     "no-undef": 0,
-    "no-shadow": 0,
     "no-trailing-spaces": 0,
     "quotes": 0,
     "consistent-return": 0,

--- a/quicktests/color/main.js
+++ b/quicktests/color/main.js
@@ -120,7 +120,7 @@ function addAllDatasets(plot, arr, numOfDatasets){
   return plot;
 }
 
-function generatePlots(plots, dataType){
+function generatePlots(dataType){
   var plottablePlots = [];
   plots.forEach(function(PlotType){
     var xScale = new Plottable.Scale.Category();
@@ -255,7 +255,7 @@ function initialize(){
 
   d3.selectAll("svg").remove();
   var dataArray = prepareData(seriesNumber);
-  generatePlots(plots, dataArray);
+  generatePlots(dataArray);
 }
 
 //setup page

--- a/quicktests/overlaying/overlaying.js
+++ b/quicktests/overlaying/overlaying.js
@@ -139,9 +139,9 @@ function populateTotalSidebarList(paths){
 
     object.value.forEach(function(quicktest){
       var singleQuicktestName = quicktest;
-      var startOlString = "<li class=\"sidebar-quicktest\"> <input class=\"quicktest-checkbox\" type=\"checkbox\">";
-      var endOlString = "</li>";
-      var quicktestStringHTML = startOlString + singleQuicktestName + endOlString;
+      var startLiString = "<li class=\"sidebar-quicktest\"> <input class=\"quicktest-checkbox\" type=\"checkbox\">";
+      var endLiString = "</li>";
+      var quicktestStringHTML = startLiString + singleQuicktestName + endLiString;
       $("#" + categoryName).append(quicktestStringHTML);
     });
   });
@@ -164,9 +164,9 @@ function populateSidebarList(paths, testsInCategory, category){
 
     allQuickTests.forEach(function(quicktest){
       var singleQuicktestName = quicktest.value;
-      var startOlString = "<li class=\"sidebar-quicktest\"> <input class=\"quicktest-checkbox\" type=\"checkbox\">";
-      var endOlString = "</li>";
-      var quicktestStringHTML = startOlString + singleQuicktestName + endOlString;
+      var startLiString = "<li class=\"sidebar-quicktest\"> <input class=\"quicktest-checkbox\" type=\"checkbox\">";
+      var endLiString = "</li>";
+      var quicktestStringHTML = startLiString + singleQuicktestName + endLiString;
       $("#" + categoryName).append(quicktestStringHTML);
     });
   $(":checkbox").attr("checked", false);
@@ -217,8 +217,7 @@ function runQuickTest(result, svg, data, branch){
   }
 }
 
-function loadAllQuickTests(quicktestsPaths, firstBranch, secondBranch){
-  var div = d3.select("#results");
+function loadAllQuickTests(quicktestsPaths, firstQTBranch, secondQTBranch){
   quicktestsPaths.forEach(function(path) { //for each quicktest
     var name = path.replace(/\w*\/|\.js/g , '');
     d3.text("http://localhost:9999/" + path, function(error, text) {
@@ -238,15 +237,13 @@ function loadAllQuickTests(quicktestsPaths, firstBranch, secondBranch){
       var secondsvg = div.append("div").attr("class", "second").append("svg").attr({width: svgWidth, height: svgHeight});
       var data = result.makeData();
 
-      runQuickTest(result, firstsvg, data, firstBranch);
-      runQuickTest(result, secondsvg, data, secondBranch);
+      runQuickTest(result, firstsvg, data, firstQTBranch);
+      runQuickTest(result, secondsvg, data, secondQTBranch);
     });
   });
 }
 //load each quicktest locally, eval it, then run quicktest
-function loadQuickTestsInCategory(quickTestNames, category, firstBranch, secondBranch){
-
-  var div = d3.select("#results");
+function loadQuickTestsInCategory(quickTestNames, category, firstQTBranch, secondQTBranch){
   quickTestNames.forEach(function(q) { //for each quicktest
     var name = q;
     d3.text("/quicktests/overlaying/tests/" + category + "/" + name + ".js", function(error, text) {
@@ -267,8 +264,8 @@ function loadQuickTestsInCategory(quickTestNames, category, firstBranch, secondB
       var secondsvg = div.append("div").attr("class", "second").append("svg").attr({width: svgWidth, height: svgHeight});
       var data = result.makeData();
 
-      runQuickTest(result, firstsvg, data, firstBranch);
-      runQuickTest(result, secondsvg, data, secondBranch);
+      runQuickTest(result, firstsvg, data, firstQTBranch);
+      runQuickTest(result, secondsvg, data, secondQTBranch);
     });
   });
 }
@@ -314,8 +311,8 @@ function loadPlottableBranches(category, branchList){
       plottableBranches[branchName1] =  $.extend(true, {}, Plottable);
       Plottable = null;
 
-      $.getScript(listOfUrl[1], function(data, testStatus){ //load second
-        if(textStatus === "success"){
+      $.getScript(listOfUrl[1], function(innerData, innerTestStatus){ //load second
+        if(innerTestStatus === "success"){
           plottableBranches[branchName2] = $.extend(true, {}, Plottable);
           Plottable = null;
           filterQuickTests(category, branchList);

--- a/quicktests/overlaying/tests/animations/inflation.js
+++ b/quicktests/overlaying/tests/animations/inflation.js
@@ -61,8 +61,8 @@ function run(svg, data, Plottable) {
     var avg_ds = new Plottable.Dataset(avg_data);
     var lineRenderer = new Plottable.Plots.Line()
               .addDataset(avg_ds)
-              .x(function(d, i) { return d.x; }, xScale)
-              .y(function(d) { return d.y; }, yScale)
+              .x(function(datum, i) { return datum.x; }, xScale)
+              .y(function(datum) { return datum.y; }, yScale)
               .attr("stroke", "#FF0000")
               .animated(true);
     plot_array.push(lineRenderer);     

--- a/quicktests/overlaying/tests/realistic/baseball.js
+++ b/quicktests/overlaying/tests/realistic/baseball.js
@@ -6,7 +6,7 @@ function run(svg, data, Plottable) {
   "use strict";
 
   d3.csv("/quicktests/overlaying/data/baseball.csv").get(function(error, rows) {
-  var data = rows;
+  data = rows;
   var dataset = new Plottable.Dataset(data);
 
   var xScale = new Plottable.Scales.Linear();

--- a/quicktests/overlaying/tests/realistic/cities.js
+++ b/quicktests/overlaying/tests/realistic/cities.js
@@ -7,7 +7,7 @@ function run(svg, data, Plottable) {
   "use strict";
 
   d3.csv("/quicktests/overlaying/data/cities.csv").get(function(error, rows) {
-  var data = rows;
+  data = rows;
   var ds = new Plottable.Dataset(data);
 
   var csRange = [];

--- a/quicktests/overlaying/tests/realistic/hockey.js
+++ b/quicktests/overlaying/tests/realistic/hockey.js
@@ -6,7 +6,7 @@ function run(svg, data, Plottable) {
   "use strict";
 
   d3.csv("/quicktests/overlaying/data/hockey.csv").get(function(error, rows) {
-  var data = rows;
+  data = rows;
   var ds = new Plottable.Dataset(data);
 
   var xScale = new Plottable.Scales.Linear().domain([0, 80]);
@@ -48,8 +48,8 @@ function run(svg, data, Plottable) {
   var x = function(d){ return d.x; };
   var y = function(d){ return d.y; };
 
-  var styleLinePlot = function(plot){
-    plot.x(x, xScale).y(y, yScale)
+  var styleLinePlot = function(linePlot){
+    linePlot.x(x, xScale).y(y, yScale)
     .attr("stroke", "#dddddd").attr("stroke-dasharray", 4);
   };
 

--- a/quicktests/overlaying/tests/realistic/rectangle.js
+++ b/quicktests/overlaying/tests/realistic/rectangle.js
@@ -33,8 +33,8 @@ function makeData() {
 function run(svg, data, Plottable) {
   "use strict";
 
-  var timeFormatStart = function (data) { return d3.time.format("%m/%d/%Y").parse(data.x);};
-  var timeFormatEnd = function (data) { return d3.time.format("%m/%d/%Y").parse(data.x2);};
+  var timeFormatStart = function (d) { return d3.time.format("%m/%d/%Y").parse(d.x);};
+  var timeFormatEnd = function (d) { return d3.time.format("%m/%d/%Y").parse(d.x2);};
 
   var xScale = new Plottable.Scales.Time();
   var yScale = new Plottable.Scales.Category();

--- a/quicktests/overlaying/tests/realistic/stocks.js
+++ b/quicktests/overlaying/tests/realistic/stocks.js
@@ -19,8 +19,8 @@ function run(svg, data, Plottable) {
 
       // load AAPL
       d3.csv("/quicktests/overlaying/data/AAPL_20140401_20140901.csv")
-        .get(function(error, rows) {
-          var aapl = rows.reverse();
+        .get(function(aaplError, aaplRows) {
+          var aapl = aaplRows.reverse();
           aapl.forEach(processDatum);
 
           // process and create chart
@@ -70,7 +70,7 @@ function run(svg, data, Plottable) {
                                   .addDataset(aaplSource)
                                   .x(function(d) { return d.Date; }, xScale)
                                   .y(function(d) { return d["Adj Close"]; }, yScale_aapl)
-                                  .attr("stroke", function(d, i, dataset) { return dataset.metadata().name; }, colorScale);
+                                  .attr("stroke", function(d, index, dataset) { return dataset.metadata().name; }, colorScale);
           if (typeof line_aapl.autorange === "function") {
             line_aapl.autorange("y");
           } else {
@@ -80,7 +80,7 @@ function run(svg, data, Plottable) {
                                   .addDataset(googSource)
                                   .x(function(d) { return d.Date; }, xScale)
                                   .y(function(d) { return d["Adj Close"]; }, yScale_goog)
-                                  .attr("stroke", function(d, i, dataset) { return dataset.metadata().name; }, colorScale);
+                                  .attr("stroke", function(d, index, dataset) { return dataset.metadata().name; }, colorScale);
           if (typeof line_aapl.autorange === "function") {
             line_goog.autorange("y");
           } else {

--- a/quicktests/overlaying/tests/realistic/symbols.js
+++ b/quicktests/overlaying/tests/realistic/symbols.js
@@ -8,9 +8,9 @@ function makeData() {
 function run(svg, data, Plottable){
   "use strict";
 
-  var d = [];
-  deep_copy(data[0], d);
-  var dataset = new Plottable.Dataset(d);
+  var plotData = [];
+  deep_copy(data[0], plotData);
+  var dataset = new Plottable.Dataset(plotData);
 
   var xScale = new Plottable.Scales.Linear();
   var yScale = new Plottable.Scales.Linear();

--- a/quicktests/quicktest.js
+++ b/quicktests/quicktest.js
@@ -147,7 +147,7 @@ function setup() {
     }
     //load github branch dropdown
     var branchOptions = {};
-    $.get("https://api.github.com/repos/palantir/plottable/branches" + auth, function(data,status){
+    $.get("https://api.github.com/repos/palantir/plottable/branches" + auth, function(){
       for(var i = 0; i < data.length; i++){
         branchOptions["val" + i] = data[i].name;
       }

--- a/quicktests/umd/lib/require.js
+++ b/quicktests/umd/lib/require.js
@@ -7,6 +7,7 @@
 //problems with requirejs.exec()/transpiler plugins that may not be strict.
 /*jslint regexp: true, nomen: true, sloppy: true */
 /*global window, navigator, document, importScripts, setTimeout, opera */
+/*eslint-disable */
 
 var requirejs, require, define;
 (function (global) {


### PR DESCRIPTION
Rule disallows shadowing of variables.

Invalid:
```javascript
var a = 10;
function foo(a) {
  doStuff(a);
}
```

Valid:
```javascript
var a = 10;
function foo(aTest) {
  doStuff(aTest);
}
```