### PR TITLE
Many plots perf improvement

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -4424,15 +4424,7 @@ var Plottable;
                 var tickLabels = this._tickLabelContainer.selectAll("." + Plottable.Axis.TICK_LABEL_CLASS).data(tickLabelValues);
                 tickLabels.enter().append("text").classed(Plottable.Axis.TICK_LABEL_CLASS, true);
                 tickLabels.exit().remove();
-                tickLabels.style("text-anchor", tickLabelTextAnchor).style("visibility", "inherit").attr(tickLabelAttrHash).text(function (s) {
-                    var formattedText = _this.formatter()(s);
-                    if (!_this._isHorizontal()) {
-                        var availableTextSpace = _this.width() - _this.tickLabelPadding();
-                        availableTextSpace -= _this._tickLabelPositioning === "center" ? _this._maxLabelTickLength() : 0;
-                        formattedText = _this._wrapper.wrap(formattedText, _this._measurer, availableTextSpace).wrappedText;
-                    }
-                    return formattedText;
-                });
+                tickLabels.style("text-anchor", tickLabelTextAnchor).style("visibility", "inherit").attr(tickLabelAttrHash).text(function (s) { return _this.formatter()(s); });
                 var labelGroupTransform = "translate(" + labelGroupTransformX + ", " + labelGroupTransformY + ")";
                 this._tickLabelContainer.attr("transform", labelGroupTransform);
                 this._showAllTickMarks();

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -176,15 +176,7 @@ export module Axes {
       tickLabels.style("text-anchor", tickLabelTextAnchor)
                 .style("visibility", "inherit")
                 .attr(tickLabelAttrHash)
-                .text((s: any) => {
-                  var formattedText = this.formatter()(s);
-                  if (!this._isHorizontal()) {
-                    var availableTextSpace = this.width() - this.tickLabelPadding();
-                    availableTextSpace -= this._tickLabelPositioning === "center" ? this._maxLabelTickLength() : 0;
-                    formattedText = this._wrapper.wrap(formattedText, this._measurer, availableTextSpace).wrappedText;
-                  }
-                  return formattedText;
-                });
+                .text((s: any) => this.formatter()(s));
 
       var labelGroupTransform = "translate(" + labelGroupTransformX + ", " + labelGroupTransformY + ")";
       this._tickLabelContainer.attr("transform", labelGroupTransform);

--- a/test/dispatchers/mouseDispatcherTests.ts
+++ b/test/dispatchers/mouseDispatcherTests.ts
@@ -104,15 +104,14 @@ describe("Dispatchers", () => {
       TestMethods.triggerFakeMouseEvent("mousedown", target, targetX, targetY);
       assert.isTrue(callbackWasCalled, "callback was called on mousedown");
 
-      var position = (function(el){
-          for (var lx = 0, ly = 0;
-                   el != null;
-                   el = (el.offsetParent || el.parentNode)) {
-               lx += (el.offsetLeft || el.clientLeft || 0);
-               ly += (el.offsetTop || el.clientTop || 0);
-          }
-          return {x: lx, y: ly};
-      })(target[0][0]);
+      var element = <HTMLElement> target[0][0];
+      var position = { x: 0, y: 0 };
+      while (element != null) {
+        position.x += (element.offsetLeft || element.clientLeft || 0);
+        position.y += (element.offsetTop || element.clientTop || 0);
+        element = <HTMLElement> (element.offsetParent || element.parentNode);
+      }
+
       var overlay = TestMethods.getSVGParent().append("div")
             .style({
               height: "400px",


### PR DESCRIPTION
I was hoping I can get more stuff in this side branch, but this is literally just a QE review of https://github.com/palantir/plottable/pull/2424 .
Merging it into develop now so @PeterFaiman can get these changes as well.

QE Notes: 
- **Regression pass**: nothing should be changed
- **What has been modified**: The numeric axis had logic for wrapping tick labels, but that never happened anyway because the tick labels which were too big were just hidden.
- **Performance improvement**: Not big, but for 60 plots on a page the load time decreases `1700ms` -> `1100ms`