### PR TITLE
[manyPlotsPerf] No more redraw on numeric axis rescale

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -4338,13 +4338,6 @@ var Plottable;
                 if (!this._isSetup) {
                     return;
                 }
-                if (!this._isHorizontal()) {
-                    var reComputedWidth = this._computeWidth();
-                    if (reComputedWidth > this.width() || reComputedWidth < (this.width() - this.margin())) {
-                        this.redraw();
-                        return;
-                    }
-                }
                 this.render();
             };
             Numeric.prototype.renderImmediately = function () {

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -75,14 +75,6 @@ export module Axes {
         return;
       }
 
-      if (!this._isHorizontal()) {
-        var reComputedWidth = this._computeWidth();
-        if (reComputedWidth > this.width() || reComputedWidth < (this.width() - this.margin())) {
-          this.redraw();
-          return;
-        }
-      }
-
       this.render();
     }
 


### PR DESCRIPTION
It seemed like it was some sort of optimization, but in reality the `_computeWidth()` was an expensive operation in itself. All tests are still passing (including overlaying)