### PR TITLE
[ESLint] - allowing for default usage of space-infix-op

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,6 @@
     "camelcase": 0,
     "comma-spacing": 0,
     "key-spacing": 0,
-    "space-infix-ops": 0,
     "no-use-before-define": 0,
     "strict": 0,
     "no-underscore-dangle": 0,

--- a/quicktests/color/main.js
+++ b/quicktests/color/main.js
@@ -55,7 +55,7 @@ var plotheight;
 //functions
 
 function togglePlotDisplay(className){
-  var classSelector = "."+className;
+  var classSelector = "." + className;
   var displayStatus = $(classSelector).css("display") === "none" ? "inline-block" : "none";
   $(classSelector).css("display", displayStatus);
 }
@@ -212,7 +212,7 @@ function makeRandomData(numPoints, series, scaleFactor) {
 }
 
 function prepareSingleData(data){
-  data[0].map(function(element){element.type = ""+ element.x; });
+  data[0].map(function(element){ element.type = "" + element.x; });
   return data;
 }
 

--- a/quicktests/overlaying/overlaying.js
+++ b/quicktests/overlaying/overlaying.js
@@ -67,7 +67,7 @@ function showSizeControls(){
 
 "use strict";
 
-var plottableBranches=[];
+var plottableBranches = [];
 var firstBranch;
 var secondBranch;
 var svgWidth;
@@ -117,7 +117,7 @@ function populateTotalSidebarList(paths){
   testsPaths.forEach(function(test){
     var slashPos = test.indexOf("/");
     var categoryString = test.substr(0, slashPos);
-    var quicktestString = test.substr(slashPos+1, test.length-1);
+    var quicktestString = test.substr(slashPos + 1, test.length - 1);
     var quicktestArray = [quicktestString];
     if (!hash[categoryString]){
       hash[categoryString] = quicktestArray;

--- a/quicktests/overlaying/tests/animations/inflation.js
+++ b/quicktests/overlaying/tests/animations/inflation.js
@@ -43,7 +43,7 @@ function run(svg, data, Plottable) {
     var dataset = new Plottable.Dataset(data[y]);
     var lineRenderer = new Plottable.Plots.Line()
               .addDataset(dataset)
-              .x(function(d, i) { return d.x + y*12; }, xScale)
+              .x(function(d, i) { return d.x + y * 12; }, xScale)
               .y(function(d) { return d.y; }, yScale)
               .attr("stroke", "#000000")
               .animated(true);
@@ -56,7 +56,7 @@ function run(svg, data, Plottable) {
     for (var month = 0; month < 12; month++){
       total += d[month].y;
     }
-    var average = total/12;
+    var average = total / 12;
     var avg_data = [{x: y * 12, y: average}, {x: y * 12 + 11, y: average}];
     var avg_ds = new Plottable.Dataset(avg_data);
     var lineRenderer = new Plottable.Plots.Line()

--- a/quicktests/overlaying/tests/functional/categoryFormatter.js
+++ b/quicktests/overlaying/tests/functional/categoryFormatter.js
@@ -21,10 +21,10 @@ function run(svg, data, Plottable) {
   var EmpIDTitle = new Plottable.Components.Label("Emp ID");
 
   var DOWFormatter = function(d) {
-      return DOW[d%7];
+      return DOW[d % 7];
   };
   var EmpIDFormatter = function(d) {
-      return Emp[d%7];
+      return Emp[d % 7];
   };
 
   var plot = new Plottable.Plots.Bar().addDataset(new Plottable.Dataset(data));

--- a/quicktests/overlaying/tests/functional/formatter.js
+++ b/quicktests/overlaying/tests/functional/formatter.js
@@ -8,7 +8,7 @@ function run(svg, data, Plottable) {
   "use strict";
 
     var large_x = function(d){
-         d.x = d.x*100000000;
+         d.x = d.x * 100000000;
     };
 
   var big_numbers = [];

--- a/quicktests/overlaying/tests/realistic/add_remove_dataset.js
+++ b/quicktests/overlaying/tests/realistic/add_remove_dataset.js
@@ -6,7 +6,7 @@ function makeData() {
     for (var i = 0; i < n; i++) {
       toReturn[i] = {
         x: startValue + i,
-        y: i > 0 ? toReturn[i-1].y + Math.random()*2-1 : Math.random() * 5
+        y: i > 0 ? toReturn[i - 1].y + Math.random() * 2 - 1 : Math.random() * 5
       };
     }
     return toReturn;

--- a/quicktests/overlaying/tests/realistic/cities.js
+++ b/quicktests/overlaying/tests/realistic/cities.js
@@ -12,7 +12,7 @@ function run(svg, data, Plottable) {
 
   var csRange = [];
   for(var i = 0; i < 30; i++){
-    var c = '#'+Math.floor(Math.random()*16777215).toString(16);
+    var c = '#' + Math.floor(Math.random() * 16777215).toString(16);
     csRange.push(c);
   }
 

--- a/quicktests/overlaying/tests/realistic/hockey.js
+++ b/quicktests/overlaying/tests/realistic/hockey.js
@@ -25,16 +25,16 @@ function run(svg, data, Plottable) {
   plot.addDataset(ds);
   plot.x(function(d){ return d.G; }, xScale)
       .y(function(d){ return d.A; }, yScale)
-      .size(function(d){ return 6 + d.Rk/10; })
+      .size(function(d){ return 6 + d.Rk / 10; })
       .attr("fill", function(d){
         var A = +d.A;
         var G = +d.G;
 
-        var slope = A/G;
+        var slope = A / G;
         var slope_offset = 0;
-        if (slope > 80/33.14 ) { slope_offset = 3; }
+        if (slope > 80 / 33.14 ) { slope_offset = 3; }
         else if (slope > 1 ) { slope_offset = 2; }
-        else if (slope > 33.14/80 ) {slope_offset = 1; }
+        else if (slope > 33.14 / 80 ) {slope_offset = 1; }
 
         var zone = A + G;
         var zone_offset = 0;

--- a/quicktests/overlaying/tests/realistic/stocks.js
+++ b/quicktests/overlaying/tests/realistic/stocks.js
@@ -35,11 +35,11 @@ function run(svg, data, Plottable) {
               "total value": getValue(0)
             }
           ];
-          for (var i=1; i<aapl.length; i++) {
+          for (var i = 1; i < aapl.length; i++) {
             var totalVal = getValue(i);
             diffData.push({
               "Date": aapl[i].Date,
-              "net change": totalVal - diffData[i-1]["total value"],
+              "net change": totalVal - diffData[i - 1]["total value"],
               "total value": totalVal
             });
           }

--- a/quicktests/overlaying/tests/realistic/symbols.js
+++ b/quicktests/overlaying/tests/realistic/symbols.js
@@ -36,7 +36,7 @@ function run(svg, data, Plottable){
   .y(function(d) { return d.y; }, yScale)
   .size(symbolSize)
   .symbol(fourSymbolAccessor)
-  .attr("fill", function(datum){return datum.y>0?(datum.x>0?"#00bb00":"#bbbbbb"):(datum.x>0?"#bbbbbb":"#bb0000"); });
+  .attr("fill", function(datum) { return datum.y > 0 ? (datum.x > 0 ? "#00bb00" : "#bbbbbb") : (datum.x > 0 ? "#bbbbbb" : "#bb0000"); });
 
   var title = new Plottable.Components.Label("n = new point, d = delete point");
   var cs = new Plottable.Scales.Color();
@@ -107,7 +107,7 @@ function run(svg, data, Plottable){
 
     key.onKeyPress(68, function(keyData){
       if(d.length > 0){
-        d.splice(d.length-1,1);
+        d.splice(d.length - 1,1);
         dataset.data(d);
       }
     });
@@ -119,7 +119,7 @@ function run(svg, data, Plottable){
 
     key.onKey(68, function(keyData){
       if(d.length > 0){
-        d.splice(d.length-1,1);
+        d.splice(d.length - 1,1);
         dataset.data(d);
       }
     });


### PR DESCRIPTION
Rule by default forces spaces around operators.

Invalid:
```javascript
var a = 5+1;
```

Valid:
```javascript
var a = 5 + 1;
```