### PR TITLE
[Grunt] No more noisy output from the concat pipeline

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -362,11 +362,17 @@ module.exports = function(grunt) {
   grunt.registerTask("dist-compile", ["test", "uglify", "compress"]);
 
   grunt.registerTask("commitjs", ["dist-compile", "gitcommit:built"]);
-  grunt.registerTask("default", ["connect", "dev-compile", "watch"]);
+  grunt.registerTask("default", ["connect", "dev-compile", "watch-silent"]);
 
   grunt.registerTask("test", ["dev-compile", "test-local"]);
   grunt.registerTask("test-local", ["blanket_mocha", "ts:verifyDefinitionFiles", "lint"]);
   grunt.registerTask("test-sauce", ["connect", "saucelabs-mocha"]);
+
+  grunt.registerTask("watch-silent", function() {
+    // HACKHACK #2508
+    grunt.log.header = function() {};
+    grunt.task.run(["watch"]);
+  });
 
   grunt.registerTask("lint", ["parallelize:tslint", "jscs", "eslint"]);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -369,7 +369,7 @@ module.exports = function(grunt) {
   grunt.registerTask("test-sauce", ["connect", "saucelabs-mocha"]);
 
   grunt.registerTask("watch-silent", function() {
-    // HACKHACK #2508
+    // Surpresses the "Running 'foo' task" messages
     grunt.log.header = function() {};
     grunt.task.run(["watch"]);
   });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -369,7 +369,7 @@ module.exports = function(grunt) {
   grunt.registerTask("test-sauce", ["connect", "saucelabs-mocha"]);
 
   grunt.registerTask("watch-silent", function() {
-    // Surpresses the "Running 'foo' task" messages
+    // Surpresses the "Running 'foo' task" messages. More info at #2507.
     grunt.log.header = function() {};
     grunt.task.run(["watch"]);
   });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -369,7 +369,7 @@ module.exports = function(grunt) {
   grunt.registerTask("test-sauce", ["connect", "saucelabs-mocha"]);
 
   grunt.registerTask("watch-silent", function() {
-    // Surpresses the "Running 'foo' task" messages. More info at #2507.
+    // Surpresses the "Running 'foo' task" messages
     grunt.log.header = function() {};
     grunt.task.run(["watch"]);
   });


### PR DESCRIPTION
Before
![screen shot 2015-07-24 at 4 55 10 pm](https://cloud.githubusercontent.com/assets/3248682/8886835/d555b324-3225-11e5-97a0-fd664c152e1d.png)

After
![screen shot 2015-07-24 at 4 59 15 pm](https://cloud.githubusercontent.com/assets/3248682/8886840/da0f413c-3225-11e5-9f48-b584b59c110b.png)

Inspiration
https://github.com/gruntjs/grunt/issues/895

This is simply removing the `Running "foo:bar" task`, for watch only. The header is still used for all our CI stuff. 

Closes #2507 