### PR TITLE
Fix measurement of bar labels

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -7301,7 +7301,7 @@ var Plottable;
                 var drawer = _super.prototype._createNodesForDataset.call(this, dataset);
                 drawer.renderArea().classed(Bar._BAR_AREA_CLASS, true);
                 var labelArea = this._renderArea.append("g").classed(Bar._LABEL_AREA_CLASS, true);
-                var measurer = new SVGTypewriter.Measurers.CacheCharacterMeasurer(labelArea);
+                var measurer = new SVGTypewriter.Measurers.Measurer(labelArea);
                 var writer = new SVGTypewriter.Writers.Writer(measurer);
                 this._labelConfig.set(dataset, { labelArea: labelArea, measurer: measurer, writer: writer });
                 return drawer;

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -215,7 +215,7 @@ export module Plots {
       var drawer = super._createNodesForDataset(dataset);
       drawer.renderArea().classed(Bar._BAR_AREA_CLASS, true);
       var labelArea = this._renderArea.append("g").classed(Bar._LABEL_AREA_CLASS, true);
-      var measurer = new SVGTypewriter.Measurers.CacheCharacterMeasurer(labelArea);
+      var measurer = new SVGTypewriter.Measurers.Measurer(labelArea);
       var writer = new SVGTypewriter.Writers.Writer(measurer);
       this._labelConfig.set(dataset, { labelArea: labelArea, measurer: measurer, writer: writer });
       return drawer;

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -432,6 +432,7 @@ export module Plots {
         var secondaryAttrTextSpace = this._isVertical ? measurement.width : measurement.height;
         var secondaryAttrAvailableSpace = this._isVertical ? w : h;
         var tooWide = secondaryAttrTextSpace + 2 * Bar._LABEL_HORIZONTAL_PADDING > secondaryAttrAvailableSpace;
+        console.log(measurement, h, w);
         if (measurement.height <= h && measurement.width <= w) {
           var offset = Math.min((primary - primarySpace) / 2, Bar._LABEL_VERTICAL_PADDING);
           if (!positive) { offset = offset * -1; }

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -672,8 +672,8 @@ describe("Plots", () => {
       });
 
       it("labels are rendered correctly across platforms", () => {
-        dataset = new Plottable.Dataset([{ x: "foo", y: 5 }, { x: "bar", y: 64000000 }, { x: "zoo", y: 12345678 }]);
-        plot.addDataset(dataset);
+        plot.removeDataset(dataset);
+        plot.addDataset(new Plottable.Dataset([{ x: "foo", y: 5 }, { x: "bar", y: 64000000 }, { x: "zoo", y: 12345678 }]));
         plot.labelsEnabled(true);
         plot.renderTo(svg);
         var texts = svg.selectAll("text")[0].map((n: any) => d3.select(n).text());

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -692,6 +692,16 @@ describe("Plots", () => {
         texts = svg.selectAll("text")[0].map((n: any) => d3.select(n).text());
         assert.lengthOf(texts, 0, "texts were immediately removed");
       });
+
+      it("labels are rendered correctly across platforms", () => {
+        dataset = new Plottable.Dataset([{ x: "foo", y: 5 }, { x: "bar", y: 64000000 }, { x: "zoo", y: 12345678 }]);
+        plot.addDataset(dataset);
+        plot.labelsEnabled(true);
+        plot.renderTo(svg);
+        var texts = svg.selectAll("text")[0].map((n: any) => d3.select(n).text());
+        assert.lengthOf(texts, 2, "both texts drawn");
+        svg.remove();
+      });
     });
 
     describe("selections()", () => {

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -671,6 +671,16 @@ describe("Plots", () => {
         svg.remove();
       });
 
+      it("labels are rendered correctly across platforms", () => {
+        dataset = new Plottable.Dataset([{ x: "foo", y: 5 }, { x: "bar", y: 64000000 }, { x: "zoo", y: 12345678 }]);
+        plot.addDataset(dataset);
+        plot.labelsEnabled(true);
+        plot.renderTo(svg);
+        var texts = svg.selectAll("text")[0].map((n: any) => d3.select(n).text());
+        assert.lengthOf(texts, 2, "both texts drawn");
+        svg.remove();
+      });
+
       it("bar labels are removed instantly on dataset change", (done) => {
         plot.labelsEnabled(true);
         plot.renderTo(svg);
@@ -691,16 +701,6 @@ describe("Plots", () => {
         dataset.data(data);
         texts = svg.selectAll("text")[0].map((n: any) => d3.select(n).text());
         assert.lengthOf(texts, 0, "texts were immediately removed");
-      });
-
-      it("labels are rendered correctly across platforms", () => {
-        dataset = new Plottable.Dataset([{ x: "foo", y: 5 }, { x: "bar", y: 64000000 }, { x: "zoo", y: 12345678 }]);
-        plot.addDataset(dataset);
-        plot.labelsEnabled(true);
-        plot.renderTo(svg);
-        var texts = svg.selectAll("text")[0].map((n: any) => d3.select(n).text());
-        assert.lengthOf(texts, 2, "both texts drawn");
-        svg.remove();
       });
     });
 


### PR DESCRIPTION
Issue was that widths of labels as computed by `CachedCharacterMeasurer` make the assumption that the width of the whole is equal to the sum of the widths of the parts. 

Given the string “27.2”, we compare the following:
- Sum of widths of individual characters: 35.233 (FF), 27.297 (Chrome)
- Width of string as a whole: 29.233 (FF), 27.25 (Chrome)

Performance testing w/ rendering 1000*2 ClusteredBars:
- `Measurer.Measurer()`: 436.9ms (Chrome)
- `Measurer.CacheCharacterMeasurer()`: 254.4ms (Chrome)

Later on, this is an issue that should be addressed in svg-typewriter, and has been filed [here](https://github.com/palantir/svg-typewriter/issues/32)

Fixes #2210 