### PR TITLE
Improved incremental build time of watch 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ test/tests.js
 
 # Visual Studio Code
 .settings/
+
+# Typescript
+.baseDir.ts

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,7 +19,6 @@ module.exports = function(grunt) {
     test: {
       src: ["test/*.ts", "typings/**/*.d.ts", "build/plottable.d.ts"],
       outDir: "build/test/",
-      // watch: "test",
       options: {
         target: "es5",
         sourceMap: false,
@@ -34,7 +33,10 @@ module.exports = function(grunt) {
         "typings/d3/d3.d.ts",
         "plottable.d.ts",
         "bower_components/svg-typewriter/svgtypewriter.d.ts"
-      ]
+      ],
+      options: {
+        compiler: "./node_modules/typescript/bin/tsc"
+      }
     }
   };
 
@@ -48,16 +50,6 @@ module.exports = function(grunt) {
       prereleaseName: "rc"
     }
   };
-
-  var FILES_TO_COMMIT = [
-    "plottable.js",
-    "plottable.min.js",
-    "plottable.d.ts",
-    "plottable.css",
-    "plottable.zip",
-    "bower.json",
-    "package.json"
-  ];
 
   var prefixMatch = "\\n *(function |var |static )?";
   var varNameMatch = "[^(:;]*(\\([^)]*\\))?"; // catch function args too
@@ -207,11 +199,12 @@ module.exports = function(grunt) {
 
   var watchConfig = {
     options: {
-      livereload: true
+      livereload: true,
+      spawn: false
     },
     rebuild: {
-      tasks: ["dev-compile"],
-      files: ["src/**/*.ts", "examples/**/*.ts"]
+      tasks: ["src-compile"],
+      files: ["src/**/*.ts"]
     },
     tests: {
       tasks: ["test-compile"],
@@ -244,6 +237,16 @@ module.exports = function(grunt) {
   var cleanConfig = {
     tscommand: ["tscommand*.tmp.txt"]
   };
+
+  var FILES_TO_COMMIT = [
+    "plottable.js",
+    "plottable.min.js",
+    "plottable.d.ts",
+    "plottable.css",
+    "plottable.zip",
+    "bower.json",
+    "package.json"
+  ];
 
   var gitcommitConfig = {
     version: {
@@ -336,25 +339,29 @@ module.exports = function(grunt) {
     "saucelabs-mocha": saucelabsMochaConfig
   });
 
+  // Loads the tasks specified in package.json
   require("load-grunt-tasks")(grunt);
 
-  // default task (this is what runs when a task isn't specified)
   grunt.registerTask("update_ts_files", updateTsFiles);
   grunt.registerTask("update_test_ts_files", updateTestTsFiles);
+
   grunt.registerTask("definitions_prod", function() {
     grunt.file.copy("build/plottable.d.ts", "plottable.d.ts");
   });
-  grunt.registerTask("test-compile", [
-    "ts:test",
-    "concat:testsMultifile",
-    "sed:testsMultifile",
-    "concat:tests"
-  ]);
-  grunt.registerTask("default", "launch");
+
+  grunt.registerTask("test-compile", ["ts:test", "concat:tests"]);
+  grunt.registerTask("src-compile", ["ts:dev", "generateJS"]);
+
   grunt.registerTask("dev-compile", [
     "update_ts_files",
     "update_test_ts_files",
-    "ts:dev",
+    "src-compile",
+    "test-compile",
+    "clean:tscommand",
+    "update-quicktests"
+  ]);
+
+  grunt.registerTask("generateJS", [
     "concat:plottable",
     "concat:svgtypewriter",
     "concat:definitions",
@@ -363,50 +370,38 @@ module.exports = function(grunt) {
     "umd:all",
     "concat:header",
     "sed:versionNumber",
-    "definitions_prod",
-    "test-compile",
-    "concat:plottableMultifile",
-    "sed:plottableMultifile",
-    "clean:tscommand",
-    "update-quicktests"
+    "definitions_prod"
   ]);
 
   grunt.registerTask("release:patch", ["bump:patch", "dist-compile", "gitcommit:version"]);
   grunt.registerTask("release:minor", ["bump:minor", "dist-compile", "gitcommit:version"]);
   grunt.registerTask("release:major", ["bump:major", "dist-compile", "gitcommit:version"]);
 
-  grunt.registerTask("dist-compile", [
-    "dev-compile",
-    "blanket_mocha",
-    "parallelize:tslint",
-    "ts:verifyDefinitionFiles",
-    "uglify",
-    "compress"
-  ]);
+  grunt.registerTask("dist-compile", ["test", "uglify", "compress"]);
 
   grunt.registerTask("commitjs", ["dist-compile", "gitcommit:built"]);
-  grunt.registerTask("launch", ["connect", "dev-compile", "watch"]);
+  grunt.registerTask("default", ["connect", "dev-compile", "watch"]);
+
+  grunt.registerTask("test", ["dev-compile", "test-local"]);
+  grunt.registerTask("test-local", ["blanket_mocha", "ts:verifyDefinitionFiles", "lint"]);
   grunt.registerTask("test-sauce", ["connect", "saucelabs-mocha"]);
-  grunt.registerTask("test", [
-    "dev-compile",
-    "blanket_mocha",
-    "parallelize:tslint",
-    "ts:verifyDefinitionFiles",
-    "jscs",
-    "eslint"
-  ]);
 
-  // Disable saucelabs for external pull requests. Check if we can see the SAUCE_USERNAME
-  var travisTests = ["test"];
+  grunt.registerTask("lint", ["parallelize:tslint", "jscs", "eslint"]);
+
+  // Disable saucelabs on dev environments by checking if SAUCE_USERNAME is an environment variable
   if (process.env.SAUCE_USERNAME) {
-    travisTests.push("test-sauce");
+    grunt.registerTask("test-travis", ["dev-compile", "test-local", "test-sauce"]);
+  } else {
+    grunt.registerTask("test-travis", ["dev-compile", "test-local"]);
   }
-  grunt.registerTask("test-travis", travisTests);
-  grunt.registerTask("bm", ["blanket_mocha"]);
 
-  grunt.registerTask("sublime", [
-    "shell:sublime",
-    "sed:sublime"
+  // Tooling
+  grunt.registerTask("sublime", ["shell:sublime", "sed:sublime"]);
+  grunt.registerTask("generateMultifile", [
+    "concat:plottableMultifile",
+    "sed:plottableMultifile",
+    "concat:testsMultifile",
+    "sed:testsMultifile"
   ]);
 
   grunt.registerTask("update-quicktests", function() {


### PR DESCRIPTION
Part of #2445 

Refactored the Gruntfile even more as a followup of #2469 and part of my hack week project.

As part of this change:
- Improved incremental build time  | Before `9.127 s` | After `3.321 s`
- Typescript is creating a `.baseDir.ts` file. Added to gitignore. Known issue. https://github.com/grunt-ts/grunt-ts/issues/77
- Tests no longer get recompiled upon src changes. This will be caught in the travis CI, which makes sense to me.

This change has been briefly tested, but I want to see how it behaves in the wild. Ping @aicioara for any discovered issues. In particular, my addition `spawn: false` in the watch config was documented as unstable.

Not included in this change:
- The incremental build time can be improved even more by somehow caching the `tsc` command. Notice that `2 s` out of the required `3.321s` are just booting the tsc (which as a dependency parses the `lib.d.ts` file). If we can use the built in watch of the TSC, that would be huge. However `grunt-ts` is lacking this feature, or rather reimplements it inefficiently. 

Pre-req for TS1.4 compatibility checking.
 