### PR TITLE
[ESLint] - applying default usage of semi-spacing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,6 @@
     "key-spacing": 0,
     "space-infix-ops": 0,
     "no-mixed-spaces-and-tabs": 0,
-    "semi-spacing": 0,
     "comma-dangle": 0,
     "no-use-before-define": 0,
     "strict": 0,

--- a/quicktests/color/main.js
+++ b/quicktests/color/main.js
@@ -213,7 +213,7 @@ function makeRandomData(numPoints, series, scaleFactor) {
 }
 
 function prepareSingleData(data){
-  data[0].map(function(element){element.type = ""+ element.x;});
+  data[0].map(function(element){element.type = ""+ element.x; });
   return data;
 }
 

--- a/quicktests/overlaying/overlaying.js
+++ b/quicktests/overlaying/overlaying.js
@@ -110,7 +110,7 @@ function setupCheckboxBinding(){
 
 function populateTotalSidebarList(paths){
   //IF CATEGORY IS ALL ******
-  var testsPaths = paths.map(function(path) {return path.replace(/.*tests\/|\.js/g, '');});
+  var testsPaths = paths.map(function(path) {return path.replace(/.*tests\/|\.js/g, ''); });
 
   //ex. animations/animate_area
   var hash = {};
@@ -182,7 +182,7 @@ function setupBindings(){
   window.onkeyup = function(e){
     var key = e.keyCode || e.which;
     var inputActive = $("#branch1, #branch2, #width, #height").is(':focus');
-    if(inputActive){return;}
+    if(inputActive){return; }
 
     var visibleQuickTests = $(".quicktest").filter(":visible").toArray();
     processKeyEvent(key, visibleQuickTests);
@@ -213,7 +213,7 @@ function runQuickTest(result, svg, data, branch){
     result.run(svg, data, plottableBranches[branch]);
     setTestBoxDimensions();
   } catch (err) {
-    setTimeout(function() {throw err;}, 0);
+    setTimeout(function() {throw err; }, 0);
   }
 }
 
@@ -277,10 +277,10 @@ function loadQuickTestsInCategory(quickTestNames, category, firstBranch, secondB
 function filterQuickTests(category, branchList){
   //filter list of quicktests to list of quicktest names to pass to doSomething
   d3.json("list_of_quicktests.json", function (data){
-    var paths = data.map(function(quickTestObj) {return quickTestObj.path;});
+    var paths = data.map(function(quickTestObj) {return quickTestObj.path; });
     if (category !== "all"){
-      var pathsInCategory = paths.filter(function(path) {return path.indexOf("tests/" + category) !== -1;});
-      var testsInCategory = pathsInCategory.map(function(path) {return path.replace(/.*\/|\.js/g, '');});
+      var pathsInCategory = paths.filter(function(path) {return path.indexOf("tests/" + category) !== -1; });
+      var testsInCategory = pathsInCategory.map(function(path) {return path.replace(/.*\/|\.js/g, ''); });
       loadQuickTestsInCategory(testsInCategory, category, branchList[0], branchList[1]);
       populateSidebarList(paths, testsInCategory, category);
     }

--- a/quicktests/overlaying/tests/functional/base_animator.js
+++ b/quicktests/overlaying/tests/functional/base_animator.js
@@ -38,9 +38,9 @@ function run(svg, data, Plottable) {
       .animator(Plottable.Plots.Animator.MAIN, animator)
       .animated(true);
    if (typeof vbar.labelsFormatter === "function") {
-     vbar.labelsFormatter(function(text){return text + "!";});
+     vbar.labelsFormatter(function(text){return text + "!"; });
    } else {
-     vbar.labelFormatter(function(text){return text + "!";});
+     vbar.labelFormatter(function(text){return text + "!"; });
    }
 
     var chart = new Plottable.Components.Table([

--- a/quicktests/overlaying/tests/realistic/animals.js
+++ b/quicktests/overlaying/tests/realistic/animals.js
@@ -90,24 +90,24 @@ function run(svg, data, Plottable){
 
   var innerPie = new Plottable.Plots.Pie();
   innerPie.addDataset(dataset);
-  innerPie.sectorValue(function(){ return 0.1;})
+  innerPie.sectorValue(function(){ return 0.1; })
   		  .innerRadius(25)
   		  .outerRadius(50)
-  		  .attr("fill", function(d){ return d.type1;}, csType1);
+  		  .attr("fill", function(d){ return d.type1; }, csType1);
 
   var midPie = new Plottable.Plots.Pie();
   midPie.addDataset(dataset);
-  midPie.sectorValue(function(){ return 0.1;})
+  midPie.sectorValue(function(){ return 0.1; })
   		  .innerRadius(50)
   		  .outerRadius(75)
-  		  .attr("fill", function(d){ return d.type2;}, csType2);  		
+  		  .attr("fill", function(d){ return d.type2; }, csType2);  		
 
   var outerPie = new Plottable.Plots.Pie();
   outerPie.addDataset(dataset);
-  outerPie.sectorValue(function(){ return 0.1;})
+  outerPie.sectorValue(function(){ return 0.1; })
   		  .innerRadius(75)
   		  .outerRadius(100)
-  		  .attr("fill", function(d){ return d.type3;}, csType3);  		    
+  		  .attr("fill", function(d){ return d.type3; }, csType3);  		    
 
   var pies = new Plottable.Components.Group([innerPie, midPie, outerPie]);
   var legendTable = new Plottable.Components.Table([[legend1],

--- a/quicktests/overlaying/tests/realistic/numeric_grid.js
+++ b/quicktests/overlaying/tests/realistic/numeric_grid.js
@@ -28,8 +28,8 @@ function run(svg, data, Plottable) {
       .x2(function(d){ return d.x2; }, xScale)
       .y2(function(d) { return d.y2; }, yScale)
   	  .attr("fill", function(d) { return d.fill; })
-  	  .attr("stroke", function(){ return "#000000";})
-  	  .attr("stroke-width", function(){ return 4;});
+  	  .attr("stroke", function(){ return "#000000"; })
+  	  .attr("stroke-width", function(){ return 4; });
 
   plot.renderTo(svg);
 }

--- a/quicktests/overlaying/tests/realistic/rectangle.js
+++ b/quicktests/overlaying/tests/realistic/rectangle.js
@@ -33,8 +33,8 @@ function makeData() {
 function run(svg, data, Plottable) {
   "use strict";
 
-  var timeFormatStart = function (data) { return d3.time.format("%m/%d/%Y").parse(data.x);};
-  var timeFormatEnd = function (data) { return d3.time.format("%m/%d/%Y").parse(data.x2);};
+  var timeFormatStart = function (data) { return d3.time.format("%m/%d/%Y").parse(data.x); };
+  var timeFormatEnd = function (data) { return d3.time.format("%m/%d/%Y").parse(data.x2); };
 
   var xScale = new Plottable.Scales.Time();
   var yScale = new Plottable.Scales.Category();

--- a/quicktests/overlaying/tests/realistic/scatter_bar.js
+++ b/quicktests/overlaying/tests/realistic/scatter_bar.js
@@ -52,8 +52,8 @@ function run(svg, data, Plottable) {
         return "#660066";
       }      
     })
-    .attr("opacity", function(){return 1;})
-    .size(function(){ return yScale.rangeBand();});
+    .attr("opacity", function(){return 1; })
+    .size(function(){ return yScale.rangeBand(); });
 
   var grid = new Plottable.Components.Gridlines(xScale, null);
 

--- a/quicktests/overlaying/tests/realistic/symbols.js
+++ b/quicktests/overlaying/tests/realistic/symbols.js
@@ -36,7 +36,7 @@ function run(svg, data, Plottable){
   .y(function(d) { return d.y; }, yScale)
   .size(symbolSize)
   .symbol(fourSymbolAccessor)
-  .attr("fill", function(datum){return datum.y>0?(datum.x>0?"#00bb00":"#bbbbbb"):(datum.x>0?"#bbbbbb":"#bb0000");});
+  .attr("fill", function(datum){return datum.y>0?(datum.x>0?"#00bb00":"#bbbbbb"):(datum.x>0?"#bbbbbb":"#bb0000"); });
 
   var title = new Plottable.Components.Label("n = new point, d = delete point");
   var cs = new Plottable.Scales.Color();

--- a/quicktests/quicktest.js
+++ b/quicktests/quicktest.js
@@ -38,7 +38,7 @@ function runSingleQuicktest(container, quickTest, data, Plottable) {
   try {
     quickTest.run(div, data, Plottable);
   } catch (err) {
-    setTimeout(function() {throw err;}, 0);
+    setTimeout(function() {throw err; }, 0);
   }
 }
 
@@ -151,7 +151,7 @@ function setup() {
       for(var i = 0; i < data.length; i++){
         branchOptions["val" + i] = data[i].name;
       }
-      var names = data.map(function(x) {return x.name;});
+      var names = data.map(function(x) {return x.name; });
       names.push("#local");
       populateDropdown($('#leftBranch'), names, "develop");
       populateDropdown($('#rightBranch'), names, "#local");
@@ -185,7 +185,7 @@ function go() {
       if (quicktestCategory === "#all" || quicktestCategory === undefined) {
         return true;
       } else {
-        return q.categories.map(function(s) {return s.toLowerCase();}).indexOf(quicktestCategory.toLowerCase()) !== -1;
+        return q.categories.map(function(s) {return s.toLowerCase(); }).indexOf(quicktestCategory.toLowerCase()) !== -1;
       }
     });
   }).then(function(qts) {


### PR DESCRIPTION
The rule enforces spacing around semicolons.  There can be no whitespace before and there must be some after.

Invalid:
```javascript
var foo = function (a) { return a ;};
```

Valid:
```javascript
var foo = function (a) { return a; };
```