### PR TITLE
[ESLint] - allowing for default usage of no-trailing-spaces

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,6 @@
     "no-return-assign": 0,
     "no-undef": 0,
     "no-shadow": 0,
-    "no-trailing-spaces": 0,
     "quotes": 0,
     "consistent-return": 0,
     "no-console": 0,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -149,7 +149,7 @@ module.exports = function(grunt) {
     bump: bumpJSON,
     umd: {
       all: {
-        src: "plottable.js", 
+        src: "plottable.js",
         template: "unit",
         objectToExport: "Plottable",
       }
@@ -341,7 +341,7 @@ module.exports = function(grunt) {
       "concat:definitions",
       "sed:definitions",
       "sed:private_definitions",
-      "umd:all", 
+      "umd:all",
       "concat:header",
       "sed:version_number",
       "definitions_prod",

--- a/quicktests/color/main.js
+++ b/quicktests/color/main.js
@@ -77,7 +77,6 @@ function setupBindings(){
   }).mousemove(function(e) {
       var windowWidth = window.innerWidth;
       var helpY = $("#help").position().top;
-      
       $("#help-description").css({ top: helpY + 28, left: windowWidth - 360 });
   });
 }
@@ -101,7 +100,7 @@ function populateSidebarList(){
 function renderPlots(plottablePlots){
   plottablePlots.forEach(function(plot){
     var plotDivName = "." + plot.constructor.name;
-    var plotDiv = d3.select(plotDivName); 
+    var plotDiv = d3.select(plotDivName);
     var box = plotDiv.append("svg").attr("height", plotheight).attr("width", plotwidth);
     var chart = new Plottable.Component.Table([[plot]]);
     chart.renderTo(box);
@@ -116,7 +115,7 @@ function addAllDatasets(plot, arr, numOfDatasets){
     arr.forEach(function(dataset){
       plot.addDataset(dataset);
     });
-  } 
+  }
   return plot;
 }
 
@@ -170,7 +169,7 @@ function generatePlots(plots, dataType){
           .project("y", "x", yScale)
           .attr("fill", "type", colorScale)
           .animate(true);
-      
+
       plot = addAllDatasets(plot, dataType[2], "multiple");
       plottablePlots.push(plot);
     }
@@ -180,12 +179,12 @@ function generatePlots(plots, dataType){
       plot = addAllDatasets(plot, dataType[0], "single");
       plottablePlots.push(plot);
     }
-    
+
   });
   renderPlots(plottablePlots);
 }
 
-var orderByX = function(a,b){ 
+var orderByX = function(a,b){
   return a.x - b.x;
 };
 

--- a/quicktests/overlaying/tests/animations/inflation.js
+++ b/quicktests/overlaying/tests/animations/inflation.js
@@ -47,7 +47,7 @@ function run(svg, data, Plottable) {
               .y(function(d) { return d.y; }, yScale)
               .attr("stroke", "#000000")
               .animated(true);
-    plot_array.push(lineRenderer); 
+    plot_array.push(lineRenderer);
   };
 
   var year_average = function(y){
@@ -65,12 +65,12 @@ function run(svg, data, Plottable) {
               .y(function(d) { return d.y; }, yScale)
               .attr("stroke", "#FF0000")
               .animated(true);
-    plot_array.push(lineRenderer);     
+    plot_array.push(lineRenderer);
   };
 
   for (var year = 0; year < data.length; year++){
-    add_year(year); 
-    year_average(year);          
+    add_year(year);
+    year_average(year);
   }
 
   var group = new Plottable.Components.Group(plot_array);

--- a/quicktests/overlaying/tests/functional/padding.js
+++ b/quicktests/overlaying/tests/functional/padding.js
@@ -49,7 +49,7 @@ function run(svg, data, Plottable) {
 
   function removePadExpNeg() {
     xScale.removePaddingExceptionsProvider(negVal);
-  }  
+  }
 
   var addBig  = new Plottable.Components.Label("include big number", 0);
   var removeBig  = new Plottable.Components.Label("remove big number", 0);
@@ -58,7 +58,7 @@ function run(svg, data, Plottable) {
   var addPadExceptionBig  = new Plottable.Components.Label("padding exception big", 0);
   var addPadExceptionNeg  = new Plottable.Components.Label("padding exception neg", 0);
   var removePadExceptionBig  = new Plottable.Components.Label("remove padding exception big", 0);
-  var removePadExceptionNeg  = new Plottable.Components.Label("remove padding exception neg", 0);  
+  var removePadExceptionNeg  = new Plottable.Components.Label("remove padding exception neg", 0);
 
   var labelTable = new Plottable.Components.Table([[addBig, addNeg],
                                                     [removeBig, removeNeg],

--- a/quicktests/overlaying/tests/realistic/animals.js
+++ b/quicktests/overlaying/tests/realistic/animals.js
@@ -79,9 +79,9 @@ function run(svg, data, Plottable){
   csType2.range(["#ff4c4c", "#cc3c3c", "#008000", "#4CA64C"]);
 
   var csType3 = new Plottable.Scales.Color();
-  csType3.domain(["odd-toed hoofed", "insectivore", "marsupial", 
+  csType3.domain(["odd-toed hoofed", "insectivore", "marsupial",
   				  "squamata", "chelonia", "malacostraca", "pterygota"]);
-  csType3.range(["#d8b2d8", "#bf7fbf", "#b266b2", "#800080", 
+  csType3.range(["#d8b2d8", "#bf7fbf", "#b266b2", "#800080",
   				"#4c004c", "#ffb6c1", "#cc919a"]);
 
   var legend1 = new Plottable.Components.Legend(csType1).xAlignment("left");
@@ -100,19 +100,19 @@ function run(svg, data, Plottable){
   midPie.sectorValue(function(){ return 0.1;})
   		  .innerRadius(50)
   		  .outerRadius(75)
-  		  .attr("fill", function(d){ return d.type2;}, csType2);  		
+  		  .attr("fill", function(d){ return d.type2;}, csType2);
 
   var outerPie = new Plottable.Plots.Pie();
   outerPie.addDataset(dataset);
   outerPie.sectorValue(function(){ return 0.1;})
   		  .innerRadius(75)
   		  .outerRadius(100)
-  		  .attr("fill", function(d){ return d.type3;}, csType3);  		    
+  		  .attr("fill", function(d){ return d.type3;}, csType3);
 
   var pies = new Plottable.Components.Group([innerPie, midPie, outerPie]);
   var legendTable = new Plottable.Components.Table([[legend1],
   													[legend2],
   													[legend3]]);
   var table = new Plottable.Components.Table([[pies, legendTable]]);
-  table.renderTo(svg);  
+  table.renderTo(svg);
 }

--- a/quicktests/overlaying/tests/realistic/phones.js
+++ b/quicktests/overlaying/tests/realistic/phones.js
@@ -84,7 +84,7 @@ function run(svg, data, Plottable) {
     .endTickLength(0);
   var RoKLabels = new Plottable.Axes.Category(yScale, "left")
     .tickLength(0)
-    .endTickLength(0);    
+    .endTickLength(0);
   var featureLabel = new Plottable.Components.Label("Feature Phones", 0);
   var smartLabel = new Plottable.Components.Label("Smart Phones", 0);
 
@@ -107,7 +107,7 @@ function run(svg, data, Plottable) {
     if(d.phoneType === "smart"){
       return d.demographic;
     }
-  };  
+  };
   var AusFeaturePlot = new Plottable.Plots.Bar("horizontal")
       .addDataset(AusDataset)
       .x(filterFeatureX, xScale_reverse)
@@ -124,26 +124,26 @@ function run(svg, data, Plottable) {
       .addDataset(IndDataset)
       .x(filterFeatureX, xScale_reverse)
       .y(filterFeatureY, yScale)
-      .attr("fill", IndColor);   
+      .attr("fill", IndColor);
 
   var IndSmartPlot = new Plottable.Plots.Bar("horizontal")
       .addDataset(IndDataset)
       .x(filterSmartX, xScale)
       .y(filterSmartY, yScale)
-      .attr("fill", IndColor); 
+      .attr("fill", IndColor);
 
   var RoKFeaturePlot = new Plottable.Plots.Bar("horizontal")
       .addDataset(RoKDataset)
       .x(filterFeatureX, xScale_reverse)
       .y(filterFeatureY, yScale)
-      .attr("fill", RoKColor);   
+      .attr("fill", RoKColor);
 
   var RoKSmartPlot = new Plottable.Plots.Bar("horizontal")
       .addDataset(RoKDataset)
       .x(filterSmartX, xScale)
       .y(filterSmartY, yScale)
-      .attr("fill", RoKColor);                
-  
+      .attr("fill", RoKColor);
+
   var table = new Plottable.Components.Table([[legend,          null,       null],
                                               [featureLabel,    null,       smartLabel],
                                               [AusFeaturePlot,  AusLabels,  AusSmartPlot],

--- a/quicktests/overlaying/tests/realistic/scatter_bar.js
+++ b/quicktests/overlaying/tests/realistic/scatter_bar.js
@@ -1,10 +1,10 @@
 function makeData() {
   "use strict";
   return [{company: "Amazon", overall: 0.37, leadership: 0.25},
-          {company: "Apple", overall: 0.30, leadership: 0.28}, 
-          {company: "Facebook", overall: 0.31, leadership: 0.23}, 
-          {company: "Google", overall: 0.30, leadership: 0.21}, 
-          {company: "Intel", overall: 0.24, leadership: 0.16}, 
+          {company: "Apple", overall: 0.30, leadership: 0.28},
+          {company: "Facebook", overall: 0.31, leadership: 0.23},
+          {company: "Google", overall: 0.30, leadership: 0.21},
+          {company: "Intel", overall: 0.24, leadership: 0.16},
           {company: "Microsoft", overall: 0.29, leadership: 0.17},
           {company: "Twitter", overall: 0.30, leadership: 0.21}, ];
 }
@@ -50,7 +50,7 @@ function run(svg, data, Plottable) {
       }
       else{
         return "#660066";
-      }      
+      }
     })
     .attr("opacity", function(){return 1;})
     .size(function(){ return yScale.rangeBand();});

--- a/quicktests/umd/app.js
+++ b/quicktests/umd/app.js
@@ -5,7 +5,7 @@ var require;
 require.config({
   paths: {
     d3: "../../bower_components/d3/d3",
-    plottable: "../../plottable" 
+    plottable: "../../plottable"
   }
 });
 
@@ -20,17 +20,17 @@ require(["d3"], function(d3) {
       { name: "B", value: 5 },
       { name: "C", value: 3 }
     ]);
-  
+
     var xScale = new Plottable.Scales.Category();
     var xAxis = new Plottable.Axes.Category(xScale, "bottom");
     var yScale = new Plottable.Scales.Linear();
     var yAxis = new Plottable.Axes.Numeric(yScale, "left");
-  
+
     var plot = new Plottable.Plots.Bar("vertical");
     plot.addDataset(dataset1);
     plot.x(function(d) { return d.name; }, xScale);
     plot.y(function(d) { return d.value; }, yScale);
-    
+
     var chart = new Plottable.Components.Table([
       [yAxis, plot],
       [null, xAxis]


### PR DESCRIPTION
Rules disallows ending with trailing whitespace.

Using {\space} as a whitespace character.

Invalid:
```javascript
var foo = 3;{\space}{\space}{\space}
```

Valid:
```javascript
var foo = 3;
```