### PR TITLE
Add a flag on Numeric axes to approximate the width of the labels.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1905,13 +1905,13 @@ declare module Plottable {
              *
              * @returns {boolean} The current approximate text width setting.
              */
-            approximateTextWidth(): boolean;
+            usesTextWidthApproximation(): boolean;
             /**
              * Sets the approximate text width setting.
              *
              * @param {boolean} enable faster but less accurate computation of text widths.
              */
-            approximateTextWidth(enable: boolean): any;
+            usesTextWidthApproximation(enable: boolean): any;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1913,7 +1913,7 @@ declare module Plottable {
              * Additionally, very abnormal fonts may not approximate reasonably.
              *
              * @param {boolean} The new text width approximation setting.
-             * @returns {Axes.Numeric} The calling Plottable.Axes.Numeric.
+             * @returns {Plottable.Axes.Numeric} The calling Plottable.Axes.Numeric.
              */
             usesTextWidthApproximation(enable: boolean): Axes.Numeric;
         }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1903,13 +1903,16 @@ declare module Plottable {
             /**
              * Gets the approximate text width setting.
              *
-             * @returns {boolean} The current approximate text width setting.
+             * @returns {boolean} The current text width approximation setting.
              */
             usesTextWidthApproximation(): boolean;
             /**
-             * Sets the approximate text width setting.
+             * Sets the approximate text width setting. Approximating text width
+             * measurements can drastically speed up plot rendering, but the plot may
+             * have extra white space that would be eliminated by exact measurements.
+             * Additionally, very abnormal fonts may not approximate reasonably.
              *
-             * @param {boolean} enable faster but less accurate computation of text widths.
+             * @param {boolean} The new text width approximation setting.
              */
             usesTextWidthApproximation(enable: boolean): void;
         }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1913,8 +1913,9 @@ declare module Plottable {
              * Additionally, very abnormal fonts may not approximate reasonably.
              *
              * @param {boolean} The new text width approximation setting.
+             * @returns {Axes.Numeric} The calling Plottable.Axes.Numeric.
              */
-            usesTextWidthApproximation(enable: boolean): void;
+            usesTextWidthApproximation(enable: boolean): Axes.Numeric;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1900,6 +1900,18 @@ declare module Plottable {
              * @returns {Numeric} The calling Numeric Axis.
              */
             tickLabelPosition(position: string): Numeric;
+            /**
+             * Gets the approximate text width setting.
+             *
+             * @returns {boolean} The current approximate text width setting.
+             */
+            approximateTextWidth(): boolean;
+            /**
+             * Sets the approximate text width setting.
+             *
+             * @param {boolean} enable faster but less accurate computation of text widths.
+             */
+            approximateTextWidth(enable: boolean): any;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1911,7 +1911,7 @@ declare module Plottable {
              *
              * @param {boolean} enable faster but less accurate computation of text widths.
              */
-            usesTextWidthApproximation(enable: boolean): any;
+            usesTextWidthApproximation(enable: boolean): void;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -4579,6 +4579,7 @@ var Plottable;
                 }
                 else {
                     this._usesTextWidthApproximation = enable;
+                    return this;
                 }
             };
             Numeric.prototype._hideEndTickLabels = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -4386,7 +4386,7 @@ var Plottable;
             Numeric.prototype._computeApproximateTextWidth = function () {
                 var _this = this;
                 var tickValues = this._getTickValues();
-                var mWidth = this._measurer.measure('M').width;
+                var mWidth = this._measurer.measure("M").width;
                 var textLengths = tickValues.map(function (v) {
                     var formattedValue = _this.formatter()(v);
                     return formattedValue.length * mWidth;

--- a/plottable.js
+++ b/plottable.js
@@ -4356,7 +4356,7 @@ var Plottable;
             function Numeric(scale, orientation) {
                 _super.call(this, scale, orientation);
                 this._tickLabelPositioning = "center";
-                this._approximateTextWidth = false;
+                this._usesTextWidthApproximation = false;
                 this.formatter(Plottable.Formatters.general());
             }
             Numeric.prototype._setup = function () {
@@ -4365,7 +4365,7 @@ var Plottable;
                 this._wrapper = new SVGTypewriter.Wrappers.Wrapper().maxLines(1);
             };
             Numeric.prototype._computeWidth = function () {
-                var maxTextWidth = this._approximateTextWidth ? this._computeApproximateTextWidth() : this._computeExactTextWidth();
+                var maxTextWidth = this._usesTextWidthApproximation ? this._computeApproximateTextWidth() : this._computeExactTextWidth();
                 if (this._tickLabelPositioning === "center") {
                     this._computedWidth = this._maxLabelTickLength() + this.tickLabelPadding() + maxTextWidth;
                 }
@@ -4573,12 +4573,12 @@ var Plottable;
                     return this;
                 }
             };
-            Numeric.prototype.approximateTextWidth = function (enable) {
+            Numeric.prototype.usesTextWidthApproximation = function (enable) {
                 if (enable == null) {
-                    return this._approximateTextWidth;
+                    return this._usesTextWidthApproximation;
                 }
                 else {
-                    this._approximateTextWidth = enable;
+                    this._usesTextWidthApproximation = enable;
                 }
             };
             Numeric.prototype._hideEndTickLabels = function () {

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -281,13 +281,16 @@ export module Axes {
     /**
      * Gets the approximate text width setting.
      *
-     * @returns {boolean} The current approximate text width setting.
+     * @returns {boolean} The current text width approximation setting.
      */
     public usesTextWidthApproximation(): boolean;
     /**
-     * Sets the approximate text width setting.
+     * Sets the approximate text width setting. Approximating text width
+     * measurements can drastically speed up plot rendering, but the plot may
+     * have extra white space that would be eliminated by exact measurements.
+     * Additionally, very abnormal fonts may not approximate reasonably.
      *
-     * @param {boolean} enable faster but less accurate computation of text widths.
+     * @param {boolean} The new text width approximation setting.
      */
     public usesTextWidthApproximation(enable: boolean): void;
     public usesTextWidthApproximation(enable?: boolean): boolean {

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -5,7 +5,7 @@ export module Axes {
   export class Numeric extends Axis<number> {
 
     private _tickLabelPositioning = "center";
-    private _approximateTextWidth = false;
+    private _usesTextWidthApproximation = false;
     private _measurer: SVGTypewriter.Measurers.Measurer;
     private _wrapper: SVGTypewriter.Wrappers.Wrapper;
 
@@ -30,7 +30,7 @@ export module Axes {
     }
 
     protected _computeWidth() {
-      var maxTextWidth = this._approximateTextWidth ? this._computeApproximateTextWidth() : this._computeExactTextWidth();
+      var maxTextWidth = this._usesTextWidthApproximation ? this._computeApproximateTextWidth() : this._computeExactTextWidth();
 
       if (this._tickLabelPositioning === "center") {
         this._computedWidth = this._maxLabelTickLength() + this.tickLabelPadding() + maxTextWidth;
@@ -283,18 +283,18 @@ export module Axes {
      *
      * @returns {boolean} The current approximate text width setting.
      */
-    public approximateTextWidth(): boolean;
+    public usesTextWidthApproximation(): boolean;
     /**
      * Sets the approximate text width setting.
      *
      * @param {boolean} enable faster but less accurate computation of text widths.
      */
-    public approximateTextWidth(enable: boolean);
-    public approximateTextWidth(enable?: boolean): boolean {
+    public usesTextWidthApproximation(enable: boolean);
+    public usesTextWidthApproximation(enable?: boolean): boolean {
       if (enable == null) {
-        return this._approximateTextWidth;
+        return this._usesTextWidthApproximation;
       } else {
-        this._approximateTextWidth = enable;
+        this._usesTextWidthApproximation = enable;
       }
     }
 

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -289,7 +289,7 @@ export module Axes {
      *
      * @param {boolean} enable faster but less accurate computation of text widths.
      */
-    public usesTextWidthApproximation(enable: boolean);
+    public usesTextWidthApproximation(enable: boolean): void;
     public usesTextWidthApproximation(enable?: boolean): boolean {
       if (enable == null) {
         return this._usesTextWidthApproximation;

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -291,7 +291,7 @@ export module Axes {
      * Additionally, very abnormal fonts may not approximate reasonably.
      *
      * @param {boolean} The new text width approximation setting.
-     * @returns {Plottable.Axes.Numeric} The calling Plottable.Axes.Numeric.
+     * @returns {Axes.Numeric} The calling Axes.Numeric.
      */
     public usesTextWidthApproximation(enable: boolean): Axes.Numeric;
     public usesTextWidthApproximation(enable?: boolean): any {

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -30,7 +30,7 @@ export module Axes {
     }
 
     protected _computeWidth() {
-      var maxTextWidth = this._approximateTextWidth ? this._computeApproximateTextWidth() : this._computeExactTextWidth()
+      var maxTextWidth = this._approximateTextWidth ? this._computeApproximateTextWidth() : this._computeExactTextWidth();
 
       if (this._tickLabelPositioning === "center") {
         this._computedWidth = this._maxLabelTickLength() + this.tickLabelPadding() + maxTextWidth;
@@ -53,7 +53,7 @@ export module Axes {
 
     private _computeApproximateTextWidth(): number {
       var tickValues = this._getTickValues();
-      var mWidth = this._measurer.measure('M').width;
+      var mWidth = this._measurer.measure("M").width;
       var textLengths = tickValues.map((v: any) => {
         var formattedValue = this.formatter()(v);
         return formattedValue.length * mWidth;

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -54,7 +54,7 @@ export module Axes {
     private _computeApproximateTextWidth(): number {
       var tickValues = this._getTickValues();
       var mWidth = this._measurer.measure("M").width;
-      var textLengths = tickValues.map((v: any) => {
+      var textLengths = tickValues.map((v: number): number => {
         var formattedValue = this.formatter()(v);
         return formattedValue.length * mWidth;
       });

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -291,7 +291,7 @@ export module Axes {
      * Additionally, very abnormal fonts may not approximate reasonably.
      *
      * @param {boolean} The new text width approximation setting.
-     * @returns {Axes.Numeric} The calling Plottable.Axes.Numeric.
+     * @returns {Plottable.Axes.Numeric} The calling Plottable.Axes.Numeric.
      */
     public usesTextWidthApproximation(enable: boolean): Axes.Numeric;
     public usesTextWidthApproximation(enable?: boolean): any {

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -291,13 +291,15 @@ export module Axes {
      * Additionally, very abnormal fonts may not approximate reasonably.
      *
      * @param {boolean} The new text width approximation setting.
+     * @returns {Axes.Numeric} The calling Plottable.Axes.Numeric.
      */
-    public usesTextWidthApproximation(enable: boolean): void;
-    public usesTextWidthApproximation(enable?: boolean): boolean {
+    public usesTextWidthApproximation(enable: boolean): Axes.Numeric;
+    public usesTextWidthApproximation(enable?: boolean): any {
       if (enable == null) {
         return this._usesTextWidthApproximation;
       } else {
         this._usesTextWidthApproximation = enable;
+        return this;
       }
     }
 

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -431,4 +431,34 @@ describe("NumericAxis", () => {
     svg.remove();
   });
 
+  it("reasonably approximates tick label sizes with approximate measuring", () => {
+    var SVG_WIDTH = 500;
+    var SVG_HEIGHT = 100;
+
+    [[-1, 1],
+     [0, 10],
+     [0, 999999999]
+    ].forEach((domainBounds) => {
+      var scale = new Plottable.Scales.Linear();
+      scale.domain(domainBounds);
+
+      var svgApprox = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      var numericAxisApprox = new Plottable.Axes.Numeric(scale, "left");
+      numericAxisApprox.usesTextWidthApproximation(true);
+      numericAxisApprox.renderTo(svgApprox);
+      var widthApprox = (<any> numericAxisApprox)._computeWidth();
+
+      var svgExact = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      var numericAxisExact = new Plottable.Axes.Numeric(scale, "left");
+      numericAxisExact.usesTextWidthApproximation(false);
+      numericAxisExact.renderTo(svgExact);
+      var widthExact = (<any> numericAxisExact)._computeWidth();
+
+      svgApprox.remove();
+      svgExact.remove();
+
+      assert.isTrue(widthApprox < (widthExact * 1.55), "an approximate scale of ["+domainBounds[0]+","+domainBounds[1]+"] is less than 55% larger than an exact scale");
+      assert.isTrue(widthApprox >= widthExact, "an approximate scale of ["+domainBounds[0]+","+domainBounds[1]+"] is smaller than an exact scale");
+    });
+  });
 });

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -435,32 +435,36 @@ describe("NumericAxis", () => {
     var SVG_WIDTH = 500;
     var SVG_HEIGHT = 100;
 
-    [[-1, 1],
-     [0, 10],
-     [0, 999999999]
-    ].forEach((domainBounds) => {
+    var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+
+    var testCases = [[-1, 1],
+                     [0, 10],
+                     [0, 999999999]];
+
+    var maxErrorFactor = 1.4;
+
+    testCases.forEach((domainBounds) => {
       var scale = new Plottable.Scales.Linear();
       scale.domain(domainBounds);
+      var numericAxis = new Plottable.Axes.Numeric(scale, "left");
 
-      var svgApprox = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      var numericAxisApprox = new Plottable.Axes.Numeric(scale, "left");
-      numericAxisApprox.usesTextWidthApproximation(true);
-      numericAxisApprox.renderTo(svgApprox);
-      var widthApprox = (<any> numericAxisApprox)._computeWidth();
+      numericAxis.usesTextWidthApproximation(true);
+      numericAxis.renderTo(svg);
+      var widthApprox = numericAxis.width();
 
-      var svgExact = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      var numericAxisExact = new Plottable.Axes.Numeric(scale, "left");
-      numericAxisExact.usesTextWidthApproximation(false);
-      numericAxisExact.renderTo(svgExact);
-      var widthExact = (<any> numericAxisExact)._computeWidth();
+      numericAxis.usesTextWidthApproximation(false);
+      numericAxis.redraw();
+      var widthExact = numericAxis.width();
 
-      svgApprox.remove();
-      svgExact.remove();
-
-      assert.isTrue(widthApprox < (widthExact * 1.55),
-        "an approximate scale of [" + domainBounds[0] + "," + domainBounds[1] + "] is less than 55% larger than an exact scale");
-      assert.isTrue(widthApprox >= widthExact,
+      assert.operator(widthApprox, "<", (widthExact * maxErrorFactor),
+        "an approximate scale of [" + domainBounds[0] + "," + domainBounds[1] + "] is less than "
+        + maxErrorFactor + "x larger than an exact scale");
+      assert.operator(widthApprox, ">=", widthExact,
         "an approximate scale of [" + domainBounds[0] + "," + domainBounds[1] + "] is smaller than an exact scale");
+
+      numericAxis.destroy();
     });
+
+    svg.remove();
   });
 });

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -457,8 +457,10 @@ describe("NumericAxis", () => {
       svgApprox.remove();
       svgExact.remove();
 
-      assert.isTrue(widthApprox < (widthExact * 1.55), "an approximate scale of ["+domainBounds[0]+","+domainBounds[1]+"] is less than 55% larger than an exact scale");
-      assert.isTrue(widthApprox >= widthExact, "an approximate scale of ["+domainBounds[0]+","+domainBounds[1]+"] is smaller than an exact scale");
+      assert.isTrue(widthApprox < (widthExact * 1.55),
+        "an approximate scale of [" + domainBounds[0] + "," + domainBounds[1] + "] is less than 55% larger than an exact scale");
+      assert.isTrue(widthApprox >= widthExact,
+        "an approximate scale of [" + domainBounds[0] + "," + domainBounds[1] + "] is smaller than an exact scale");
     });
   });
 });


### PR DESCRIPTION
Part of #2433

Approximating the width reduces measure() calls, which are expensive. Using a simple approximation speeds things up on my machine by 30% or more, depending on how many labels are measured to render the graph.

JSFiddle: http://jsfiddle.net/uk3b4ykj/1/

API Changes:

* `Plottable.Axes.Numeric.usesTextWidthApproximation(enable: boolean)` has been added as a getter/setter to enable approximation

This approximation is particularly suited to the Numeric axis, as numbers are all basically the same size in most fonts.

A test running 20 graphs takes between 400 and 500 ms to run.

![head-20](https://cloud.githubusercontent.com/assets/6878538/8814096/c4231d22-2fbd-11e5-8d65-fd4ef0a29f00.png)

With approximate text measuring, it takes between 250 and 350 ms.

![branch-20](https://cloud.githubusercontent.com/assets/6878538/8814105/dacb4a2c-2fbd-11e5-96ad-050489c051b8.png)

This is definitely due to the measurement calls, as can be seen in the below timeline of a single graph render.

![head-1](https://cloud.githubusercontent.com/assets/6878538/8814113/e8b5abe6-2fbd-11e5-97fa-f502b7b3caec.png)

And the corresponding improvement.

![branch-1](https://cloud.githubusercontent.com/assets/6878538/8814123/0084b866-2fbe-11e5-93c1-f648df50e719.png)
