### PR TITLE
[ESLint] - applying default usage of use-before-define

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,7 @@
     "camelcase": 0,
     "comma-spacing": 0,
     "key-spacing": 0,
-    "no-use-before-define": 0,
+    "no-use-before-define": [2, "nofunc"],
     "strict": 0,
     "no-underscore-dangle": 0
   }

--- a/quicktests/overlaying/tests/functional/titleLegend_change.js
+++ b/quicktests/overlaying/tests/functional/titleLegend_change.js
@@ -59,17 +59,6 @@ function run(svg, data, Plottable) {
   renderGrape.attr("fill", colorProjector, colorScale1);
 
   var renderArea = new Plottable.Components.Group([scatterPlot, linePlot]);
-  function emptyTitle() {
-    title1.text("");
-  }
-
-  function smallTitle() {
-    title1.text("tiny");
-  }
-
-  function longTitle() {
-    title1.text("abcdefghij klmnopqrs tuvwxyz ABCDEF GHIJK LMNOP QRSTUV WXYZ");
-  }
 
   function noPlots() {
     colorScale1.domain([]);
@@ -107,6 +96,18 @@ function run(svg, data, Plottable) {
   var legend1 = new Plottable.Components.Legend(colorScale1);
   legend1.maxEntriesPerRow(1);
   var titleTable = new Plottable.Components.Table([[title1, legend1]]);
+
+  function emptyTitle() {
+    title1.text("");
+  }
+
+  function smallTitle() {
+    title1.text("tiny");
+  }
+
+  function longTitle() {
+    title1.text("abcdefghij klmnopqrs tuvwxyz ABCDEF GHIJK LMNOP QRSTUV WXYZ");
+  }
 
   var noTitleLabel  = new Plottable.Components.Label("no title", 0);
   var shortTitleLabel  = new Plottable.Components.Label("tiny title", 0);


### PR DESCRIPTION
Enforcing that variables can only be used after they have been declared / defined.  The configuration has been modified from the default to allow for usage of functions before they are declared.

Invalid:
```javascript
doStuff(foo);
var foo = 10;
```

Valid:
```javascript
var foo = 10;
doStuff(foo);
```