### PR TITLE
Fixed animate line data parsing issue in FF

### DIFF
--- a/quicktests/overlaying/tests/animations/animate_line.js
+++ b/quicktests/overlaying/tests/animations/animate_line.js
@@ -1,8 +1,8 @@
 
 function makeData() {
   "use strict";
-  var data = [{x: new Date("2014-04-01 00:24"), y: 4},
-              {x: new Date("2014-08-29 00:24"), y: 6}];
+  var data = [{x: new Date("4/1/2014 00:24"), y: 4},
+              {x: new Date("8/29/2014 00:24"), y: 6}];
   return data;
 }
 
@@ -12,7 +12,7 @@ function run(svg, data, Plottable) {
   var xScale = new Plottable.Scales.Time();
   var xAxis = new Plottable.Axes.Time(xScale, "bottom");
 
-  var extent = function(){ return [new Date("2014-04-01 00:24"), new Date("2014-08-29 00:24")]; };
+  var extent = function(){ return [new Date("4/1/2014 00:24"), new Date("8/29/2014 00:24")]; };
   xScale.addPaddingExceptionsProvider(extent);
 
   var yScale = new Plottable.Scales.Linear();


### PR DESCRIPTION
Closes #2440
Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse