### PR TITLE
Add enable/disable functionality to Interaction

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3423,6 +3423,14 @@ declare module Plottable {
          */
         detachFrom(component: Component): Interaction;
         /**
+         * Gets whether this Interaction is enabled.
+         */
+        enabled(): boolean;
+        /**
+         * Enables or disables this Interaction.
+         */
+        enabled(enabled: boolean): Interaction;
+        /**
          * Translates an <svg>-coordinate-space point to Component-space coordinates.
          *
          * @param {Point} p A Point in <svg>-space coordinates.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3428,6 +3428,9 @@ declare module Plottable {
         enabled(): boolean;
         /**
          * Enables or disables this Interaction.
+         *
+         * @param {boolean} enabled Whether the Interaction should be enabled.
+         * @return {Interaction} The calling Interaction.
          */
         enabled(enabled: boolean): Interaction;
         /**

--- a/plottable.js
+++ b/plottable.js
@@ -8721,15 +8721,12 @@ var Plottable;
          * @returns {Interaction} The calling Interaction.
          */
         Interaction.prototype.attachTo = function (component) {
-            this._detach();
+            this._disconnect();
             this._componentAttachedTo = component;
-            this._attach();
+            this._connect();
             return this;
         };
-        /**
-         * Attaches to existing _componentAttachedTo if enabled.
-         */
-        Interaction.prototype._attach = function () {
+        Interaction.prototype._connect = function () {
             if (this.enabled() && this._componentAttachedTo != null && !this._isAnchored) {
                 this._componentAttachedTo.onAnchor(this._anchorCallback);
             }
@@ -8742,15 +8739,11 @@ var Plottable;
          * @returns {Interaction} The calling Interaction.
          */
         Interaction.prototype.detachFrom = function (component) {
-            this._detach();
+            this._disconnect();
             this._componentAttachedTo = null;
             return this;
         };
-        /**
-         * Detaches from existing _componentAttachedTo (if it exists)
-         * without overwriting _componentAttachedTo.
-         */
-        Interaction.prototype._detach = function () {
+        Interaction.prototype._disconnect = function () {
             if (this._isAnchored) {
                 this._unanchor();
             }
@@ -8764,10 +8757,10 @@ var Plottable;
             }
             this._enabled = enabled;
             if (this._enabled) {
-                this._attach();
+                this._connect();
             }
             else {
-                this._detach();
+                this._disconnect();
             }
             return this;
         };

--- a/plottable.js
+++ b/plottable.js
@@ -8705,6 +8705,7 @@ var Plottable;
         function Interaction() {
             var _this = this;
             this._anchorCallback = function (component) { return _this._anchor(component); };
+            this._enabled = true;
         }
         Interaction.prototype._anchor = function (component) {
             this._isAnchored = true;
@@ -8720,12 +8721,18 @@ var Plottable;
          * @returns {Interaction} The calling Interaction.
          */
         Interaction.prototype.attachTo = function (component) {
-            if (this._componentAttachedTo) {
-                this.detachFrom(this._componentAttachedTo);
-            }
+            this._detach();
             this._componentAttachedTo = component;
-            component.onAnchor(this._anchorCallback);
+            this._attach();
             return this;
+        };
+        /**
+         * Attaches to existing _componentAttachedTo if enabled.
+         */
+        Interaction.prototype._attach = function () {
+            if (this.enabled() && this._componentAttachedTo != null && !this._isAnchored) {
+                this._componentAttachedTo.onAnchor(this._anchorCallback);
+            }
         };
         /**
          * Detaches this Interaction from the Component.
@@ -8735,11 +8742,33 @@ var Plottable;
          * @returns {Interaction} The calling Interaction.
          */
         Interaction.prototype.detachFrom = function (component) {
+            this._detach();
+            this._componentAttachedTo = null;
+            return this;
+        };
+        /**
+         * Detaches from existing _componentAttachedTo (if it exists)
+         * without overwriting _componentAttachedTo.
+         */
+        Interaction.prototype._detach = function () {
             if (this._isAnchored) {
                 this._unanchor();
             }
-            this._componentAttachedTo = null;
-            component.offAnchor(this._anchorCallback);
+            if (this._componentAttachedTo != null) {
+                this._componentAttachedTo.offAnchor(this._anchorCallback);
+            }
+        };
+        Interaction.prototype.enabled = function (enabled) {
+            if (enabled == null) {
+                return this._enabled;
+            }
+            this._enabled = enabled;
+            if (this._enabled) {
+                this._attach();
+            }
+            else {
+                this._detach();
+            }
             return this;
         };
         /**

--- a/src/interactions/interaction.ts
+++ b/src/interactions/interaction.ts
@@ -7,6 +7,7 @@ export class Interaction {
   private _anchorCallback = (component: Component) => this._anchor(component);
 
   private _isAnchored: boolean;
+  private _enabled = true;
 
   protected _anchor(component: Component) {
     this._isAnchored = true;
@@ -24,14 +25,19 @@ export class Interaction {
    * @returns {Interaction} The calling Interaction.
    */
   public attachTo(component: Component) {
-    if (this._componentAttachedTo) {
-      this.detachFrom(this._componentAttachedTo);
-    }
-
+    this._detach();
     this._componentAttachedTo = component;
-    component.onAnchor(this._anchorCallback);
-
+    this._attach();
     return this;
+  }
+
+  /**
+   * Attaches to existing _componentAttachedTo if enabled.
+   */
+  private _attach() {
+    if (this.enabled() && this._componentAttachedTo != null && !this._isAnchored) {
+      this._componentAttachedTo.onAnchor(this._anchorCallback);
+    }
   }
 
   /**
@@ -42,12 +48,42 @@ export class Interaction {
    * @returns {Interaction} The calling Interaction.
    */
   public detachFrom(component: Component) {
+    this._detach();
+    this._componentAttachedTo = null;
+    return this;
+  }
+
+  /**
+   * Detaches from existing _componentAttachedTo (if it exists)
+   * without overwriting _componentAttachedTo.
+   */
+  private _detach() {
     if (this._isAnchored) {
       this._unanchor();
     }
-    this._componentAttachedTo = null;
-    component.offAnchor(this._anchorCallback);
+    if (this._componentAttachedTo != null) {
+      this._componentAttachedTo.offAnchor(this._anchorCallback);
+    }
+  }
 
+  /**
+   * Gets whether this Interaction is enabled.
+   */
+  public enabled(): boolean;
+  /**
+   * Enables or disables this Interaction.
+   */
+  public enabled(enabled: boolean): Interaction;
+  public enabled(enabled?: boolean): any {
+    if (enabled == null) {
+      return this._enabled;
+    }
+    this._enabled = enabled;
+    if (this._enabled) {
+      this._attach();
+    } else {
+      this._detach();
+    }
     return this;
   }
 

--- a/src/interactions/interaction.ts
+++ b/src/interactions/interaction.ts
@@ -25,16 +25,13 @@ export class Interaction {
    * @returns {Interaction} The calling Interaction.
    */
   public attachTo(component: Component) {
-    this._detach();
+    this._disconnect();
     this._componentAttachedTo = component;
-    this._attach();
+    this._connect();
     return this;
   }
 
-  /**
-   * Attaches to existing _componentAttachedTo if enabled.
-   */
-  private _attach() {
+  private _connect() {
     if (this.enabled() && this._componentAttachedTo != null && !this._isAnchored) {
       this._componentAttachedTo.onAnchor(this._anchorCallback);
     }
@@ -48,16 +45,12 @@ export class Interaction {
    * @returns {Interaction} The calling Interaction.
    */
   public detachFrom(component: Component) {
-    this._detach();
+    this._disconnect();
     this._componentAttachedTo = null;
     return this;
   }
 
-  /**
-   * Detaches from existing _componentAttachedTo (if it exists)
-   * without overwriting _componentAttachedTo.
-   */
-  private _detach() {
+  private _disconnect() {
     if (this._isAnchored) {
       this._unanchor();
     }
@@ -80,9 +73,9 @@ export class Interaction {
     }
     this._enabled = enabled;
     if (this._enabled) {
-      this._attach();
+      this._connect();
     } else {
-      this._detach();
+      this._disconnect();
     }
     return this;
   }

--- a/src/interactions/interaction.ts
+++ b/src/interactions/interaction.ts
@@ -65,6 +65,9 @@ export class Interaction {
   public enabled(): boolean;
   /**
    * Enables or disables this Interaction.
+   *
+   * @param {boolean} enabled Whether the Interaction should be enabled.
+   * @return {Interaction} The calling Interaction.
    */
   public enabled(enabled: boolean): Interaction;
   public enabled(enabled?: boolean): any {

--- a/test/interactions/interactionTests.ts
+++ b/test/interactions/interactionTests.ts
@@ -154,5 +154,69 @@ describe("Interactions", () => {
       svg1.remove();
       svg2.remove();
     });
+
+    describe("enabled()", () => {
+      it("setting and querying status", () => {
+        var interaction = new Plottable.Interaction();
+        assert.isTrue(interaction.enabled(), "defaults to enabled");
+        interaction.enabled(false);
+        assert.isFalse(interaction.enabled(), "enabled status set to false");
+        interaction.enabled(true);
+        assert.isTrue(interaction.enabled(), "enabled status set to true");
+      });
+
+      it("no longer responds when disabled", () => {
+        var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        var component = new Plottable.Component();
+        component.renderTo(svg);
+
+        var clickInteraction = new Plottable.Interactions.Click();
+        var callbackCalled = false;
+        var callback = () => callbackCalled = true;
+        clickInteraction.onClick(callback);
+        clickInteraction.attachTo(component);
+
+        clickInteraction.enabled(false);
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        assert.isFalse(callbackCalled, "callback is not called when Interaction is disabled");
+
+        clickInteraction.enabled(true);
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        assert.isTrue(callbackCalled, "callback is called when Interaction is re-enabled");
+
+        svg.remove();
+      });
+
+      it("can be attached to new Component while disabled", () => {
+        var svg1 = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        var svg2 = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        var component1 = new Plottable.Component();
+        var component2 = new Plottable.Component();
+        component1.renderTo(svg1);
+        component2.renderTo(svg2);
+
+        var clickInteraction = new Plottable.Interactions.Click();
+        var callbackCalled = false;
+        var callback = () => callbackCalled = true;
+        clickInteraction.onClick(callback);
+        clickInteraction.attachTo(component1);
+
+        clickInteraction.enabled(false);
+        clickInteraction.attachTo(component2);
+        TestMethods.triggerFakeMouseEvent("mousedown", component2.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        TestMethods.triggerFakeMouseEvent("mouseup", component2.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        assert.isFalse(callbackCalled, "stays disabled even if attachTo() is called again");
+
+        clickInteraction.enabled(true);
+        TestMethods.triggerFakeMouseEvent("mousedown", component2.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        TestMethods.triggerFakeMouseEvent("mouseup", component2.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        assert.isTrue(callbackCalled, "re-enabled");
+
+        svg1.remove();
+        svg2.remove();
+      });
+    });
   });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -8809,6 +8809,59 @@ describe("Interactions", function () {
             svg1.remove();
             svg2.remove();
         });
+        describe("enabled()", function () {
+            it("setting and querying status", function () {
+                var interaction = new Plottable.Interaction();
+                assert.isTrue(interaction.enabled(), "defaults to enabled");
+                interaction.enabled(false);
+                assert.isFalse(interaction.enabled(), "enabled status set to false");
+                interaction.enabled(true);
+                assert.isTrue(interaction.enabled(), "enabled status set to true");
+            });
+            it("no longer responds when disabled", function () {
+                var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+                var component = new Plottable.Component();
+                component.renderTo(svg);
+                var clickInteraction = new Plottable.Interactions.Click();
+                var callbackCalled = false;
+                var callback = function () { return callbackCalled = true; };
+                clickInteraction.onClick(callback);
+                clickInteraction.attachTo(component);
+                clickInteraction.enabled(false);
+                TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+                TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+                assert.isFalse(callbackCalled, "callback is not called when Interaction is disabled");
+                clickInteraction.enabled(true);
+                TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+                TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+                assert.isTrue(callbackCalled, "callback is called when Interaction is re-enabled");
+                svg.remove();
+            });
+            it("can be attached to new Component while disabled", function () {
+                var svg1 = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+                var svg2 = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+                var component1 = new Plottable.Component();
+                var component2 = new Plottable.Component();
+                component1.renderTo(svg1);
+                component2.renderTo(svg2);
+                var clickInteraction = new Plottable.Interactions.Click();
+                var callbackCalled = false;
+                var callback = function () { return callbackCalled = true; };
+                clickInteraction.onClick(callback);
+                clickInteraction.attachTo(component1);
+                clickInteraction.enabled(false);
+                clickInteraction.attachTo(component2);
+                TestMethods.triggerFakeMouseEvent("mousedown", component2.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+                TestMethods.triggerFakeMouseEvent("mouseup", component2.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+                assert.isFalse(callbackCalled, "stays disabled even if attachTo() is called again");
+                clickInteraction.enabled(true);
+                TestMethods.triggerFakeMouseEvent("mousedown", component2.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+                TestMethods.triggerFakeMouseEvent("mouseup", component2.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+                assert.isTrue(callbackCalled, "re-enabled");
+                svg1.remove();
+                svg2.remove();
+            });
+        });
     });
 });
 


### PR DESCRIPTION
For temporarily disabling an `Interaction` without permanently disconnecting it from the `Component` it was attached to.

API:
```Typescript
/**
 * Gets whether this Interaction is enabled.
 */
public enabled(): boolean;
/**
 * Enables or disables this Interaction.
 */
public enabled(enabled: boolean): Interaction;
```

Example fiddle: http://jsfiddle.net/j0fnbmvr/

Open questions: Should interactive `Component`s (like `DragBoxLayer`) implement this functionality as well? Or is giving access to the internal `Interaction` sufficient?

Close #696.