### PR TITLE
[ESLint] - applying default usage of consistent-return

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,6 @@
     "no-shadow": 0,
     "no-trailing-spaces": 0,
     "quotes": 0,
-    "consistent-return": 0,
     "no-console": 0,
     "no-unused-vars": 0,
     "no-multi-spaces": 0,

--- a/quicktests/umd/lib/require.js
+++ b/quicktests/umd/lib/require.js
@@ -7,6 +7,7 @@
 //problems with requirejs.exec()/transpiler plugins that may not be strict.
 /*jslint regexp: true, nomen: true, sloppy: true */
 /*global window, navigator, document, importScripts, setTimeout, opera */
+/*eslint-disable */
 
 var requirejs, require, define;
 (function (global) {


### PR DESCRIPTION
Rules disallows functions being inconsistent with returning something or returning nothing.

Invalid:
```javascript
function foo() {
  if (boolean) {
    return bar;
  } else {
    return;
  }
}
```

Valid:
```javascript
function foo() {
  if (boolean) {
    return bar;
  } else {
    return baz;
  }
}
```