### PR TITLE
[ESLint] - applying default usage of key-spacing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,6 @@
     "no-multi-spaces": 0,
     "camelcase": 0,
     "comma-spacing": 0,
-    "key-spacing": 0,
     "no-use-before-define": 0,
     "strict": 0,
     "no-underscore-dangle": 0

--- a/quicktests/overlaying/tests/realistic/numeric_grid.js
+++ b/quicktests/overlaying/tests/realistic/numeric_grid.js
@@ -1,15 +1,15 @@
 function makeData() {
   "use strict";
-  return [{fill: "#FFFFFF",	x:0, x2:13, y:0, y2:7},
-          {fill: "#FF0000",	x:0, x2:13, y:7, y2:20},
-          {fill: "#0000FF",	x:13, x2:20, y:0, y2:7},
-          {fill: "#FFFFFF",	x:13, x2:20, y:7, y2:13},
-          {fill: "#FFFF00",	x:13, x2:20, y:13, y2:20},
-          {fill: "#FFFF00",	x:20, x2:30, y:0, y2:10},
-          {fill: "#0000FF",	x:20, x2:27, y:10, y2:13},
-          {fill: "#FFFFFF",	x:27, x2:30, y:10, y2:17},
-          {fill: "#FFFFFF",	x:20, x2:27, y:13, y2:20},
-          {fill: "#FF0000",	x:27, x2:30, y:17, y2:20}
+  return [{fill: "#FFFFFF",	x: 0, x2: 13, y: 0, y2: 7},
+          {fill: "#FF0000",	x: 0, x2: 13, y: 7, y2: 20},
+          {fill: "#0000FF",	x: 13, x2: 20, y: 0, y2: 7},
+          {fill: "#FFFFFF",	x: 13, x2: 20, y: 7, y2: 13},
+          {fill: "#FFFF00",	x: 13, x2: 20, y: 13, y2: 20},
+          {fill: "#FFFF00",	x: 20, x2: 30, y: 0, y2: 10},
+          {fill: "#0000FF",	x: 20, x2: 27, y: 10, y2: 13},
+          {fill: "#FFFFFF",	x: 27, x2: 30, y: 10, y2: 17},
+          {fill: "#FFFFFF",	x: 20, x2: 27, y: 13, y2: 20},
+          {fill: "#FF0000",	x: 27, x2: 30, y: 17, y2: 20}
          ];
 }
 


### PR DESCRIPTION
This enforces spacing around keys and values in object literals.  By default, there is no space between the key and the ":" and there is a space between the ":" and the value.

Invalid:
```javascript
var a = { foo :"bar" };
```

Valid:
```javascript
var a = { foo: "bar" };
```