### PR TITLE
PanZoom performance improvement

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2541,8 +2541,8 @@ declare module Plottable {
          * @param {Scale} yScale The y scale to use.
          */
         constructor();
-        performanceEnabled(): boolean;
-        performanceEnabled(performanceEnabled: boolean): XYPlot<X, Y>;
+        lazyDomainChange(): boolean;
+        lazyDomainChange(lazyDomainChange: boolean): XYPlot<X, Y>;
         /**
          * Gets the AccessorScaleBinding for X.
          */

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2533,7 +2533,6 @@ declare module Plottable {
     class XYPlot<X, Y> extends Plot {
         protected static _X_KEY: string;
         protected static _Y_KEY: string;
-        tempScrollTimeout: number;
         /**
          * An XYPlot is a Plot that displays data along two primary directions, X and Y.
          *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2307,6 +2307,7 @@ declare module Plottable {
     class Plot extends Component {
         protected static _ANIMATION_MAX_DURATION: number;
         protected _renderArea: d3.Selection<void>;
+        protected _renderCallback: ScaleCallback<Scale<any, any>>;
         protected _propertyExtents: d3.Map<any[]>;
         protected _propertyBindings: d3.Map<Plots.AccessorScaleBinding<any, any>>;
         /**

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2541,6 +2541,8 @@ declare module Plottable {
          * @param {Scale} yScale The y scale to use.
          */
         constructor();
+        performanceEnabled(): boolean;
+        performanceEnabled(performanceEnabled: boolean): XYPlot<X, Y>;
         /**
          * Gets the AccessorScaleBinding for X.
          */

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2542,12 +2542,12 @@ declare module Plottable {
          */
         constructor();
         /**
-         * Returns the lazy domain change setting on the plot
-         * @return {boolean} The lazy domain change setting
+         * Returns the whether or not the rendering is deferred for performance boost.
+         * @return {boolean} The deferred rendering option
          */
         deferredRendering(): boolean;
         /**
-         * Sets / unsets the lazy domain change on the plot.
+         * Sets / unsets the deferred rendering option
          * Activating this option improves the performance of plot interaction (pan / zoom) by
          * performing lazy renders, only after the interaction has stopped. Because re-rendering
          * is no longer performed during the interaction, the zooming might experience a small

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2545,7 +2545,7 @@ declare module Plottable {
          * Returns the lazy domain change setting on the plot
          * @return {boolean} The lazy domain change setting
          */
-        lazyDomainChange(): boolean;
+        deferredRendering(): boolean;
         /**
          * Sets / unsets the lazy domain change on the plot.
          * Activating this option improves the performance of plot interaction (pan / zoom) by
@@ -2555,7 +2555,7 @@ declare module Plottable {
          *
          * This option is intended for cases where performance is an issue.
          */
-        lazyDomainChange(lazyDomainChange: boolean): XYPlot<X, Y>;
+        deferredRendering(deferredRendering: boolean): XYPlot<X, Y>;
         /**
          * Gets the AccessorScaleBinding for X.
          */

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2541,7 +2541,20 @@ declare module Plottable {
          * @param {Scale} yScale The y scale to use.
          */
         constructor();
+        /**
+         * Returns the lazy domain change setting on the plot
+         * @return {boolean} The lazy domain change setting
+         */
         lazyDomainChange(): boolean;
+        /**
+         * Sets / unsets the lazy domain change on the plot.
+         * Activating this option improves the performance of plot interaction (pan / zoom) by
+         * performing lazy renders, only after the interaction has stopped. Because re-rendering
+         * is no longer performed during the interaction, the zooming might experience a small
+         * resolution degradation, before the lazy re-render is performed.
+         *
+         * This option is intended for cases where performance is an issue.
+         */
         lazyDomainChange(lazyDomainChange: boolean): XYPlot<X, Y>;
         /**
          * Gets the AccessorScaleBinding for X.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2533,6 +2533,7 @@ declare module Plottable {
     class XYPlot<X, Y> extends Plot {
         protected static _X_KEY: string;
         protected static _Y_KEY: string;
+        tempScrollTimeout: number;
         /**
          * An XYPlot is a Plot that displays data along two primary directions, X and Y.
          *

--- a/plottable.js
+++ b/plottable.js
@@ -6549,8 +6549,8 @@ var Plottable;
                     return;
                 }
                 _lastSeenDomainX = scale.domain();
-                _scalingX = (scale.scale(_this._cachedDomainX[1]) - scale.scale(_this._cachedDomainX[0])) / (scale.scale(_lastSeenDomainX[1]) - scale.scale(_lastSeenDomainX[0]));
-                _deltaX = scale.scale(_this._cachedDomainX[0]) - scale.scale(_lastSeenDomainX[0]);
+                _scalingX = (scale.scale(_this._cachedDomainX[1]) - scale.scale(_this._cachedDomainX[0])) / (scale.scale(_lastSeenDomainX[1]) - scale.scale(_lastSeenDomainX[0])) || 1;
+                _deltaX = scale.scale(_this._cachedDomainX[0]) - scale.scale(_lastSeenDomainX[0]) || 0;
                 _registerDeferredRendering();
             };
             var _lazyDomainChangeCallbackY = function (scale) {
@@ -6558,8 +6558,8 @@ var Plottable;
                     return;
                 }
                 _lastSeenDomainY = scale.domain();
-                _scalingY = (scale.scale(_this._cachedDomainY[1]) - scale.scale(_this._cachedDomainY[0])) / (scale.scale(_lastSeenDomainY[1]) - scale.scale(_lastSeenDomainY[0]));
-                _deltaY = scale.scale(_this._cachedDomainY[0]) - scale.scale(_lastSeenDomainY[0]) * _scalingY;
+                _scalingY = (scale.scale(_this._cachedDomainY[1]) - scale.scale(_this._cachedDomainY[0])) / (scale.scale(_lastSeenDomainY[1]) - scale.scale(_lastSeenDomainY[0])) || 1;
+                _deltaY = scale.scale(_this._cachedDomainY[0]) - scale.scale(_lastSeenDomainY[0]) * _scalingY || 0;
                 _registerDeferredRendering();
             };
             this._renderCallback = function (scale) {

--- a/plottable.js
+++ b/plottable.js
@@ -6516,49 +6516,49 @@ var Plottable;
             this._autoAdjustXScaleDomain = false;
             this._autoAdjustYScaleDomain = false;
             this._lazyDomainChange = false;
-            this._lazyDomainingKnownDomainX = [null, null];
-            this._lazyDomainingKnownDomainY = [null, null];
+            this._lazyDomainChangeCachedDomainX = [null, null];
+            this._lazyDomainChangeCachedDomainY = [null, null];
             this.addClass("xy-plot");
             this._adjustYDomainOnChangeFromXCallback = function (scale) { return _this._adjustYDomainOnChangeFromX(); };
             this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
-            var _lazyDomainingTimeoutReference = 0;
-            var _lazyDomainingDeltaX = 0;
-            var _lazyDomainingDeltaY = 0;
-            var _lazyDomainingScaleX = 1;
-            var _lazyDomainingScaleY = 1;
-            var _lazyDomainingSeenDomainX = null;
-            var _lazyDomainingSeenDomainY = null;
-            var tempScrollTimeout = 500;
-            this._fastPanZoomOnXCallback = function (scale) {
+            var _timeoutReference = 0;
+            var _deltaX = 0;
+            var _deltaY = 0;
+            var _scalingX = 1;
+            var _scalingY = 1;
+            var _lastSeenDomainX = null;
+            var _lastSeenDomainY = null;
+            var _lazyDomainChangeTimeout = 500;
+            this._lazyDomainChangeCallbackX = function (scale) {
                 if (!_this._isAnchored) {
                     return;
                 }
-                _lazyDomainingSeenDomainX = scale.domain();
-                _lazyDomainingScaleX = (scale.scale(_this._lazyDomainingKnownDomainX[1]) - scale.scale(_this._lazyDomainingKnownDomainX[0])) / (scale.scale(_lazyDomainingSeenDomainX[1]) - scale.scale(_lazyDomainingSeenDomainX[0]));
-                _lazyDomainingDeltaX = scale.scale(_this._lazyDomainingKnownDomainX[0]) - scale.scale(_lazyDomainingSeenDomainX[0]);
+                _lastSeenDomainX = scale.domain();
+                _scalingX = (scale.scale(_this._lazyDomainChangeCachedDomainX[1]) - scale.scale(_this._lazyDomainChangeCachedDomainX[0])) / (scale.scale(_lastSeenDomainX[1]) - scale.scale(_lastSeenDomainX[0]));
+                _deltaX = scale.scale(_this._lazyDomainChangeCachedDomainX[0]) - scale.scale(_lastSeenDomainX[0]);
                 _triggerLazyDomainChange();
             };
-            this._fastPanZoomOnYCallback = function (scale) {
+            this._lazyDomainChangeCallbackY = function (scale) {
                 if (!_this._isAnchored) {
                     return;
                 }
-                _lazyDomainingSeenDomainY = scale.domain();
-                _lazyDomainingScaleY = (scale.scale(_this._lazyDomainingKnownDomainY[1]) - scale.scale(_this._lazyDomainingKnownDomainY[0])) / (scale.scale(_lazyDomainingSeenDomainY[1]) - scale.scale(_lazyDomainingSeenDomainY[0]));
-                _lazyDomainingDeltaY = scale.scale(_this._lazyDomainingKnownDomainY[0]) - scale.scale(_lazyDomainingSeenDomainY[0]) * _lazyDomainingScaleY;
+                _lastSeenDomainY = scale.domain();
+                _scalingY = (scale.scale(_this._lazyDomainChangeCachedDomainY[1]) - scale.scale(_this._lazyDomainChangeCachedDomainY[0])) / (scale.scale(_lastSeenDomainY[1]) - scale.scale(_lastSeenDomainY[0]));
+                _deltaY = scale.scale(_this._lazyDomainChangeCachedDomainY[0]) - scale.scale(_lastSeenDomainY[0]) * _scalingY;
                 _triggerLazyDomainChange();
             };
             var _triggerLazyDomainChange = function () {
                 if (_this._renderArea != null) {
-                    _this._renderArea.attr("transform", "translate(" + _lazyDomainingDeltaX + ", " + _lazyDomainingDeltaY + ")" + "scale(" + _lazyDomainingScaleX + ", " + _lazyDomainingScaleY + ")");
-                    clearTimeout(_lazyDomainingTimeoutReference);
-                    _lazyDomainingTimeoutReference = setTimeout(function () {
-                        _this._lazyDomainingKnownDomainX = _lazyDomainingSeenDomainX;
-                        _this._lazyDomainingKnownDomainY = _lazyDomainingSeenDomainY;
-                        _lazyDomainingDeltaX = 0;
-                        _lazyDomainingDeltaY = 0;
+                    _this._renderArea.attr("transform", "translate(" + _deltaX + ", " + _deltaY + ")" + "scale(" + _scalingX + ", " + _scalingY + ")");
+                    clearTimeout(_timeoutReference);
+                    _timeoutReference = setTimeout(function () {
+                        _this._lazyDomainChangeCachedDomainX = _lastSeenDomainX;
+                        _this._lazyDomainChangeCachedDomainY = _lastSeenDomainY;
+                        _deltaX = 0;
+                        _deltaY = 0;
                         _this.render();
                         _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
-                    }, tempScrollTimeout);
+                    }, _lazyDomainChangeTimeout);
                 }
             };
         }
@@ -6568,23 +6568,23 @@ var Plottable;
             }
             if (lazyDomainChange) {
                 if (this.x() && this.x().scale) {
-                    this._lazyDomainingKnownDomainX = this.x().scale.domain();
-                    this.x().scale.onUpdate(this._fastPanZoomOnXCallback);
+                    this._lazyDomainChangeCachedDomainX = this.x().scale.domain();
+                    this.x().scale.onUpdate(this._lazyDomainChangeCallbackX);
                     this.x().scale.offUpdate(this._renderCallback);
                 }
                 if (this.y() && this.y().scale) {
-                    this._lazyDomainingKnownDomainY = this.y().scale.domain();
-                    this.y().scale.onUpdate(this._fastPanZoomOnYCallback);
+                    this._lazyDomainChangeCachedDomainY = this.y().scale.domain();
+                    this.y().scale.onUpdate(this._lazyDomainChangeCallbackY);
                     this.y().scale.offUpdate(this._renderCallback);
                 }
             }
             else {
                 if (this.x() && this.x().scale) {
-                    this.x().scale.offUpdate(this._fastPanZoomOnXCallback);
+                    this.x().scale.offUpdate(this._lazyDomainChangeCallbackX);
                     this.x().scale.onUpdate(this._renderCallback);
                 }
                 if (this.y() && this.y().scale) {
-                    this.y().scale.offUpdate(this._fastPanZoomOnYCallback);
+                    this.y().scale.offUpdate(this._lazyDomainChangeCallbackY);
                     this.y().scale.onUpdate(this._renderCallback);
                 }
             }
@@ -6640,7 +6640,7 @@ var Plottable;
             _super.prototype._uninstallScaleForKey.call(this, scale, key);
             var adjustCallback = key === XYPlot._X_KEY ? this._adjustYDomainOnChangeFromXCallback : this._adjustXDomainOnChangeFromYCallback;
             scale.offUpdate(adjustCallback);
-            var fastPanZoomCallback = key === XYPlot._X_KEY ? this._fastPanZoomOnXCallback : this._fastPanZoomOnYCallback;
+            var fastPanZoomCallback = key === XYPlot._X_KEY ? this._lazyDomainChangeCallbackX : this._lazyDomainChangeCallbackY;
             scale.offUpdate(fastPanZoomCallback);
         };
         XYPlot.prototype._installScaleForKey = function (scale, key) {
@@ -6650,12 +6650,12 @@ var Plottable;
             if (this._lazyDomainChange) {
                 scale.offUpdate(this._renderCallback);
                 if (key === XYPlot._X_KEY) {
-                    scale.onUpdate(this._fastPanZoomOnXCallback);
-                    this._lazyDomainingKnownDomainX = scale.domain();
+                    scale.onUpdate(this._lazyDomainChangeCallbackX);
+                    this._lazyDomainChangeCachedDomainX = scale.domain();
                 }
                 else {
-                    scale.onUpdate(this._fastPanZoomOnYCallback);
-                    this._lazyDomainingKnownDomainY = scale.domain();
+                    scale.onUpdate(this._lazyDomainChangeCallbackY);
+                    this._lazyDomainChangeCachedDomainY = scale.domain();
                 }
             }
         };
@@ -6663,11 +6663,11 @@ var Plottable;
             _super.prototype.destroy.call(this);
             if (this.x().scale) {
                 this.x().scale.offUpdate(this._adjustYDomainOnChangeFromXCallback);
-                this.x().scale.offUpdate(this._fastPanZoomOnXCallback);
+                this.x().scale.offUpdate(this._lazyDomainChangeCallbackX);
             }
             if (this.y().scale) {
                 this.y().scale.offUpdate(this._adjustXDomainOnChangeFromYCallback);
-                this.y().scale.offUpdate(this._fastPanZoomOnYCallback);
+                this.y().scale.offUpdate(this._lazyDomainChangeCallbackY);
             }
             return this;
         };

--- a/plottable.js
+++ b/plottable.js
@@ -6526,10 +6526,11 @@ var Plottable;
                 y0: 0,
                 y1: 1
             };
-            this.old_dx = 0;
-            this.old_dy = 0;
-            this.old_sx = 1;
-            this.old_sy = 1;
+            this.deltaX = 0;
+            this.deltaY = 0;
+            this.scaleX = 1;
+            this.scaleY = 1;
+            this._performanceEnabled = false;
             this.addClass("xy-plot");
             this._adjustYDomainOnChangeFromXCallback = function (scale) { return _this._adjustYDomainOnChangeFromX(); };
             this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
@@ -6542,38 +6543,49 @@ var Plottable;
         XYPlot.prototype._fastPanZoomOnX = function (scale) {
             var _this = this;
             var domain = scale.domain();
-            var scaleX = (scale.scale(this._temp.x1) - scale.scale(this._temp.x0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
-            this.old_sx = scaleX;
-            var deltaX = scale.scale(this._temp.x0) - scale.scale(domain[0]);
-            this.old_dx = deltaX;
-            this._renderArea && this._renderArea.attr('transform', 'translate(' + deltaX + ', ' + this.old_dy + ')' + 'scale(' + scaleX + ', ' + this.old_sy + ')');
-            clearTimeout(this._to1);
-            this._to1 = setTimeout(function () {
-                _this._temp.x0 = domain[0];
-                _this._temp.x1 = domain[1];
-                _this.old_dx = 0;
-                _this.old_dy = 0;
-                _this.render();
-                _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
-            }, 500);
+            if (!this._isAnchored) {
+                this._temp.x0 = domain[0];
+                this._temp.x1 = domain[1];
+                return;
+            }
+            this.scaleX = (scale.scale(this._temp.x1) - scale.scale(this._temp.x0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
+            this.deltaX = scale.scale(this._temp.x0) - scale.scale(domain[0]);
+            console.log(this.deltaX);
+            if (this._renderArea != null) {
+                this._renderArea.attr('transform', 'translate(' + this.deltaX + ', ' + this.deltaY + ')' + 'scale(' + this.scaleX + ', ' + this.scaleY + ')');
+                clearTimeout(this._to1);
+                this._to1 = setTimeout(function () {
+                    _this._temp.x0 = domain[0];
+                    _this._temp.x1 = domain[1];
+                    _this.deltaX = 0;
+                    _this.deltaY = 0;
+                    _this.render();
+                    _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
+                }, 0);
+            }
         };
         XYPlot.prototype._fastPanZoomOnY = function (scale) {
             var _this = this;
             var domain = scale.domain();
-            var scaleY = (scale.scale(this._temp.y1) - scale.scale(this._temp.y0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
-            this.old_sy = scaleY;
-            var deltaY = scale.scale(this._temp.y0) - scale.scale(domain[0]) * scaleY;
-            this.old_dy = deltaY;
-            this._renderArea && this._renderArea.attr('transform', 'translate(' + this.old_dx + ', ' + deltaY + ')' + 'scale(' + this.old_sx + ', ' + scaleY + ')');
-            clearTimeout(this._to2);
-            this._to2 = setTimeout(function () {
-                _this._temp.y0 = domain[0];
-                _this._temp.y1 = domain[1];
-                _this.old_dx = 0;
-                _this.old_dy = 0;
-                _this.render();
-                _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
-            }, 500);
+            if (!this._isAnchored) {
+                this._temp.y0 = domain[0];
+                this._temp.y1 = domain[1];
+                return;
+            }
+            this.scaleY = (scale.scale(this._temp.y1) - scale.scale(this._temp.y0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
+            this.deltaY = scale.scale(this._temp.y0) - scale.scale(domain[0]) * this.scaleY;
+            if (!this._renderArea != null) {
+                this._renderArea.attr('transform', 'translate(' + this.deltaX + ', ' + this.deltaY + ')' + 'scale(' + this.scaleX + ', ' + this.scaleY + ')');
+                clearTimeout(this._to2);
+                this._to2 = setTimeout(function () {
+                    _this._temp.y0 = domain[0];
+                    _this._temp.y1 = domain[1];
+                    _this.deltaX = 0;
+                    _this.deltaY = 0;
+                    _this.render();
+                    _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
+                }, 0);
+            }
         };
         XYPlot.prototype.x = function (x, xScale) {
             if (x == null) {

--- a/plottable.js
+++ b/plottable.js
@@ -6536,8 +6536,6 @@ var Plottable;
             this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
             this._fastPanZoomOnXCallback = function (scale) { return _this._fastPanZoomOnX(scale); };
             this._fastPanZoomOnYCallback = function (scale) { return _this._fastPanZoomOnY(scale); };
-            this._renderCallback = function () {
-            };
         }
         XYPlot.prototype._fastPanZoomOnX = function (scale) {
             var _this = this;
@@ -6559,7 +6557,7 @@ var Plottable;
                     _this.deltaY = 0;
                     _this.render();
                     _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
-                }, 0);
+                }, 500);
             }
         };
         XYPlot.prototype._fastPanZoomOnY = function (scale) {
@@ -6582,7 +6580,7 @@ var Plottable;
                     _this.deltaY = 0;
                     _this.render();
                     _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
-                }, 0);
+                }, 500);
             }
         };
         XYPlot.prototype.performanceEnabled = function (performanceEnabled) {
@@ -6591,6 +6589,14 @@ var Plottable;
             }
             if (performanceEnabled) {
                 console.log(1);
+                if (this.x() && this.x().scale) {
+                    this.x().scale.onUpdate(this._fastPanZoomOnXCallback);
+                    this.x().scale.offUpdate(this._renderCallback);
+                }
+                if (this.y() && this.y().scale) {
+                    this.y().scale.onUpdate(this._fastPanZoomOnYCallback);
+                    this.y().scale.offUpdate(this._renderCallback);
+                }
             }
             else {
             }
@@ -6653,12 +6659,11 @@ var Plottable;
             _super.prototype._installScaleForKey.call(this, scale, key);
             var adjustCallback = key === XYPlot._X_KEY ? this._adjustYDomainOnChangeFromXCallback : this._adjustXDomainOnChangeFromYCallback;
             scale.onUpdate(adjustCallback);
-            console.log(2);
-            // if (this._performanceEnabled) {
-            var fastPanZoomCallback = key === XYPlot._X_KEY ? this._fastPanZoomOnXCallback : this._fastPanZoomOnYCallback;
-            scale.onUpdate(fastPanZoomCallback);
-            // scale.offUpdate(this._renderCallback);
-            // }
+            if (this._performanceEnabled) {
+                var fastPanZoomCallback = key === XYPlot._X_KEY ? this._fastPanZoomOnXCallback : this._fastPanZoomOnYCallback;
+                scale.onUpdate(fastPanZoomCallback);
+                scale.offUpdate(this._renderCallback);
+            }
         };
         XYPlot.prototype.destroy = function () {
             _super.prototype.destroy.call(this);

--- a/plottable.js
+++ b/plottable.js
@@ -5916,13 +5916,23 @@ var Plottable;
             this._dataChanged = false;
             this._animate = false;
             this._animators = {};
+            this._to = 0;
             this._clipPathEnabled = true;
             this.addClass("plot");
             this._datasetToDrawer = new Plottable.Utils.Map();
             this._attrBindings = d3.map();
             this._attrExtents = d3.map();
             this._includedValuesProvider = function (scale) { return _this._includedValuesForScale(scale); };
-            this._renderCallback = function (scale) { return _this.render(); };
+            var _timeout = 0;
+            this._renderCallback = function (scale) {
+                _this._renderArea && _this._renderArea.attr('transform', 'translate(100, 100)');
+                clearTimeout(_this._to);
+                _this._to = setTimeout(function () {
+                    _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0)');
+                    _this.render();
+                }, 500);
+                // console.log(_timeout);
+            };
             this._onDatasetUpdateCallback = function () { return _this._onDatasetUpdate(); };
             this._propertyBindings = d3.map();
             this._propertyExtents = d3.map();

--- a/plottable.js
+++ b/plottable.js
@@ -6524,6 +6524,7 @@ var Plottable;
             this._fastPanZoomScaleY = 1;
             this._fastPanZoomKnownDomainX = [null, null];
             this._fastPanZoomKnownDomainY = [null, null];
+            this.tempScrollTimeout = 500;
             this.addClass("xy-plot");
             this._adjustYDomainOnChangeFromXCallback = function (scale) { return _this._adjustYDomainOnChangeFromX(); };
             this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
@@ -6547,7 +6548,7 @@ var Plottable;
                     _this._fastPanZoomDeltaY = 0;
                     _this.render();
                     _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
-                }, 500);
+                }, this.tempScrollTimeout);
             }
         };
         XYPlot.prototype._fastPanZoomOnY = function (scale) {
@@ -6567,7 +6568,7 @@ var Plottable;
                     _this._fastPanZoomDeltaY = 0;
                     _this.render();
                     _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
-                }, 500);
+                }, this.tempScrollTimeout);
             }
         };
         XYPlot.prototype.performanceEnabled = function (performanceEnabled) {

--- a/plottable.js
+++ b/plottable.js
@@ -6531,9 +6531,9 @@ var Plottable;
             this.old_sx = 1;
             this.old_sy = 1;
             this.addClass("xy-plot");
-            // X
-            this._adjustYDomainOnChangeFromXCallback = function (scale) {
-                _this._adjustYDomainOnChangeFromX();
+            this._adjustYDomainOnChangeFromXCallback = function (scale) { return _this._adjustYDomainOnChangeFromX(); };
+            this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
+            this._fastPanZoomOnXCallback = function (scale) {
                 var domain = scale.domain();
                 var scaleX = (scale.scale(_this._temp.x1) - scale.scale(_this._temp.x0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
                 _this.old_sx = scaleX;
@@ -6550,9 +6550,7 @@ var Plottable;
                     _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
                 }, 500);
             };
-            // Y
-            this._adjustXDomainOnChangeFromYCallback = function (scale) {
-                _this._adjustXDomainOnChangeFromY();
+            this._fastPanZoomOnYCallback = function (scale) {
                 var domain = scale.domain();
                 var scaleY = (scale.scale(_this._temp.y1) - scale.scale(_this._temp.y0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
                 _this.old_sy = scaleY;
@@ -6580,6 +6578,7 @@ var Plottable;
             if (this._autoAdjustYScaleDomain) {
                 this._updateYExtentsAndAutodomain();
             }
+            // TODO This is extra (_bindProperty -> _bind -> _installScale -> onUpdate with thi smethod)
             if (xScale != null) {
                 xScale.onUpdate(this._adjustYDomainOnChangeFromXCallback);
             }
@@ -6594,6 +6593,7 @@ var Plottable;
             if (this._autoAdjustXScaleDomain) {
                 this._updateXExtentsAndAutodomain();
             }
+            // TODO This is extra (_bindProperty -> _bind -> _installScale -> onUpdate with thi smethod)
             if (yScale != null) {
                 yScale.onUpdate(this._adjustXDomainOnChangeFromYCallback);
             }
@@ -6627,19 +6627,25 @@ var Plottable;
             _super.prototype._uninstallScaleForKey.call(this, scale, key);
             var adjustCallback = key === XYPlot._X_KEY ? this._adjustYDomainOnChangeFromXCallback : this._adjustXDomainOnChangeFromYCallback;
             scale.offUpdate(adjustCallback);
+            var fastPanZoomCallback = key === XYPlot._X_KEY ? this._fastPanZoomOnXCallback : this._fastPanZoomOnYCallback;
+            scale.offUpdate(fastPanZoomCallback);
         };
         XYPlot.prototype._installScaleForKey = function (scale, key) {
             _super.prototype._installScaleForKey.call(this, scale, key);
             var adjustCallback = key === XYPlot._X_KEY ? this._adjustYDomainOnChangeFromXCallback : this._adjustXDomainOnChangeFromYCallback;
             scale.onUpdate(adjustCallback);
+            var fastPanZoomCallback = key === XYPlot._X_KEY ? this._fastPanZoomOnXCallback : this._fastPanZoomOnYCallback;
+            scale.onUpdate(fastPanZoomCallback);
         };
         XYPlot.prototype.destroy = function () {
             _super.prototype.destroy.call(this);
             if (this.x().scale) {
                 this.x().scale.offUpdate(this._adjustYDomainOnChangeFromXCallback);
+                this.x().scale.offUpdate(this._fastPanZoomOnXCallback);
             }
             if (this.y().scale) {
                 this.y().scale.offUpdate(this._adjustXDomainOnChangeFromYCallback);
+                this.y().scale.offUpdate(this._fastPanZoomOnYCallback);
             }
             return this;
         };

--- a/plottable.js
+++ b/plottable.js
@@ -6516,61 +6516,57 @@ var Plottable;
             this._autoAdjustXScaleDomain = false;
             this._autoAdjustYScaleDomain = false;
             this._performanceEnabled = false;
-            this._fastPanZoomTimeoutReferenceX = 0;
-            this._fastPanZoomTimeoutReferenceY = 0;
-            this._fastPanZoomDeltaX = 0;
-            this._fastPanZoomDeltaY = 0;
-            this._fastPanZoomScaleX = 1;
-            this._fastPanZoomScaleY = 1;
             this._fastPanZoomKnownDomainX = [null, null];
             this._fastPanZoomKnownDomainY = [null, null];
-            this.tempScrollTimeout = 500;
             this.addClass("xy-plot");
             this._adjustYDomainOnChangeFromXCallback = function (scale) { return _this._adjustYDomainOnChangeFromX(); };
             this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
-            this._fastPanZoomOnXCallback = function (scale) { return _this._fastPanZoomOnX(scale); };
-            this._fastPanZoomOnYCallback = function (scale) { return _this._fastPanZoomOnY(scale); };
+            var _fastPanZoomTimeoutReferenceX = 0;
+            var _fastPanZoomTimeoutReferenceY = 0;
+            var _fastPanZoomDeltaX = 0;
+            var _fastPanZoomDeltaY = 0;
+            var _fastPanZoomScaleX = 1;
+            var _fastPanZoomScaleY = 1;
+            var tempScrollTimeout = 500;
+            this._fastPanZoomOnXCallback = function (scale) {
+                if (!_this._isAnchored) {
+                    return;
+                }
+                var domain = scale.domain();
+                _fastPanZoomScaleX = (scale.scale(_this._fastPanZoomKnownDomainX[1]) - scale.scale(_this._fastPanZoomKnownDomainX[0])) / (scale.scale(domain[1]) - scale.scale(domain[0]));
+                _fastPanZoomDeltaX = scale.scale(_this._fastPanZoomKnownDomainX[0]) - scale.scale(domain[0]);
+                if (_this._renderArea != null) {
+                    _this._renderArea.attr("transform", "translate(" + _fastPanZoomDeltaX + ", " + _fastPanZoomDeltaY + ")" + "scale(" + _fastPanZoomScaleX + ", " + _fastPanZoomScaleY + ")");
+                    clearTimeout(_fastPanZoomTimeoutReferenceX);
+                    _fastPanZoomTimeoutReferenceX = setTimeout(function () {
+                        _this._fastPanZoomKnownDomainX = domain;
+                        _fastPanZoomDeltaX = 0;
+                        _fastPanZoomDeltaY = 0;
+                        _this.render();
+                        _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
+                    }, tempScrollTimeout);
+                }
+            };
+            this._fastPanZoomOnYCallback = function (scale) {
+                if (!_this._isAnchored) {
+                    return;
+                }
+                var domain = scale.domain();
+                _fastPanZoomScaleY = (scale.scale(_this._fastPanZoomKnownDomainY[1]) - scale.scale(_this._fastPanZoomKnownDomainY[0])) / (scale.scale(domain[1]) - scale.scale(domain[0]));
+                _fastPanZoomDeltaY = scale.scale(_this._fastPanZoomKnownDomainY[0]) - scale.scale(domain[0]) * _fastPanZoomScaleY;
+                if (!_this._renderArea != null) {
+                    _this._renderArea.attr("transform", "translate(" + _fastPanZoomDeltaX + ", " + _fastPanZoomDeltaY + ")" + "scale(" + _fastPanZoomScaleX + ", " + _fastPanZoomScaleY + ")");
+                    clearTimeout(_fastPanZoomTimeoutReferenceY);
+                    _fastPanZoomTimeoutReferenceY = setTimeout(function () {
+                        _this._fastPanZoomKnownDomainY = domain;
+                        _fastPanZoomDeltaX = 0;
+                        _fastPanZoomDeltaY = 0;
+                        _this.render();
+                        _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
+                    }, tempScrollTimeout);
+                }
+            };
         }
-        XYPlot.prototype._fastPanZoomOnX = function (scale) {
-            var _this = this;
-            if (!this._isAnchored) {
-                return;
-            }
-            var domain = scale.domain();
-            this._fastPanZoomScaleX = (scale.scale(this._fastPanZoomKnownDomainX[1]) - scale.scale(this._fastPanZoomKnownDomainX[0])) / (scale.scale(domain[1]) - scale.scale(domain[0]));
-            this._fastPanZoomDeltaX = scale.scale(this._fastPanZoomKnownDomainX[0]) - scale.scale(domain[0]);
-            if (this._renderArea != null) {
-                this._renderArea.attr("transform", "translate(" + this._fastPanZoomDeltaX + ", " + this._fastPanZoomDeltaY + ")" + "scale(" + this._fastPanZoomScaleX + ", " + this._fastPanZoomScaleY + ")");
-                clearTimeout(this._fastPanZoomTimeoutReferenceX);
-                this._fastPanZoomTimeoutReferenceX = setTimeout(function () {
-                    _this._fastPanZoomKnownDomainX = domain;
-                    _this._fastPanZoomDeltaX = 0;
-                    _this._fastPanZoomDeltaY = 0;
-                    _this.render();
-                    _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
-                }, this.tempScrollTimeout);
-            }
-        };
-        XYPlot.prototype._fastPanZoomOnY = function (scale) {
-            var _this = this;
-            if (!this._isAnchored) {
-                return;
-            }
-            var domain = scale.domain();
-            this._fastPanZoomScaleY = (scale.scale(this._fastPanZoomKnownDomainY[1]) - scale.scale(this._fastPanZoomKnownDomainY[0])) / (scale.scale(domain[1]) - scale.scale(domain[0]));
-            this._fastPanZoomDeltaY = scale.scale(this._fastPanZoomKnownDomainY[0]) - scale.scale(domain[0]) * this._fastPanZoomScaleY;
-            if (!this._renderArea != null) {
-                this._renderArea.attr("transform", "translate(" + this._fastPanZoomDeltaX + ", " + this._fastPanZoomDeltaY + ")" + "scale(" + this._fastPanZoomScaleX + ", " + this._fastPanZoomScaleY + ")");
-                clearTimeout(this._fastPanZoomTimeoutReferenceY);
-                this._fastPanZoomTimeoutReferenceY = setTimeout(function () {
-                    _this._fastPanZoomKnownDomainY = domain;
-                    _this._fastPanZoomDeltaX = 0;
-                    _this._fastPanZoomDeltaY = 0;
-                    _this.render();
-                    _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
-                }, this.tempScrollTimeout);
-            }
-        };
         XYPlot.prototype.performanceEnabled = function (performanceEnabled) {
             if (performanceEnabled == null) {
                 return this._performanceEnabled;
@@ -6657,9 +6653,15 @@ var Plottable;
             var adjustCallback = key === XYPlot._X_KEY ? this._adjustYDomainOnChangeFromXCallback : this._adjustXDomainOnChangeFromYCallback;
             scale.onUpdate(adjustCallback);
             if (this._performanceEnabled) {
-                var fastPanZoomCallback = key === XYPlot._X_KEY ? this._fastPanZoomOnXCallback : this._fastPanZoomOnYCallback;
-                scale.onUpdate(fastPanZoomCallback);
                 scale.offUpdate(this._renderCallback);
+                if (key === XYPlot._X_KEY) {
+                    scale.onUpdate(this._fastPanZoomOnXCallback);
+                    this._fastPanZoomKnownDomainX = scale.domain();
+                }
+                else {
+                    scale.onUpdate(this._fastPanZoomOnYCallback);
+                    this._fastPanZoomKnownDomainY = scale.domain();
+                }
             }
         };
         XYPlot.prototype.destroy = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -6520,12 +6520,6 @@ var Plottable;
             this._autoAdjustYScaleDomain = false;
             this._to1 = -1;
             this._to2 = -1;
-            this._temp = {
-                x0: 0,
-                x1: 1,
-                y0: 0,
-                y1: 1
-            };
             this.deltaX = 0;
             this.deltaY = 0;
             this.scaleX = 1;
@@ -6536,6 +6530,12 @@ var Plottable;
             this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
             this._fastPanZoomOnXCallback = function (scale) { return _this._fastPanZoomOnX(scale); };
             this._fastPanZoomOnYCallback = function (scale) { return _this._fastPanZoomOnY(scale); };
+            this._temp = {
+                x0: null,
+                x1: null,
+                y0: null,
+                y1: null,
+            };
         }
         XYPlot.prototype._fastPanZoomOnX = function (scale) {
             var _this = this;

--- a/plottable.js
+++ b/plottable.js
@@ -6531,10 +6531,11 @@ var Plottable;
             this.old_sx = 1;
             this.old_sy = 1;
             this.addClass("xy-plot");
+            // X
             this._adjustYDomainOnChangeFromXCallback = function (scale) {
                 _this._adjustYDomainOnChangeFromX();
                 var domain = scale.domain();
-                var scaleX = (_this._temp.x1 - _this._temp.x0) / (domain[1] - domain[0]);
+                var scaleX = (scale.scale(_this._temp.x1) - scale.scale(_this._temp.x0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
                 _this.old_sx = scaleX;
                 var deltaX = scale.scale(_this._temp.x0) - scale.scale(domain[0]);
                 _this.old_dx = deltaX;
@@ -6549,13 +6550,15 @@ var Plottable;
                     _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
                 }, 500);
             };
+            // Y
             this._adjustXDomainOnChangeFromYCallback = function (scale) {
                 _this._adjustXDomainOnChangeFromY();
                 var domain = scale.domain();
-                var deltaY = -scale.scale(domain[0]) + scale.scale(_this._temp.y0);
-                _this.old_dy;
-                var scaleY = (_this._temp.y1 - _this._temp.y0) / (domain[1] - domain[0]);
+                var scaleY = (scale.scale(_this._temp.y1) - scale.scale(_this._temp.y0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
                 _this.old_sy = scaleY;
+                var deltaY = -scale.scale(domain[0]) * scaleY + scale.scale(_this._temp.y0);
+                _this.old_dy = deltaY;
+                console.log(scale.scale(_this._temp.y0), scale.scale(domain[0]), domain[0], scaleY);
                 _this._renderArea && _this._renderArea.attr('transform', 'translate(' + _this.old_dx + ', ' + deltaY + ')' + 'scale(' + _this.old_sx + ', ' + scaleY + ')');
                 clearTimeout(_this._to2);
                 _this._to2 = setTimeout(function () {

--- a/plottable.js
+++ b/plottable.js
@@ -6521,10 +6521,10 @@ var Plottable;
             this._to1 = -1;
             this._to2 = -1;
             this._temp = {
-                x0: null,
-                x1: null,
-                y0: null,
-                y1: null
+                x0: 0,
+                x1: 1,
+                y0: 0,
+                y1: 1
             };
             this.deltaX = 0;
             this.deltaY = 0;
@@ -6541,11 +6541,6 @@ var Plottable;
             var _this = this;
             var domain = scale.domain();
             if (!this._isAnchored) {
-                this._temp.x0 = domain[0];
-                this._temp.x1 = domain[1];
-                return;
-            }
-            if (this._temp.x0 == null) {
                 this._temp.x0 = domain[0];
                 this._temp.x1 = domain[1];
                 return;
@@ -6573,11 +6568,6 @@ var Plottable;
                 this._temp.y1 = domain[1];
                 return;
             }
-            if (this._temp.y0 == null) {
-                this._temp.y0 = domain[0];
-                this._temp.y1 = domain[1];
-                return;
-            }
             this.scaleY = (scale.scale(this._temp.y1) - scale.scale(this._temp.y0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
             this.deltaY = scale.scale(this._temp.y0) - scale.scale(domain[0]) * this.scaleY;
             if (!this._renderArea != null) {
@@ -6601,10 +6591,14 @@ var Plottable;
                 if (this.x() && this.x().scale) {
                     this.x().scale.onUpdate(this._fastPanZoomOnXCallback);
                     this.x().scale.offUpdate(this._renderCallback);
+                    this._temp.x0 = this.x().scale.domain()[0];
+                    this._temp.x1 = this.x().scale.domain()[1];
                 }
                 if (this.y() && this.y().scale) {
                     this.y().scale.onUpdate(this._fastPanZoomOnYCallback);
                     this.y().scale.offUpdate(this._renderCallback);
+                    this._temp.y0 = this.y().scale.domain()[0];
+                    this._temp.y1 = this.y().scale.domain()[1];
                 }
             }
             else {

--- a/plottable.js
+++ b/plottable.js
@@ -6529,6 +6529,8 @@ var Plottable;
             var _lastSeenDomainX = null;
             var _lastSeenDomainY = null;
             var _lazyDomainChangeTimeout = 500;
+            var _lazyDomainChangeCallbackX;
+            var _lazyDomainChangeCallbackY;
             var _triggerLazyDomainChange = function () {
                 if (_this._renderArea == null) {
                     return;
@@ -6544,7 +6546,7 @@ var Plottable;
                     _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
                 }, _lazyDomainChangeTimeout);
             };
-            this._lazyDomainChangeCallbackX = function (scale) {
+            _lazyDomainChangeCallbackX = function (scale) {
                 if (!_this._isAnchored) {
                     return;
                 }
@@ -6553,7 +6555,7 @@ var Plottable;
                 _deltaX = scale.scale(_this._lazyDomainChangeCachedDomainX[0]) - scale.scale(_lastSeenDomainX[0]);
                 _triggerLazyDomainChange();
             };
-            this._lazyDomainChangeCallbackY = function (scale) {
+            _lazyDomainChangeCallbackY = function (scale) {
                 if (!_this._isAnchored) {
                     return;
                 }
@@ -6564,10 +6566,10 @@ var Plottable;
             };
             this._renderCallback = function (scale) {
                 if (_this.lazyDomainChange() && _this.x() && _this.x().scale === scale) {
-                    _this._lazyDomainChangeCallbackX(scale);
+                    _lazyDomainChangeCallbackX(scale);
                 }
                 else if (_this.lazyDomainChange() && _this.y() && _this.y().scale === scale) {
-                    _this._lazyDomainChangeCallbackY(scale);
+                    _lazyDomainChangeCallbackY(scale);
                 }
                 else {
                     _this.render();

--- a/plottable.js
+++ b/plottable.js
@@ -6515,58 +6515,58 @@ var Plottable;
             _super.call(this);
             this._autoAdjustXScaleDomain = false;
             this._autoAdjustYScaleDomain = false;
-            this._lazyDomainChange = false;
-            this._lazyDomainChangeCachedDomainX = [null, null];
-            this._lazyDomainChangeCachedDomainY = [null, null];
+            this._deferredRendering = false;
+            this._performanceCachedDomainX = [null, null];
+            this._performanceCachedDomainY = [null, null];
             this.addClass("xy-plot");
             this._adjustYDomainOnChangeFromXCallback = function (scale) { return _this._adjustYDomainOnChangeFromX(); };
             this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
-            var _timeoutReference = 0;
             var _deltaX = 0;
             var _deltaY = 0;
             var _scalingX = 1;
             var _scalingY = 1;
             var _lastSeenDomainX = null;
             var _lastSeenDomainY = null;
-            var _lazyDomainChangeTimeout = 500;
-            var _triggerLazyDomainChange = function () {
+            var _timeoutReference = 0;
+            var _deferredRenderingTimeout = 500;
+            var _registerDeferredRendering = function () {
                 if (_this._renderArea == null) {
                     return;
                 }
                 _this._renderArea.attr("transform", "translate(" + _deltaX + ", " + _deltaY + ")" + "scale(" + _scalingX + ", " + _scalingY + ")");
                 clearTimeout(_timeoutReference);
                 _timeoutReference = setTimeout(function () {
-                    _this._lazyDomainChangeCachedDomainX = _lastSeenDomainX;
-                    _this._lazyDomainChangeCachedDomainY = _lastSeenDomainY;
+                    _this._performanceCachedDomainX = _lastSeenDomainX;
+                    _this._performanceCachedDomainY = _lastSeenDomainY;
                     _deltaX = 0;
                     _deltaY = 0;
                     _this.render();
                     _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
-                }, _lazyDomainChangeTimeout);
+                }, _deferredRenderingTimeout);
             };
             var _lazyDomainChangeCallbackX = function (scale) {
                 if (!_this._isAnchored) {
                     return;
                 }
                 _lastSeenDomainX = scale.domain();
-                _scalingX = (scale.scale(_this._lazyDomainChangeCachedDomainX[1]) - scale.scale(_this._lazyDomainChangeCachedDomainX[0])) / (scale.scale(_lastSeenDomainX[1]) - scale.scale(_lastSeenDomainX[0]));
-                _deltaX = scale.scale(_this._lazyDomainChangeCachedDomainX[0]) - scale.scale(_lastSeenDomainX[0]);
-                _triggerLazyDomainChange();
+                _scalingX = (scale.scale(_this._performanceCachedDomainX[1]) - scale.scale(_this._performanceCachedDomainX[0])) / (scale.scale(_lastSeenDomainX[1]) - scale.scale(_lastSeenDomainX[0]));
+                _deltaX = scale.scale(_this._performanceCachedDomainX[0]) - scale.scale(_lastSeenDomainX[0]);
+                _registerDeferredRendering();
             };
             var _lazyDomainChangeCallbackY = function (scale) {
                 if (!_this._isAnchored) {
                     return;
                 }
                 _lastSeenDomainY = scale.domain();
-                _scalingY = (scale.scale(_this._lazyDomainChangeCachedDomainY[1]) - scale.scale(_this._lazyDomainChangeCachedDomainY[0])) / (scale.scale(_lastSeenDomainY[1]) - scale.scale(_lastSeenDomainY[0]));
-                _deltaY = scale.scale(_this._lazyDomainChangeCachedDomainY[0]) - scale.scale(_lastSeenDomainY[0]) * _scalingY;
-                _triggerLazyDomainChange();
+                _scalingY = (scale.scale(_this._performanceCachedDomainY[1]) - scale.scale(_this._performanceCachedDomainY[0])) / (scale.scale(_lastSeenDomainY[1]) - scale.scale(_lastSeenDomainY[0]));
+                _deltaY = scale.scale(_this._performanceCachedDomainY[0]) - scale.scale(_lastSeenDomainY[0]) * _scalingY;
+                _registerDeferredRendering();
             };
             this._renderCallback = function (scale) {
-                if (_this.lazyDomainChange() && _this.x() && _this.x().scale === scale) {
+                if (_this.deferredRendering() && _this.x() && _this.x().scale === scale) {
                     _lazyDomainChangeCallbackX(scale);
                 }
-                else if (_this.lazyDomainChange() && _this.y() && _this.y().scale === scale) {
+                else if (_this.deferredRendering() && _this.y() && _this.y().scale === scale) {
                     _lazyDomainChangeCallbackY(scale);
                 }
                 else {
@@ -6574,19 +6574,19 @@ var Plottable;
                 }
             };
         }
-        XYPlot.prototype.lazyDomainChange = function (lazyDomainChange) {
-            if (lazyDomainChange == null) {
-                return this._lazyDomainChange;
+        XYPlot.prototype.deferredRendering = function (deferredRendering) {
+            if (deferredRendering == null) {
+                return this._deferredRendering;
             }
-            if (lazyDomainChange) {
+            if (deferredRendering) {
                 if (this.x() && this.x().scale) {
-                    this._lazyDomainChangeCachedDomainX = this.x().scale.domain();
+                    this._performanceCachedDomainX = this.x().scale.domain();
                 }
                 if (this.y() && this.y().scale) {
-                    this._lazyDomainChangeCachedDomainY = this.y().scale.domain();
+                    this._performanceCachedDomainY = this.y().scale.domain();
                 }
             }
-            this._lazyDomainChange = lazyDomainChange;
+            this._deferredRendering = deferredRendering;
             return this;
         };
         XYPlot.prototype.x = function (x, xScale) {

--- a/plottable.js
+++ b/plottable.js
@@ -6533,43 +6533,47 @@ var Plottable;
             this.addClass("xy-plot");
             this._adjustYDomainOnChangeFromXCallback = function (scale) { return _this._adjustYDomainOnChangeFromX(); };
             this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
-            this._fastPanZoomOnXCallback = function (scale) {
-                var domain = scale.domain();
-                var scaleX = (scale.scale(_this._temp.x1) - scale.scale(_this._temp.x0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
-                _this.old_sx = scaleX;
-                var deltaX = scale.scale(_this._temp.x0) - scale.scale(domain[0]);
-                _this.old_dx = deltaX;
-                _this._renderArea && _this._renderArea.attr('transform', 'translate(' + deltaX + ', ' + _this.old_dy + ')' + 'scale(' + scaleX + ', ' + _this.old_sy + ')');
-                clearTimeout(_this._to1);
-                _this._to1 = setTimeout(function () {
-                    _this._temp.x0 = domain[0];
-                    _this._temp.x1 = domain[1];
-                    _this.old_dx = 0;
-                    _this.old_dy = 0;
-                    _this.render();
-                    _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
-                }, 500);
-            };
-            this._fastPanZoomOnYCallback = function (scale) {
-                var domain = scale.domain();
-                var scaleY = (scale.scale(_this._temp.y1) - scale.scale(_this._temp.y0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
-                _this.old_sy = scaleY;
-                var deltaY = scale.scale(_this._temp.y0) - scale.scale(domain[0]) * scaleY;
-                _this.old_dy = deltaY;
-                _this._renderArea && _this._renderArea.attr('transform', 'translate(' + _this.old_dx + ', ' + deltaY + ')' + 'scale(' + _this.old_sx + ', ' + scaleY + ')');
-                clearTimeout(_this._to2);
-                _this._to2 = setTimeout(function () {
-                    _this._temp.y0 = domain[0];
-                    _this._temp.y1 = domain[1];
-                    _this.old_dx = 0;
-                    _this.old_dy = 0;
-                    _this.render();
-                    _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
-                }, 500);
-            };
+            this._fastPanZoomOnXCallback = function (scale) { return _this._fastPanZoomOnX(scale); };
+            this._fastPanZoomOnYCallback = function (scale) { return _this._fastPanZoomOnY(scale); };
             this._renderCallback = function (scale) {
             };
         }
+        XYPlot.prototype._fastPanZoomOnX = function (scale) {
+            var _this = this;
+            var domain = scale.domain();
+            var scaleX = (scale.scale(this._temp.x1) - scale.scale(this._temp.x0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
+            this.old_sx = scaleX;
+            var deltaX = scale.scale(this._temp.x0) - scale.scale(domain[0]);
+            this.old_dx = deltaX;
+            this._renderArea && this._renderArea.attr('transform', 'translate(' + deltaX + ', ' + this.old_dy + ')' + 'scale(' + scaleX + ', ' + this.old_sy + ')');
+            clearTimeout(this._to1);
+            this._to1 = setTimeout(function () {
+                _this._temp.x0 = domain[0];
+                _this._temp.x1 = domain[1];
+                _this.old_dx = 0;
+                _this.old_dy = 0;
+                _this.render();
+                _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
+            }, 500);
+        };
+        XYPlot.prototype._fastPanZoomOnY = function (scale) {
+            var _this = this;
+            var domain = scale.domain();
+            var scaleY = (scale.scale(this._temp.y1) - scale.scale(this._temp.y0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
+            this.old_sy = scaleY;
+            var deltaY = scale.scale(this._temp.y0) - scale.scale(domain[0]) * scaleY;
+            this.old_dy = deltaY;
+            this._renderArea && this._renderArea.attr('transform', 'translate(' + this.old_dx + ', ' + deltaY + ')' + 'scale(' + this.old_sx + ', ' + scaleY + ')');
+            clearTimeout(this._to2);
+            this._to2 = setTimeout(function () {
+                _this._temp.y0 = domain[0];
+                _this._temp.y1 = domain[1];
+                _this.old_dx = 0;
+                _this.old_dy = 0;
+                _this.render();
+                _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
+            }, 500);
+        };
         XYPlot.prototype.x = function (x, xScale) {
             if (x == null) {
                 return this._propertyBindings.get(XYPlot._X_KEY);

--- a/plottable.js
+++ b/plottable.js
@@ -6521,10 +6521,10 @@ var Plottable;
             this._to1 = -1;
             this._to2 = -1;
             this._temp = {
-                x0: 0,
-                x1: 1,
-                y0: 0,
-                y1: 1
+                x0: null,
+                x1: null,
+                y0: null,
+                y1: null
             };
             this.deltaX = 0;
             this.deltaY = 0;
@@ -6541,6 +6541,11 @@ var Plottable;
             var _this = this;
             var domain = scale.domain();
             if (!this._isAnchored) {
+                this._temp.x0 = domain[0];
+                this._temp.x1 = domain[1];
+                return;
+            }
+            if (this._temp.x0 == null) {
                 this._temp.x0 = domain[0];
                 this._temp.x1 = domain[1];
                 return;
@@ -6564,6 +6569,11 @@ var Plottable;
             var _this = this;
             var domain = scale.domain();
             if (!this._isAnchored) {
+                this._temp.y0 = domain[0];
+                this._temp.y1 = domain[1];
+                return;
+            }
+            if (this._temp.y0 == null) {
                 this._temp.y0 = domain[0];
                 this._temp.y1 = domain[1];
                 return;

--- a/plottable.js
+++ b/plottable.js
@@ -6556,9 +6556,8 @@ var Plottable;
                 var domain = scale.domain();
                 var scaleY = (scale.scale(_this._temp.y1) - scale.scale(_this._temp.y0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
                 _this.old_sy = scaleY;
-                var deltaY = -scale.scale(domain[0]) * scaleY + scale.scale(_this._temp.y0);
+                var deltaY = scale.scale(_this._temp.y0) - scale.scale(domain[0]) * scaleY;
                 _this.old_dy = deltaY;
-                console.log(scale.scale(_this._temp.y0), scale.scale(domain[0]), domain[0], scaleY);
                 _this._renderArea && _this._renderArea.attr('transform', 'translate(' + _this.old_dx + ', ' + deltaY + ')' + 'scale(' + _this.old_sx + ', ' + scaleY + ')');
                 clearTimeout(_this._to2);
                 _this._to2 = setTimeout(function () {

--- a/plottable.js
+++ b/plottable.js
@@ -6525,6 +6525,8 @@ var Plottable;
             this._fastPanZoomDeltaY = 0;
             this._fastPanZoomScaleX = 1;
             this._fastPanZoomScaleY = 1;
+            this._fastPanZoomKnownDomainX = [null, null];
+            this._fastPanZoomKnownDomainY = [null, null];
             this.addClass("xy-plot");
             this._adjustYDomainOnChangeFromXCallback = function (scale) { return _this._adjustYDomainOnChangeFromX(); };
             this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
@@ -6541,18 +6543,18 @@ var Plottable;
             var _this = this;
             var domain = scale.domain();
             if (!this._isAnchored) {
-                this._fastPanZoomKnownDomain.x0 = domain[0];
-                this._fastPanZoomKnownDomain.x1 = domain[1];
+                this._fastPanZoomKnownDomainX[0] = domain[0];
+                this._fastPanZoomKnownDomainX[1] = domain[1];
                 return;
             }
-            this._fastPanZoomScaleX = (scale.scale(this._fastPanZoomKnownDomain.x1) - scale.scale(this._fastPanZoomKnownDomain.x0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
-            this._fastPanZoomDeltaX = scale.scale(this._fastPanZoomKnownDomain.x0) - scale.scale(domain[0]);
+            this._fastPanZoomScaleX = (scale.scale(this._fastPanZoomKnownDomainX[1]) - scale.scale(this._fastPanZoomKnownDomainX[0])) / (scale.scale(domain[1]) - scale.scale(domain[0]));
+            this._fastPanZoomDeltaX = scale.scale(this._fastPanZoomKnownDomainX[0]) - scale.scale(domain[0]);
             if (this._renderArea != null) {
                 this._renderArea.attr('transform', 'translate(' + this._fastPanZoomDeltaX + ', ' + this._fastPanZoomDeltaY + ')' + 'scale(' + this._fastPanZoomScaleX + ', ' + this._fastPanZoomScaleY + ')');
                 clearTimeout(this._fastPanZoomTimeoutX);
                 this._fastPanZoomTimeoutX = setTimeout(function () {
-                    _this._fastPanZoomKnownDomain.x0 = domain[0];
-                    _this._fastPanZoomKnownDomain.x1 = domain[1];
+                    _this._fastPanZoomKnownDomainX[0] = domain[0];
+                    _this._fastPanZoomKnownDomainX[1] = domain[1];
                     _this._fastPanZoomDeltaX = 0;
                     _this._fastPanZoomDeltaY = 0;
                     _this.render();
@@ -6564,18 +6566,18 @@ var Plottable;
             var _this = this;
             var domain = scale.domain();
             if (!this._isAnchored) {
-                this._fastPanZoomKnownDomain.y0 = domain[0];
-                this._fastPanZoomKnownDomain.y1 = domain[1];
+                this._fastPanZoomKnownDomainY[0] = domain[0];
+                this._fastPanZoomKnownDomainY[1] = domain[1];
                 return;
             }
-            this._fastPanZoomScaleY = (scale.scale(this._fastPanZoomKnownDomain.y1) - scale.scale(this._fastPanZoomKnownDomain.y0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
-            this._fastPanZoomDeltaY = scale.scale(this._fastPanZoomKnownDomain.y0) - scale.scale(domain[0]) * this._fastPanZoomScaleY;
+            this._fastPanZoomScaleY = (scale.scale(this._fastPanZoomKnownDomainY[1]) - scale.scale(this._fastPanZoomKnownDomainY[0])) / (scale.scale(domain[1]) - scale.scale(domain[0]));
+            this._fastPanZoomDeltaY = scale.scale(this._fastPanZoomKnownDomainY[0]) - scale.scale(domain[0]) * this._fastPanZoomScaleY;
             if (!this._renderArea != null) {
                 this._renderArea.attr('transform', 'translate(' + this._fastPanZoomDeltaX + ', ' + this._fastPanZoomDeltaY + ')' + 'scale(' + this._fastPanZoomScaleX + ', ' + this._fastPanZoomScaleY + ')');
                 clearTimeout(this._fastPanZoomTimeoutY);
                 this._fastPanZoomTimeoutY = setTimeout(function () {
-                    _this._fastPanZoomKnownDomain.y0 = domain[0];
-                    _this._fastPanZoomKnownDomain.y1 = domain[1];
+                    _this._fastPanZoomKnownDomainY[0] = domain[0];
+                    _this._fastPanZoomKnownDomainY[1] = domain[1];
                     _this._fastPanZoomDeltaX = 0;
                     _this._fastPanZoomDeltaY = 0;
                     _this.render();
@@ -6591,14 +6593,14 @@ var Plottable;
                 if (this.x() && this.x().scale) {
                     this.x().scale.onUpdate(this._fastPanZoomOnXCallback);
                     this.x().scale.offUpdate(this._renderCallback);
-                    this._fastPanZoomKnownDomain.x0 = this.x().scale.domain()[0];
-                    this._fastPanZoomKnownDomain.x1 = this.x().scale.domain()[1];
+                    this._fastPanZoomKnownDomainX[0] = this.x().scale.domain()[0];
+                    this._fastPanZoomKnownDomainX[1] = this.x().scale.domain()[1];
                 }
                 if (this.y() && this.y().scale) {
                     this.y().scale.onUpdate(this._fastPanZoomOnYCallback);
                     this.y().scale.offUpdate(this._renderCallback);
-                    this._fastPanZoomKnownDomain.y0 = this.y().scale.domain()[0];
-                    this._fastPanZoomKnownDomain.y1 = this.y().scale.domain()[1];
+                    this._fastPanZoomKnownDomainY[0] = this.y().scale.domain()[0];
+                    this._fastPanZoomKnownDomainY[1] = this.y().scale.domain()[1];
                 }
             }
             else {

--- a/plottable.js
+++ b/plottable.js
@@ -6521,44 +6521,39 @@ var Plottable;
             this.addClass("xy-plot");
             this._adjustYDomainOnChangeFromXCallback = function (scale) { return _this._adjustYDomainOnChangeFromX(); };
             this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
-            var _lazyDomainingTimeoutReferenceX = 0;
-            var _lazyDomainingTimeoutReferenceY = 0;
+            var _lazyDomainingTimeoutReference = 0;
             var _lazyDomainingDeltaX = 0;
             var _lazyDomainingDeltaY = 0;
             var _lazyDomainingScaleX = 1;
             var _lazyDomainingScaleY = 1;
+            var _lazyDomainingSeenDomainX = null;
+            var _lazyDomainingSeenDomainY = null;
             var tempScrollTimeout = 500;
             this._fastPanZoomOnXCallback = function (scale) {
                 if (!_this._isAnchored) {
                     return;
                 }
-                var domain = scale.domain();
-                _lazyDomainingScaleX = (scale.scale(_this._lazyDomainingKnownDomainX[1]) - scale.scale(_this._lazyDomainingKnownDomainX[0])) / (scale.scale(domain[1]) - scale.scale(domain[0]));
-                _lazyDomainingDeltaX = scale.scale(_this._lazyDomainingKnownDomainX[0]) - scale.scale(domain[0]);
-                if (_this._renderArea != null) {
-                    _this._renderArea.attr("transform", "translate(" + _lazyDomainingDeltaX + ", " + _lazyDomainingDeltaY + ")" + "scale(" + _lazyDomainingScaleX + ", " + _lazyDomainingScaleY + ")");
-                    clearTimeout(_lazyDomainingTimeoutReferenceX);
-                    _lazyDomainingTimeoutReferenceX = setTimeout(function () {
-                        _this._lazyDomainingKnownDomainX = domain;
-                        _lazyDomainingDeltaX = 0;
-                        _lazyDomainingDeltaY = 0;
-                        _this.render();
-                        _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
-                    }, tempScrollTimeout);
-                }
+                _lazyDomainingSeenDomainX = scale.domain();
+                _lazyDomainingScaleX = (scale.scale(_this._lazyDomainingKnownDomainX[1]) - scale.scale(_this._lazyDomainingKnownDomainX[0])) / (scale.scale(_lazyDomainingSeenDomainX[1]) - scale.scale(_lazyDomainingSeenDomainX[0]));
+                _lazyDomainingDeltaX = scale.scale(_this._lazyDomainingKnownDomainX[0]) - scale.scale(_lazyDomainingSeenDomainX[0]);
+                _triggerLazyDomainChange();
             };
             this._fastPanZoomOnYCallback = function (scale) {
                 if (!_this._isAnchored) {
                     return;
                 }
-                var domain = scale.domain();
-                _lazyDomainingScaleY = (scale.scale(_this._lazyDomainingKnownDomainY[1]) - scale.scale(_this._lazyDomainingKnownDomainY[0])) / (scale.scale(domain[1]) - scale.scale(domain[0]));
-                _lazyDomainingDeltaY = scale.scale(_this._lazyDomainingKnownDomainY[0]) - scale.scale(domain[0]) * _lazyDomainingScaleY;
-                if (!_this._renderArea != null) {
+                _lazyDomainingSeenDomainY = scale.domain();
+                _lazyDomainingScaleY = (scale.scale(_this._lazyDomainingKnownDomainY[1]) - scale.scale(_this._lazyDomainingKnownDomainY[0])) / (scale.scale(_lazyDomainingSeenDomainY[1]) - scale.scale(_lazyDomainingSeenDomainY[0]));
+                _lazyDomainingDeltaY = scale.scale(_this._lazyDomainingKnownDomainY[0]) - scale.scale(_lazyDomainingSeenDomainY[0]) * _lazyDomainingScaleY;
+                _triggerLazyDomainChange();
+            };
+            var _triggerLazyDomainChange = function () {
+                if (_this._renderArea != null) {
                     _this._renderArea.attr("transform", "translate(" + _lazyDomainingDeltaX + ", " + _lazyDomainingDeltaY + ")" + "scale(" + _lazyDomainingScaleX + ", " + _lazyDomainingScaleY + ")");
-                    clearTimeout(_lazyDomainingTimeoutReferenceY);
-                    _lazyDomainingTimeoutReferenceY = setTimeout(function () {
-                        _this._lazyDomainingKnownDomainY = domain;
+                    clearTimeout(_lazyDomainingTimeoutReference);
+                    _lazyDomainingTimeoutReference = setTimeout(function () {
+                        _this._lazyDomainingKnownDomainX = _lazyDomainingSeenDomainX;
+                        _this._lazyDomainingKnownDomainY = _lazyDomainingSeenDomainY;
                         _lazyDomainingDeltaX = 0;
                         _lazyDomainingDeltaY = 0;
                         _this.render();

--- a/plottable.js
+++ b/plottable.js
@@ -6534,11 +6534,10 @@ var Plottable;
             this.addClass("xy-plot");
             this._adjustYDomainOnChangeFromXCallback = function (scale) { return _this._adjustYDomainOnChangeFromX(); };
             this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
-            this._fastPanZoomOnXCallback = function (scale) {
-            }; //this._fastPanZoomOnX(scale);
-            this._fastPanZoomOnYCallback = function (scale) {
-            }; //this._fastPanZoomOnY(scale);
-            // this._renderCallback = (scale) => {}
+            this._fastPanZoomOnXCallback = function (scale) { return _this._fastPanZoomOnX(scale); };
+            this._fastPanZoomOnYCallback = function (scale) { return _this._fastPanZoomOnY(scale); };
+            this._renderCallback = function () {
+            };
         }
         XYPlot.prototype._fastPanZoomOnX = function (scale) {
             var _this = this;
@@ -6550,7 +6549,6 @@ var Plottable;
             }
             this.scaleX = (scale.scale(this._temp.x1) - scale.scale(this._temp.x0)) / (scale.scale(domain[1]) - scale.scale(domain[0]));
             this.deltaX = scale.scale(this._temp.x0) - scale.scale(domain[0]);
-            console.log(this.deltaX);
             if (this._renderArea != null) {
                 this._renderArea.attr('transform', 'translate(' + this.deltaX + ', ' + this.deltaY + ')' + 'scale(' + this.scaleX + ', ' + this.scaleY + ')');
                 clearTimeout(this._to1);
@@ -6586,6 +6584,18 @@ var Plottable;
                     _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
                 }, 0);
             }
+        };
+        XYPlot.prototype.performanceEnabled = function (performanceEnabled) {
+            if (performanceEnabled == null) {
+                return this._performanceEnabled;
+            }
+            if (performanceEnabled) {
+                console.log(1);
+            }
+            else {
+            }
+            this._performanceEnabled = performanceEnabled;
+            return this;
         };
         XYPlot.prototype.x = function (x, xScale) {
             if (x == null) {
@@ -6643,8 +6653,12 @@ var Plottable;
             _super.prototype._installScaleForKey.call(this, scale, key);
             var adjustCallback = key === XYPlot._X_KEY ? this._adjustYDomainOnChangeFromXCallback : this._adjustXDomainOnChangeFromYCallback;
             scale.onUpdate(adjustCallback);
+            console.log(2);
+            // if (this._performanceEnabled) {
             var fastPanZoomCallback = key === XYPlot._X_KEY ? this._fastPanZoomOnXCallback : this._fastPanZoomOnYCallback;
             scale.onUpdate(fastPanZoomCallback);
+            // scale.offUpdate(this._renderCallback);
+            // }
         };
         XYPlot.prototype.destroy = function () {
             _super.prototype.destroy.call(this);

--- a/plottable.js
+++ b/plottable.js
@@ -6515,33 +6515,33 @@ var Plottable;
             _super.call(this);
             this._autoAdjustXScaleDomain = false;
             this._autoAdjustYScaleDomain = false;
-            this._performanceEnabled = false;
-            this._fastPanZoomKnownDomainX = [null, null];
-            this._fastPanZoomKnownDomainY = [null, null];
+            this._lazyDomainChange = false;
+            this._lazyDomainingKnownDomainX = [null, null];
+            this._lazyDomainingKnownDomainY = [null, null];
             this.addClass("xy-plot");
             this._adjustYDomainOnChangeFromXCallback = function (scale) { return _this._adjustYDomainOnChangeFromX(); };
             this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
-            var _fastPanZoomTimeoutReferenceX = 0;
-            var _fastPanZoomTimeoutReferenceY = 0;
-            var _fastPanZoomDeltaX = 0;
-            var _fastPanZoomDeltaY = 0;
-            var _fastPanZoomScaleX = 1;
-            var _fastPanZoomScaleY = 1;
+            var _lazyDomainingTimeoutReferenceX = 0;
+            var _lazyDomainingTimeoutReferenceY = 0;
+            var _lazyDomainingDeltaX = 0;
+            var _lazyDomainingDeltaY = 0;
+            var _lazyDomainingScaleX = 1;
+            var _lazyDomainingScaleY = 1;
             var tempScrollTimeout = 500;
             this._fastPanZoomOnXCallback = function (scale) {
                 if (!_this._isAnchored) {
                     return;
                 }
                 var domain = scale.domain();
-                _fastPanZoomScaleX = (scale.scale(_this._fastPanZoomKnownDomainX[1]) - scale.scale(_this._fastPanZoomKnownDomainX[0])) / (scale.scale(domain[1]) - scale.scale(domain[0]));
-                _fastPanZoomDeltaX = scale.scale(_this._fastPanZoomKnownDomainX[0]) - scale.scale(domain[0]);
+                _lazyDomainingScaleX = (scale.scale(_this._lazyDomainingKnownDomainX[1]) - scale.scale(_this._lazyDomainingKnownDomainX[0])) / (scale.scale(domain[1]) - scale.scale(domain[0]));
+                _lazyDomainingDeltaX = scale.scale(_this._lazyDomainingKnownDomainX[0]) - scale.scale(domain[0]);
                 if (_this._renderArea != null) {
-                    _this._renderArea.attr("transform", "translate(" + _fastPanZoomDeltaX + ", " + _fastPanZoomDeltaY + ")" + "scale(" + _fastPanZoomScaleX + ", " + _fastPanZoomScaleY + ")");
-                    clearTimeout(_fastPanZoomTimeoutReferenceX);
-                    _fastPanZoomTimeoutReferenceX = setTimeout(function () {
-                        _this._fastPanZoomKnownDomainX = domain;
-                        _fastPanZoomDeltaX = 0;
-                        _fastPanZoomDeltaY = 0;
+                    _this._renderArea.attr("transform", "translate(" + _lazyDomainingDeltaX + ", " + _lazyDomainingDeltaY + ")" + "scale(" + _lazyDomainingScaleX + ", " + _lazyDomainingScaleY + ")");
+                    clearTimeout(_lazyDomainingTimeoutReferenceX);
+                    _lazyDomainingTimeoutReferenceX = setTimeout(function () {
+                        _this._lazyDomainingKnownDomainX = domain;
+                        _lazyDomainingDeltaX = 0;
+                        _lazyDomainingDeltaY = 0;
                         _this.render();
                         _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
                     }, tempScrollTimeout);
@@ -6552,33 +6552,33 @@ var Plottable;
                     return;
                 }
                 var domain = scale.domain();
-                _fastPanZoomScaleY = (scale.scale(_this._fastPanZoomKnownDomainY[1]) - scale.scale(_this._fastPanZoomKnownDomainY[0])) / (scale.scale(domain[1]) - scale.scale(domain[0]));
-                _fastPanZoomDeltaY = scale.scale(_this._fastPanZoomKnownDomainY[0]) - scale.scale(domain[0]) * _fastPanZoomScaleY;
+                _lazyDomainingScaleY = (scale.scale(_this._lazyDomainingKnownDomainY[1]) - scale.scale(_this._lazyDomainingKnownDomainY[0])) / (scale.scale(domain[1]) - scale.scale(domain[0]));
+                _lazyDomainingDeltaY = scale.scale(_this._lazyDomainingKnownDomainY[0]) - scale.scale(domain[0]) * _lazyDomainingScaleY;
                 if (!_this._renderArea != null) {
-                    _this._renderArea.attr("transform", "translate(" + _fastPanZoomDeltaX + ", " + _fastPanZoomDeltaY + ")" + "scale(" + _fastPanZoomScaleX + ", " + _fastPanZoomScaleY + ")");
-                    clearTimeout(_fastPanZoomTimeoutReferenceY);
-                    _fastPanZoomTimeoutReferenceY = setTimeout(function () {
-                        _this._fastPanZoomKnownDomainY = domain;
-                        _fastPanZoomDeltaX = 0;
-                        _fastPanZoomDeltaY = 0;
+                    _this._renderArea.attr("transform", "translate(" + _lazyDomainingDeltaX + ", " + _lazyDomainingDeltaY + ")" + "scale(" + _lazyDomainingScaleX + ", " + _lazyDomainingScaleY + ")");
+                    clearTimeout(_lazyDomainingTimeoutReferenceY);
+                    _lazyDomainingTimeoutReferenceY = setTimeout(function () {
+                        _this._lazyDomainingKnownDomainY = domain;
+                        _lazyDomainingDeltaX = 0;
+                        _lazyDomainingDeltaY = 0;
                         _this.render();
                         _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
                     }, tempScrollTimeout);
                 }
             };
         }
-        XYPlot.prototype.performanceEnabled = function (performanceEnabled) {
-            if (performanceEnabled == null) {
-                return this._performanceEnabled;
+        XYPlot.prototype.lazyDomainChange = function (lazyDomainChange) {
+            if (lazyDomainChange == null) {
+                return this._lazyDomainChange;
             }
-            if (performanceEnabled) {
+            if (lazyDomainChange) {
                 if (this.x() && this.x().scale) {
-                    this._fastPanZoomKnownDomainX = this.x().scale.domain();
+                    this._lazyDomainingKnownDomainX = this.x().scale.domain();
                     this.x().scale.onUpdate(this._fastPanZoomOnXCallback);
                     this.x().scale.offUpdate(this._renderCallback);
                 }
                 if (this.y() && this.y().scale) {
-                    this._fastPanZoomKnownDomainY = this.y().scale.domain();
+                    this._lazyDomainingKnownDomainY = this.y().scale.domain();
                     this.y().scale.onUpdate(this._fastPanZoomOnYCallback);
                     this.y().scale.offUpdate(this._renderCallback);
                 }
@@ -6593,7 +6593,7 @@ var Plottable;
                     this.y().scale.onUpdate(this._renderCallback);
                 }
             }
-            this._performanceEnabled = performanceEnabled;
+            this._lazyDomainChange = lazyDomainChange;
             return this;
         };
         XYPlot.prototype.x = function (x, xScale) {
@@ -6652,15 +6652,15 @@ var Plottable;
             _super.prototype._installScaleForKey.call(this, scale, key);
             var adjustCallback = key === XYPlot._X_KEY ? this._adjustYDomainOnChangeFromXCallback : this._adjustXDomainOnChangeFromYCallback;
             scale.onUpdate(adjustCallback);
-            if (this._performanceEnabled) {
+            if (this._lazyDomainChange) {
                 scale.offUpdate(this._renderCallback);
                 if (key === XYPlot._X_KEY) {
                     scale.onUpdate(this._fastPanZoomOnXCallback);
-                    this._fastPanZoomKnownDomainX = scale.domain();
+                    this._lazyDomainingKnownDomainX = scale.domain();
                 }
                 else {
                     scale.onUpdate(this._fastPanZoomOnYCallback);
-                    this._fastPanZoomKnownDomainY = scale.domain();
+                    this._lazyDomainingKnownDomainY = scale.domain();
                 }
             }
         };

--- a/plottable.js
+++ b/plottable.js
@@ -6518,8 +6518,8 @@ var Plottable;
             _super.call(this);
             this._autoAdjustXScaleDomain = false;
             this._autoAdjustYScaleDomain = false;
-            this._to1 = 0;
-            this._to2 = 0;
+            this._to1 = -1;
+            this._to2 = -1;
             this._temp = {
                 x0: 0,
                 x1: 1,
@@ -6533,10 +6533,11 @@ var Plottable;
             this.addClass("xy-plot");
             this._adjustYDomainOnChangeFromXCallback = function (scale) { return _this._adjustYDomainOnChangeFromX(); };
             this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
-            this._fastPanZoomOnXCallback = function (scale) { return _this._fastPanZoomOnX(scale); };
-            this._fastPanZoomOnYCallback = function (scale) { return _this._fastPanZoomOnY(scale); };
-            this._renderCallback = function (scale) {
-            };
+            this._fastPanZoomOnXCallback = function (scale) {
+            }; //this._fastPanZoomOnX(scale);
+            this._fastPanZoomOnYCallback = function (scale) {
+            }; //this._fastPanZoomOnY(scale);
+            // this._renderCallback = (scale) => {}
         }
         XYPlot.prototype._fastPanZoomOnX = function (scale) {
             var _this = this;
@@ -6582,10 +6583,6 @@ var Plottable;
             if (this._autoAdjustYScaleDomain) {
                 this._updateYExtentsAndAutodomain();
             }
-            // TODO This is extra (_bindProperty -> _bind -> _installScale -> onUpdate with thi smethod)
-            if (xScale != null) {
-                xScale.onUpdate(this._adjustYDomainOnChangeFromXCallback);
-            }
             this.render();
             return this;
         };
@@ -6596,10 +6593,6 @@ var Plottable;
             this._bindProperty(XYPlot._Y_KEY, y, yScale);
             if (this._autoAdjustXScaleDomain) {
                 this._updateXExtentsAndAutodomain();
-            }
-            // TODO This is extra (_bindProperty -> _bind -> _installScale -> onUpdate with thi smethod)
-            if (yScale != null) {
-                yScale.onUpdate(this._adjustXDomainOnChangeFromYCallback);
             }
             this.render();
             return this;

--- a/plottable.js
+++ b/plottable.js
@@ -5917,6 +5917,12 @@ var Plottable;
             this._animate = false;
             this._animators = {};
             this._to = 0;
+            this._temp = {
+                x0: 0,
+                x1: 0,
+                y0: 0,
+                y1: 0
+            };
             this._clipPathEnabled = true;
             this.addClass("plot");
             this._datasetToDrawer = new Plottable.Utils.Map();
@@ -5925,13 +5931,23 @@ var Plottable;
             this._includedValuesProvider = function (scale) { return _this._includedValuesForScale(scale); };
             var _timeout = 0;
             this._renderCallback = function (scale) {
-                _this._renderArea && _this._renderArea.attr('transform', 'translate(100, 100)');
+                var domain = scale.domain();
+                var range = scale.range();
+                console.log(_this._temp.x0);
+                var deltaX = -scale.scale(domain[0]) + scale.scale(_this._temp.x0);
+                var deltaY = -scale.scale(range[0]) + scale.scale(_this._temp.y0);
+                // deltaX = scale.scale(deltaX);
+                // deltaY = scale.scale(deltaY);
+                _this._renderArea && _this._renderArea.attr('transform', 'translate(' + deltaY + ', ' + deltaX + ')');
                 clearTimeout(_this._to);
                 _this._to = setTimeout(function () {
                     _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0)');
+                    _this._temp.x0 = domain[0];
+                    _this._temp.x1 = domain[1];
+                    _this._temp.y0 = range[0];
+                    _this._temp.y1 = range[1];
                     _this.render();
                 }, 500);
-                // console.log(_timeout);
             };
             this._onDatasetUpdateCallback = function () { return _this._onDatasetUpdate(); };
             this._propertyBindings = d3.map();

--- a/plottable.js
+++ b/plottable.js
@@ -6516,8 +6516,8 @@ var Plottable;
             this._autoAdjustXScaleDomain = false;
             this._autoAdjustYScaleDomain = false;
             this._deferredRendering = false;
-            this._performanceCachedDomainX = [null, null];
-            this._performanceCachedDomainY = [null, null];
+            this._cachedDomainX = [null, null];
+            this._cachedDomainY = [null, null];
             this.addClass("xy-plot");
             this._adjustYDomainOnChangeFromXCallback = function (scale) { return _this._adjustYDomainOnChangeFromX(); };
             this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
@@ -6536,8 +6536,8 @@ var Plottable;
                 _this._renderArea.attr("transform", "translate(" + _deltaX + ", " + _deltaY + ")" + "scale(" + _scalingX + ", " + _scalingY + ")");
                 clearTimeout(_timeoutReference);
                 _timeoutReference = setTimeout(function () {
-                    _this._performanceCachedDomainX = _lastSeenDomainX;
-                    _this._performanceCachedDomainY = _lastSeenDomainY;
+                    _this._cachedDomainX = _lastSeenDomainX;
+                    _this._cachedDomainY = _lastSeenDomainY;
                     _deltaX = 0;
                     _deltaY = 0;
                     _this.render();
@@ -6549,8 +6549,8 @@ var Plottable;
                     return;
                 }
                 _lastSeenDomainX = scale.domain();
-                _scalingX = (scale.scale(_this._performanceCachedDomainX[1]) - scale.scale(_this._performanceCachedDomainX[0])) / (scale.scale(_lastSeenDomainX[1]) - scale.scale(_lastSeenDomainX[0]));
-                _deltaX = scale.scale(_this._performanceCachedDomainX[0]) - scale.scale(_lastSeenDomainX[0]);
+                _scalingX = (scale.scale(_this._cachedDomainX[1]) - scale.scale(_this._cachedDomainX[0])) / (scale.scale(_lastSeenDomainX[1]) - scale.scale(_lastSeenDomainX[0]));
+                _deltaX = scale.scale(_this._cachedDomainX[0]) - scale.scale(_lastSeenDomainX[0]);
                 _registerDeferredRendering();
             };
             var _lazyDomainChangeCallbackY = function (scale) {
@@ -6558,8 +6558,8 @@ var Plottable;
                     return;
                 }
                 _lastSeenDomainY = scale.domain();
-                _scalingY = (scale.scale(_this._performanceCachedDomainY[1]) - scale.scale(_this._performanceCachedDomainY[0])) / (scale.scale(_lastSeenDomainY[1]) - scale.scale(_lastSeenDomainY[0]));
-                _deltaY = scale.scale(_this._performanceCachedDomainY[0]) - scale.scale(_lastSeenDomainY[0]) * _scalingY;
+                _scalingY = (scale.scale(_this._cachedDomainY[1]) - scale.scale(_this._cachedDomainY[0])) / (scale.scale(_lastSeenDomainY[1]) - scale.scale(_lastSeenDomainY[0]));
+                _deltaY = scale.scale(_this._cachedDomainY[0]) - scale.scale(_lastSeenDomainY[0]) * _scalingY;
                 _registerDeferredRendering();
             };
             this._renderCallback = function (scale) {
@@ -6580,10 +6580,10 @@ var Plottable;
             }
             if (deferredRendering) {
                 if (this.x() && this.x().scale) {
-                    this._performanceCachedDomainX = this.x().scale.domain();
+                    this._cachedDomainX = this.x().scale.domain();
                 }
                 if (this.y() && this.y().scale) {
-                    this._performanceCachedDomainY = this.y().scale.domain();
+                    this._cachedDomainY = this.y().scale.domain();
                 }
             }
             this._deferredRendering = deferredRendering;

--- a/plottable.js
+++ b/plottable.js
@@ -6588,7 +6588,6 @@ var Plottable;
                 return this._performanceEnabled;
             }
             if (performanceEnabled) {
-                console.log(1);
                 if (this.x() && this.x().scale) {
                     this.x().scale.onUpdate(this._fastPanZoomOnXCallback);
                     this.x().scale.offUpdate(this._renderCallback);
@@ -6599,6 +6598,14 @@ var Plottable;
                 }
             }
             else {
+                if (this.x() && this.x().scale) {
+                    this.x().scale.offUpdate(this._fastPanZoomOnXCallback);
+                    this.x().scale.onUpdate(this._renderCallback);
+                }
+                if (this.y() && this.y().scale) {
+                    this.y().scale.offUpdate(this._fastPanZoomOnYCallback);
+                    this.y().scale.onUpdate(this._renderCallback);
+                }
             }
             this._performanceEnabled = performanceEnabled;
             return this;

--- a/plottable.js
+++ b/plottable.js
@@ -6519,8 +6519,8 @@ var Plottable;
             this._autoAdjustXScaleDomain = false;
             this._autoAdjustYScaleDomain = false;
             this._performanceEnabled = false;
-            this._fastPanZoomTimeoutX = 0;
-            this._fastPanZoomTimeoutY = 0;
+            this._fastPanZoomTimeoutReferenceX = 0;
+            this._fastPanZoomTimeoutReferenceY = 0;
             this._fastPanZoomDeltaX = 0;
             this._fastPanZoomDeltaY = 0;
             this._fastPanZoomScaleX = 1;
@@ -6532,29 +6532,20 @@ var Plottable;
             this._adjustXDomainOnChangeFromYCallback = function (scale) { return _this._adjustXDomainOnChangeFromY(); };
             this._fastPanZoomOnXCallback = function (scale) { return _this._fastPanZoomOnX(scale); };
             this._fastPanZoomOnYCallback = function (scale) { return _this._fastPanZoomOnY(scale); };
-            this._fastPanZoomKnownDomain = {
-                x0: null,
-                x1: null,
-                y0: null,
-                y1: null,
-            };
         }
         XYPlot.prototype._fastPanZoomOnX = function (scale) {
             var _this = this;
             var domain = scale.domain();
             if (!this._isAnchored) {
-                this._fastPanZoomKnownDomainX[0] = domain[0];
-                this._fastPanZoomKnownDomainX[1] = domain[1];
                 return;
             }
             this._fastPanZoomScaleX = (scale.scale(this._fastPanZoomKnownDomainX[1]) - scale.scale(this._fastPanZoomKnownDomainX[0])) / (scale.scale(domain[1]) - scale.scale(domain[0]));
             this._fastPanZoomDeltaX = scale.scale(this._fastPanZoomKnownDomainX[0]) - scale.scale(domain[0]);
             if (this._renderArea != null) {
                 this._renderArea.attr('transform', 'translate(' + this._fastPanZoomDeltaX + ', ' + this._fastPanZoomDeltaY + ')' + 'scale(' + this._fastPanZoomScaleX + ', ' + this._fastPanZoomScaleY + ')');
-                clearTimeout(this._fastPanZoomTimeoutX);
-                this._fastPanZoomTimeoutX = setTimeout(function () {
-                    _this._fastPanZoomKnownDomainX[0] = domain[0];
-                    _this._fastPanZoomKnownDomainX[1] = domain[1];
+                clearTimeout(this._fastPanZoomTimeoutReferenceX);
+                this._fastPanZoomTimeoutReferenceX = setTimeout(function () {
+                    _this._fastPanZoomKnownDomainX = domain;
                     _this._fastPanZoomDeltaX = 0;
                     _this._fastPanZoomDeltaY = 0;
                     _this.render();
@@ -6566,18 +6557,15 @@ var Plottable;
             var _this = this;
             var domain = scale.domain();
             if (!this._isAnchored) {
-                this._fastPanZoomKnownDomainY[0] = domain[0];
-                this._fastPanZoomKnownDomainY[1] = domain[1];
                 return;
             }
             this._fastPanZoomScaleY = (scale.scale(this._fastPanZoomKnownDomainY[1]) - scale.scale(this._fastPanZoomKnownDomainY[0])) / (scale.scale(domain[1]) - scale.scale(domain[0]));
             this._fastPanZoomDeltaY = scale.scale(this._fastPanZoomKnownDomainY[0]) - scale.scale(domain[0]) * this._fastPanZoomScaleY;
             if (!this._renderArea != null) {
                 this._renderArea.attr('transform', 'translate(' + this._fastPanZoomDeltaX + ', ' + this._fastPanZoomDeltaY + ')' + 'scale(' + this._fastPanZoomScaleX + ', ' + this._fastPanZoomScaleY + ')');
-                clearTimeout(this._fastPanZoomTimeoutY);
-                this._fastPanZoomTimeoutY = setTimeout(function () {
-                    _this._fastPanZoomKnownDomainY[0] = domain[0];
-                    _this._fastPanZoomKnownDomainY[1] = domain[1];
+                clearTimeout(this._fastPanZoomTimeoutReferenceY);
+                this._fastPanZoomTimeoutReferenceY = setTimeout(function () {
+                    _this._fastPanZoomKnownDomainY = domain;
                     _this._fastPanZoomDeltaX = 0;
                     _this._fastPanZoomDeltaY = 0;
                     _this.render();
@@ -6591,16 +6579,14 @@ var Plottable;
             }
             if (performanceEnabled) {
                 if (this.x() && this.x().scale) {
+                    this._fastPanZoomKnownDomainX = this.x().scale.domain();
                     this.x().scale.onUpdate(this._fastPanZoomOnXCallback);
                     this.x().scale.offUpdate(this._renderCallback);
-                    this._fastPanZoomKnownDomainX[0] = this.x().scale.domain()[0];
-                    this._fastPanZoomKnownDomainX[1] = this.x().scale.domain()[1];
                 }
                 if (this.y() && this.y().scale) {
+                    this._fastPanZoomKnownDomainY = this.y().scale.domain();
                     this.y().scale.onUpdate(this._fastPanZoomOnYCallback);
                     this.y().scale.offUpdate(this._renderCallback);
-                    this._fastPanZoomKnownDomainY[0] = this.y().scale.domain()[0];
-                    this._fastPanZoomKnownDomainY[1] = this.y().scale.domain()[1];
                 }
             }
             else {

--- a/plottable.js
+++ b/plottable.js
@@ -6529,6 +6529,20 @@ var Plottable;
             var _lastSeenDomainX = null;
             var _lastSeenDomainY = null;
             var _lazyDomainChangeTimeout = 500;
+            var _triggerLazyDomainChange = function () {
+                if (_this._renderArea != null) {
+                    _this._renderArea.attr("transform", "translate(" + _deltaX + ", " + _deltaY + ")" + "scale(" + _scalingX + ", " + _scalingY + ")");
+                    clearTimeout(_timeoutReference);
+                    _timeoutReference = setTimeout(function () {
+                        _this._lazyDomainChangeCachedDomainX = _lastSeenDomainX;
+                        _this._lazyDomainChangeCachedDomainY = _lastSeenDomainY;
+                        _deltaX = 0;
+                        _deltaY = 0;
+                        _this.render();
+                        _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
+                    }, _lazyDomainChangeTimeout);
+                }
+            };
             this._lazyDomainChangeCallbackX = function (scale) {
                 if (!_this._isAnchored) {
                     return;
@@ -6546,20 +6560,6 @@ var Plottable;
                 _scalingY = (scale.scale(_this._lazyDomainChangeCachedDomainY[1]) - scale.scale(_this._lazyDomainChangeCachedDomainY[0])) / (scale.scale(_lastSeenDomainY[1]) - scale.scale(_lastSeenDomainY[0]));
                 _deltaY = scale.scale(_this._lazyDomainChangeCachedDomainY[0]) - scale.scale(_lastSeenDomainY[0]) * _scalingY;
                 _triggerLazyDomainChange();
-            };
-            var _triggerLazyDomainChange = function () {
-                if (_this._renderArea != null) {
-                    _this._renderArea.attr("transform", "translate(" + _deltaX + ", " + _deltaY + ")" + "scale(" + _scalingX + ", " + _scalingY + ")");
-                    clearTimeout(_timeoutReference);
-                    _timeoutReference = setTimeout(function () {
-                        _this._lazyDomainChangeCachedDomainX = _lastSeenDomainX;
-                        _this._lazyDomainChangeCachedDomainY = _lastSeenDomainY;
-                        _deltaX = 0;
-                        _deltaY = 0;
-                        _this.render();
-                        _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
-                    }, _lazyDomainChangeTimeout);
-                }
             };
         }
         XYPlot.prototype.lazyDomainChange = function (lazyDomainChange) {

--- a/plottable.js
+++ b/plottable.js
@@ -6529,8 +6529,6 @@ var Plottable;
             var _lastSeenDomainX = null;
             var _lastSeenDomainY = null;
             var _lazyDomainChangeTimeout = 500;
-            var _lazyDomainChangeCallbackX;
-            var _lazyDomainChangeCallbackY;
             var _triggerLazyDomainChange = function () {
                 if (_this._renderArea == null) {
                     return;
@@ -6546,7 +6544,7 @@ var Plottable;
                     _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
                 }, _lazyDomainChangeTimeout);
             };
-            _lazyDomainChangeCallbackX = function (scale) {
+            var _lazyDomainChangeCallbackX = function (scale) {
                 if (!_this._isAnchored) {
                     return;
                 }
@@ -6555,7 +6553,7 @@ var Plottable;
                 _deltaX = scale.scale(_this._lazyDomainChangeCachedDomainX[0]) - scale.scale(_lastSeenDomainX[0]);
                 _triggerLazyDomainChange();
             };
-            _lazyDomainChangeCallbackY = function (scale) {
+            var _lazyDomainChangeCallbackY = function (scale) {
                 if (!_this._isAnchored) {
                     return;
                 }

--- a/plottable.js
+++ b/plottable.js
@@ -5922,10 +5922,7 @@ var Plottable;
             this._attrBindings = d3.map();
             this._attrExtents = d3.map();
             this._includedValuesProvider = function (scale) { return _this._includedValuesForScale(scale); };
-            var _timeout = 0;
-            this._renderCallback = function (scale) {
-                _this.render();
-            };
+            this._renderCallback = function (scale) { return _this.render(); };
             this._onDatasetUpdateCallback = function () { return _this._onDatasetUpdate(); };
             this._propertyBindings = d3.map();
             this._propertyExtents = d3.map();
@@ -6535,41 +6532,41 @@ var Plottable;
         }
         XYPlot.prototype._fastPanZoomOnX = function (scale) {
             var _this = this;
-            var domain = scale.domain();
             if (!this._isAnchored) {
                 return;
             }
+            var domain = scale.domain();
             this._fastPanZoomScaleX = (scale.scale(this._fastPanZoomKnownDomainX[1]) - scale.scale(this._fastPanZoomKnownDomainX[0])) / (scale.scale(domain[1]) - scale.scale(domain[0]));
             this._fastPanZoomDeltaX = scale.scale(this._fastPanZoomKnownDomainX[0]) - scale.scale(domain[0]);
             if (this._renderArea != null) {
-                this._renderArea.attr('transform', 'translate(' + this._fastPanZoomDeltaX + ', ' + this._fastPanZoomDeltaY + ')' + 'scale(' + this._fastPanZoomScaleX + ', ' + this._fastPanZoomScaleY + ')');
+                this._renderArea.attr("transform", "translate(" + this._fastPanZoomDeltaX + ", " + this._fastPanZoomDeltaY + ")" + "scale(" + this._fastPanZoomScaleX + ", " + this._fastPanZoomScaleY + ")");
                 clearTimeout(this._fastPanZoomTimeoutReferenceX);
                 this._fastPanZoomTimeoutReferenceX = setTimeout(function () {
                     _this._fastPanZoomKnownDomainX = domain;
                     _this._fastPanZoomDeltaX = 0;
                     _this._fastPanZoomDeltaY = 0;
                     _this.render();
-                    _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
+                    _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
                 }, 500);
             }
         };
         XYPlot.prototype._fastPanZoomOnY = function (scale) {
             var _this = this;
-            var domain = scale.domain();
             if (!this._isAnchored) {
                 return;
             }
+            var domain = scale.domain();
             this._fastPanZoomScaleY = (scale.scale(this._fastPanZoomKnownDomainY[1]) - scale.scale(this._fastPanZoomKnownDomainY[0])) / (scale.scale(domain[1]) - scale.scale(domain[0]));
             this._fastPanZoomDeltaY = scale.scale(this._fastPanZoomKnownDomainY[0]) - scale.scale(domain[0]) * this._fastPanZoomScaleY;
             if (!this._renderArea != null) {
-                this._renderArea.attr('transform', 'translate(' + this._fastPanZoomDeltaX + ', ' + this._fastPanZoomDeltaY + ')' + 'scale(' + this._fastPanZoomScaleX + ', ' + this._fastPanZoomScaleY + ')');
+                this._renderArea.attr("transform", "translate(" + this._fastPanZoomDeltaX + ", " + this._fastPanZoomDeltaY + ")" + "scale(" + this._fastPanZoomScaleX + ", " + this._fastPanZoomScaleY + ")");
                 clearTimeout(this._fastPanZoomTimeoutReferenceY);
                 this._fastPanZoomTimeoutReferenceY = setTimeout(function () {
                     _this._fastPanZoomKnownDomainY = domain;
                     _this._fastPanZoomDeltaX = 0;
                     _this._fastPanZoomDeltaY = 0;
                     _this.render();
-                    _this._renderArea && _this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
+                    _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
                 }, 500);
             }
         };

--- a/quicktests/color/index.html
+++ b/quicktests/color/index.html
@@ -4,7 +4,7 @@
   <script src="../../bower_components/d3/d3.js" charset="utf-8"></script>
   <script src="../../plottable.js"></script>
   <script src="../exampleUtil.js"></script>
- 
+
   <link rel="stylesheet" type="text/css" href="../../plottable.css">
   <link rel="stylesheet" type="text/css" href="main.css">
 
@@ -17,7 +17,7 @@
 <div class="sidebar"></div>
 
 <div id="help-description">
-  <p>Test different color schemes with Plottable plots! 
+  <p>Test different color schemes with Plottable plots!
   <p>Locally change default plottable colors in plottable.css
   <p>Enter a number of series to render in SVGs of specified width and height
   <p>Control what plots to hide/show using the sidebar

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -53,10 +53,7 @@ export class Plot extends Component {
     this._attrBindings = d3.map<Plots.AccessorScaleBinding<any, any>>();
     this._attrExtents = d3.map<any[]>();
     this._includedValuesProvider = (scale: Scale<any, any>) => this._includedValuesForScale(scale);
-    var _timeout = 0;
-    this._renderCallback = (scale) => {
-      this.render();
-    }
+    this._renderCallback = (scale) => this.render();
     this._onDatasetUpdateCallback = () => this._onDatasetUpdate();
     this._propertyBindings = d3.map<Plots.AccessorScaleBinding<any, any>>();
     this._propertyExtents = d3.map<any[]>();

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -40,6 +40,8 @@ export class Plot extends Component {
   protected _propertyExtents: d3.Map<any[]>;
   protected _propertyBindings: d3.Map<Plots.AccessorScaleBinding<any, any>>;
 
+  private _to = 0;
+
   /**
    * A Plot draws some visualization of the inputted Datasets.
    *
@@ -53,7 +55,16 @@ export class Plot extends Component {
     this._attrBindings = d3.map<Plots.AccessorScaleBinding<any, any>>();
     this._attrExtents = d3.map<any[]>();
     this._includedValuesProvider = (scale: Scale<any, any>) => this._includedValuesForScale(scale);
-    this._renderCallback = (scale) => this.render();
+    var _timeout = 0;
+    this._renderCallback = (scale) => {
+      this._renderArea && this._renderArea.attr('transform', 'translate(100, 100)');
+      clearTimeout(this._to);
+      this._to = setTimeout(() => {
+        this._renderArea && this._renderArea.attr('transform', 'translate(0, 0)');
+        this.render();
+      }, 500);
+      // console.log(_timeout);
+    }
     this._onDatasetUpdateCallback = () => this._onDatasetUpdate();
     this._propertyBindings = d3.map<Plots.AccessorScaleBinding<any, any>>();
     this._propertyExtents = d3.map<any[]>();

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -34,13 +34,20 @@ export class Plot extends Component {
   private _animate = false;
   private _animators: {[animator: string]: Animator} = {};
 
-  private _renderCallback: ScaleCallback<Scale<any, any>>;
+  protected _renderCallback: ScaleCallback<Scale<any, any>>;
   private _onDatasetUpdateCallback: DatasetCallback;
 
   protected _propertyExtents: d3.Map<any[]>;
   protected _propertyBindings: d3.Map<Plots.AccessorScaleBinding<any, any>>;
 
   private _to = 0;
+
+  private _temp = {
+    x0: 0,
+    x1: 0,
+    y0: 0,
+    y1: 0
+  };
 
   /**
    * A Plot draws some visualization of the inputted Datasets.
@@ -57,13 +64,27 @@ export class Plot extends Component {
     this._includedValuesProvider = (scale: Scale<any, any>) => this._includedValuesForScale(scale);
     var _timeout = 0;
     this._renderCallback = (scale) => {
-      this._renderArea && this._renderArea.attr('transform', 'translate(100, 100)');
+      var domain = scale.domain();
+      var range = scale.range();
+
+      console.log(this._temp.x0);
+
+      var deltaX = - scale.scale(domain[0]) + scale.scale(this._temp.x0);
+      var deltaY = - scale.scale(range[0]) + scale.scale(this._temp.y0);
+
+      // deltaX = scale.scale(deltaX);
+      // deltaY = scale.scale(deltaY);
+
+      this._renderArea && this._renderArea.attr('transform', 'translate(' + deltaY + ', ' + deltaX + ')');
       clearTimeout(this._to);
       this._to = setTimeout(() => {
         this._renderArea && this._renderArea.attr('transform', 'translate(0, 0)');
+        this._temp.x0 = domain[0];
+        this._temp.x1 = domain[1];
+        this._temp.y0 = range[0];
+        this._temp.y1 = range[1];
         this.render();
       }, 500);
-      // console.log(_timeout);
     }
     this._onDatasetUpdateCallback = () => this._onDatasetUpdate();
     this._propertyBindings = d3.map<Plots.AccessorScaleBinding<any, any>>();

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -40,15 +40,6 @@ export class Plot extends Component {
   protected _propertyExtents: d3.Map<any[]>;
   protected _propertyBindings: d3.Map<Plots.AccessorScaleBinding<any, any>>;
 
-  private _to = 0;
-
-  private _temp = {
-    x0: 0,
-    x1: 0,
-    y0: 0,
-    y1: 0
-  };
-
   /**
    * A Plot draws some visualization of the inputted Datasets.
    *
@@ -64,27 +55,7 @@ export class Plot extends Component {
     this._includedValuesProvider = (scale: Scale<any, any>) => this._includedValuesForScale(scale);
     var _timeout = 0;
     this._renderCallback = (scale) => {
-      var domain = scale.domain();
-      var range = scale.range();
-
-      console.log(this._temp.x0);
-
-      var deltaX = - scale.scale(domain[0]) + scale.scale(this._temp.x0);
-      var deltaY = - scale.scale(range[0]) + scale.scale(this._temp.y0);
-
-      // deltaX = scale.scale(deltaX);
-      // deltaY = scale.scale(deltaY);
-
-      this._renderArea && this._renderArea.attr('transform', 'translate(' + deltaY + ', ' + deltaX + ')');
-      clearTimeout(this._to);
-      this._to = setTimeout(() => {
-        this._renderArea && this._renderArea.attr('transform', 'translate(0, 0)');
-        this._temp.x0 = domain[0];
-        this._temp.x1 = domain[1];
-        this._temp.y0 = range[0];
-        this._temp.y1 = range[1];
-        this.render();
-      }, 500);
+      this.render();
     }
     this._onDatasetUpdateCallback = () => this._onDatasetUpdate();
     this._propertyBindings = d3.map<Plots.AccessorScaleBinding<any, any>>();

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -60,8 +60,8 @@ export class XYPlot<X, Y> extends Plot {
       }
       _lastSeenDomainX = scale.domain();
       _scalingX = (scale.scale(this._cachedDomainX[1]) - scale.scale(this._cachedDomainX[0])) /
-        (scale.scale(_lastSeenDomainX[1]) - scale.scale(_lastSeenDomainX[0]));
-      _deltaX = scale.scale(this._cachedDomainX[0]) - scale.scale(_lastSeenDomainX[0]);
+        (scale.scale(_lastSeenDomainX[1]) - scale.scale(_lastSeenDomainX[0])) || 1;
+      _deltaX = scale.scale(this._cachedDomainX[0]) - scale.scale(_lastSeenDomainX[0]) || 0;
 
       _registerDeferredRendering();
     };
@@ -72,9 +72,8 @@ export class XYPlot<X, Y> extends Plot {
       }
       _lastSeenDomainY = scale.domain();
       _scalingY = (scale.scale(this._cachedDomainY[1]) - scale.scale(this._cachedDomainY[0])) /
-        (scale.scale(_lastSeenDomainY[1]) - scale.scale(_lastSeenDomainY[0]));
-      _deltaY = scale.scale(this._cachedDomainY[0]) -
-        scale.scale(_lastSeenDomainY[0]) * _scalingY;
+        (scale.scale(_lastSeenDomainY[1]) - scale.scale(_lastSeenDomainY[0])) || 1;
+      _deltaY = scale.scale(this._cachedDomainY[0]) - scale.scale(_lastSeenDomainY[0]) * _scalingY || 0;
 
       _registerDeferredRendering();
     };

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -13,16 +13,8 @@ export class XYPlot<X, Y> extends Plot {
   private _fastPanZoomOnXCallback: ScaleCallback<Scale<X, any>>;
   private _fastPanZoomOnYCallback: ScaleCallback<Scale<Y, any>>;
 
-  private _fastPanZoomTimeoutReferenceX = 0;
-  private _fastPanZoomTimeoutReferenceY = 0;
-  private _fastPanZoomDeltaX = 0;
-  private _fastPanZoomDeltaY = 0;
-  private _fastPanZoomScaleX = 1;
-  private _fastPanZoomScaleY = 1;
   private _fastPanZoomKnownDomainX: X[] = [null, null];
   private _fastPanZoomKnownDomainY: Y[] = [null, null];
-
-  public tempScrollTimeout = 500;
 
   /**
    * An XYPlot is a Plot that displays data along two primary directions, X and Y.
@@ -38,58 +30,63 @@ export class XYPlot<X, Y> extends Plot {
     this._adjustYDomainOnChangeFromXCallback = (scale) => this._adjustYDomainOnChangeFromX();
     this._adjustXDomainOnChangeFromYCallback = (scale) => this._adjustXDomainOnChangeFromY();
 
-    this._fastPanZoomOnXCallback = (scale) => this._fastPanZoomOnX(scale);
-    this._fastPanZoomOnYCallback = (scale) => this._fastPanZoomOnY(scale);
-  }
+    var _fastPanZoomTimeoutReferenceX = 0;
+    var _fastPanZoomTimeoutReferenceY = 0;
+    var _fastPanZoomDeltaX = 0;
+    var _fastPanZoomDeltaY = 0;
+    var _fastPanZoomScaleX = 1;
+    var _fastPanZoomScaleY = 1;
+    var tempScrollTimeout = 500;
 
-  private _fastPanZoomOnX(scale: Scale<X, number>) {
-    if (!this._isAnchored) {
-      return;
-    }
+    this._fastPanZoomOnXCallback = (scale) => {
+      if (!this._isAnchored) {
+        return;
+      }
 
-    var domain = scale.domain();
-    this._fastPanZoomScaleX = (scale.scale(this._fastPanZoomKnownDomainX[1]) - scale.scale(this._fastPanZoomKnownDomainX[0])) /
-                              (scale.scale(domain[1]) - scale.scale(domain[0]));
-    this._fastPanZoomDeltaX = scale.scale(this._fastPanZoomKnownDomainX[0]) - scale.scale(domain[0]);
+      var domain = scale.domain();
+      _fastPanZoomScaleX = (scale.scale(this._fastPanZoomKnownDomainX[1]) - scale.scale(this._fastPanZoomKnownDomainX[0])) /
+                                (scale.scale(domain[1]) - scale.scale(domain[0]));
+      _fastPanZoomDeltaX = scale.scale(this._fastPanZoomKnownDomainX[0]) - scale.scale(domain[0]);
 
-    if (this._renderArea != null) {
-      this._renderArea.attr("transform",
-        "translate(" + this._fastPanZoomDeltaX + ", " + this._fastPanZoomDeltaY + ")" +
-        "scale(" + this._fastPanZoomScaleX + ", " + this._fastPanZoomScaleY + ")");
-      clearTimeout(this._fastPanZoomTimeoutReferenceX);
-      this._fastPanZoomTimeoutReferenceX = setTimeout(() => {
-        this._fastPanZoomKnownDomainX = domain;
-        this._fastPanZoomDeltaX = 0;
-        this._fastPanZoomDeltaY = 0;
-        this.render();
-        this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
-      }, this.tempScrollTimeout);
-    }
-  }
+      if (this._renderArea != null) {
+        this._renderArea.attr("transform",
+          "translate(" + _fastPanZoomDeltaX + ", " + _fastPanZoomDeltaY + ")" +
+          "scale(" + _fastPanZoomScaleX + ", " + _fastPanZoomScaleY + ")");
+        clearTimeout(_fastPanZoomTimeoutReferenceX);
+        _fastPanZoomTimeoutReferenceX = setTimeout(() => {
+          this._fastPanZoomKnownDomainX = domain;
+          _fastPanZoomDeltaX = 0;
+          _fastPanZoomDeltaY = 0;
+          this.render();
+          this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
+        }, tempScrollTimeout);
+      }
+    };
 
-  private _fastPanZoomOnY(scale: Scale<Y, number>) {
-    if (!this._isAnchored) {
-      return;
-    }
+    this._fastPanZoomOnYCallback = (scale) => {
+      if (!this._isAnchored) {
+        return;
+      }
 
-    var domain = scale.domain();
-    this._fastPanZoomScaleY = (scale.scale(this._fastPanZoomKnownDomainY[1]) - scale.scale(this._fastPanZoomKnownDomainY[0])) /
-                              (scale.scale(domain[1]) - scale.scale(domain[0]));
-    this._fastPanZoomDeltaY = scale.scale(this._fastPanZoomKnownDomainY[0]) - scale.scale(domain[0]) * this._fastPanZoomScaleY;
+      var domain = scale.domain();
+      _fastPanZoomScaleY = (scale.scale(this._fastPanZoomKnownDomainY[1]) - scale.scale(this._fastPanZoomKnownDomainY[0])) /
+                                (scale.scale(domain[1]) - scale.scale(domain[0]));
+      _fastPanZoomDeltaY = scale.scale(this._fastPanZoomKnownDomainY[0]) - scale.scale(domain[0]) * _fastPanZoomScaleY;
 
-    if (!this._renderArea != null) {
-      this._renderArea.attr("transform",
-        "translate(" + this._fastPanZoomDeltaX + ", " + this._fastPanZoomDeltaY + ")" +
-        "scale(" + this._fastPanZoomScaleX + ", " + this._fastPanZoomScaleY + ")");
-      clearTimeout(this._fastPanZoomTimeoutReferenceY);
-      this._fastPanZoomTimeoutReferenceY = setTimeout(() => {
-        this._fastPanZoomKnownDomainY = domain;
-        this._fastPanZoomDeltaX = 0;
-        this._fastPanZoomDeltaY = 0;
-        this.render();
-        this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
-      }, this.tempScrollTimeout);
-    }
+      if (!this._renderArea != null) {
+        this._renderArea.attr("transform",
+          "translate(" + _fastPanZoomDeltaX + ", " + _fastPanZoomDeltaY + ")" +
+          "scale(" + _fastPanZoomScaleX + ", " + _fastPanZoomScaleY + ")");
+        clearTimeout(_fastPanZoomTimeoutReferenceY);
+        _fastPanZoomTimeoutReferenceY = setTimeout(() => {
+          this._fastPanZoomKnownDomainY = domain;
+          _fastPanZoomDeltaX = 0;
+          _fastPanZoomDeltaY = 0;
+          this.render();
+          this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
+        }, tempScrollTimeout);
+      }
+    };
   }
 
   public performanceEnabled(): boolean;
@@ -234,10 +231,14 @@ export class XYPlot<X, Y> extends Plot {
     scale.onUpdate(adjustCallback);
 
     if (this._performanceEnabled) {
-      var fastPanZoomCallback = key === XYPlot._X_KEY ? this._fastPanZoomOnXCallback
-                                                      : this._fastPanZoomOnYCallback;
-      scale.onUpdate(fastPanZoomCallback);
       scale.offUpdate(this._renderCallback);
+      if (key === XYPlot._X_KEY) {
+        scale.onUpdate(this._fastPanZoomOnXCallback);
+        this._fastPanZoomKnownDomainX = scale.domain();
+      } else {
+        scale.onUpdate(this._fastPanZoomOnYCallback);
+        this._fastPanZoomKnownDomainY = scale.domain();
+      }
     }
   }
 

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -44,60 +44,55 @@ export class XYPlot<X, Y> extends Plot {
     this._adjustYDomainOnChangeFromXCallback = (scale) => this._adjustYDomainOnChangeFromX();
     this._adjustXDomainOnChangeFromYCallback = (scale) => this._adjustXDomainOnChangeFromY();
 
-    this._fastPanZoomOnXCallback = (scale) => {
+    this._fastPanZoomOnXCallback = (scale) => this._fastPanZoomOnX(scale);
+    this._fastPanZoomOnYCallback = (scale) => this._fastPanZoomOnY(scale);
+    this._renderCallback = (scale) => {}
+  }
 
-      var domain = scale.domain();
-      var scaleX = (scale.scale(this._temp.x1) - scale.scale(this._temp.x0)) /
-                   (scale.scale(domain[1]) - scale.scale(domain[0]));
-      this.old_sx = scaleX;
+  private _fastPanZoomOnX(scale: Scale<any, any>) {
+    var domain = scale.domain();
+    var scaleX = (scale.scale(this._temp.x1) - scale.scale(this._temp.x0)) /
+                 (scale.scale(domain[1]) - scale.scale(domain[0]));
+    this.old_sx = scaleX;
 
-      var deltaX = scale.scale(this._temp.x0) - scale.scale(domain[0]);
-      this.old_dx = deltaX;
+    var deltaX = scale.scale(this._temp.x0) - scale.scale(domain[0]);
+    this.old_dx = deltaX;
 
-      this._renderArea && this._renderArea.attr('transform',
-        'translate(' + deltaX + ', ' + this.old_dy + ')' +
-        'scale(' + scaleX +', ' + this.old_sy + ')');
-      clearTimeout(this._to1);
-      this._to1 = setTimeout(() => {
-        this._temp.x0 = domain[0];
-        this._temp.x1 = domain[1];
-        this.old_dx = 0;
-        this.old_dy = 0;
-        this.render();
-        this._renderArea && this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
-      }, 500);
-    }
+    this._renderArea && this._renderArea.attr('transform',
+      'translate(' + deltaX + ', ' + this.old_dy + ')' +
+      'scale(' + scaleX +', ' + this.old_sy + ')');
+    clearTimeout(this._to1);
+    this._to1 = setTimeout(() => {
+      this._temp.x0 = domain[0];
+      this._temp.x1 = domain[1];
+      this.old_dx = 0;
+      this.old_dy = 0;
+      this.render();
+      this._renderArea && this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
+    }, 500);
+  }
 
+  private _fastPanZoomOnY(scale: Scale<any, any>) {
+    var domain = scale.domain();
+    var scaleY = (scale.scale(this._temp.y1) - scale.scale(this._temp.y0)) /
+                 (scale.scale(domain[1]) - scale.scale(domain[0]));
+    this.old_sy = scaleY;
 
-    this._fastPanZoomOnYCallback = (scale) => {
+    var deltaY = scale.scale(this._temp.y0) - scale.scale(domain[0]) * scaleY;
+    this.old_dy = deltaY;
 
-      var domain = scale.domain();
-
-      var scaleY = (scale.scale(this._temp.y1) - scale.scale(this._temp.y0)) /
-                   (scale.scale(domain[1]) - scale.scale(domain[0]));
-      this.old_sy = scaleY;
-
-      var deltaY = scale.scale(this._temp.y0) - scale.scale(domain[0]) * scaleY;
-      this.old_dy = deltaY;
-
-      this._renderArea && this._renderArea.attr('transform',
-        'translate(' + this.old_dx + ', ' + deltaY + ')' +
-        'scale(' + this.old_sx + ', ' + scaleY + ')');
-      clearTimeout(this._to2);
-      this._to2 = setTimeout(() => {
-        this._temp.y0 = domain[0];
-        this._temp.y1 = domain[1];
-        this.old_dx = 0;
-        this.old_dy = 0;
-        this.render();
-        this._renderArea && this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
-      }, 500);
-    }
-
-    this._renderCallback = (scale) => {
-    }
-
-
+    this._renderArea && this._renderArea.attr('transform',
+      'translate(' + this.old_dx + ', ' + deltaY + ')' +
+      'scale(' + this.old_sx + ', ' + scaleY + ')');
+    clearTimeout(this._to2);
+    this._to2 = setTimeout(() => {
+      this._temp.y0 = domain[0];
+      this._temp.y1 = domain[1];
+      this.old_dx = 0;
+      this.old_dy = 0;
+      this.render();
+      this._renderArea && this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
+    }, 500);
   }
 
   /**

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -9,12 +9,12 @@ export class XYPlot<X, Y> extends Plot {
   private _adjustYDomainOnChangeFromXCallback: ScaleCallback<Scale<any, any>>;
   private _adjustXDomainOnChangeFromYCallback: ScaleCallback<Scale<any, any>>;
 
-  private _performanceEnabled = false;
+  private _lazyDomainChange = false;
   private _fastPanZoomOnXCallback: ScaleCallback<Scale<X, any>>;
   private _fastPanZoomOnYCallback: ScaleCallback<Scale<Y, any>>;
 
-  private _fastPanZoomKnownDomainX: X[] = [null, null];
-  private _fastPanZoomKnownDomainY: Y[] = [null, null];
+  private _lazyDomainingKnownDomainX: X[] = [null, null];
+  private _lazyDomainingKnownDomainY: Y[] = [null, null];
 
   /**
    * An XYPlot is a Plot that displays data along two primary directions, X and Y.
@@ -30,12 +30,12 @@ export class XYPlot<X, Y> extends Plot {
     this._adjustYDomainOnChangeFromXCallback = (scale) => this._adjustYDomainOnChangeFromX();
     this._adjustXDomainOnChangeFromYCallback = (scale) => this._adjustXDomainOnChangeFromY();
 
-    var _fastPanZoomTimeoutReferenceX = 0;
-    var _fastPanZoomTimeoutReferenceY = 0;
-    var _fastPanZoomDeltaX = 0;
-    var _fastPanZoomDeltaY = 0;
-    var _fastPanZoomScaleX = 1;
-    var _fastPanZoomScaleY = 1;
+    var _lazyDomainingTimeoutReferenceX = 0;
+    var _lazyDomainingTimeoutReferenceY = 0;
+    var _lazyDomainingDeltaX = 0;
+    var _lazyDomainingDeltaY = 0;
+    var _lazyDomainingScaleX = 1;
+    var _lazyDomainingScaleY = 1;
     var tempScrollTimeout = 500;
 
     this._fastPanZoomOnXCallback = (scale) => {
@@ -44,19 +44,19 @@ export class XYPlot<X, Y> extends Plot {
       }
 
       var domain = scale.domain();
-      _fastPanZoomScaleX = (scale.scale(this._fastPanZoomKnownDomainX[1]) - scale.scale(this._fastPanZoomKnownDomainX[0])) /
+      _lazyDomainingScaleX = (scale.scale(this._lazyDomainingKnownDomainX[1]) - scale.scale(this._lazyDomainingKnownDomainX[0])) /
                                 (scale.scale(domain[1]) - scale.scale(domain[0]));
-      _fastPanZoomDeltaX = scale.scale(this._fastPanZoomKnownDomainX[0]) - scale.scale(domain[0]);
+      _lazyDomainingDeltaX = scale.scale(this._lazyDomainingKnownDomainX[0]) - scale.scale(domain[0]);
 
       if (this._renderArea != null) {
         this._renderArea.attr("transform",
-          "translate(" + _fastPanZoomDeltaX + ", " + _fastPanZoomDeltaY + ")" +
-          "scale(" + _fastPanZoomScaleX + ", " + _fastPanZoomScaleY + ")");
-        clearTimeout(_fastPanZoomTimeoutReferenceX);
-        _fastPanZoomTimeoutReferenceX = setTimeout(() => {
-          this._fastPanZoomKnownDomainX = domain;
-          _fastPanZoomDeltaX = 0;
-          _fastPanZoomDeltaY = 0;
+          "translate(" + _lazyDomainingDeltaX + ", " + _lazyDomainingDeltaY + ")" +
+          "scale(" + _lazyDomainingScaleX + ", " + _lazyDomainingScaleY + ")");
+        clearTimeout(_lazyDomainingTimeoutReferenceX);
+        _lazyDomainingTimeoutReferenceX = setTimeout(() => {
+          this._lazyDomainingKnownDomainX = domain;
+          _lazyDomainingDeltaX = 0;
+          _lazyDomainingDeltaY = 0;
           this.render();
           this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
         }, tempScrollTimeout);
@@ -69,19 +69,19 @@ export class XYPlot<X, Y> extends Plot {
       }
 
       var domain = scale.domain();
-      _fastPanZoomScaleY = (scale.scale(this._fastPanZoomKnownDomainY[1]) - scale.scale(this._fastPanZoomKnownDomainY[0])) /
+      _lazyDomainingScaleY = (scale.scale(this._lazyDomainingKnownDomainY[1]) - scale.scale(this._lazyDomainingKnownDomainY[0])) /
                                 (scale.scale(domain[1]) - scale.scale(domain[0]));
-      _fastPanZoomDeltaY = scale.scale(this._fastPanZoomKnownDomainY[0]) - scale.scale(domain[0]) * _fastPanZoomScaleY;
+      _lazyDomainingDeltaY = scale.scale(this._lazyDomainingKnownDomainY[0]) - scale.scale(domain[0]) * _lazyDomainingScaleY;
 
       if (!this._renderArea != null) {
         this._renderArea.attr("transform",
-          "translate(" + _fastPanZoomDeltaX + ", " + _fastPanZoomDeltaY + ")" +
-          "scale(" + _fastPanZoomScaleX + ", " + _fastPanZoomScaleY + ")");
-        clearTimeout(_fastPanZoomTimeoutReferenceY);
-        _fastPanZoomTimeoutReferenceY = setTimeout(() => {
-          this._fastPanZoomKnownDomainY = domain;
-          _fastPanZoomDeltaX = 0;
-          _fastPanZoomDeltaY = 0;
+          "translate(" + _lazyDomainingDeltaX + ", " + _lazyDomainingDeltaY + ")" +
+          "scale(" + _lazyDomainingScaleX + ", " + _lazyDomainingScaleY + ")");
+        clearTimeout(_lazyDomainingTimeoutReferenceY);
+        _lazyDomainingTimeoutReferenceY = setTimeout(() => {
+          this._lazyDomainingKnownDomainY = domain;
+          _lazyDomainingDeltaX = 0;
+          _lazyDomainingDeltaY = 0;
           this.render();
           this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
         }, tempScrollTimeout);
@@ -89,21 +89,21 @@ export class XYPlot<X, Y> extends Plot {
     };
   }
 
-  public performanceEnabled(): boolean;
-  public performanceEnabled(performanceEnabled: boolean): XYPlot<X, Y>;
-  public performanceEnabled(performanceEnabled?: boolean): any {
-    if (performanceEnabled == null) {
-      return this._performanceEnabled;
+  public lazyDomainChange(): boolean;
+  public lazyDomainChange(lazyDomainChange: boolean): XYPlot<X, Y>;
+  public lazyDomainChange(lazyDomainChange?: boolean): any {
+    if (lazyDomainChange == null) {
+      return this._lazyDomainChange;
     }
 
-    if (performanceEnabled) {
+    if (lazyDomainChange) {
       if (this.x() && this.x().scale) {
-        this._fastPanZoomKnownDomainX = this.x().scale.domain();
+        this._lazyDomainingKnownDomainX = this.x().scale.domain();
         this.x().scale.onUpdate(this._fastPanZoomOnXCallback);
         this.x().scale.offUpdate(this._renderCallback);
       }
       if (this.y() && this.y().scale) {
-        this._fastPanZoomKnownDomainY = this.y().scale.domain();
+        this._lazyDomainingKnownDomainY = this.y().scale.domain();
         this.y().scale.onUpdate(this._fastPanZoomOnYCallback);
         this.y().scale.offUpdate(this._renderCallback);
       }
@@ -118,7 +118,7 @@ export class XYPlot<X, Y> extends Plot {
       }
     }
 
-    this._performanceEnabled = performanceEnabled;
+    this._lazyDomainChange = lazyDomainChange;
     return this;
   }
 
@@ -230,14 +230,14 @@ export class XYPlot<X, Y> extends Plot {
                                                : this._adjustXDomainOnChangeFromYCallback;
     scale.onUpdate(adjustCallback);
 
-    if (this._performanceEnabled) {
+    if (this._lazyDomainChange) {
       scale.offUpdate(this._renderCallback);
       if (key === XYPlot._X_KEY) {
         scale.onUpdate(this._fastPanZoomOnXCallback);
-        this._fastPanZoomKnownDomainX = scale.domain();
+        this._lazyDomainingKnownDomainX = scale.domain();
       } else {
         scale.onUpdate(this._fastPanZoomOnYCallback);
-        this._fastPanZoomKnownDomainY = scale.domain();
+        this._lazyDomainingKnownDomainY = scale.domain();
       }
     }
   }

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -21,6 +21,9 @@ export class XYPlot<X, Y> extends Plot {
   private _fastPanZoomScaleX = 1;
   private _fastPanZoomScaleY = 1;
 
+  private _fastPanZoomKnownDomainX: [X] = [null, null];
+  private _fastPanZoomKnownDomainY: [Y] = [null, null];
+
   private _fastPanZoomKnownDomain: {x0: X; x1: X; y0: Y; y1: Y; };
 
 
@@ -53,14 +56,14 @@ export class XYPlot<X, Y> extends Plot {
     var domain = scale.domain();
 
     if (!this._isAnchored) {
-      this._fastPanZoomKnownDomain.x0 = domain[0];
-      this._fastPanZoomKnownDomain.x1 = domain[1];
+      this._fastPanZoomKnownDomainX[0] = domain[0];
+      this._fastPanZoomKnownDomainX[1] = domain[1];
       return;
     }
 
-    this._fastPanZoomScaleX = (scale.scale(this._fastPanZoomKnownDomain.x1) - scale.scale(this._fastPanZoomKnownDomain.x0)) /
-                  (scale.scale(domain[1]) - scale.scale(domain[0]));
-    this._fastPanZoomDeltaX = scale.scale(this._fastPanZoomKnownDomain.x0) - scale.scale(domain[0]);
+    this._fastPanZoomScaleX = (scale.scale(this._fastPanZoomKnownDomainX[1]) - scale.scale(this._fastPanZoomKnownDomainX[0])) /
+                              (scale.scale(domain[1]) - scale.scale(domain[0]));
+    this._fastPanZoomDeltaX = scale.scale(this._fastPanZoomKnownDomainX[0]) - scale.scale(domain[0]);
 
     if (this._renderArea != null) {
       this._renderArea.attr('transform',
@@ -68,8 +71,8 @@ export class XYPlot<X, Y> extends Plot {
         'scale(' + this._fastPanZoomScaleX +', ' + this._fastPanZoomScaleY + ')');
       clearTimeout(this._fastPanZoomTimeoutX);
       this._fastPanZoomTimeoutX = setTimeout(() => {
-        this._fastPanZoomKnownDomain.x0 = domain[0];
-        this._fastPanZoomKnownDomain.x1 = domain[1];
+        this._fastPanZoomKnownDomainX[0] = domain[0];
+        this._fastPanZoomKnownDomainX[1] = domain[1];
         this._fastPanZoomDeltaX = 0;
         this._fastPanZoomDeltaY = 0;
         this.render();
@@ -83,15 +86,15 @@ export class XYPlot<X, Y> extends Plot {
     var domain = scale.domain();
 
     if (!this._isAnchored) {
-      this._fastPanZoomKnownDomain.y0 = domain[0];
-      this._fastPanZoomKnownDomain.y1 = domain[1];
+      this._fastPanZoomKnownDomainY[0] = domain[0];
+      this._fastPanZoomKnownDomainY[1] = domain[1];
       return;
     }
 
-    this._fastPanZoomScaleY = (scale.scale(this._fastPanZoomKnownDomain.y1) - scale.scale(this._fastPanZoomKnownDomain.y0)) /
+    this._fastPanZoomScaleY = (scale.scale(this._fastPanZoomKnownDomainY[1]) - scale.scale(this._fastPanZoomKnownDomainY[0])) /
                   (scale.scale(domain[1]) - scale.scale(domain[0]));
 
-    this._fastPanZoomDeltaY = scale.scale(this._fastPanZoomKnownDomain.y0) - scale.scale(domain[0]) * this._fastPanZoomScaleY;
+    this._fastPanZoomDeltaY = scale.scale(this._fastPanZoomKnownDomainY[0]) - scale.scale(domain[0]) * this._fastPanZoomScaleY;
 
     if (!this._renderArea != null) {
       this._renderArea.attr('transform',
@@ -99,8 +102,8 @@ export class XYPlot<X, Y> extends Plot {
         'scale(' + this._fastPanZoomScaleX + ', ' + this._fastPanZoomScaleY + ')');
       clearTimeout(this._fastPanZoomTimeoutY);
       this._fastPanZoomTimeoutY = setTimeout(() => {
-        this._fastPanZoomKnownDomain.y0 = domain[0];
-        this._fastPanZoomKnownDomain.y1 = domain[1];
+        this._fastPanZoomKnownDomainY[0] = domain[0];
+        this._fastPanZoomKnownDomainY[1] = domain[1];
         this._fastPanZoomDeltaX = 0;
         this._fastPanZoomDeltaY = 0;
         this.render();
@@ -120,14 +123,14 @@ export class XYPlot<X, Y> extends Plot {
       if (this.x() && this.x().scale) {
         this.x().scale.onUpdate(this._fastPanZoomOnXCallback);
         this.x().scale.offUpdate(this._renderCallback);
-        this._fastPanZoomKnownDomain.x0 = this.x().scale.domain()[0];
-        this._fastPanZoomKnownDomain.x1 = this.x().scale.domain()[1];
+        this._fastPanZoomKnownDomainX[0] = this.x().scale.domain()[0];
+        this._fastPanZoomKnownDomainX[1] = this.x().scale.domain()[1];
       }
       if (this.y() && this.y().scale) {
         this.y().scale.onUpdate(this._fastPanZoomOnYCallback);
         this.y().scale.offUpdate(this._renderCallback);
-        this._fastPanZoomKnownDomain.y0 = this.y().scale.domain()[0];
-        this._fastPanZoomKnownDomain.y1 = this.y().scale.domain()[1];
+        this._fastPanZoomKnownDomainY[0] = this.y().scale.domain()[0];
+        this._fastPanZoomKnownDomainY[1] = this.y().scale.domain()[1];
       }
     } else {
       if (this.x() && this.x().scale) {

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -91,12 +91,12 @@ export class XYPlot<X, Y> extends Plot {
   }
 
   /**
-   * Returns the lazy domain change setting on the plot
-   * @return {boolean} The lazy domain change setting
+   * Returns the whether or not the rendering is deferred for performance boost.
+   * @return {boolean} The deferred rendering option
    */
   public deferredRendering(): boolean;
   /**
-   * Sets / unsets the lazy domain change on the plot.
+   * Sets / unsets the deferred rendering option
    * Activating this option improves the performance of plot interaction (pan / zoom) by
    * performing lazy renders, only after the interaction has stopped. Because re-rendering
    * is no longer performed during the interaction, the zooming might experience a small

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -72,10 +72,8 @@ export class XYPlot<X, Y> extends Plot {
                    (scale.scale(domain[1]) - scale.scale(domain[0]));
       this.old_sy = scaleY;
 
-      var deltaY = - scale.scale(domain[0]) * scaleY + scale.scale(this._temp.y0);
+      var deltaY = scale.scale(this._temp.y0) - scale.scale(domain[0]) * scaleY;
       this.old_dy = deltaY;
-
-      console.log(scale.scale(this._temp.y0), scale.scale(domain[0]), domain[0], scaleY)
 
       this._renderArea && this._renderArea.attr('transform',
         'translate(' + this.old_dx + ', ' + deltaY + ')' +

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -16,10 +16,10 @@ export class XYPlot<X, Y> extends Plot {
   private _to2 = -1;
 
   private _temp = {
-    x0: 0,
-    x1: 1,
-    y0: 0,
-    y1: 1
+    x0: null,
+    x1: null,
+    y0: null,
+    y1: null
   };
 
   private deltaX = 0;
@@ -57,6 +57,12 @@ export class XYPlot<X, Y> extends Plot {
       return;
     }
 
+    if (this._temp.x0 == null) {
+      this._temp.x0 = domain[0];
+      this._temp.x1 = domain[1];
+      return;
+    }
+
     this.scaleX = (scale.scale(this._temp.x1) - scale.scale(this._temp.x0)) /
                   (scale.scale(domain[1]) - scale.scale(domain[0]));
     this.deltaX = scale.scale(this._temp.x0) - scale.scale(domain[0]);
@@ -86,6 +92,13 @@ export class XYPlot<X, Y> extends Plot {
       this._temp.y1 = domain[1];
       return;
     }
+
+    if (this._temp.y0 == null) {
+      this._temp.y0 = domain[0];
+      this._temp.y1 = domain[1];
+      return;
+    }
+
 
     this.scaleY = (scale.scale(this._temp.y1) - scale.scale(this._temp.y0)) /
                   (scale.scale(domain[1]) - scale.scale(domain[0]));

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -10,9 +10,6 @@ export class XYPlot<X, Y> extends Plot {
   private _adjustXDomainOnChangeFromYCallback: ScaleCallback<Scale<any, any>>;
 
   private _lazyDomainChange = false;
-  private _lazyDomainChangeCallbackX: ScaleCallback<Scale<X, any>>;
-  private _lazyDomainChangeCallbackY: ScaleCallback<Scale<Y, any>>;
-
   private _lazyDomainChangeCachedDomainX: X[] = [null, null];
   private _lazyDomainChangeCachedDomainY: Y[] = [null, null];
 
@@ -38,6 +35,8 @@ export class XYPlot<X, Y> extends Plot {
     var _lastSeenDomainX: X[] = null;
     var _lastSeenDomainY: Y[] = null;
     var _lazyDomainChangeTimeout = 500;
+    var _lazyDomainChangeCallbackX: ScaleCallback<Scale<X, any>>;
+    var _lazyDomainChangeCallbackY: ScaleCallback<Scale<Y, any>>;
 
     var _triggerLazyDomainChange = () => {
       if (this._renderArea == null) {
@@ -58,7 +57,7 @@ export class XYPlot<X, Y> extends Plot {
       }, _lazyDomainChangeTimeout);
     };
 
-    this._lazyDomainChangeCallbackX = (scale) => {
+    _lazyDomainChangeCallbackX = (scale) => {
       if (!this._isAnchored) {
         return;
       }
@@ -71,7 +70,7 @@ export class XYPlot<X, Y> extends Plot {
       _triggerLazyDomainChange();
     };
 
-    this._lazyDomainChangeCallbackY = (scale) => {
+    _lazyDomainChangeCallbackY = (scale) => {
       if (!this._isAnchored) {
         return;
       }
@@ -87,9 +86,9 @@ export class XYPlot<X, Y> extends Plot {
 
     this._renderCallback = (scale) => {
       if (this.lazyDomainChange() && this.x() && this.x().scale === scale) {
-        this._lazyDomainChangeCallbackX(scale);
+        _lazyDomainChangeCallbackX(scale);
       } else if (this.lazyDomainChange() && this.y() && this.y().scale === scale) {
-        this._lazyDomainChangeCallbackY(scale);
+        _lazyDomainChangeCallbackY(scale);
       } else {
         this.render();
       }

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -116,8 +116,6 @@ export class XYPlot<X, Y> extends Plot {
     }
 
     if (performanceEnabled) {
-      console.log(1);
-
       if (this.x() && this.x().scale) {
         this.x().scale.onUpdate(this._fastPanZoomOnXCallback);
         this.x().scale.offUpdate(this._renderCallback);
@@ -127,6 +125,14 @@ export class XYPlot<X, Y> extends Plot {
         this.y().scale.offUpdate(this._renderCallback);
       }
     } else {
+      if (this.x() && this.x().scale) {
+        this.x().scale.offUpdate(this._fastPanZoomOnXCallback);
+        this.x().scale.onUpdate(this._renderCallback);
+      }
+      if (this.y() && this.y().scale) {
+        this.y().scale.offUpdate(this._fastPanZoomOnYCallback);
+        this.y().scale.onUpdate(this._renderCallback);
+      }
 
     }
 

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -16,10 +16,10 @@ export class XYPlot<X, Y> extends Plot {
   private _to2 = -1;
 
   private _temp = {
-    x0: null,
-    x1: null,
-    y0: null,
-    y1: null
+    x0: 0,
+    x1: 1,
+    y0: 0,
+    y1: 1
   };
 
   private deltaX = 0;
@@ -57,12 +57,6 @@ export class XYPlot<X, Y> extends Plot {
       return;
     }
 
-    if (this._temp.x0 == null) {
-      this._temp.x0 = domain[0];
-      this._temp.x1 = domain[1];
-      return;
-    }
-
     this.scaleX = (scale.scale(this._temp.x1) - scale.scale(this._temp.x0)) /
                   (scale.scale(domain[1]) - scale.scale(domain[0]));
     this.deltaX = scale.scale(this._temp.x0) - scale.scale(domain[0]);
@@ -92,13 +86,6 @@ export class XYPlot<X, Y> extends Plot {
       this._temp.y1 = domain[1];
       return;
     }
-
-    if (this._temp.y0 == null) {
-      this._temp.y0 = domain[0];
-      this._temp.y1 = domain[1];
-      return;
-    }
-
 
     this.scaleY = (scale.scale(this._temp.y1) - scale.scale(this._temp.y0)) /
                   (scale.scale(domain[1]) - scale.scale(domain[0]));
@@ -132,10 +119,14 @@ export class XYPlot<X, Y> extends Plot {
       if (this.x() && this.x().scale) {
         this.x().scale.onUpdate(this._fastPanZoomOnXCallback);
         this.x().scale.offUpdate(this._renderCallback);
+        this._temp.x0 = this.x().scale.domain()[0];
+        this._temp.x1 = this.x().scale.domain()[1];
       }
       if (this.y() && this.y().scale) {
         this.y().scale.onUpdate(this._fastPanZoomOnYCallback);
         this.y().scale.offUpdate(this._renderCallback);
+        this._temp.y0 = this.y().scale.domain()[0];
+        this._temp.y1 = this.y().scale.domain()[1];
       }
     } else {
       if (this.x() && this.x().scale) {

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -15,12 +15,7 @@ export class XYPlot<X, Y> extends Plot {
   private _to1 = -1;
   private _to2 = -1;
 
-  private _temp = {
-    x0: 0,
-    x1: 1,
-    y0: 0,
-    y1: 1
-  };
+  private _temp: {x0: X; x1: X; y0: Y; y1: Y; };
 
   private deltaX = 0;
   private deltaY = 0;
@@ -46,6 +41,13 @@ export class XYPlot<X, Y> extends Plot {
 
     this._fastPanZoomOnXCallback = (scale) => this._fastPanZoomOnX(scale);
     this._fastPanZoomOnYCallback = (scale) => this._fastPanZoomOnY(scale);
+
+    this._temp = {
+      x0: null,
+      x1: null,
+      y0: null,
+      y1: null,
+    }
   }
 
   private _fastPanZoomOnX(scale: Scale<any, any>) {

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -63,7 +63,6 @@ export class XYPlot<X, Y> extends Plot {
         this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
       }, 500);
     }
-
   }
 
   private _fastPanZoomOnY(scale: Scale<Y, number>) {
@@ -73,8 +72,7 @@ export class XYPlot<X, Y> extends Plot {
 
     var domain = scale.domain();
     this._fastPanZoomScaleY = (scale.scale(this._fastPanZoomKnownDomainY[1]) - scale.scale(this._fastPanZoomKnownDomainY[0])) /
-                  (scale.scale(domain[1]) - scale.scale(domain[0]));
-
+                              (scale.scale(domain[1]) - scale.scale(domain[0]));
     this._fastPanZoomDeltaY = scale.scale(this._fastPanZoomKnownDomainY[0]) - scale.scale(domain[0]) * this._fastPanZoomScaleY;
 
     if (!this._renderArea != null) {
@@ -119,7 +117,6 @@ export class XYPlot<X, Y> extends Plot {
         this.y().scale.offUpdate(this._fastPanZoomOnYCallback);
         this.y().scale.onUpdate(this._renderCallback);
       }
-
     }
 
     this._performanceEnabled = performanceEnabled;

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -46,8 +46,6 @@ export class XYPlot<X, Y> extends Plot {
 
     this._fastPanZoomOnXCallback = (scale) => this._fastPanZoomOnX(scale);
     this._fastPanZoomOnYCallback = (scale) => this._fastPanZoomOnY(scale);
-
-    this._renderCallback = () => {};
   }
 
   private _fastPanZoomOnX(scale: Scale<any, any>) {
@@ -75,13 +73,12 @@ export class XYPlot<X, Y> extends Plot {
         this.deltaY = 0;
         this.render();
         this._renderArea && this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
-      }, 0);
+      }, 500);
     }
 
   }
 
   private _fastPanZoomOnY(scale: Scale<any, any>) {
-
     var domain = scale.domain();
 
     if (!this._isAnchored) {
@@ -107,7 +104,7 @@ export class XYPlot<X, Y> extends Plot {
         this.deltaY = 0;
         this.render();
         this._renderArea && this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
-      }, 0);
+      }, 500);
     }
   }
 
@@ -121,14 +118,14 @@ export class XYPlot<X, Y> extends Plot {
     if (performanceEnabled) {
       console.log(1);
 
-      // if (this.x() && this.x().scale) {
-      //   this.x().scale.onUpdate(this._fastPanZoomOnXCallback);
-      //   this.x().scale.offUpdate(this._renderCallback);
-      // }
-      // if (this.y() && this.y().scale) {
-      //   this.y().scale.onUpdate(this._fastPanZoomOnYCallback);
-      //   this.y().scale.offUpdate(this._renderCallback);
-      // }
+      if (this.x() && this.x().scale) {
+        this.x().scale.onUpdate(this._fastPanZoomOnXCallback);
+        this.x().scale.offUpdate(this._renderCallback);
+      }
+      if (this.y() && this.y().scale) {
+        this.y().scale.onUpdate(this._fastPanZoomOnYCallback);
+        this.y().scale.offUpdate(this._renderCallback);
+      }
     } else {
 
     }
@@ -245,14 +242,12 @@ export class XYPlot<X, Y> extends Plot {
                                                : this._adjustXDomainOnChangeFromYCallback;
     scale.onUpdate(adjustCallback);
 
-    console.log(2);
-    // if (this._performanceEnabled) {
+    if (this._performanceEnabled) {
       var fastPanZoomCallback = key === XYPlot._X_KEY ? this._fastPanZoomOnXCallback
                                                       : this._fastPanZoomOnYCallback;
       scale.onUpdate(fastPanZoomCallback);
-      // scale.offUpdate(this._renderCallback);
-
-    // }
+      scale.offUpdate(this._renderCallback);
+    }
   }
 
   public destroy() {

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -39,6 +39,23 @@ export class XYPlot<X, Y> extends Plot {
     var _lastSeenDomainY: Y[] = null;
     var _lazyDomainChangeTimeout = 500;
 
+    var _triggerLazyDomainChange = () => {
+      if (this._renderArea != null) {
+        this._renderArea.attr("transform",
+          "translate(" + _deltaX + ", " + _deltaY + ")" +
+          "scale(" + _scalingX + ", " + _scalingY + ")");
+        clearTimeout(_timeoutReference);
+        _timeoutReference = setTimeout(() => {
+          this._lazyDomainChangeCachedDomainX = _lastSeenDomainX;
+          this._lazyDomainChangeCachedDomainY = _lastSeenDomainY;
+          _deltaX = 0;
+          _deltaY = 0;
+          this.render();
+          this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
+        }, _lazyDomainChangeTimeout);
+      }
+    };
+
     this._lazyDomainChangeCallbackX = (scale) => {
       if (!this._isAnchored) {
         return;
@@ -64,23 +81,6 @@ export class XYPlot<X, Y> extends Plot {
         scale.scale(_lastSeenDomainY[0]) * _scalingY;
 
       _triggerLazyDomainChange();
-    };
-
-    var _triggerLazyDomainChange = () => {
-      if (this._renderArea != null) {
-        this._renderArea.attr("transform",
-          "translate(" + _deltaX + ", " + _deltaY + ")" +
-          "scale(" + _scalingX + ", " + _scalingY + ")");
-        clearTimeout(_timeoutReference);
-        _timeoutReference = setTimeout(() => {
-          this._lazyDomainChangeCachedDomainX = _lastSeenDomainX;
-          this._lazyDomainChangeCachedDomainY = _lastSeenDomainY;
-          _deltaX = 0;
-          _deltaY = 0;
-          this.render();
-          this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
-        }, _lazyDomainChangeTimeout);
-      }
     };
   }
 

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -22,13 +22,13 @@ export class XYPlot<X, Y> extends Plot {
     y1: 1
   };
 
-  private old_dx = 0;
-  private old_dy = 0;
+  private deltaX = 0;
+  private deltaY = 0;
 
-  private old_sx = 1;
-  private old_sy = 1;
+  private scaleX = 1;
+  private scaleY = 1;
 
-
+  private _performanceEnabled = false;
 
   /**
    * An XYPlot is a Plot that displays data along two primary directions, X and Y.
@@ -51,49 +51,80 @@ export class XYPlot<X, Y> extends Plot {
 
   private _fastPanZoomOnX(scale: Scale<any, any>) {
     var domain = scale.domain();
-    var scaleX = (scale.scale(this._temp.x1) - scale.scale(this._temp.x0)) /
-                 (scale.scale(domain[1]) - scale.scale(domain[0]));
-    this.old_sx = scaleX;
 
-    var deltaX = scale.scale(this._temp.x0) - scale.scale(domain[0]);
-    this.old_dx = deltaX;
-
-    this._renderArea && this._renderArea.attr('transform',
-      'translate(' + deltaX + ', ' + this.old_dy + ')' +
-      'scale(' + scaleX +', ' + this.old_sy + ')');
-    clearTimeout(this._to1);
-    this._to1 = setTimeout(() => {
+    if (!this._isAnchored) {
       this._temp.x0 = domain[0];
       this._temp.x1 = domain[1];
-      this.old_dx = 0;
-      this.old_dy = 0;
-      this.render();
-      this._renderArea && this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
-    }, 500);
+      return;
+    }
+
+    this.scaleX = (scale.scale(this._temp.x1) - scale.scale(this._temp.x0)) /
+                  (scale.scale(domain[1]) - scale.scale(domain[0]));
+    this.deltaX = scale.scale(this._temp.x0) - scale.scale(domain[0]);
+
+    console.log(this.deltaX);
+
+    if (this._renderArea != null) {
+      this._renderArea.attr('transform',
+        'translate(' + this.deltaX + ', ' + this.deltaY + ')' +
+        'scale(' + this.scaleX +', ' + this.scaleY + ')');
+      clearTimeout(this._to1);
+      this._to1 = setTimeout(() => {
+        this._temp.x0 = domain[0];
+        this._temp.x1 = domain[1];
+        this.deltaX = 0;
+        this.deltaY = 0;
+        this.render();
+        this._renderArea && this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
+      }, 0);
+    }
+
   }
 
   private _fastPanZoomOnY(scale: Scale<any, any>) {
     var domain = scale.domain();
-    var scaleY = (scale.scale(this._temp.y1) - scale.scale(this._temp.y0)) /
-                 (scale.scale(domain[1]) - scale.scale(domain[0]));
-    this.old_sy = scaleY;
 
-    var deltaY = scale.scale(this._temp.y0) - scale.scale(domain[0]) * scaleY;
-    this.old_dy = deltaY;
-
-    this._renderArea && this._renderArea.attr('transform',
-      'translate(' + this.old_dx + ', ' + deltaY + ')' +
-      'scale(' + this.old_sx + ', ' + scaleY + ')');
-    clearTimeout(this._to2);
-    this._to2 = setTimeout(() => {
+    if (!this._isAnchored) {
       this._temp.y0 = domain[0];
       this._temp.y1 = domain[1];
-      this.old_dx = 0;
-      this.old_dy = 0;
-      this.render();
-      this._renderArea && this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
-    }, 500);
+      return;
+    }
+
+    this.scaleY = (scale.scale(this._temp.y1) - scale.scale(this._temp.y0)) /
+                  (scale.scale(domain[1]) - scale.scale(domain[0]));
+
+    this.deltaY = scale.scale(this._temp.y0) - scale.scale(domain[0]) * this.scaleY;
+
+    if (!this._renderArea != null) {
+      this._renderArea.attr('transform',
+        'translate(' + this.deltaX + ', ' + this.deltaY + ')' +
+        'scale(' + this.scaleX + ', ' + this.scaleY + ')');
+      clearTimeout(this._to2);
+      this._to2 = setTimeout(() => {
+        this._temp.y0 = domain[0];
+        this._temp.y1 = domain[1];
+        this.deltaX = 0;
+        this.deltaY = 0;
+        this.render();
+        this._renderArea && this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
+      }, 0);
+    }
   }
+
+  // public performanceEnabled(performanceEnabled: boolean) {
+  //   if (performanceEnabled == null) {
+  //     return this._performanceEnabled;
+  //   }
+
+  //   if (perfromanceEnabled) {
+  //     // this._renderCallback = (scale) => {}
+  //   } else {
+
+  //   }
+
+  //   this._performanceEnabled = performanceEnabled;
+  //   return this;
+  // }
 
   /**
    * Gets the AccessorScaleBinding for X.

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -10,8 +10,8 @@ export class XYPlot<X, Y> extends Plot {
   private _adjustXDomainOnChangeFromYCallback: ScaleCallback<Scale<any, any>>;
 
   private _performanceEnabled = false;
-  private _fastPanZoomOnXCallback: ScaleCallback<Scale<any, any>>;
-  private _fastPanZoomOnYCallback: ScaleCallback<Scale<any, any>>;
+  private _fastPanZoomOnXCallback: ScaleCallback<Scale<X, any>>;
+  private _fastPanZoomOnYCallback: ScaleCallback<Scale<Y, any>>;
 
   private _fastPanZoomTimeoutReferenceX = 0;
   private _fastPanZoomTimeoutReferenceY = 0;

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -22,7 +22,6 @@ export class XYPlot<X, Y> extends Plot {
   private _fastPanZoomKnownDomainX: X[] = [null, null];
   private _fastPanZoomKnownDomainY: Y[] = [null, null];
 
-
   /**
    * An XYPlot is a Plot that displays data along two primary directions, X and Y.
    *
@@ -42,55 +41,53 @@ export class XYPlot<X, Y> extends Plot {
   }
 
   private _fastPanZoomOnX(scale: Scale<X, number>) {
-    var domain = scale.domain();
-
     if (!this._isAnchored) {
       return;
     }
 
+    var domain = scale.domain();
     this._fastPanZoomScaleX = (scale.scale(this._fastPanZoomKnownDomainX[1]) - scale.scale(this._fastPanZoomKnownDomainX[0])) /
                               (scale.scale(domain[1]) - scale.scale(domain[0]));
     this._fastPanZoomDeltaX = scale.scale(this._fastPanZoomKnownDomainX[0]) - scale.scale(domain[0]);
 
     if (this._renderArea != null) {
-      this._renderArea.attr('transform',
-        'translate(' + this._fastPanZoomDeltaX + ', ' + this._fastPanZoomDeltaY + ')' +
-        'scale(' + this._fastPanZoomScaleX +', ' + this._fastPanZoomScaleY + ')');
+      this._renderArea.attr("transform",
+        "translate(" + this._fastPanZoomDeltaX + ", " + this._fastPanZoomDeltaY + ")" +
+        "scale(" + this._fastPanZoomScaleX + ", " + this._fastPanZoomScaleY + ")");
       clearTimeout(this._fastPanZoomTimeoutReferenceX);
       this._fastPanZoomTimeoutReferenceX = setTimeout(() => {
         this._fastPanZoomKnownDomainX = domain;
         this._fastPanZoomDeltaX = 0;
         this._fastPanZoomDeltaY = 0;
         this.render();
-        this._renderArea && this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
+        this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
       }, 500);
     }
 
   }
 
   private _fastPanZoomOnY(scale: Scale<Y, number>) {
-    var domain = scale.domain();
-
     if (!this._isAnchored) {
       return;
     }
 
+    var domain = scale.domain();
     this._fastPanZoomScaleY = (scale.scale(this._fastPanZoomKnownDomainY[1]) - scale.scale(this._fastPanZoomKnownDomainY[0])) /
                   (scale.scale(domain[1]) - scale.scale(domain[0]));
 
     this._fastPanZoomDeltaY = scale.scale(this._fastPanZoomKnownDomainY[0]) - scale.scale(domain[0]) * this._fastPanZoomScaleY;
 
     if (!this._renderArea != null) {
-      this._renderArea.attr('transform',
-        'translate(' + this._fastPanZoomDeltaX + ', ' + this._fastPanZoomDeltaY + ')' +
-        'scale(' + this._fastPanZoomScaleX + ', ' + this._fastPanZoomScaleY + ')');
+      this._renderArea.attr("transform",
+        "translate(" + this._fastPanZoomDeltaX + ", " + this._fastPanZoomDeltaY + ")" +
+        "scale(" + this._fastPanZoomScaleX + ", " + this._fastPanZoomScaleY + ")");
       clearTimeout(this._fastPanZoomTimeoutReferenceY);
       this._fastPanZoomTimeoutReferenceY = setTimeout(() => {
         this._fastPanZoomKnownDomainY = domain;
         this._fastPanZoomDeltaX = 0;
         this._fastPanZoomDeltaY = 0;
         this.render();
-        this._renderArea && this._renderArea.attr('transform', 'translate(0, 0) scale(1, 1)');
+        this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
       }, 500);
     }
   }

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -22,6 +22,8 @@ export class XYPlot<X, Y> extends Plot {
   private _fastPanZoomKnownDomainX: X[] = [null, null];
   private _fastPanZoomKnownDomainY: Y[] = [null, null];
 
+  public tempScrollTimeout = 500;
+
   /**
    * An XYPlot is a Plot that displays data along two primary directions, X and Y.
    *
@@ -61,7 +63,7 @@ export class XYPlot<X, Y> extends Plot {
         this._fastPanZoomDeltaY = 0;
         this.render();
         this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
-      }, 500);
+      }, this.tempScrollTimeout);
     }
   }
 
@@ -86,7 +88,7 @@ export class XYPlot<X, Y> extends Plot {
         this._fastPanZoomDeltaY = 0;
         this.render();
         this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
-      }, 500);
+      }, this.tempScrollTimeout);
     }
   }
 

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -44,9 +44,10 @@ export class XYPlot<X, Y> extends Plot {
     this._adjustYDomainOnChangeFromXCallback = (scale) => this._adjustYDomainOnChangeFromX();
     this._adjustXDomainOnChangeFromYCallback = (scale) => this._adjustXDomainOnChangeFromY();
 
-    this._fastPanZoomOnXCallback = (scale) => {}//this._fastPanZoomOnX(scale);
-    this._fastPanZoomOnYCallback = (scale) => {}//this._fastPanZoomOnY(scale);
-    // this._renderCallback = (scale) => {}
+    this._fastPanZoomOnXCallback = (scale) => this._fastPanZoomOnX(scale);
+    this._fastPanZoomOnYCallback = (scale) => this._fastPanZoomOnY(scale);
+
+    this._renderCallback = () => {};
   }
 
   private _fastPanZoomOnX(scale: Scale<any, any>) {
@@ -61,8 +62,6 @@ export class XYPlot<X, Y> extends Plot {
     this.scaleX = (scale.scale(this._temp.x1) - scale.scale(this._temp.x0)) /
                   (scale.scale(domain[1]) - scale.scale(domain[0]));
     this.deltaX = scale.scale(this._temp.x0) - scale.scale(domain[0]);
-
-    console.log(this.deltaX);
 
     if (this._renderArea != null) {
       this._renderArea.attr('transform',
@@ -82,6 +81,7 @@ export class XYPlot<X, Y> extends Plot {
   }
 
   private _fastPanZoomOnY(scale: Scale<any, any>) {
+
     var domain = scale.domain();
 
     if (!this._isAnchored) {
@@ -111,20 +111,31 @@ export class XYPlot<X, Y> extends Plot {
     }
   }
 
-  // public performanceEnabled(performanceEnabled: boolean) {
-  //   if (performanceEnabled == null) {
-  //     return this._performanceEnabled;
-  //   }
+  public performanceEnabled(): boolean;
+  public performanceEnabled(performanceEnabled: boolean): XYPlot<X, Y>;
+  public performanceEnabled(performanceEnabled?: boolean): any {
+    if (performanceEnabled == null) {
+      return this._performanceEnabled;
+    }
 
-  //   if (perfromanceEnabled) {
-  //     // this._renderCallback = (scale) => {}
-  //   } else {
+    if (performanceEnabled) {
+      console.log(1);
 
-  //   }
+      // if (this.x() && this.x().scale) {
+      //   this.x().scale.onUpdate(this._fastPanZoomOnXCallback);
+      //   this.x().scale.offUpdate(this._renderCallback);
+      // }
+      // if (this.y() && this.y().scale) {
+      //   this.y().scale.onUpdate(this._fastPanZoomOnYCallback);
+      //   this.y().scale.offUpdate(this._renderCallback);
+      // }
+    } else {
 
-  //   this._performanceEnabled = performanceEnabled;
-  //   return this;
-  // }
+    }
+
+    this._performanceEnabled = performanceEnabled;
+    return this;
+  }
 
   /**
    * Gets the AccessorScaleBinding for X.
@@ -234,9 +245,14 @@ export class XYPlot<X, Y> extends Plot {
                                                : this._adjustXDomainOnChangeFromYCallback;
     scale.onUpdate(adjustCallback);
 
-    var fastPanZoomCallback = key === XYPlot._X_KEY ? this._fastPanZoomOnXCallback
-                                                    : this._fastPanZoomOnYCallback;
-    scale.onUpdate(fastPanZoomCallback);
+    console.log(2);
+    // if (this._performanceEnabled) {
+      var fastPanZoomCallback = key === XYPlot._X_KEY ? this._fastPanZoomOnXCallback
+                                                      : this._fastPanZoomOnYCallback;
+      scale.onUpdate(fastPanZoomCallback);
+      // scale.offUpdate(this._renderCallback);
+
+    // }
   }
 
   public destroy() {

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -12,8 +12,8 @@ export class XYPlot<X, Y> extends Plot {
   private _fastPanZoomOnXCallback: ScaleCallback<Scale<any, any>>;
   private _fastPanZoomOnYCallback: ScaleCallback<Scale<any, any>>;
 
-  private _to1 = 0;
-  private _to2 = 0;
+  private _to1 = -1;
+  private _to2 = -1;
 
   private _temp = {
     x0: 0,
@@ -44,9 +44,9 @@ export class XYPlot<X, Y> extends Plot {
     this._adjustYDomainOnChangeFromXCallback = (scale) => this._adjustYDomainOnChangeFromX();
     this._adjustXDomainOnChangeFromYCallback = (scale) => this._adjustXDomainOnChangeFromY();
 
-    this._fastPanZoomOnXCallback = (scale) => this._fastPanZoomOnX(scale);
-    this._fastPanZoomOnYCallback = (scale) => this._fastPanZoomOnY(scale);
-    this._renderCallback = (scale) => {}
+    this._fastPanZoomOnXCallback = (scale) => {}//this._fastPanZoomOnX(scale);
+    this._fastPanZoomOnYCallback = (scale) => {}//this._fastPanZoomOnY(scale);
+    // this._renderCallback = (scale) => {}
   }
 
   private _fastPanZoomOnX(scale: Scale<any, any>) {
@@ -124,11 +124,6 @@ export class XYPlot<X, Y> extends Plot {
       this._updateYExtentsAndAutodomain();
     }
 
-    // TODO This is extra (_bindProperty -> _bind -> _installScale -> onUpdate with thi smethod)
-    if (xScale != null) {
-      xScale.onUpdate(this._adjustYDomainOnChangeFromXCallback);
-    }
-
     this.render();
     return this;
   }
@@ -161,11 +156,6 @@ export class XYPlot<X, Y> extends Plot {
     this._bindProperty(XYPlot._Y_KEY, y, yScale);
     if (this._autoAdjustXScaleDomain) {
       this._updateXExtentsAndAutodomain();
-    }
-
-    // TODO This is extra (_bindProperty -> _bind -> _installScale -> onUpdate with thi smethod)
-    if (yScale != null) {
-      yScale.onUpdate(this._adjustXDomainOnChangeFromYCallback);
     }
 
     this.render();

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -35,14 +35,11 @@ export class XYPlot<X, Y> extends Plot {
     var _lastSeenDomainX: X[] = null;
     var _lastSeenDomainY: Y[] = null;
     var _lazyDomainChangeTimeout = 500;
-    var _lazyDomainChangeCallbackX: ScaleCallback<Scale<X, any>>;
-    var _lazyDomainChangeCallbackY: ScaleCallback<Scale<Y, any>>;
 
     var _triggerLazyDomainChange = () => {
       if (this._renderArea == null) {
         return;
       }
-
       this._renderArea.attr("transform",
         "translate(" + _deltaX + ", " + _deltaY + ")" +
         "scale(" + _scalingX + ", " + _scalingY + ")");
@@ -57,11 +54,10 @@ export class XYPlot<X, Y> extends Plot {
       }, _lazyDomainChangeTimeout);
     };
 
-    _lazyDomainChangeCallbackX = (scale) => {
+    var _lazyDomainChangeCallbackX = (scale: Scale<X, any>) => {
       if (!this._isAnchored) {
         return;
       }
-
       _lastSeenDomainX = scale.domain();
       _scalingX = (scale.scale(this._lazyDomainChangeCachedDomainX[1]) - scale.scale(this._lazyDomainChangeCachedDomainX[0])) /
         (scale.scale(_lastSeenDomainX[1]) - scale.scale(_lastSeenDomainX[0]));
@@ -70,11 +66,10 @@ export class XYPlot<X, Y> extends Plot {
       _triggerLazyDomainChange();
     };
 
-    _lazyDomainChangeCallbackY = (scale) => {
+    var _lazyDomainChangeCallbackY = (scale: Scale<Y, any>) => {
       if (!this._isAnchored) {
         return;
       }
-
       _lastSeenDomainY = scale.domain();
       _scalingY = (scale.scale(this._lazyDomainChangeCachedDomainY[1]) - scale.scale(this._lazyDomainChangeCachedDomainY[0])) /
         (scale.scale(_lastSeenDomainY[1]) - scale.scale(_lastSeenDomainY[0]));
@@ -93,7 +88,6 @@ export class XYPlot<X, Y> extends Plot {
         this.render();
       }
     };
-
   }
 
   /**

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -36,11 +36,13 @@ export class XYPlot<X, Y> extends Plot {
     super();
     this.addClass("xy-plot");
 
+    // X
     this._adjustYDomainOnChangeFromXCallback = (scale) => {
       this._adjustYDomainOnChangeFromX();
 
       var domain = scale.domain();
-      var scaleX = (this._temp.x1 - this._temp.x0) / (domain[1] - domain[0]);
+      var scaleX = (scale.scale(this._temp.x1) - scale.scale(this._temp.x0)) /
+                   (scale.scale(domain[1]) - scale.scale(domain[0]));
       this.old_sx = scaleX;
 
       var deltaX = scale.scale(this._temp.x0) - scale.scale(domain[0]);
@@ -60,16 +62,20 @@ export class XYPlot<X, Y> extends Plot {
       }, 500);
     }
 
+    // Y
     this._adjustXDomainOnChangeFromYCallback = (scale) => {
       this._adjustXDomainOnChangeFromY();
 
       var domain = scale.domain();
 
-      var scaleY = (this._temp.y1 - this._temp.y0) / (domain[1] - domain[0]);
+      var scaleY = (scale.scale(this._temp.y1) - scale.scale(this._temp.y0)) /
+                   (scale.scale(domain[1]) - scale.scale(domain[0]));
       this.old_sy = scaleY;
 
-      var deltaY = - scale.scale(domain[0]) + scale.scale(this._temp.y0);
-      this.old_dy;
+      var deltaY = - scale.scale(domain[0]) * scaleY + scale.scale(this._temp.y0);
+      this.old_dy = deltaY;
+
+      console.log(scale.scale(this._temp.y0), scale.scale(domain[0]), domain[0], scaleY)
 
       this._renderArea && this._renderArea.attr('transform',
         'translate(' + this.old_dx + ', ' + deltaY + ')' +

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -10,8 +10,8 @@ export class XYPlot<X, Y> extends Plot {
   private _adjustXDomainOnChangeFromYCallback: ScaleCallback<Scale<any, any>>;
 
   private _deferredRendering = false;
-  private _performanceCachedDomainX: X[] = [null, null];
-  private _performanceCachedDomainY: Y[] = [null, null];
+  private _cachedDomainX: X[] = [null, null];
+  private _cachedDomainY: Y[] = [null, null];
 
   /**
    * An XYPlot is a Plot that displays data along two primary directions, X and Y.
@@ -45,8 +45,8 @@ export class XYPlot<X, Y> extends Plot {
         "scale(" + _scalingX + ", " + _scalingY + ")");
       clearTimeout(_timeoutReference);
       _timeoutReference = setTimeout(() => {
-        this._performanceCachedDomainX = _lastSeenDomainX;
-        this._performanceCachedDomainY = _lastSeenDomainY;
+        this._cachedDomainX = _lastSeenDomainX;
+        this._cachedDomainY = _lastSeenDomainY;
         _deltaX = 0;
         _deltaY = 0;
         this.render();
@@ -59,9 +59,9 @@ export class XYPlot<X, Y> extends Plot {
         return;
       }
       _lastSeenDomainX = scale.domain();
-      _scalingX = (scale.scale(this._performanceCachedDomainX[1]) - scale.scale(this._performanceCachedDomainX[0])) /
+      _scalingX = (scale.scale(this._cachedDomainX[1]) - scale.scale(this._cachedDomainX[0])) /
         (scale.scale(_lastSeenDomainX[1]) - scale.scale(_lastSeenDomainX[0]));
-      _deltaX = scale.scale(this._performanceCachedDomainX[0]) - scale.scale(_lastSeenDomainX[0]);
+      _deltaX = scale.scale(this._cachedDomainX[0]) - scale.scale(_lastSeenDomainX[0]);
 
       _registerDeferredRendering();
     };
@@ -71,9 +71,9 @@ export class XYPlot<X, Y> extends Plot {
         return;
       }
       _lastSeenDomainY = scale.domain();
-      _scalingY = (scale.scale(this._performanceCachedDomainY[1]) - scale.scale(this._performanceCachedDomainY[0])) /
+      _scalingY = (scale.scale(this._cachedDomainY[1]) - scale.scale(this._cachedDomainY[0])) /
         (scale.scale(_lastSeenDomainY[1]) - scale.scale(_lastSeenDomainY[0]));
-      _deltaY = scale.scale(this._performanceCachedDomainY[0]) -
+      _deltaY = scale.scale(this._cachedDomainY[0]) -
         scale.scale(_lastSeenDomainY[0]) * _scalingY;
 
       _registerDeferredRendering();
@@ -112,10 +112,10 @@ export class XYPlot<X, Y> extends Plot {
 
     if (deferredRendering) {
       if (this.x() && this.x().scale) {
-        this._performanceCachedDomainX = this.x().scale.domain();
+        this._cachedDomainX = this.x().scale.domain();
       }
       if (this.y() && this.y().scale) {
-        this._performanceCachedDomainY = this.y().scale.domain();
+        this._cachedDomainY = this.y().scale.domain();
       }
     }
 

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -84,7 +84,20 @@ export class XYPlot<X, Y> extends Plot {
     };
   }
 
+  /**
+   * Returns the lazy domain change setting on the plot
+   * @return {boolean} The lazy domain change setting
+   */
   public lazyDomainChange(): boolean;
+  /**
+   * Sets / unsets the lazy domain change on the plot.
+   * Activating this option improves the performance of plot interaction (pan / zoom) by
+   * performing lazy renders, only after the interaction has stopped. Because re-rendering
+   * is no longer performed during the interaction, the zooming might experience a small
+   * resolution degradation, before the lazy re-render is performed.
+   *
+   * This option is intended for cases where performance is an issue.
+   */
   public lazyDomainChange(lazyDomainChange: boolean): XYPlot<X, Y>;
   public lazyDomainChange(lazyDomainChange?: boolean): any {
     if (lazyDomainChange == null) {


### PR DESCRIPTION
Closes #2352

**Description**: If we are having a ScatterPlot with a lot of data points, every time we update the scale (which happens on every single pan or zoom), all the `DOM` elements corresponding to the points get modified (in particular translated). This is a costly operation and can be improved by translating the parent `<g>` and letting the drawing engine do the heavy lifting. 

**Problem1**: We cannot account nicely for scaling (when zooming) here. That is because the scale on the top element also modifies the size of the points (and that is not acceptable). Therefore, we ran for a compromise: Scale the points (i.e. zoom badly and lose resolution) during the zoom and recompute all the points after no more interaction exists.

**Problem2**: Because of Problem1, we no longer have the same default behavior. Therefore, there is a switch `XYPlot.deferredRendering()`. 

**Unimplemented ideas**:
- <del>Maybe call performanceEnabled() something else, such that we can have finer grained performance enabling in the future </del>
- <del>Document everything, especially the new public method </del>
- <del>Extract the 500 ms in the setTimeout in some variable </del>
- Add tests?

---

#### Fiddles
Before: http://jsfiddle.net/rk0sx69o/
After: http://jsfiddle.net/rk0sx69o/7/

---

#### Numbers
Scatter Plot with 8000 points `6x increase`:
- Before: `175 ms` per update
- After: `3 ms` per update (capped by browser)

Old Scatter Plot with 8000 points has same performance as new Scatter Plot with 50 000


---

#### QE Notes: 
- Regression test: With the option `deferredRendering` turned off (that is the default). There should be absolutely no change.
- Feature test: With the option `deferredRendering` turned on, panning should behave the same. Zooming however, should behave weirdly (points / lines on plot appear to grow or shrink), but it should default to better quality after 0.5 seconds. The behavior should be the same as when zooming in/out on google map, i.e. low quality during zoom and get back to normal once we have data.
- Performance test: With the option `deferredRendering` turned on, panning and zooming should be 10x or more faster
- Additional notes: All plots except Pie Plot should be affected