### PR TITLE
Setting non-string Label text

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1935,7 +1935,7 @@ declare module Plottable {
              * A Label is a Component that displays a single line of text.
              *
              * @constructor
-             * @param {number|string} [displayText=""] The text of the Label.
+             * @param {number | string} [displayText=""] The text of the Label.
              * @param {number} [angle=0] The angle of the Label in degrees (-90/0/90). 0 is horizontal.
              */
             constructor(displayText?: number | string, angle?: number);
@@ -1948,7 +1948,7 @@ declare module Plottable {
             /**
              * Sets the Label's text.
              *
-             * @param {nubmer|string} displayText
+             * @param {number | string} displayText
              * @returns {Label} The calling Label.
              */
             text(displayText: number | string): Label;
@@ -1982,7 +1982,7 @@ declare module Plottable {
             static TITLE_LABEL_CLASS: string;
             /**
              * @constructor
-             * @param {number|string} [text]
+             * @param {number | string} [text]
              * @param {number} [angle] One of -90/0/90. 0 is horizontal.
              */
             constructor(text?: number | string, angle?: number);
@@ -1991,7 +1991,7 @@ declare module Plottable {
             static AXIS_LABEL_CLASS: string;
             /**
              * @constructor
-             * @param {number|string} [text]
+             * @param {number | string} [text]
              * @param {number} [angle] One of -90/0/90. 0 is horizontal.
              */
             constructor(text?: number | string, angle?: number);

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1935,10 +1935,10 @@ declare module Plottable {
              * A Label is a Component that displays a single line of text.
              *
              * @constructor
-             * @param {string} [displayText=""] The text of the Label.
+             * @param {number|string} [displayText=""] The text of the Label.
              * @param {number} [angle=0] The angle of the Label in degrees (-90/0/90). 0 is horizontal.
              */
-            constructor(displayText?: string, angle?: number);
+            constructor(displayText?: number | string, angle?: number);
             requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
             protected _setup(): void;
             /**
@@ -1948,10 +1948,10 @@ declare module Plottable {
             /**
              * Sets the Label's text.
              *
-             * @param {string} displayText
+             * @param {nubmer|string} displayText
              * @returns {Label} The calling Label.
              */
-            text(displayText: string): Label;
+            text(displayText: number | string): Label;
             /**
              * Gets the angle of the Label in degrees.
              */
@@ -1982,19 +1982,19 @@ declare module Plottable {
             static TITLE_LABEL_CLASS: string;
             /**
              * @constructor
-             * @param {string} [text]
+             * @param {number|string} [text]
              * @param {number} [angle] One of -90/0/90. 0 is horizontal.
              */
-            constructor(text?: string, angle?: number);
+            constructor(text?: number | string, angle?: number);
         }
         class AxisLabel extends Label {
             static AXIS_LABEL_CLASS: string;
             /**
              * @constructor
-             * @param {string} [text]
+             * @param {number|string} [text]
              * @param {number} [angle] One of -90/0/90. 0 is horizontal.
              */
-            constructor(text?: string, angle?: number);
+            constructor(text?: number | string, angle?: number);
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -4794,7 +4794,7 @@ var Plottable;
              * A Label is a Component that displays a single line of text.
              *
              * @constructor
-             * @param {number|string} [displayText=""] The text of the Label.
+             * @param {number | string} [displayText=""] The text of the Label.
              * @param {number} [angle=0] The angle of the Label in degrees (-90/0/90). 0 is horizontal.
              */
             function Label(displayText, angle) {
@@ -4902,7 +4902,7 @@ var Plottable;
             __extends(TitleLabel, _super);
             /**
              * @constructor
-             * @param {number|string} [text]
+             * @param {number | string} [text]
              * @param {number} [angle] One of -90/0/90. 0 is horizontal.
              */
             function TitleLabel(text, angle) {
@@ -4917,7 +4917,7 @@ var Plottable;
             __extends(AxisLabel, _super);
             /**
              * @constructor
-             * @param {number|string} [text]
+             * @param {number | string} [text]
              * @param {number} [angle] One of -90/0/90. 0 is horizontal.
              */
             function AxisLabel(text, angle) {

--- a/plottable.js
+++ b/plottable.js
@@ -4824,15 +4824,18 @@ var Plottable;
                 this._writer = new SVGTypewriter.Writers.Writer(this._measurer, this._wrapper);
                 this.text(this._text);
             };
+            /**
+             * Sets the Label's text.
+             *
+             * @param {nubmer | string} displayText
+             * @returns {Label} The calling Label.
+             */
             Label.prototype.text = function (displayText) {
                 if (displayText === undefined) {
                     return this._text;
                 }
                 else {
-                    if (typeof displayText == "number") {
-                        displayText = displayText.toString();
-                    }
-                    this._text = displayText;
+                    this._text = "" + displayText;
                     this.redraw();
                     return this;
                 }
@@ -4903,6 +4906,11 @@ var Plottable;
         Components.Label = Label;
         var TitleLabel = (function (_super) {
             __extends(TitleLabel, _super);
+            /**
+             * @constructor
+             * @param {number | string} [text]
+             * @param {number} [angle] One of -90/0/90. 0 is horizontal.
+             */
             function TitleLabel(text, angle) {
                 _super.call(this, text, angle);
                 this.addClass(TitleLabel.TITLE_LABEL_CLASS);
@@ -4913,6 +4921,11 @@ var Plottable;
         Components.TitleLabel = TitleLabel;
         var AxisLabel = (function (_super) {
             __extends(AxisLabel, _super);
+            /**
+             * @constructor
+             * @param {number | string} [text]
+             * @param {number} [angle] One of -90/0/90. 0 is horizontal.
+             */
             function AxisLabel(text, angle) {
                 _super.call(this, text, angle);
                 this.addClass(AxisLabel.AXIS_LABEL_CLASS);

--- a/plottable.js
+++ b/plottable.js
@@ -4829,6 +4829,9 @@ var Plottable;
                     return this._text;
                 }
                 else {
+                    if (typeof displayText == "number") {
+                        displayText = displayText.toString();
+                    }
                     this._text = displayText;
                     this.redraw();
                     return this;

--- a/plottable.js
+++ b/plottable.js
@@ -4794,7 +4794,7 @@ var Plottable;
              * A Label is a Component that displays a single line of text.
              *
              * @constructor
-             * @param {string} [displayText=""] The text of the Label.
+             * @param {number|string} [displayText=""] The text of the Label.
              * @param {number} [angle=0] The angle of the Label in degrees (-90/0/90). 0 is horizontal.
              */
             function Label(displayText, angle) {
@@ -4824,12 +4824,6 @@ var Plottable;
                 this._writer = new SVGTypewriter.Writers.Writer(this._measurer, this._wrapper);
                 this.text(this._text);
             };
-            /**
-             * Sets the Label's text.
-             *
-             * @param {nubmer | string} displayText
-             * @returns {Label} The calling Label.
-             */
             Label.prototype.text = function (displayText) {
                 if (displayText === undefined) {
                     return this._text;
@@ -4908,7 +4902,7 @@ var Plottable;
             __extends(TitleLabel, _super);
             /**
              * @constructor
-             * @param {number | string} [text]
+             * @param {number|string} [text]
              * @param {number} [angle] One of -90/0/90. 0 is horizontal.
              */
             function TitleLabel(text, angle) {
@@ -4923,7 +4917,7 @@ var Plottable;
             __extends(AxisLabel, _super);
             /**
              * @constructor
-             * @param {number | string} [text]
+             * @param {number|string} [text]
              * @param {number} [angle] One of -90/0/90. 0 is horizontal.
              */
             function AxisLabel(text, angle) {

--- a/plottable.js
+++ b/plottable.js
@@ -4903,11 +4903,6 @@ var Plottable;
         Components.Label = Label;
         var TitleLabel = (function (_super) {
             __extends(TitleLabel, _super);
-            /**
-             * @constructor
-             * @param {string} [text]
-             * @param {number} [angle] One of -90/0/90. 0 is horizontal.
-             */
             function TitleLabel(text, angle) {
                 _super.call(this, text, angle);
                 this.addClass(TitleLabel.TITLE_LABEL_CLASS);
@@ -4918,11 +4913,6 @@ var Plottable;
         Components.TitleLabel = TitleLabel;
         var AxisLabel = (function (_super) {
             __extends(AxisLabel, _super);
-            /**
-             * @constructor
-             * @param {string} [text]
-             * @param {number} [angle] One of -90/0/90. 0 is horizontal.
-             */
             function AxisLabel(text, angle) {
                 _super.call(this, text, angle);
                 this.addClass(AxisLabel.AXIS_LABEL_CLASS);

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -54,20 +54,14 @@ export module Components {
     /**
      * Sets the Label's text.
      *
-     * @param {nubmer} displayText
-     * @param {string} displayText
+     * @param {nubmer | string} displayText
      * @returns {Label} The calling Label.
      */
-    public text(displayText: number): Label;
-    public text(displayText: string): Label;
-    public text(displayText?): any {
+    public text(displayText?: number | string): Label {
       if (displayText === undefined) {
         return this._text;
       } else {
-        if (typeof displayText == "number") {
-          displayText = displayText.toString();
-        }
-        this._text = displayText;
+        this._text = "" + displayText;
         this.redraw();
         return this;
       }
@@ -162,13 +156,10 @@ export module Components {
     public static TITLE_LABEL_CLASS = "title-label";
     /**
      * @constructor
-     * @param {number} [text]
-     * @param {string} [text]
+     * @param {number | string} [text]
      * @param {number} [angle] One of -90/0/90. 0 is horizontal.
      */
-    constructor(text: number, angle: number); 
-    constructor(text: string, angle: number);
-    constructor(text?, angle?) {
+    constructor(text?: number | string, angle?: number) {
       super(text, angle);
       this.addClass(TitleLabel.TITLE_LABEL_CLASS);
     }
@@ -178,13 +169,10 @@ export module Components {
     public static AXIS_LABEL_CLASS = "axis-label";
     /**
      * @constructor
-     * @param {number} [text]
-     * @param {string} [text]
+     * @param {number | string} [text]
      * @param {number} [angle] One of -90/0/90. 0 is horizontal.
      */
-    constructor(text: number, angle: number); 
-    constructor(text: string, angle: number);
-    constructor(text?, angle?) {
+    constructor(text?: number | string, angle?: number) {
       super(text, angle);
       this.addClass(AxisLabel.AXIS_LABEL_CLASS);
     }

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -162,10 +162,13 @@ export module Components {
     public static TITLE_LABEL_CLASS = "title-label";
     /**
      * @constructor
+     * @param {number} [text]
      * @param {string} [text]
      * @param {number} [angle] One of -90/0/90. 0 is horizontal.
      */
-    constructor(text?: string, angle?: number) {
+    constructor(text: number, angle: number); 
+    constructor(text: string, angle: number);
+    constructor(text?, angle?) {
       super(text, angle);
       this.addClass(TitleLabel.TITLE_LABEL_CLASS);
     }
@@ -175,10 +178,13 @@ export module Components {
     public static AXIS_LABEL_CLASS = "axis-label";
     /**
      * @constructor
+     * @param {number} [text]
      * @param {string} [text]
      * @param {number} [angle] One of -90/0/90. 0 is horizontal.
      */
-    constructor(text?: string, angle?: number) {
+    constructor(text: number, angle: number); 
+    constructor(text: string, angle: number);
+    constructor(text?, angle?) {
       super(text, angle);
       this.addClass(AxisLabel.AXIS_LABEL_CLASS);
     }

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -15,10 +15,10 @@ export module Components {
      * A Label is a Component that displays a single line of text.
      *
      * @constructor
-     * @param {number|string} [displayText=""] The text of the Label.
+     * @param {number | string} [displayText=""] The text of the Label.
      * @param {number} [angle=0] The angle of the Label in degrees (-90/0/90). 0 is horizontal.
      */
-    constructor(displayText: number|string = "", angle: number = 0) {
+    constructor(displayText: number | string = "", angle = 0) {
       super();
       this.addClass("label");
       this.text(displayText);
@@ -54,11 +54,11 @@ export module Components {
     /**
      * Sets the Label's text.
      *
-     * @param {nubmer|string} displayText
+     * @param {number | string} displayText
      * @returns {Label} The calling Label.
      */
-    public text(displayText: number|string): Label;
-    public text(displayText?: number|string): any {
+    public text(displayText: number | string): Label;
+    public text(displayText?: number | string): any {
       if (displayText === undefined) {
         return this._text;
       } else {
@@ -157,10 +157,10 @@ export module Components {
     public static TITLE_LABEL_CLASS = "title-label";
     /**
      * @constructor
-     * @param {number|string} [text]
+     * @param {number | string} [text]
      * @param {number} [angle] One of -90/0/90. 0 is horizontal.
      */
-    constructor(text?: number|string, angle?: number) {
+    constructor(text?: number | string, angle?: number) {
       super(text, angle);
       this.addClass(TitleLabel.TITLE_LABEL_CLASS);
     }
@@ -170,10 +170,10 @@ export module Components {
     public static AXIS_LABEL_CLASS = "axis-label";
     /**
      * @constructor
-     * @param {number|string} [text]
+     * @param {number | string} [text]
      * @param {number} [angle] One of -90/0/90. 0 is horizontal.
      */
-    constructor(text?: number|string, angle?: number) {
+    constructor(text?: number | string, angle?: number) {
       super(text, angle);
       this.addClass(AxisLabel.AXIS_LABEL_CLASS);
     }

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -15,10 +15,10 @@ export module Components {
      * A Label is a Component that displays a single line of text.
      *
      * @constructor
-     * @param {string} [displayText=""] The text of the Label.
+     * @param {number|string} [displayText=""] The text of the Label.
      * @param {number} [angle=0] The angle of the Label in degrees (-90/0/90). 0 is horizontal.
      */
-    constructor(displayText = "", angle = 0) {
+    constructor(displayText: number|string = "", angle: number = 0) {
       super();
       this.addClass("label");
       this.text(displayText);
@@ -54,10 +54,11 @@ export module Components {
     /**
      * Sets the Label's text.
      *
-     * @param {nubmer | string} displayText
+     * @param {nubmer|string} displayText
      * @returns {Label} The calling Label.
      */
-    public text(displayText?: number | string): Label {
+    public text(displayText: number|string): Label;
+    public text(displayText?: number|string): any {
       if (displayText === undefined) {
         return this._text;
       } else {
@@ -156,10 +157,10 @@ export module Components {
     public static TITLE_LABEL_CLASS = "title-label";
     /**
      * @constructor
-     * @param {number | string} [text]
+     * @param {number|string} [text]
      * @param {number} [angle] One of -90/0/90. 0 is horizontal.
      */
-    constructor(text?: number | string, angle?: number) {
+    constructor(text?: number|string, angle?: number) {
       super(text, angle);
       this.addClass(TitleLabel.TITLE_LABEL_CLASS);
     }
@@ -169,10 +170,10 @@ export module Components {
     public static AXIS_LABEL_CLASS = "axis-label";
     /**
      * @constructor
-     * @param {number | string} [text]
+     * @param {number|string} [text]
      * @param {number} [angle] One of -90/0/90. 0 is horizontal.
      */
-    constructor(text?: number | string, angle?: number) {
+    constructor(text?: number|string, angle?: number) {
       super(text, angle);
       this.addClass(AxisLabel.AXIS_LABEL_CLASS);
     }

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -54,14 +54,19 @@ export module Components {
     /**
      * Sets the Label's text.
      *
+     * @param {nubmer} displayText
      * @param {string} displayText
      * @returns {Label} The calling Label.
      */
+    public text(displayText: number): Label;
     public text(displayText: string): Label;
-    public text(displayText?: string): any {
+    public text(displayText?): any {
       if (displayText === undefined) {
         return this._text;
       } else {
+        if (typeof displayText == "number") {
+          displayText = displayText.toString();
+        }
         this._text = displayText;
         this.redraw();
         return this;

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -191,9 +191,10 @@ describe("Labels", () => {
   });
 
   it("Label can takes number as displayText", () => {
+    var label: Plottable.Components.Label;
     assert.doesNotThrow(() => {
-      var label = new Plottable.Components.Label(1);
-      assert.strictEqual(label.text(), "1", "text equal to input number");
+      label = new Plottable.Components.Label(1);
     }, Error, "Label does not crash on invalid values");
+    assert.strictEqual(label.text(), "1", "text equal to input number");
   });
 });

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -189,4 +189,22 @@ describe("Labels", () => {
     var testLabel = new Plottable.Components.Label("testing label");
     assert.throws(() => testLabel.padding(-10), Error, "Cannot be less than 0");
   });
+
+  it("TitleLabel can takes number as displayText", () => {
+    var svg = TestMethods.generateSVG(100, 100);
+    var label = new Plottable.Components.TitleLabel(1);
+    label.renderTo(svg);
+    var text = (<any> label)._content.select("text");
+    assert.strictEqual(text.text(), "1", "text equal to input number");
+    svg.remove();
+  });
+
+  it("AxisLabel can takes number as displayText", () => {
+    var svg = TestMethods.generateSVG(100, 100);
+    var label = new Plottable.Components.AxisLabel(1);
+    label.renderTo(svg);
+    var text = (<any> label)._content.select("text");
+    assert.strictEqual(text.text(), "1", "text equal to input number");
+    svg.remove();
+  });
 });

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -190,21 +190,10 @@ describe("Labels", () => {
     assert.throws(() => testLabel.padding(-10), Error, "Cannot be less than 0");
   });
 
-  it("TitleLabel can takes number as displayText", () => {
-    var svg = TestMethods.generateSVG(100, 100);
-    var label = new Plottable.Components.TitleLabel(1);
-    label.renderTo(svg);
-    var text = (<any> label)._content.select("text");
-    assert.strictEqual(text.text(), "1", "text equal to input number");
-    svg.remove();
-  });
-
-  it("AxisLabel can takes number as displayText", () => {
-    var svg = TestMethods.generateSVG(100, 100);
-    var label = new Plottable.Components.AxisLabel(1);
-    label.renderTo(svg);
-    var text = (<any> label)._content.select("text");
-    assert.strictEqual(text.text(), "1", "text equal to input number");
-    svg.remove();
+  it("Label can takes number as displayText", () => {
+    assert.doesNotThrow(() => {
+      var label = new Plottable.Components.Label(1);
+      assert.strictEqual(label.text(), "1", "text equal to input number");
+    }, Error, "Label does not crash on invalid values");
   });
 });

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -194,7 +194,7 @@ describe("Labels", () => {
     var label: Plottable.Components.Label;
     assert.doesNotThrow(() => {
       label = new Plottable.Components.Label(1);
-    }, Error, "Label does not crash on invalid values");
+    }, Error, "Label does not crash on numeric values");
     assert.strictEqual(label.text(), "1", "text equal to input number");
   });
 });


### PR DESCRIPTION
Add overloads for Label.text(), TitleLabel constructor and AxisLabel constructor.

Fixes #2140 