### PR TITLE
Deprecate Plottable.MILLISECONDS_IN_ONE_DAY & Formatters.relativeDate()

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -596,7 +596,7 @@ declare module Plottable {
      * The number of milliseconds between midnight one day and the next is
      * not a fixed quantity.
      *
-     * use date.setDate(Date.getDate() + n) instead.
+     * Use date.setDate(date.getDate() + number_of_days) instead.
      *
      */
     var MILLISECONDS_IN_ONE_DAY: number;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -596,7 +596,7 @@ declare module Plottable {
      * The number of milliseconds between midnight one day and the next is
      * not a fixed quantity.
      *
-     * use Date#setDate(Date#getDate() + n) instead.
+     * use date.setDate(Date.getDate() + n) instead.
      *
      */
     var MILLISECONDS_IN_ONE_DAY: number;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -590,6 +590,15 @@ declare module Plottable {
 
 declare module Plottable {
     type Formatter = (d: any) => string;
+    /**
+     * This field is deprecated and will be removed in v2.0.0.
+     *
+     * The number of milliseconds between midnight one day and the next is
+     * not a fixed quantity.
+     *
+     * use Date#setDate(Date#getDate() + n) instead.
+     *
+     */
     var MILLISECONDS_IN_ONE_DAY: number;
     module Formatters {
         /**

--- a/plottable.js
+++ b/plottable.js
@@ -1117,6 +1117,15 @@ var Plottable;
 ///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
+    /**
+     * This field is deprecated and will be removed in v2.0.0.
+     *
+     * The number of milliseconds between midnight one day and the next is
+     * not a fixed quantity.
+     *
+     * use Date#setDate(Date#getDate() + n) instead.
+     *
+     */
     Plottable.MILLISECONDS_IN_ONE_DAY = 24 * 60 * 60 * 1000;
     var Formatters;
     (function (Formatters) {
@@ -1311,6 +1320,7 @@ var Plottable;
             if (baseValue === void 0) { baseValue = 0; }
             if (increment === void 0) { increment = Plottable.MILLISECONDS_IN_ONE_DAY; }
             if (label === void 0) { label = ""; }
+            Plottable.Utils.Window.deprecated("relativeDate()", "1.2", "Not safe for use with time zones.");
             return function (d) {
                 var relativeDate = Math.round((d.valueOf() - baseValue) / increment);
                 return relativeDate.toString() + label;
@@ -2252,15 +2262,21 @@ var Plottable;
                 return _super.prototype._setDomain.call(this, values);
             };
             Time.prototype._defaultExtent = function () {
-                var endTimeValue = new Date().valueOf();
-                var startTimeValue = endTimeValue - Plottable.MILLISECONDS_IN_ONE_DAY;
+                var now = new Date();
+                var endTimeValue = now.valueOf();
+                now.setDate(now.getDate() - 1);
+                var startTimeValue = now.valueOf();
                 return [new Date(startTimeValue), new Date(endTimeValue)];
             };
             Time.prototype._expandSingleValueDomain = function (singleValueDomain) {
                 var startTime = singleValueDomain[0].getTime();
                 var endTime = singleValueDomain[1].getTime();
                 if (startTime === endTime) {
-                    return [new Date(startTime - Plottable.MILLISECONDS_IN_ONE_DAY), new Date(endTime + Plottable.MILLISECONDS_IN_ONE_DAY)];
+                    var startDate = new Date(startTime);
+                    startDate.setDate(startDate.getDate() - 1);
+                    var endDate = new Date(endTime);
+                    endDate.setDate(endDate.getDate() + 1);
+                    return [startDate, endDate];
                 }
                 return singleValueDomain;
             };

--- a/plottable.js
+++ b/plottable.js
@@ -1123,7 +1123,7 @@ var Plottable;
      * The number of milliseconds between midnight one day and the next is
      * not a fixed quantity.
      *
-     * use Date#setDate(Date#getDate() + n) instead.
+     * use date.setDate(Date.getDate() + n) instead.
      *
      */
     Plottable.MILLISECONDS_IN_ONE_DAY = 24 * 60 * 60 * 1000;
@@ -1320,7 +1320,7 @@ var Plottable;
             if (baseValue === void 0) { baseValue = 0; }
             if (increment === void 0) { increment = Plottable.MILLISECONDS_IN_ONE_DAY; }
             if (label === void 0) { label = ""; }
-            Plottable.Utils.Window.deprecated("relativeDate()", "1.2", "Not safe for use with time zones.");
+            Plottable.Utils.Window.deprecated("relativeDate()", "1.3", "Not safe for use with time zones.");
             return function (d) {
                 var relativeDate = Math.round((d.valueOf() - baseValue) / increment);
                 return relativeDate.toString() + label;

--- a/plottable.js
+++ b/plottable.js
@@ -1123,7 +1123,7 @@ var Plottable;
      * The number of milliseconds between midnight one day and the next is
      * not a fixed quantity.
      *
-     * use date.setDate(Date.getDate() + n) instead.
+     * Use date.setDate(date.getDate() + number_of_days) instead.
      *
      */
     Plottable.MILLISECONDS_IN_ONE_DAY = 24 * 60 * 60 * 1000;

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -4,6 +4,15 @@ module Plottable {
 
 export type Formatter = (d: any) => string;
 
+/**
+ * This field is deprecated and will be removed in v2.0.0.
+ * 
+ * The number of milliseconds between midnight one day and the next is 
+ * not a fixed quantity.
+ * 
+ * use Date#setDate(Date.getDate() + n) instead.
+ * 
+ */
 export var MILLISECONDS_IN_ONE_DAY = 24 * 60 * 60 * 1000;
 
 export module Formatters {
@@ -199,6 +208,7 @@ export module Formatters {
    * @returns {Formatter} A formatter for time/date values.
    */
   export function relativeDate(baseValue: number = 0, increment: number = MILLISECONDS_IN_ONE_DAY, label: string = "") {
+    Plottable.Utils.Window.deprecated("relativeDate()", "1.2", "Not safe for use with time zones.");
     return (d: any) => {
       var relativeDate = Math.round((d.valueOf() - baseValue) / increment);
       return relativeDate.toString() + label;

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -10,7 +10,7 @@ export type Formatter = (d: any) => string;
  * The number of milliseconds between midnight one day and the next is 
  * not a fixed quantity.
  * 
- * use Date#setDate(Date.getDate() + n) instead.
+ * use date.setDate(Date.getDate() + n) instead.
  * 
  */
 export var MILLISECONDS_IN_ONE_DAY = 24 * 60 * 60 * 1000;
@@ -208,7 +208,7 @@ export module Formatters {
    * @returns {Formatter} A formatter for time/date values.
    */
   export function relativeDate(baseValue: number = 0, increment: number = MILLISECONDS_IN_ONE_DAY, label: string = "") {
-    Plottable.Utils.Window.deprecated("relativeDate()", "1.2", "Not safe for use with time zones.");
+    Plottable.Utils.Window.deprecated("relativeDate()", "1.3", "Not safe for use with time zones.");
     return (d: any) => {
       var relativeDate = Math.round((d.valueOf() - baseValue) / increment);
       return relativeDate.toString() + label;

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -10,7 +10,7 @@ export type Formatter = (d: any) => string;
  * The number of milliseconds between midnight one day and the next is 
  * not a fixed quantity.
  * 
- * use date.setDate(Date.getDate() + n) instead.
+ * Use date.setDate(date.getDate() + number_of_days) instead.
  * 
  */
 export var MILLISECONDS_IN_ONE_DAY = 24 * 60 * 60 * 1000;

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -38,8 +38,10 @@ export module Scales {
     }
 
     protected _defaultExtent(): Date[] {
-      var endTimeValue = new Date().valueOf();
-      var startTimeValue = endTimeValue - MILLISECONDS_IN_ONE_DAY;
+      var now = new Date();
+      var endTimeValue = now.valueOf();
+      now.setDate(now.getDate() - 1);
+      var startTimeValue = now.valueOf();
       return [new Date(startTimeValue), new Date(endTimeValue)];
     }
 
@@ -47,7 +49,11 @@ export module Scales {
       var startTime = singleValueDomain[0].getTime();
       var endTime = singleValueDomain[1].getTime();
       if (startTime === endTime) {
-        return [new Date(startTime - MILLISECONDS_IN_ONE_DAY), new Date(endTime + MILLISECONDS_IN_ONE_DAY)];
+        var startDate = new Date(startTime);
+        startDate.setDate(startDate.getDate() - 1);
+        var endDate = new Date(endTime);
+        endDate.setDate(endDate.getDate() + 1);
+        return [startDate, endDate];
       }
       return singleValueDomain;
     }


### PR DESCRIPTION
Also remove from non-deprecated src.

Fixes #2402 

