### PR TITLE
Travis-CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
 - '0.12'
-before_install:
-- phantomjs -v
 notifications:
   email: false
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: node_js
 node_js:
-- '0.10'
+- '0.12'
+before_install:
+- phantomjs -v
 notifications:
   email: false
+sudo: false
+cache:
+  directories:
+  - node_modules
 env:
   global:
   - secure: D/VxpQ0fvxqD75Qgwa0HcxbQYNsIv+D7RJ+khiAwNlsluY9VKH84O0hmCQ1ijHKrUTGbSEqAkbNS+D0hvngmSfLCgsNhZyDVTZ0s2kzjV2v5jXrvppr7TmBsCUcp6+5CEgoL/0UL3w+Me3bq9WioMDD0AkmAwAdR/B2LJojEsEY=


### PR DESCRIPTION
Adding `sudo: false` switches us over to Travis' container-based infrastructure, which should give us modest performance boosts in testing.