### PR TITLE
Cache the plottable colors on the Color Scale

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1078,6 +1078,7 @@ declare module Plottable {
             constructor(scaleType?: string);
             extentOfValues(values: string[]): string[];
             protected _getExtent(): string[];
+            static invalidateColorCache(): void;
             /**
              * Returns the color-string corresponding to a given string.
              * If there are not enough colors in the range(), a lightened version of an existing color will be used.

--- a/plottable.js
+++ b/plottable.js
@@ -2214,7 +2214,6 @@ var Plottable;
             Color._LOOP_LIGHTEN_FACTOR = 1.6;
             // The maximum number of colors we are getting from CSS stylesheets
             Color._MAXIMUM_COLORS_FROM_CSS = 256;
-            Color._plottableColorCache = null;
             return Color;
         })(Plottable.Scale);
         Scales.Color = Color;

--- a/plottable.js
+++ b/plottable.js
@@ -2129,7 +2129,10 @@ var Plottable;
                 switch (scaleType) {
                     case null:
                     case undefined:
-                        scale = d3.scale.ordinal().range(Color._getPlottableColors());
+                        if (Color._plottableColorCache == null) {
+                            Color._plottableColorCache = Color._getPlottableColors();
+                        }
+                        scale = d3.scale.ordinal().range(Color._plottableColorCache);
                         break;
                     case "Category10":
                     case "category10":
@@ -2162,6 +2165,9 @@ var Plottable;
             // Duplicated from OrdinalScale._getExtent - should be removed in #388
             Color.prototype._getExtent = function () {
                 return Plottable.Utils.Array.uniq(this._getAllIncludedValues());
+            };
+            Color.invalidateColorCache = function () {
+                Color._plottableColorCache = null;
             };
             Color._getPlottableColors = function () {
                 var plottableDefaultColors = [];
@@ -2208,6 +2214,7 @@ var Plottable;
             Color._LOOP_LIGHTEN_FACTOR = 1.6;
             // The maximum number of colors we are getting from CSS stylesheets
             Color._MAXIMUM_COLORS_FROM_CSS = 256;
+            Color._plottableColorCache = null;
             return Color;
         })(Plottable.Scale);
         Scales.Color = Color;

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -8,6 +8,8 @@ export module Scales {
     // The maximum number of colors we are getting from CSS stylesheets
     private static _MAXIMUM_COLORS_FROM_CSS = 256;
 
+    private static _plottableColorCache: string[] = null;
+
     private _d3Scale: d3.scale.Ordinal<string, string>;
 
     /**
@@ -24,7 +26,10 @@ export module Scales {
       switch (scaleType) {
         case null:
         case undefined:
-          scale = d3.scale.ordinal<string, string>().range(Color._getPlottableColors());
+          if (Color._plottableColorCache == null) {
+            Color._plottableColorCache = Color._getPlottableColors();
+          }
+          scale = d3.scale.ordinal<string, string>().range(Color._plottableColorCache);
           break;
         case "Category10":
         case "category10":
@@ -59,6 +64,10 @@ export module Scales {
     // Duplicated from OrdinalScale._getExtent - should be removed in #388
     protected _getExtent(): string[] {
       return Utils.Array.uniq(this._getAllIncludedValues());
+    }
+
+    public static invalidateColorCache(): void {
+      Color._plottableColorCache = null;
     }
 
     private static _getPlottableColors(): string[] {

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -8,7 +8,7 @@ export module Scales {
     // The maximum number of colors we are getting from CSS stylesheets
     private static _MAXIMUM_COLORS_FROM_CSS = 256;
 
-    private static _plottableColorCache: string[] = null;
+    private static _plottableColorCache: string[];
 
     private _d3Scale: d3.scale.Ordinal<string, string>;
 
@@ -66,7 +66,7 @@ export module Scales {
       return Utils.Array.uniq(this._getAllIncludedValues());
     }
 
-    public static invalidateColorCache(): void {
+    public static invalidateColorCache() {
       Color._plottableColorCache = null;
     }
 

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -142,6 +142,23 @@ describe("Scales", () => {
         "Unloading the CSS should cause color scales fallback to default colors");
     });
 
+     it("caches CSS specified colors unless the cache is invalidated", () => {
+      var style = d3.select("body").append("style");
+      style.html(".plottable-colors-0 {background-color: #ff0000 !important; }");
+      Plottable.Scales.Color.invalidateColorCache();
+      var scale = new Plottable.Scales.Color();
+      style.remove();
+
+      assert.strictEqual(scale.range()[0], "#ff0000", "User has specified red color for first color scale color");
+
+      var scaleCached = new Plottable.Scales.Color();
+      assert.strictEqual(scaleCached.range()[0], "#ff0000", "The red color should still be cached");
+
+      Plottable.Scales.Color.invalidateColorCache();
+      var scaleFresh = new Plottable.Scales.Color();
+      assert.strictEqual(scaleFresh.range()[0], "#5279c7", "Invalidating the cache should reset the red color to the default");
+    });
+
     it("should try to recover from malicious CSS styleseets", () => {
       var defaultNumberOfColors = 10;
 

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -128,8 +128,10 @@ describe("Scales", () => {
     it("accepts CSS specified colors", () => {
       var style = d3.select("body").append("style");
       style.html(".plottable-colors-0 {background-color: #ff0000 !important; }");
+      Plottable.Scales.Color.invalidateColorCache();
       var scale = new Plottable.Scales.Color();
       style.remove();
+      Plottable.Scales.Color.invalidateColorCache();
       assert.strictEqual(scale.range()[0], "#ff0000", "User has specified red color for first color scale color");
       assert.strictEqual(scale.range()[1], "#fd373e", "The second color of the color scale should be the same");
 
@@ -149,8 +151,10 @@ describe("Scales", () => {
 
       var maliciousStyle = d3.select("body").append("style");
       maliciousStyle.html("* {background-color: #fff000;}");
+      Plottable.Scales.Color.invalidateColorCache();
       var affectedScale = new Plottable.Scales.Color();
       maliciousStyle.remove();
+      Plottable.Scales.Color.invalidateColorCache();
       var colorRange = affectedScale.range();
       assert.strictEqual(colorRange.length, defaultNumberOfColors + 1,
         "it should detect the end of the given colors and the fallback to the * selector, " +
@@ -169,8 +173,10 @@ describe("Scales", () => {
 
       var maliciousStyle = d3.select("body").append("style");
       maliciousStyle.html("[class^='plottable-'] {background-color: pink;}");
+      Plottable.Scales.Color.invalidateColorCache();
       var affectedScale = new Plottable.Scales.Color();
       maliciousStyle.remove();
+      Plottable.Scales.Color.invalidateColorCache();
       var maximumColorsFromCss = (<any> Plottable.Scales.Color)._MAXIMUM_COLORS_FROM_CSS;
       assert.strictEqual(affectedScale.range().length, maximumColorsFromCss,
         "current malicious CSS countermeasure is to cap maximum number of colors to 256");


### PR DESCRIPTION
Color._getPlottableColors() hits the DOM every time, which in turn
occurs every time a Color Scale is constructed. Adding a static cache
saves a few ms on every new Color().