### PR TITLE
[ESLint] - applying default usage of no-console

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,6 @@
   "rules": {
     "no-eval": 0,
     "quotes": [2, "double", "avoid-escape"],
-    "no-console": 0,
     "no-unused-vars": [2, {"vars": "local"}],
     "no-multi-spaces": 0,
     "no-use-before-define": [2, "nofunc"]

--- a/quicktests/overlaying/overlaying.js
+++ b/quicktests/overlaying/overlaying.js
@@ -217,10 +217,6 @@ function loadAllQuickTests(quicktestsPaths, firstQTBranch, secondQTBranch){
   quicktestsPaths.forEach(function(path) { //for each quicktest
     var name = path.replace(/\w*\/|\.js/g, "");
     d3.text("http://localhost:9999/" + path, function(error, text) {
-      if (error !== null) {
-        console.warn("Tried to load nonexistant quicktest ");
-        return;
-      }
       text = "(function(){" + text +
           "\nreturn {makeData: makeData, run: run};" +
                "})();" +
@@ -243,10 +239,6 @@ function loadQuickTestsInCategory(quickTestNames, category, firstQTBranch, secon
   quickTestNames.forEach(function(q) { //for each quicktest
     var name = q;
     d3.text("/quicktests/overlaying/tests/" + category + "/" + name + ".js", function(error, text) {
-      if (error !== null) {
-        console.warn("Tried to load nonexistant quicktest " + name);
-        return;
-      }
       text = "(function(){" + text +
           "\nreturn {makeData: makeData, run: run};" +
                "})();" +
@@ -314,9 +306,6 @@ function loadPlottableBranches(category, branchList){
           filterQuickTests(category, branchList);
         }
       });
-    }
-    else if(textStatus === "error"){
-      console.log("could not retrieve Plottable branch, check if url " + listOfUrl[0] + " is correct!");
     }
   });
 }

--- a/quicktests/overlaying/overlaying.js
+++ b/quicktests/overlaying/overlaying.js
@@ -217,6 +217,9 @@ function loadAllQuickTests(quicktestsPaths, firstQTBranch, secondQTBranch){
   quicktestsPaths.forEach(function(path) { //for each quicktest
     var name = path.replace(/\w*\/|\.js/g, "");
     d3.text("http://localhost:9999/" + path, function(error, text) {
+      if (error !== null) {
+        throw new Error("Tried to load nonexistant quicktest.");
+      }
       text = "(function(){" + text +
           "\nreturn {makeData: makeData, run: run};" +
                "})();" +
@@ -239,6 +242,9 @@ function loadQuickTestsInCategory(quickTestNames, category, firstQTBranch, secon
   quickTestNames.forEach(function(q) { //for each quicktest
     var name = q;
     d3.text("/quicktests/overlaying/tests/" + category + "/" + name + ".js", function(error, text) {
+      if (error !== null) {
+        throw new Error("Tried to load nonexistant quicktest.");
+      }
       text = "(function(){" + text +
           "\nreturn {makeData: makeData, run: run};" +
                "})();" +
@@ -306,6 +312,8 @@ function loadPlottableBranches(category, branchList){
           filterQuickTests(category, branchList);
         }
       });
+    } else if (textStatus === "error"){
+      throw new Error("could not retrieve Plottable branch, check if url " + listOfUrl[0] + " is correct!");
     }
   });
 }


### PR DESCRIPTION
Enforces that console statements are not used.  Especially for `console.log`, these statements are generally not helpful in production level code.  Albeit, they are useful at development level.  We can decide if we want to utilize this or not.

At the very least, we should probably use Plottable's warn so that we don't run into IE issues