### PR TITLE
API endpoint to specify opacity of legend

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1114,6 +1114,20 @@ declare module Plottable {
              * @constructor
              */
             constructor();
+            /**
+             * Returns the opacity corresponding to a given string.
+             * If there are not enough opacities in the range(), the scale will recycle values from the start of the range.
+             *
+             * @param {string} value
+             * @returns {number}
+             */
+            scale(value: string): number;
+            extentOfValues(values: string[]): string[];
+            protected _getExtent(): string[];
+            protected _getDomain(): string[];
+            protected _setBackingScaleDomain(values: string[]): void;
+            protected _getRange(): number[];
+            protected _setRange(values: number[]): d3.scale.Ordinal<string, number>;
         }
     }
 }
@@ -2090,6 +2104,32 @@ declare module Plottable {
              * @returns {Legend} The calling Legend.
              */
             colorScale(colorScale: Scales.Color): Legend;
+            /**
+             * Gets the Opacity Scale.
+             *
+             * @returns {Scales.Opacity}
+             */
+            opacityScale(): Scales.Opacity;
+            /**
+             * Sets the Opacity Scale.
+             *
+             * @param {Scales.Opacity} scale
+             * @returns {Legend} The calling Legend.
+             */
+            opacityScale(opacityScale: Scales.Opacity): Legend;
+            /**
+             * Returns whether the opacity scale should apply to the text in the legend
+             *
+             * @returns {boolean}
+             */
+            setOpacityToText(): boolean;
+            /**
+             * Sets whether the opacity scale should apply to the text in the legend
+             *
+             * @param {boolean} setOpacityToText
+             * @returns {Legend} The calling Legend.
+             */
+            setOpacityToText(setOpacityToText: boolean): Legend;
             destroy(): void;
             requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
             /**

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1107,6 +1107,20 @@ declare module Plottable {
 
 declare module Plottable {
     module Scales {
+        class Opacity extends Scale<string, number> {
+            /**
+             * An Opacity Scale maps string values to opacity values between 0 and 1.
+             *
+             * @constructor
+             */
+            constructor();
+        }
+    }
+}
+
+
+declare module Plottable {
+    module Scales {
         class Time extends QuantitativeScale<Date> {
             /**
              * A Time Scale maps Date objects to numbers.

--- a/plottable.js
+++ b/plottable.js
@@ -5020,10 +5020,12 @@ var Plottable;
                     throw new Error("Legend requires a colorScale");
                 }
                 this._colorScale = colorScale;
+                this._redrawColorCallback = function (scale) { return _this.redraw(); };
+                this._colorScale.onUpdate(this._redrawColorCallback);
                 this._opacityScale = new Plottable.Scales.Opacity(); // default scale maps all values to opacity 1.0
                 this._applyOpacityToText = false;
-                this._redrawCallback = function (scale) { return _this.redraw(); };
-                this._colorScale.onUpdate(this._redrawCallback);
+                this._redrawOpacityCallback = function (scale) { return _this.redraw(); };
+                this._opacityScale.onUpdate(this._redrawOpacityCallback);
                 this.xAlignment("right").yAlignment("top");
                 this.comparator(function (a, b) { return _this._colorScale.domain().indexOf(a) - _this._colorScale.domain().indexOf(b); });
                 this._symbolFactoryAccessor = function () { return Plottable.SymbolFactories.circle(); };
@@ -5059,9 +5061,9 @@ var Plottable;
             };
             Legend.prototype.colorScale = function (colorScale) {
                 if (colorScale != null) {
-                    this._colorScale.offUpdate(this._redrawCallback);
+                    this._colorScale.offUpdate(this._redrawColorCallback);
                     this._colorScale = colorScale;
-                    this._colorScale.onUpdate(this._redrawCallback);
+                    this._colorScale.onUpdate(this._redrawColorCallback);
                     this.redraw();
                     return this;
                 }
@@ -5071,9 +5073,9 @@ var Plottable;
             };
             Legend.prototype.opacityScale = function (opacityScale) {
                 if (opacityScale != null) {
-                    this._opacityScale.offUpdate(this._redrawCallback);
+                    this._opacityScale.offUpdate(this._redrawOpacityCallback);
                     this._opacityScale = opacityScale;
-                    this._opacityScale.onUpdate(this._redrawCallback);
+                    this._opacityScale.onUpdate(this._redrawOpacityCallback);
                     this.redraw();
                     return this;
                 }
@@ -5093,7 +5095,8 @@ var Plottable;
             };
             Legend.prototype.destroy = function () {
                 _super.prototype.destroy.call(this);
-                this._colorScale.offUpdate(this._redrawCallback);
+                this._colorScale.offUpdate(this._redrawColorCallback);
+                this._opacityScale.offUpdate(this._redrawOpacityCallback);
             };
             Legend.prototype._calculateLayoutInfo = function (availableWidth, availableHeight) {
                 var _this = this;

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -18,6 +18,8 @@ export module Components {
 
     private _padding = 5;
     private _colorScale: Scales.Color;
+    private _opacityScale: Scales.Opacity;
+    private _applyOpacityToText: boolean;
     private _maxEntriesPerRow: number;
     private _comparator: (a: string, b: string) => number;
     private _measurer: SVGTypewriter.Measurers.Measurer;
@@ -42,6 +44,8 @@ export module Components {
       }
 
       this._colorScale = colorScale;
+      this._opacityScale = new Scales.Opacity(); // default scale maps all values to opacity 1.0
+      this._applyOpacityToText = false;
       this._redrawCallback = (scale) => this.redraw();
       this._colorScale.onUpdate(this._redrawCallback);
 
@@ -129,6 +133,54 @@ export module Components {
         return this;
       } else {
         return this._colorScale;
+      }
+    }
+
+    /**
+     * Gets the Opacity Scale.
+     *
+     * @returns {Scales.Opacity}
+     */
+    public opacityScale(): Scales.Opacity;
+    /**
+     * Sets the Opacity Scale.
+     *
+     * @param {Scales.Opacity} scale
+     * @returns {Legend} The calling Legend.
+     */
+    public opacityScale(opacityScale: Scales.Opacity): Legend;
+    public opacityScale(opacityScale?: Scales.Opacity): any {
+      if (opacityScale != null) {
+        this._opacityScale.offUpdate(this._redrawCallback);
+        this._opacityScale = opacityScale;
+        this._opacityScale.onUpdate(this._redrawCallback);
+        this.redraw();
+        return this;
+      } else {
+        return this._opacityScale;
+      }
+    }
+
+    /**
+     * Returns whether the opacity scale should apply to the text in the legend
+     *
+     * @returns {boolean}
+     */
+    public setOpacityToText(): boolean;
+    /**
+     * Sets whether the opacity scale should apply to the text in the legend
+     *
+     * @param {boolean} setOpacityToText
+     * @returns {Legend} The calling Legend.
+     */
+    public setOpacityToText(setOpacityToText: boolean): Legend;
+    public setOpacityToText(setOpacityToText: boolean): any {
+      if (setOpacityToText != null) {
+        this._setOpacityToText = setOpacityToText;
+        this.redraw();
+        return this;
+      } else {
+        return this._setOpacityToText;
       }
     }
 
@@ -280,6 +332,7 @@ export module Components {
       entries.select("path").attr("d", (d: any, i: number) => this.symbol()(d, i)(layout.textHeight * 0.6))
                             .attr("transform", "translate(" + (layout.textHeight / 2) + "," + layout.textHeight / 2 + ")")
                             .attr("fill", (value: string) => this._colorScale.scale(value) )
+                            .attr("opacity", (value: string) => this._opacityScale.scale(value) )
                             .classed(Legend.LEGEND_SYMBOL_CLASS, true);
 
       var padding = this._padding;
@@ -288,6 +341,7 @@ export module Components {
       textContainers.append("title").text((value: string) => value);
       var self = this;
       textContainers.attr("transform", "translate(" + layout.textHeight + ", 0)")
+                    .attr("opacity", (value: string) => this._setOpacityToText ? this._opacityScale.scale(value) : 1)
                     .each(function(value: string) {
                       var container = d3.select(this);
                       var maxTextLength = layout.entryLengths.get(value) - layout.textHeight - padding;

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -19,6 +19,7 @@ export module Components {
     private _padding = 5;
     private _colorScale: Scales.Color;
     private _opacityScale: Scales.Opacity;
+    private _setOpacityToText: boolean;
     private _applyOpacityToText: boolean;
     private _maxEntriesPerRow: number;
     private _comparator: (a: string, b: string) => number;
@@ -26,7 +27,8 @@ export module Components {
     private _wrapper: SVGTypewriter.Wrappers.Wrapper;
     private _writer: SVGTypewriter.Writers.Writer;
     private _symbolFactoryAccessor: (datum: any, index: number) => SymbolFactory;
-    private _redrawCallback: ScaleCallback<Scales.Color>;
+    private _redrawColorCallback: ScaleCallback<Scales.Color>;
+    private _redrawOpacityCallback: ScaleCallback<Scales.Opacity>;
 
     /**
      * The Legend consists of a series of entries, each with a color and label taken from the Color Scale.
@@ -44,10 +46,13 @@ export module Components {
       }
 
       this._colorScale = colorScale;
+      this._redrawColorCallback = (scale) => this.redraw();
+      this._colorScale.onUpdate(this._redrawColorCallback);
+
       this._opacityScale = new Scales.Opacity(); // default scale maps all values to opacity 1.0
       this._applyOpacityToText = false;
-      this._redrawCallback = (scale) => this.redraw();
-      this._colorScale.onUpdate(this._redrawCallback);
+      this._redrawOpacityCallback = (scale) => this.redraw();
+      this._opacityScale.onUpdate(this._redrawOpacityCallback);
 
       this.xAlignment("right").yAlignment("top");
       this.comparator((a: string, b: string) => this._colorScale.domain().indexOf(a) - this._colorScale.domain().indexOf(b));
@@ -126,9 +131,9 @@ export module Components {
     public colorScale(colorScale: Scales.Color): Legend;
     public colorScale(colorScale?: Scales.Color): any {
       if (colorScale != null) {
-        this._colorScale.offUpdate(this._redrawCallback);
+        this._colorScale.offUpdate(this._redrawColorCallback);
         this._colorScale = colorScale;
-        this._colorScale.onUpdate(this._redrawCallback);
+        this._colorScale.onUpdate(this._redrawColorCallback);
         this.redraw();
         return this;
       } else {
@@ -151,9 +156,9 @@ export module Components {
     public opacityScale(opacityScale: Scales.Opacity): Legend;
     public opacityScale(opacityScale?: Scales.Opacity): any {
       if (opacityScale != null) {
-        this._opacityScale.offUpdate(this._redrawCallback);
+        this._opacityScale.offUpdate(this._redrawOpacityCallback);
         this._opacityScale = opacityScale;
-        this._opacityScale.onUpdate(this._redrawCallback);
+        this._opacityScale.onUpdate(this._redrawOpacityCallback);
         this.redraw();
         return this;
       } else {
@@ -174,7 +179,7 @@ export module Components {
      * @returns {Legend} The calling Legend.
      */
     public setOpacityToText(setOpacityToText: boolean): Legend;
-    public setOpacityToText(setOpacityToText: boolean): any {
+    public setOpacityToText(setOpacityToText?: boolean): any {
       if (setOpacityToText != null) {
         this._setOpacityToText = setOpacityToText;
         this.redraw();
@@ -186,7 +191,8 @@ export module Components {
 
     public destroy() {
       super.destroy();
-      this._colorScale.offUpdate(this._redrawCallback);
+      this._colorScale.offUpdate(this._redrawColorCallback);
+      this._opacityScale.offUpdate(this._redrawOpacityCallback);
     }
 
     private _calculateLayoutInfo(availableWidth: number, availableHeight: number) {

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -29,6 +29,7 @@
 /// <reference path="scales/modifiedLogScale.ts" />
 /// <reference path="scales/categoryScale.ts" />
 /// <reference path="scales/colorScale.ts" />
+/// <reference path="scales/opacityScale.ts" />
 /// <reference path="scales/timeScale.ts" />
 /// <reference path="scales/interpolatedColorScale.ts" />
 /// <reference path="scales/tickGenerators.ts" />

--- a/src/scales/opacityScale.ts
+++ b/src/scales/opacityScale.ts
@@ -27,11 +27,11 @@ export module Scales {
       return this._d3Scale(value);
     }
 
-    public extentOfValues(values: number[]): number[] {
+    public extentOfValues(values: string[]): string[] {
       return Utils.Array.uniq(this._getAllIncludedValues());
     }
 
-    protected _getExtent(): number[] {
+    protected _getExtent(): string[] {
       return Utils.Array.uniq(this._getAllIncludedValues());
     }
 
@@ -39,7 +39,7 @@ export module Scales {
       return this._d3Scale.domain();
     }
 
-    protected _setBackingScaleDomain(values: number[]) {
+    protected _setBackingScaleDomain(values: string[]) {
       this._d3Scale.domain(values);
     }
 
@@ -47,7 +47,7 @@ export module Scales {
       return this._d3Scale.range();
     }
 
-    protected _setRange(values: R[]) {
+    protected _setRange(values: number[]) {
       return this._d3Scale.range(values);
     }
 

--- a/src/scales/opacityScale.ts
+++ b/src/scales/opacityScale.ts
@@ -1,0 +1,56 @@
+///<reference path="../reference.ts" />
+
+module Plottable {
+export module Scales {
+  export class Opacity extends Scale<string, number> {
+
+    private _d3Scale: d3.scale.Ordinal<string, number>;
+
+    /**
+     * An Opacity Scale maps string values to opacity values between 0 and 1.
+     *
+     * @constructor
+     */
+    constructor() {
+      super();
+      this._d3Scale = d3.scale.ordinal<string, number>().range([1]);
+    }
+
+    /**
+     * Returns the opacity corresponding to a given string.
+     * If there are not enough opacities in the range(), the scale will recycle values from the start of the range.
+     *
+     * @param {string} value
+     * @returns {number}
+     */
+    public scale(value: string): number {
+      return this._d3Scale(value);
+    }
+
+    public extentOfValues(values: number[]): number[] {
+      return Utils.Array.uniq(this._getAllIncludedValues());
+    }
+
+    protected _getExtent(): number[] {
+      return Utils.Array.uniq(this._getAllIncludedValues());
+    }
+
+    protected _getDomain() {
+      return this._d3Scale.domain();
+    }
+
+    protected _setBackingScaleDomain(values: number[]) {
+      this._d3Scale.domain(values);
+    }
+
+    protected _getRange() {
+      return this._d3Scale.range();
+    }
+
+    protected _setRange(values: R[]) {
+      return this._d3Scale.range(values);
+    }
+
+  }
+}
+}

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -5,6 +5,7 @@ var assert = chai.assert;
 describe("Legend", () => {
   var svg: d3.Selection<void>;
   var color: Plottable.Scales.Color;
+  var opacity: Plottable.Scales.Opacity;
   var legend: Plottable.Components.Legend;
 
   var entrySelector = "." + Plottable.Components.Legend.LEGEND_ENTRY_CLASS;
@@ -15,6 +16,7 @@ describe("Legend", () => {
     svg = TestMethods.generateSVG(400, 400);
     color = new Plottable.Scales.Color();
     legend = new Plottable.Components.Legend(color);
+    opacity = new Plottable.Scales.Opacity();
   });
 
   it("a basic legend renders", () => {
@@ -30,6 +32,7 @@ describe("Legend", () => {
       assert.strictEqual(text, d, "the text node has correct text");
       var symbol = d3this.select("." + Plottable.Components.Legend.LEGEND_SYMBOL_CLASS);
       assert.strictEqual(symbol.attr("fill"), color.scale(d), "the symbol's fill is set properly");
+      assert.strictEqual(symbol.attr("opacity"), '1', "the symbol's opacity defaults to 1");
     });
     svg.remove();
   });
@@ -225,6 +228,35 @@ describe("Legend", () => {
 
     assert.strictEqual(idealSpaceRequest.minWidth, constrainedRequest.minWidth,
       "won't settle for less width if entries would be truncated");
+    svg.remove();
+  });
+
+  it("renders with correct opacity for each symbol and/or text when specified", () => {
+    var commonDomain = ["foo", "bar", "baz"];
+    color.domain(commonDomain);
+    opacity.domain(commonDomain)
+      .range([0.8, 0.5, 0.2]);
+    legend.opacityScale(opacity);
+    legend.renderTo(svg);
+
+    var rows = (<any> legend)._content.selectAll(entrySelector);
+
+    rows.each(function(d: any, i: number) {
+      var d3this = d3.select(this);
+      var textContainer = d3this.select(".text-container");
+      assert.strictEqual(textContainer.attr("opacity"), '1', "the text by default still has opacity 1");
+      var symbol = d3this.select("." + Plottable.Components.Legend.LEGEND_SYMBOL_CLASS);
+      assert.strictEqual(symbol.attr("opacity"), String(opacity.scale(d)), "the symbol's opacity follows the opacity scale");
+    });
+
+    legend.setOpacityToText(true).redraw();
+    var rows = (<any> legend)._content.selectAll(entrySelector);
+
+    rows.each(function(d: any, i: number) {
+      var d3this = d3.select(this);
+      var textContainer = d3this.select(".text-container");
+      assert.strictEqual(textContainer.attr("opacity"), String(opacity.scale(d)), "the text's opacity follows the opacity scale");
+    });
     svg.remove();
   });
 

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -32,7 +32,7 @@ describe("Legend", () => {
       assert.strictEqual(text, d, "the text node has correct text");
       var symbol = d3this.select("." + Plottable.Components.Legend.LEGEND_SYMBOL_CLASS);
       assert.strictEqual(symbol.attr("fill"), color.scale(d), "the symbol's fill is set properly");
-      assert.strictEqual(symbol.attr("opacity"), '1', "the symbol's opacity defaults to 1");
+      assert.strictEqual(symbol.attr("opacity"), "1", "the symbol's opacity defaults to 1");
     });
     svg.remove();
   });
@@ -244,13 +244,13 @@ describe("Legend", () => {
     rows.each(function(d: any, i: number) {
       var d3this = d3.select(this);
       var textContainer = d3this.select(".text-container");
-      assert.strictEqual(textContainer.attr("opacity"), '1', "the text by default still has opacity 1");
+      assert.strictEqual(textContainer.attr("opacity"), "1", "the text by default still has opacity 1");
       var symbol = d3this.select("." + Plottable.Components.Legend.LEGEND_SYMBOL_CLASS);
       assert.strictEqual(symbol.attr("opacity"), String(opacity.scale(d)), "the symbol's opacity follows the opacity scale");
     });
 
     legend.setOpacityToText(true).redraw();
-    var rows = (<any> legend)._content.selectAll(entrySelector);
+    rows = (<any> legend)._content.selectAll(entrySelector);
 
     rows.each(function(d: any, i: number) {
       var d3this = d3.select(this);

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -201,6 +201,28 @@ describe("Scales", () => {
 
   });
 
+
+  describe("Opacity Scales", () => {
+    it("default scale maps all values to opacity 1", () => {
+      var scale = new Plottable.Scales.Opacity();
+      scale.domain(["foo", "bar", "baz"]);
+      assert.strictEqual(1, scale.scale("foo"));
+      assert.strictEqual(1, scale.scale("bar"));
+      assert.strictEqual(1, scale.scale("baz"));
+    });
+
+    it("scale cycles through range values if range is larger than domain", () => {
+      var scale = new Plottable.Scales.Opacity();
+      scale.domain(["foo", "bar", "baz", "qux"]);
+      scale.range([0.2, 0.7])
+      assert.strictEqual(0.2, scale.scale("foo"));
+      assert.strictEqual(0.7, scale.scale("bar"));
+      assert.strictEqual(0.2, scale.scale("baz"));
+      assert.strictEqual(0.7, scale.scale("qux"));
+    });
+  });
+
+
   describe("Interpolated Color Scales", () => {
     it("default scale uses reds and a linear scale type", () => {
       var scale = new Plottable.Scales.InterpolatedColor();

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -201,7 +201,6 @@ describe("Scales", () => {
 
   });
 
-
   describe("Opacity Scales", () => {
     it("default scale maps all values to opacity 1", () => {
       var scale = new Plottable.Scales.Opacity();
@@ -214,14 +213,13 @@ describe("Scales", () => {
     it("scale cycles through range values if range is larger than domain", () => {
       var scale = new Plottable.Scales.Opacity();
       scale.domain(["foo", "bar", "baz", "qux"]);
-      scale.range([0.2, 0.7])
+      scale.range([0.2, 0.7]);
       assert.strictEqual(0.2, scale.scale("foo"));
       assert.strictEqual(0.7, scale.scale("bar"));
       assert.strictEqual(0.2, scale.scale("baz"));
       assert.strictEqual(0.7, scale.scale("qux"));
     });
   });
-
 
   describe("Interpolated Color Scales", () => {
     it("default scale uses reds and a linear scale type", () => {


### PR DESCRIPTION
Fixes #2434 -- motivation is that opacity of many Plottable components can be specified directly via .attr(), but this is not true for legend.

User can now create Scale.Opacity which can be passed into a legend. If unspecified, opacity is by default 1. User can set whether to apply the opacity scale to just the symbols or the legend text as well.

Demo: http://plnkr.co/edit/5lQh9oanj9bw1gRjPlyp?p=preview

This doesn't cover InterpolatedColorLegend, but we can do something similar easily.