### PR TITLE
Add a license field to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "plottable.js",
   "description": "A library for creating charts out of D3",
   "version": "1.4.0",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/palantir/plottable.git"


### PR DESCRIPTION
I just noticed this, and decided to fix it because why not? Unless there is a reason this is not set already.

Currently npm install warns with the following message:

`npm WARN package.json plottable.js@1.4.0 No license field.`

Plottable is MIT licensed, according to the LICENSE file, and I don't like this warning message.