### PR TITLE
add enabled() method for DragBoxLayer.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -4009,6 +4009,14 @@ declare module Plottable {
              * Gets the internal Interactions.Drag of the DragBoxLayer.
              */
             dragInteraction(): Interactions.Drag;
+            /**
+             * Enables or disables the interaction and drag box.
+             */
+            enabled(enabled: boolean): DragBoxLayer;
+            /**
+             * Gets the enabled state.
+             */
+            enabled(): boolean;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -10325,6 +10325,13 @@ var Plottable;
             DragBoxLayer.prototype.dragInteraction = function () {
                 return this._dragInteraction;
             };
+            DragBoxLayer.prototype.enabled = function (enabled) {
+                if (enabled == null) {
+                    return this._dragInteraction.enabled();
+                }
+                this._dragInteraction.enabled(enabled);
+                return this;
+            };
             return DragBoxLayer;
         })(Components.SelectionBoxLayer);
         Components.DragBoxLayer = DragBoxLayer;

--- a/src/components/dragBoxLayer.ts
+++ b/src/components/dragBoxLayer.ts
@@ -344,6 +344,22 @@ export module Components {
     public dragInteraction() {
       return this._dragInteraction;
     }
+
+    /**
+     * Enables or disables the interaction and drag box.
+     */
+    public enabled(enabled: boolean): DragBoxLayer;
+    /**
+     * Gets the enabled state.
+     */
+    public enabled(): boolean;
+    public enabled(enabled?: boolean): any {
+      if (enabled == null) {
+        return this._dragInteraction.enabled();
+      }
+      this._dragInteraction.enabled(enabled);
+      return this;
+    }
   }
 }
 }

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -36,7 +36,7 @@ describe("Interactive Components", () => {
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var dbl = new Plottable.Components.DragBoxLayer();
       assert.isTrue(dbl.enabled(), "drag box layer is enabled by default");
-      assert.strictEqual(dbl.enabled(false), dbl, "enabled(b) returns itself");
+      assert.strictEqual(dbl.enabled(false), dbl, "enabled(boolean) returns itself");
       assert.isFalse(dbl.enabled(), "drag box layer reports when it is disabled");
       svg.remove();
     });

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -32,6 +32,40 @@ describe("Interactive Components", () => {
       svg.remove();
     });
 
+    it("enabled() properly modifies the state", () => {
+      var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      var dbl = new Plottable.Components.DragBoxLayer();
+      assert.isTrue(dbl.enabled(), "drag box layer is enabled by default");
+      assert.strictEqual(dbl.enabled(false), dbl, "enabled(b) returns itself");
+      assert.isFalse(dbl.enabled(), "drag box layer reports when it is disabled");
+      svg.remove();
+    });
+
+    it("disables box when enabled(false)", () => {
+      var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      var dbl = new Plottable.Components.DragBoxLayer();
+      dbl.enabled(false);
+      dbl.renderTo(svg);
+      assert.isFalse(dbl.boxVisible(), "box is hidden initially");
+
+      var startPoint = {
+        x: SVG_WIDTH / 4,
+        y: SVG_HEIGHT / 4
+      };
+      var endPoint = {
+        x: SVG_WIDTH / 2,
+        y: SVG_HEIGHT / 2
+      };
+
+      var target = dbl.background();
+      TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+      assert.isFalse(dbl.boxVisible(), "box is not shown when disabled");
+      dbl.enabled(true);
+      TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+      assert.isTrue(dbl.boxVisible(), "box is shown when enabled");
+      svg.remove();
+    });
+
     it("dismisses on click", () => {
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var dbl = new Plottable.Components.DragBoxLayer();

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -32,7 +32,7 @@ describe("Interactive Components", () => {
       svg.remove();
     });
 
-    it("enabled() properly modifies the state", () => {
+    it("enabled(boolean) properly modifies the state", () => {
       var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       var dbl = new Plottable.Components.DragBoxLayer();
       assert.isTrue(dbl.enabled(), "drag box layer is enabled by default");


### PR DESCRIPTION
This simply passes through to the underlying interaction object.

Fixes #2386.
