### PR TITLE
Fix autoranging on Plots.Segment and Plots.Rectangle

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3193,6 +3193,7 @@ declare module Plottable {
              */
             y2(y2: number | Accessor<number> | Y | Accessor<Y>): Plots.Segment<X, Y>;
             protected _propertyProjectors(): AttributeToProjector;
+            protected _extentsForProperty(attr: string): any[];
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2777,6 +2777,7 @@ declare module Plottable {
                 y: any;
             };
             protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
+            protected _extentsForProperty(attr: string): any[];
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -6977,6 +6977,8 @@ var Plottable;
              */
             function Rectangle() {
                 _super.call(this);
+                this._xExtent = [];
+                this._yExtent = [];
                 this.animator("rectangles", new Plottable.Animators.Null());
                 this.addClass("rectangle-plot");
             }
@@ -7130,6 +7132,45 @@ var Plottable;
                     dataToDraw.set(dataset, data);
                 });
                 return dataToDraw;
+            };
+            Rectangle.prototype._extentsForProperty = function (attr) {
+                if (attr === "x" && this.x2() == null || attr === "y" && this.y2() == null) {
+                    return _super.prototype._extentsForProperty.call(this, attr);
+                }
+                else {
+                    return [this._aggregatedExtentForProperty(attr)];
+                }
+            };
+            Rectangle.prototype._aggregatedExtentForProperty = function (attr) {
+                var _this = this;
+                var filter = this._filterForProperty((attr === "y" || attr === "y2") ? "y" : "x");
+                var xValues = [];
+                var yValues = [];
+                var datasets = this.datasets();
+                datasets.forEach(function (dataset) {
+                    dataset.data().forEach(function (datum, index) {
+                        if (filter != null && !filter(datum, index, dataset)) {
+                            return;
+                        }
+                        if (attr === "y" || attr === "y2") {
+                            var yAccessor = _this.y().accessor;
+                            yValues.push(yAccessor(datum, index, dataset));
+                            if (_this.y2()) {
+                                var y2Accessor = _this.y2().accessor;
+                                yValues.push(y2Accessor(datum, index, dataset));
+                            }
+                        }
+                        else {
+                            var xAccessor = _this.x().accessor;
+                            xValues.push(xAccessor(datum, index, dataset));
+                            if (_this.x2()) {
+                                var x2Accessor = _this.x2().accessor;
+                                xValues.push(x2Accessor(datum, index, dataset));
+                            }
+                        }
+                    });
+                });
+                return (attr === "y" || attr === "y2") ? [Plottable.Utils.Math.min(yValues, 0), Plottable.Utils.Math.max(yValues, 0)] : [Plottable.Utils.Math.min(xValues, 0), Plottable.Utils.Math.max(xValues, 0)];
             };
             Rectangle._X2_KEY = "x2";
             Rectangle._Y2_KEY = "y2";

--- a/plottable.js
+++ b/plottable.js
@@ -8510,6 +8510,45 @@ var Plottable;
                 attrToProjector["y2"] = this.y2() == null ? Plottable.Plot._scaledAccessor(this.y()) : Plottable.Plot._scaledAccessor(this.y2());
                 return attrToProjector;
             };
+            Segment.prototype._extentsForProperty = function (attr) {
+                if (attr === "x" && this.x2() == null || attr === "y" && this.y2() == null) {
+                    return _super.prototype._extentsForProperty.call(this, attr);
+                }
+                else {
+                    return [this._aggregatedExtentForProperty(attr)];
+                }
+            };
+            Segment.prototype._aggregatedExtentForProperty = function (attr) {
+                var _this = this;
+                var filter = this._filterForProperty((attr === "y" || attr === "y2") ? "y" : "x");
+                var xValues = [];
+                var yValues = [];
+                var datasets = this.datasets();
+                datasets.forEach(function (dataset) {
+                    dataset.data().forEach(function (datum, index) {
+                        if (filter != null && !filter(datum, index, dataset)) {
+                            return;
+                        }
+                        if (attr === "y" || attr === "y2") {
+                            var yAccessor = _this.y().accessor;
+                            yValues.push(yAccessor(datum, index, dataset));
+                            if (_this.y2()) {
+                                var y2Accessor = _this.y2().accessor;
+                                yValues.push(y2Accessor(datum, index, dataset));
+                            }
+                        }
+                        else {
+                            var xAccessor = _this.x().accessor;
+                            xValues.push(xAccessor(datum, index, dataset));
+                            if (_this.x2()) {
+                                var x2Accessor = _this.x2().accessor;
+                                xValues.push(x2Accessor(datum, index, dataset));
+                            }
+                        }
+                    });
+                });
+                return (attr === "y" || attr === "y2") ? [Plottable.Utils.Math.min(yValues, 0), Plottable.Utils.Math.max(yValues, 0)] : [Plottable.Utils.Math.min(xValues, 0), Plottable.Utils.Math.max(xValues, 0)];
+            };
             Segment._X2_KEY = "x2";
             Segment._Y2_KEY = "y2";
             return Segment;

--- a/plottable.js
+++ b/plottable.js
@@ -6977,8 +6977,6 @@ var Plottable;
              */
             function Rectangle() {
                 _super.call(this);
-                this._xExtent = [];
-                this._yExtent = [];
                 this.animator("rectangles", new Plottable.Animators.Null());
                 this.addClass("rectangle-plot");
             }

--- a/src/plots/rectanglePlot.ts
+++ b/src/plots/rectanglePlot.ts
@@ -5,8 +5,6 @@ export module Plots {
   export class Rectangle<X, Y> extends XYPlot<X, Y> {
     private static _X2_KEY = "x2";
     private static _Y2_KEY = "y2";
-    private _xExtent: number[] = [];
-    private _yExtent: number[] = [];
 
     /**
      * A Rectangle Plot displays rectangles based on the data.
@@ -291,16 +289,16 @@ export module Plots {
             yValues.push(yAccessor(datum, index, dataset));
             if (this.y2()) {
               var y2Accessor = this.y2().accessor;
-              yValues.push(y2Accessor(datum, index, dataset));        
+              yValues.push(y2Accessor(datum, index, dataset));
             }
           } else {
             var xAccessor = this.x().accessor;
             xValues.push(xAccessor(datum, index, dataset));
             if (this.x2()) {
               var x2Accessor = this.x2().accessor;
-              xValues.push(x2Accessor(datum, index, dataset));          
+              xValues.push(x2Accessor(datum, index, dataset));
             }
-          }          
+          }
         });
       });
       return (attr === "y" || attr === "y2") ? [Utils.Math.min(yValues, 0), Utils.Math.max(yValues, 0)] :

--- a/src/plots/rectanglePlot.ts
+++ b/src/plots/rectanglePlot.ts
@@ -5,6 +5,8 @@ export module Plots {
   export class Rectangle<X, Y> extends XYPlot<X, Y> {
     private static _X2_KEY = "x2";
     private static _Y2_KEY = "y2";
+    private _xExtent: number[] = [];
+    private _yExtent: number[] = [];
 
     /**
      * A Rectangle Plot displays rectangles based on the data.
@@ -265,6 +267,45 @@ export module Plots {
       return dataToDraw;
     }
 
+    protected _extentsForProperty(attr: string) {
+      if (attr === "x" && this.x2() == null ||
+          attr === "y" && this.y2() == null) {
+        return super._extentsForProperty(attr);
+      } else {
+        return [this._aggregatedExtentForProperty(attr)];
+      }
+    }
+
+    private _aggregatedExtentForProperty(attr: string) {
+      var filter = this._filterForProperty((attr === "y" || attr === "y2") ? "y" : "x");
+      var xValues: number[] = [];
+      var yValues: number[] = [];
+      var datasets = this.datasets();
+      datasets.forEach((dataset) => {
+        dataset.data().forEach((datum, index) => {
+          if (filter != null && !filter(datum, index, dataset)) {
+            return;
+          }
+          if (attr === "y" || attr === "y2") {
+            var yAccessor = this.y().accessor;
+            yValues.push(yAccessor(datum, index, dataset));
+            if (this.y2()) {
+              var y2Accessor = this.y2().accessor;
+              yValues.push(y2Accessor(datum, index, dataset));        
+            }
+          } else {
+            var xAccessor = this.x().accessor;
+            xValues.push(xAccessor(datum, index, dataset));
+            if (this.x2()) {
+              var x2Accessor = this.x2().accessor;
+              xValues.push(x2Accessor(datum, index, dataset));          
+            }
+          }          
+        });
+      });
+      return (attr === "y" || attr === "y2") ? [Utils.Math.min(yValues, 0), Utils.Math.max(yValues, 0)] :
+                                               [Utils.Math.min(xValues, 0), Utils.Math.max(xValues, 0)];
+    }
   }
 }
 }

--- a/src/plots/segmentPlot.ts
+++ b/src/plots/segmentPlot.ts
@@ -154,6 +154,46 @@ export module Plots {
       attrToProjector["y2"] = this.y2() == null ? Plot._scaledAccessor(this.y()) : Plot._scaledAccessor(this.y2());
       return attrToProjector;
     }
+
+    protected _extentsForProperty(attr: string) {
+      if (attr === "x" && this.x2() == null ||
+          attr === "y" && this.y2() == null) {
+        return super._extentsForProperty(attr);
+      } else {
+        return [this._aggregatedExtentForProperty(attr)];
+      }
+    }
+
+    private _aggregatedExtentForProperty(attr: string) {
+      var filter = this._filterForProperty((attr === "y" || attr === "y2") ? "y" : "x");
+      var xValues: number[] = [];
+      var yValues: number[] = [];
+      var datasets = this.datasets();
+      datasets.forEach((dataset) => {
+        dataset.data().forEach((datum, index) => {
+          if (filter != null && !filter(datum, index, dataset)) {
+            return;
+          }
+          if (attr === "y" || attr === "y2") {
+            var yAccessor = this.y().accessor;
+            yValues.push(yAccessor(datum, index, dataset));
+            if (this.y2()) {
+              var y2Accessor = this.y2().accessor;
+              yValues.push(y2Accessor(datum, index, dataset));        
+            }
+          } else {
+            var xAccessor = this.x().accessor;
+            xValues.push(xAccessor(datum, index, dataset));
+            if (this.x2()) {
+              var x2Accessor = this.x2().accessor;
+              xValues.push(x2Accessor(datum, index, dataset));          
+            }
+          }          
+        });
+      });
+      return (attr === "y" || attr === "y2") ? [Utils.Math.min(yValues, 0), Utils.Math.max(yValues, 0)] :
+                                               [Utils.Math.min(xValues, 0), Utils.Math.max(xValues, 0)];
+    }
   }
 }
 }

--- a/src/plots/segmentPlot.ts
+++ b/src/plots/segmentPlot.ts
@@ -179,16 +179,16 @@ export module Plots {
             yValues.push(yAccessor(datum, index, dataset));
             if (this.y2()) {
               var y2Accessor = this.y2().accessor;
-              yValues.push(y2Accessor(datum, index, dataset));        
+              yValues.push(y2Accessor(datum, index, dataset));
             }
           } else {
             var xAccessor = this.x().accessor;
             xValues.push(xAccessor(datum, index, dataset));
             if (this.x2()) {
               var x2Accessor = this.x2().accessor;
-              xValues.push(x2Accessor(datum, index, dataset));          
+              xValues.push(x2Accessor(datum, index, dataset));
             }
-          }          
+          }
         });
       });
       return (attr === "y" || attr === "y2") ? [Utils.Math.min(yValues, 0), Utils.Math.max(yValues, 0)] :


### PR DESCRIPTION
Open questions:

* There's currently code duplication between `Plots.Segment` and `Plots.Rectangle` in the way extents are calculated to encompass both `x` and `x2` (or `y` and `y2`). Should this go in a Util function, and what should it be called?

http://jsfiddle.net/hy3vak9k/

Fixes #2463 