### PR TITLE
[ESLint] - applying default usage of camelcase

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,7 @@
     "d3": true,
     "Plottable": true,
     "makeRandomData": true,
-    "deep_copy": true
+    "deepCopy": true
   },
   "rules": {
     "no-eval": 0,
@@ -15,7 +15,6 @@
     "no-console": 0,
     "no-unused-vars": [2, {"vars": "local"}],
     "no-multi-spaces": 0,
-    "camelcase": 0,
     "comma-spacing": 0,
     "no-use-before-define": 0,
     "strict": 0

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
         removeComments: false
       }
     },
-    verify_d_ts: {
+    verifyDefinitionFiles: {
       src: ["typings/d3/d3.d.ts",
             "typings/touch-events/touch-events.d.ts",
             "plottable.d.ts",
@@ -62,18 +62,18 @@ module.exports = function(grunt) {
   var nestedBraceMatch = ": \\{[^{}]*\\}";
   var typeNameMatch = ": [^;]*";
   var finalMatch = "((" + nestedBraceMatch + ")|(" + typeNameMatch + "))?\\n?;";
-  var jsdoc_init = "\\n *\\/\\*\\* *\\n";
-  var jsdoc_mid = "( *\\*[^\\n]*\\n)+";
-  var jsdoc_end = " *\\*\\/ *";
-  var jsdoc = "(" + jsdoc_init + jsdoc_mid + jsdoc_end + ")?";
+  var jsdocInit = "\\n *\\/\\*\\* *\\n";
+  var jsdocMid = "( *\\*[^\\n]*\\n)+";
+  var jsdocEnd = " *\\*\\/ *";
+  var jsdoc = "(" + jsdocInit + jsdocMid + jsdocEnd + ")?";
 
   var sedJSON = {
-    private_definitions: {
+    privateDefinitions: {
       pattern: jsdoc + prefixMatch + "private " + varNameMatch + finalMatch,
       replacement: "",
       path: "build/plottable.d.ts"
     },
-    plottable_multifile: {
+    plottableMultifile: {
       pattern: '/// *<reference path="([^."]*).ts" */>',
       replacement: 'synchronousRequire("/build/src/$1.js");',
       path: "plottable_multifile.js"
@@ -83,7 +83,7 @@ module.exports = function(grunt) {
       replacement: "",
       path: "build/plottable.d.ts"
     },
-    tests_multifile: {
+    testsMultifile: {
       pattern: '/// *<reference path="([^."]*).ts" */>',
       replacement: 'synchronousRequire("/build/test/$1.js");',
       path: "test/tests_multifile.js"
@@ -93,7 +93,7 @@ module.exports = function(grunt) {
       replacement: '/// <reference path="../$1" />',
       path: "build/sublime.d.ts"
     },
-    version_number: {
+    versionNumber: {
       pattern: "@VERSION",
       replacement: "<%= pkg.version %>",
       path: "plottable.js"
@@ -158,11 +158,11 @@ module.exports = function(grunt) {
         src: ["license_header.txt", "plottable.js"],
         dest: "plottable.js"
       },
-      plottable_multifile: {
+      plottableMultifile: {
         src: ["synchronousRequire.js", "src/reference.ts"],
         dest: "plottable_multifile.js"
       },
-      tests_multifile: {
+      testsMultifile: {
         src: ["synchronousRequire.js", "test/testReference.ts"],
         dest: "test/tests_multifile.js"
       },
@@ -238,7 +238,7 @@ module.exports = function(grunt) {
         "files": ["quicktests/overlaying/tests/**/*.js"]
       }
     },
-    blanket_mocha: {
+    "blanket_mocha": {
       all: ['test/coverage.html'],
       options: {
         threshold: 70
@@ -326,12 +326,12 @@ module.exports = function(grunt) {
   });
   grunt.registerTask("test-compile", [
                                   "ts:test",
-                                  "concat:tests_multifile",
-                                  "sed:tests_multifile",
+                                  "concat:testsMultifile",
+                                  "sed:testsMultifile",
                                   "concat:tests"
                                   ]);
   grunt.registerTask("default", "launch");
-  var compile_task = [
+  var compileTask = [
       "update_ts_files",
       "update_test_ts_files",
       "ts:dev",
@@ -339,19 +339,19 @@ module.exports = function(grunt) {
       "concat:svgtypewriter",
       "concat:definitions",
       "sed:definitions",
-      "sed:private_definitions",
+      "sed:privateDefinitions",
       "umd:all",
       "concat:header",
-      "sed:version_number",
+      "sed:versionNumber",
       "definitions_prod",
       "test-compile",
-      "concat:plottable_multifile",
-      "sed:plottable_multifile",
+      "concat:plottableMultifile",
+      "sed:plottableMultifile",
       "clean:tscommand",
       "update-qt"
   ];
 
-  grunt.registerTask("dev-compile", compile_task);
+  grunt.registerTask("dev-compile", compileTask);
 
   grunt.registerTask("release:patch", ["bump:patch", "dist-compile", "gitcommit:version"]);
   grunt.registerTask("release:minor", ["bump:minor", "dist-compile", "gitcommit:version"]);
@@ -361,7 +361,7 @@ module.exports = function(grunt) {
                                   "dev-compile",
                                   "blanket_mocha",
                                   "parallelize:tslint",
-                                  "ts:verify_d_ts",
+                                  "ts:verifyDefinitionFiles",
                                   "uglify",
                                   "compress"
                                   ]);
@@ -370,7 +370,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask("launch", ["connect", "dev-compile", "watch"]);
   grunt.registerTask("test-sauce", ["connect", "saucelabs-mocha"]);
-  grunt.registerTask("test", ["dev-compile", "blanket_mocha", "parallelize:tslint", "jshint", "ts:verify_d_ts", "jscs", "eslint"]);
+  grunt.registerTask("test", ["dev-compile", "blanket_mocha", "parallelize:tslint", "jshint", "ts:verifyDefinitionFiles", "jscs", "eslint"]);
   // Disable saucelabs for external pull requests. Check if we can see the SAUCE_USERNAME
   var travisTests = ["test"];
   if (process.env.SAUCE_USERNAME) {

--- a/quicktests/exampleUtil.js
+++ b/quicktests/exampleUtil.js
@@ -122,10 +122,10 @@ function generateHeightWeightData(n) {
   return data;
 }
 
-function deep_copy(from, to){
+function deepCopy(from, to){
   "use strict";
-  var deep_copy_xy = function(d){
+  var deepCopyXY = function(d){
     to.push({'x': d.x, 'y': d.y});
   };
-  from.forEach(deep_copy_xy);
+  from.forEach(deepCopyXY);
 }

--- a/quicktests/overlaying/tests/animations/inflation.js
+++ b/quicktests/overlaying/tests/animations/inflation.js
@@ -2,7 +2,7 @@
 function makeData() {
   "use strict";
   var inflationData = function(years, baseline, resistance){
-    var dataset_array = [];
+    var datasets = [];
     var current = baseline;
     var up = true;
     for( var i = 0; i < years; i++){
@@ -16,9 +16,9 @@ function makeData() {
         current = obj.y;
         data.push(obj);
       }
-      dataset_array.push(data);
+      datasets.push(data);
     }
-    return dataset_array;
+    return datasets;
   };
 
   var d = inflationData(5, 2, 0.4);
@@ -36,9 +36,9 @@ function run(svg, data, Plottable) {
    var yearFormatter = function(d) { return Math.floor(d / 12) + 1999; };
    xAxis.formatter(yearFormatter);
 
-  var plot_array = [];
+  var plots = [];
 
-  var add_year = function(y){
+  var addYear = function(y){
     var dataset = new Plottable.Dataset(data[y]);
     var lineRenderer = new Plottable.Plots.Line()
               .addDataset(dataset)
@@ -46,46 +46,46 @@ function run(svg, data, Plottable) {
               .y(function(d) { return d.y; }, yScale)
               .attr("stroke", "#000000")
               .animated(true);
-    plot_array.push(lineRenderer);
+    plots.push(lineRenderer);
   };
 
-  var year_average = function(y){
+  var yearAverage = function(y){
     var d = data[y];
     var total = 0;
     for (var month = 0; month < 12; month++){
       total += d[month].y;
     }
     var average = total / 12;
-    var avg_data = [{x: y * 12, y: average}, {x: y * 12 + 11, y: average}];
-    var avg_ds = new Plottable.Dataset(avg_data);
+    var avgData = [{x: y * 12, y: average}, {x: y * 12 + 11, y: average}];
+    var avgDataset = new Plottable.Dataset(avgData);
     var lineRenderer = new Plottable.Plots.Line()
-              .addDataset(avg_ds)
+              .addDataset(avgDataset)
               .x(function(datum) { return datum.x; }, xScale)
               .y(function(datum) { return datum.y; }, yScale)
               .attr("stroke", "#ff0000")
               .attr("stroke-width", 4)
               .attr("stroke-dasharray", 4)
               .animated(true);
-    plot_array.push(lineRenderer);
+    plots.push(lineRenderer);
   };
 
   for (var year = 0; year < data.length; year++){
-    add_year(year);
-    year_average(year);
+    addYear(year);
+    yearAverage(year);
   }
 
-  var group = new Plottable.Components.Group(plot_array);
+  var group = new Plottable.Components.Group(plots);
 
- var add_click = function(plot){
+ var addClick = function(plot){
       new Plottable.Interactions.Click().onClick(function(){
       var d = plot.datasets()[0].data();
       plot.datasets()[0].data(d);
     }).attachTo(plot);
  };
 
-  for( var i = 0; i < plot_array.length; i++){
-    var plot = plot_array[i];
-    add_click(plot);
+  for( var i = 0; i < plots.length; i++){
+    var plot = plots[i];
+    addClick(plot);
   }
 
   var lineChart = new Plottable.Components.Table([[yAxis, group],

--- a/quicktests/overlaying/tests/animations/inflationsegment.js
+++ b/quicktests/overlaying/tests/animations/inflationsegment.js
@@ -2,7 +2,7 @@
 function makeData() {
   "use strict";
   var inflationData = function(years, baseline, resistance){
-    var dataset_array = [];
+    var datasets = [];
     var current = baseline;
     var up = true;
     for( var i = 0; i < years; i++){
@@ -16,9 +16,9 @@ function makeData() {
         current = obj.y;
         data.push(obj);
       }
-      dataset_array.push(data);
+      datasets.push(data);
     }
-    return dataset_array;
+    return datasets;
   };
 
   var d = inflationData(5, 2, 0.4);
@@ -36,10 +36,10 @@ function run(svg, data, Plottable) {
    var yearFormatter = function(d) { return Math.floor(d / 12) + 1999; };
    xAxis.formatter(yearFormatter);
 
-  var plot_array = [];
-  var segment_data = [];
+  var plots = [];
+  var segmentData = [];
 
-  var add_year = function(y){
+  var addYear = function(y){
     var dataset = new Plottable.Dataset(data[y]);
     var lineRenderer = new Plottable.Plots.Line()
               .addDataset(dataset)
@@ -47,39 +47,39 @@ function run(svg, data, Plottable) {
               .y(function(d) { return d.y; }, yScale)
               .attr("stroke", "#000000")
               .animated(true);
-    plot_array.push(lineRenderer);
+    plots.push(lineRenderer);
   };
 
-  var year_average = function(y){
+  var yearAverage = function(y){
     var d = data[y];
     var total = 0;
     for (var month = 0; month < 12; month++){
       total += d[month].y;
     }
     var average = total / 12;
-    segment_data.push({x: y * 12, y: average, x2: y * 12 + 11});
+    segmentData.push({x: y * 12, y: average, x2: y * 12 + 11});
   };
 
-  var get_x = function(d) { return d.x; };
-  var get_x2 = function(d) { return d.x2; };
-  var get_y = function(d) { return d.y; };
+  var getX = function(d) { return d.x; };
+  var getX2 = function(d) { return d.x2; };
+  var getY = function(d) { return d.y; };
 
   for (var year = 0; year < data.length; year++){
-    add_year(year);
-    year_average(year);
+    addYear(year);
+    yearAverage(year);
     var segmentPlot = new Plottable.Plots.Segment()
-      .x(get_x, xScale)
-      .y(get_y, yScale)
-      .x2(get_x2, xScale)
-      .addDataset(new Plottable.Dataset(segment_data))
+      .x(getX, xScale)
+      .y(getY, yScale)
+      .x2(getX2, xScale)
+      .addDataset(new Plottable.Dataset(segmentData))
       .attr("stroke", "#ff0000")
       .attr("stroke-width", 4)
       .attr("stroke-dasharray", 4)
       .animated(true);
-    plot_array.push(segmentPlot);
+    plots.push(segmentPlot);
   }
 
-  var group = new Plottable.Components.Group(plot_array);
+  var group = new Plottable.Components.Group(plots);
 
   var lineChart = new Plottable.Components.Table([[yAxis, group],
                                                  [null,  xAxis]]);

--- a/quicktests/overlaying/tests/basic/basic_allPlots.js
+++ b/quicktests/overlaying/tests/basic/basic_allPlots.js
@@ -10,10 +10,10 @@ function run(svg, data, Plottable) {
     var xScale = new Plottable.Scales.Linear();
     var yScale = new Plottable.Scales.Linear();
 
-    var axis_array = [];
+    var axes = [];
     for(var i = 0; i < 5; i++){
-        axis_array.push(new Plottable.Axes.Numeric(xScale, "bottom"));
-        axis_array.push(new Plottable.Axes.Numeric(yScale, "left"));
+        axes.push(new Plottable.Axes.Numeric(xScale, "bottom"));
+        axes.push(new Plottable.Axes.Numeric(yScale, "left"));
     }
 
     var dataset = new Plottable.Dataset(data);
@@ -26,16 +26,16 @@ function run(svg, data, Plottable) {
 
     //title + legend
 
-    var scatterTable = new Plottable.Components.Table([[axis_array[1], scatterPlot],
-                                                     [null, axis_array[0]]]);
-    var lineTable = new Plottable.Components.Table([[axis_array[3], linePlot],
-                                                     [null, axis_array[2]]]);
-    var areaTable = new Plottable.Components.Table([[axis_array[5], areaPlot],
-                                                     [null, axis_array[4]]]);
-    var vbarTable = new Plottable.Components.Table([[axis_array[7], vbarPlot],
-                                                     [null, axis_array[6]]]);
-    var hbarTable = new Plottable.Components.Table([[axis_array[9], hbarPlot],
-                                                     [null, axis_array[8]]]);
+    var scatterTable = new Plottable.Components.Table([[axes[1], scatterPlot],
+                                                     [null, axes[0]]]);
+    var lineTable = new Plottable.Components.Table([[axes[3], linePlot],
+                                                     [null, axes[2]]]);
+    var areaTable = new Plottable.Components.Table([[axes[5], areaPlot],
+                                                     [null, axes[4]]]);
+    var vbarTable = new Plottable.Components.Table([[axes[7], vbarPlot],
+                                                     [null, axes[6]]]);
+    var hbarTable = new Plottable.Components.Table([[axes[9], hbarPlot],
+                                                     [null, axes[8]]]);
     var bigTable = new Plottable.Components.Table([[scatterTable, lineTable],
                                                   [areaTable, vbarTable],
                                                   [hbarTable, null]]);

--- a/quicktests/overlaying/tests/functional/categoryFormatter.js
+++ b/quicktests/overlaying/tests/functional/categoryFormatter.js
@@ -36,18 +36,18 @@ function run(svg, data, Plottable) {
 
   bigTable.renderTo(svg);
 
-  function identity_frmt() {
+  function useIdentityFormatter() {
     xAxis.formatter(Plottable.Formatters.identity());
   }
-  function dow_frmt() {
+  function useDOWFormatter() {
      xAxis.formatter(DOWFormatter);
   }
-  function emp_frmt() {
+  function useEmpIdFormatter() {
      xAxis.formatter(EmpIDFormatter);
   }
 
-  new Plottable.Interactions.Click().onClick(identity_frmt).attachTo(IdTitle);
-  new Plottable.Interactions.Click().onClick(dow_frmt).attachTo(DowTitle);
-  new Plottable.Interactions.Click().onClick(emp_frmt).attachTo(EmpIDTitle);
+  new Plottable.Interactions.Click().onClick(useIdentityFormatter).attachTo(IdTitle);
+  new Plottable.Interactions.Click().onClick(useDOWFormatter).attachTo(DowTitle);
+  new Plottable.Interactions.Click().onClick(useEmpIdFormatter).attachTo(EmpIDTitle);
 
 }

--- a/quicktests/overlaying/tests/functional/formatter.js
+++ b/quicktests/overlaying/tests/functional/formatter.js
@@ -7,14 +7,14 @@ function makeData() {
 function run(svg, data, Plottable) {
   "use strict";
 
-    var large_x = function(d){
+    var largeX = function(d){
          d.x = d.x * 100000000;
     };
 
-  var big_numbers = [];
-  deep_copy(data[0], big_numbers);
-  big_numbers.forEach(large_x);
-  var dataseries1 = new Plottable.Dataset(big_numbers);
+  var bigNumbers = [];
+  deepCopy(data[0], bigNumbers);
+  bigNumbers.forEach(largeX);
+  var dataseries1 = new Plottable.Dataset(bigNumbers);
 
   //Axis
   var xScale = new Plottable.Scales.Linear();
@@ -41,41 +41,41 @@ function run(svg, data, Plottable) {
 
   bigTable.renderTo(svg);
 
-  function identity_frmt() {
+  function useIdentityFormatter() {
     xAxis.formatter(Plottable.Formatters.identity());
     yAxis.formatter(Plottable.Formatters.identity());
   }
-  function general_frmt() {
+  function useGeneralFormatter() {
     xAxis.formatter(Plottable.Formatters.general(2));
     yAxis.formatter(Plottable.Formatters.general(2));
   }
-  function fixed_frmt() {
+  function useFixedFormatter() {
     xAxis.formatter(Plottable.Formatters.fixed(2));
     yAxis.formatter(Plottable.Formatters.fixed(2));
   }
-  function currency_frmt() {
+  function useCurrencyFormatter() {
     xAxis.formatter(Plottable.Formatters.currency(2, '$', true));
     yAxis.formatter(Plottable.Formatters.currency(2, '$', true));
   }
-  function percentage_frmt() {
+  function usePercentageFormatter() {
     xAxis.formatter(Plottable.Formatters.percentage(2));
     yAxis.formatter(Plottable.Formatters.percentage(2));
   }
-  function SI_frmt() {
+  function useSIFormatter() {
      xAxis.formatter(Plottable.Formatters.siSuffix(2));
      yAxis.formatter(Plottable.Formatters.siSuffix(2));
   }
-  function custom_frmt() {
+  function useCustomFormatter() {
      xAxis.formatter(custFormatter);
      yAxis.formatter(custFormatter);
   }
 
-  new Plottable.Interactions.Click().onClick(identity_frmt).attachTo(IdTitle);
-  new Plottable.Interactions.Click().onClick(general_frmt).attachTo(GenTitle);
-  new Plottable.Interactions.Click().onClick(fixed_frmt).attachTo(FixTitle);
-  new Plottable.Interactions.Click().onClick(currency_frmt).attachTo(CurrTitle);
-  new Plottable.Interactions.Click().onClick(percentage_frmt).attachTo(PerTitle);
-  new Plottable.Interactions.Click().onClick(SI_frmt).attachTo(SITitle);
-  new Plottable.Interactions.Click().onClick(custom_frmt).attachTo(CustTitle);
+  new Plottable.Interactions.Click().onClick(useIdentityFormatter).attachTo(IdTitle);
+  new Plottable.Interactions.Click().onClick(useGeneralFormatter).attachTo(GenTitle);
+  new Plottable.Interactions.Click().onClick(useFixedFormatter).attachTo(FixTitle);
+  new Plottable.Interactions.Click().onClick(useCurrencyFormatter).attachTo(CurrTitle);
+  new Plottable.Interactions.Click().onClick(usePercentageFormatter).attachTo(PerTitle);
+  new Plottable.Interactions.Click().onClick(useSIFormatter).attachTo(SITitle);
+  new Plottable.Interactions.Click().onClick(useCustomFormatter).attachTo(CustTitle);
 
 }

--- a/quicktests/overlaying/tests/realistic/hockey.js
+++ b/quicktests/overlaying/tests/realistic/hockey.js
@@ -31,18 +31,18 @@ function run(svg, data, Plottable) {
         var G = +d.G;
 
         var slope = A / G;
-        var slope_offset = 0;
-        if (slope > 80 / 33.14 ) { slope_offset = 3; }
-        else if (slope > 1 ) { slope_offset = 2; }
-        else if (slope > 33.14 / 80 ) {slope_offset = 1; }
+        var slopeOffset = 0;
+        if (slope > 80 / 33.14 ) { slopeOffset = 3; }
+        else if (slope > 1 ) { slopeOffset = 2; }
+        else if (slope > 33.14 / 80 ) {slopeOffset = 1; }
 
         var zone = A + G;
-        var zone_offset = 0;
-        if (zone > 20) { zone_offset = 1; }
-        if (zone > 40) { zone_offset = 2; }
-        if (zone > 60) { zone_offset = 3; }
+        var zoneOffset = 0;
+        if (zone > 20) { zoneOffset = 1; }
+        if (zone > 40) { zoneOffset = 2; }
+        if (zone > 60) { zoneOffset = 3; }
 
-        return colorRange[slope_offset * 4 + zone_offset];
+        return colorRange[slopeOffset * 4 + zoneOffset];
       });
 
   var x = function(d){ return d.x; };

--- a/quicktests/overlaying/tests/realistic/phones.js
+++ b/quicktests/overlaying/tests/realistic/phones.js
@@ -73,7 +73,7 @@ function run(svg, data, Plottable) {
   var RoKDataset = new Plottable.Dataset(data.korea);
 
   var xScale = new Plottable.Scales.Linear().domain([0, 1]);
-  var xScale_reverse = new Plottable.Scales.Linear().domain([1, 0]);
+  var xScaleReverse = new Plottable.Scales.Linear().domain([1, 0]);
   var yScale = new Plottable.Scales.Category();
 
   var AusLabels = new Plottable.Axes.Category(yScale, "left")
@@ -110,7 +110,7 @@ function run(svg, data, Plottable) {
   };
   var AusFeaturePlot = new Plottable.Plots.Bar("horizontal")
       .addDataset(AusDataset)
-      .x(filterFeatureX, xScale_reverse)
+      .x(filterFeatureX, xScaleReverse)
       .y(filterFeatureY, yScale)
       .attr("fill", AusColor);
 
@@ -122,7 +122,7 @@ function run(svg, data, Plottable) {
 
   var IndFeaturePlot = new Plottable.Plots.Bar("horizontal")
       .addDataset(IndDataset)
-      .x(filterFeatureX, xScale_reverse)
+      .x(filterFeatureX, xScaleReverse)
       .y(filterFeatureY, yScale)
       .attr("fill", IndColor);
 
@@ -134,7 +134,7 @@ function run(svg, data, Plottable) {
 
   var RoKFeaturePlot = new Plottable.Plots.Bar("horizontal")
       .addDataset(RoKDataset)
-      .x(filterFeatureX, xScale_reverse)
+      .x(filterFeatureX, xScaleReverse)
       .y(filterFeatureY, yScale)
       .attr("fill", RoKColor);
 

--- a/quicktests/overlaying/tests/realistic/stocks.js
+++ b/quicktests/overlaying/tests/realistic/stocks.js
@@ -52,54 +52,46 @@ function run(svg, data, Plottable) {
           var xAxis = new Plottable.Axes.Time(xScale, "bottom");
           var xAxisTop = new Plottable.Axes.Time(xScale, "top");
 
-          var yScale_aapl = new Plottable.Scales.Linear();
-          var yAxis_aapl = new Plottable.Axes.Numeric(yScale_aapl, "right").showEndTickLabels(true);
-          var label_aapl = new Plottable.Components.AxisLabel("AAPL").angle(90);
+          var yScaleAAPL = new Plottable.Scales.Linear();
+          var yAxisAAPL = new Plottable.Axes.Numeric(yScaleAAPL, "right").showEndTickLabels(true);
+          var labelAAPL = new Plottable.Components.AxisLabel("AAPL").angle(90);
 
-          var yScale_goog = new Plottable.Scales.Linear();
-          var yAxis_goog = new Plottable.Axes.Numeric(yScale_goog, "left").xAlignment("right").showEndTickLabels(true);
-          var label_goog = new Plottable.Components.AxisLabel("GOOG").angle(-90);
+          var yScaleGOOG = new Plottable.Scales.Linear();
+          var yAxisGOOG = new Plottable.Axes.Numeric(yScaleGOOG, "left").xAlignment("right").showEndTickLabels(true);
+          var labelGOOG = new Plottable.Components.AxisLabel("GOOG").angle(-90);
 
           var colorScale = new Plottable.Scales.Color();
 
           var aaplSource = new Plottable.Dataset(aapl, {name: "AAPL"} );
           var googSource = new Plottable.Dataset(goog, {name: "GOOG"} );
 
-          var line_aapl = new Plottable.Plots.Line().animated(true)
+          var lineAAPL = new Plottable.Plots.Line().animated(true)
                                   .addDataset(aaplSource)
                                   .x(function(d) { return d.Date; }, xScale)
-                                  .y(function(d) { return d["Adj Close"]; }, yScale_aapl)
+                                  .y(function(d) { return d["Adj Close"]; }, yScaleAAPL)
                                   .attr("stroke", function(d, index, dataset) { return dataset.metadata().name; }, colorScale);
-          if (typeof line_aapl.autorange === "function") {
-            line_aapl.autorange("y");
-          } else {
-            line_aapl.autorangeMode("y");
-          }
-          var line_goog = new Plottable.Plots.Line().animated(true)
+          lineAAPL.autorangeMode("y");
+          var lineGOOG = new Plottable.Plots.Line().animated(true)
                                   .addDataset(googSource)
                                   .x(function(d) { return d.Date; }, xScale)
-                                  .y(function(d) { return d["Adj Close"]; }, yScale_goog)
+                                  .y(function(d) { return d["Adj Close"]; }, yScaleGOOG)
                                   .attr("stroke", function(d, index, dataset) { return dataset.metadata().name; }, colorScale);
-          if (typeof line_aapl.autorange === "function") {
-            line_goog.autorange("y");
-          } else {
-            line_goog.autorangeMode("y");
-          }
+          lineGOOG.autorangeMode("y");
 
           // should be one line plot, pending #917
 
           var legend = new Plottable.Components.Legend(colorScale);
           legend.maxEntriesPerRow(1);
           legend.yAlignment("top");
-          var plotArea = new Plottable.Components.Group([line_aapl, line_goog, legend]);
+          var plotArea = new Plottable.Components.Group([lineAAPL, lineGOOG, legend]);
 
-          var yScale_diff = new Plottable.Scales.Linear();
+          var yScaleDiff = new Plottable.Scales.Linear();
 
           var DAY_MILLIS = 24 * 60 * 60 * 1000;
-          var bar_diff = new Plottable.Plots.Bar("vertical").animated(true)
+          var barDiff = new Plottable.Plots.Bar("vertical").animated(true)
                                   .addDataset(new Plottable.Dataset(diffData))
                                   .x(function(d) { return d.Date; }, xScale)
-                                  .y(function(d) { return d["net change"]; }, yScale_diff)
+                                  .y(function(d) { return d["net change"]; }, yScaleDiff)
                                   .attr("width", function() { return xScale.scale(DAY_MILLIS) - xScale.scale(0); })
                                   .attr("fill", function(d) {
                                     return d["net change"] > 0 ? colorScale.range()[2] : colorScale.range()[6];
@@ -107,8 +99,8 @@ function run(svg, data, Plottable) {
 
           var table = new Plottable.Components.Table([
                             [null      , null      , xAxisTop, null      , null      ],
-                            [label_goog, yAxis_goog, plotArea, yAxis_aapl, label_aapl],
-                            [null      , null      , bar_diff, null      , null      ],
+                            [labelGOOG, yAxisGOOG, plotArea, yAxisAAPL, labelAAPL],
+                            [null      , null      , barDiff , null      , null      ],
                             [null      , null      , xAxis   , null      , null      ]]);
 
           table.rowWeight(2, 0.3);

--- a/quicktests/overlaying/tests/realistic/symbols.js
+++ b/quicktests/overlaying/tests/realistic/symbols.js
@@ -9,7 +9,7 @@ function run(svg, data, Plottable){
   "use strict";
 
   var plotData = [];
-  deep_copy(data[0], plotData);
+  deepCopy(data[0], plotData);
   var dataset = new Plottable.Dataset(plotData);
 
   var xScale = new Plottable.Scales.Linear();


### PR DESCRIPTION
Enforces that variables are camelcased.  From my gatherings of Javascript, camelCasing variables is more conventional than underscore separation.

Invalid:
```javascript
var foo_bar = 5;
```

Valid:
```javascript
var fooBar = 5;
```