### PR TITLE
Add movable() API point to DragBoxLayer

### DIFF
--- a/plottable.css
+++ b/plottable.css
@@ -143,6 +143,19 @@ svg.plottable {
 .plottable .drag-box-layer.x-resizable.y-resizable .drag-corner-br {
   cursor: nwse-resize;
 }
+
+.plottable .drag-box-layer.movable .selection-area {
+  cursor: move; /* IE fallback */
+  cursor: -moz-grab;
+  cursor: -webkit-grab;
+  cursor: grab;
+}
+
+.plottable .drag-box-layer.movable .selection-area:active {
+  cursor: -moz-grabbing;
+  cursor: -webkit-grabbing;
+  cursor: grabbing;
+}
 /* /DragBoxLayer */
 
 .plottable .legend text {

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -4018,7 +4018,16 @@ declare module Plottable {
              */
             resizable(canResize: boolean): DragBoxLayer;
             protected _setResizableClasses(canResize: boolean): void;
+            /**
+             * Gets whether or not the drag box is movable.
+             */
             movable(): boolean;
+            /**
+             * Sets whether or not the drag box is movable.
+             *
+             * @param {boolean} movable
+             * @return {DragBoxLayer} The calling DragBoxLayer.
+             */
             movable(movable: boolean): DragBoxLayer;
             /**
              * Sets the callback to be called when dragging starts.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -4018,6 +4018,8 @@ declare module Plottable {
              */
             resizable(canResize: boolean): DragBoxLayer;
             protected _setResizableClasses(canResize: boolean): void;
+            movable(): boolean;
+            movable(movable: boolean): DragBoxLayer;
             /**
              * Sets the callback to be called when dragging starts.
              *

--- a/plottable.js
+++ b/plottable.js
@@ -10491,11 +10491,11 @@ var Plottable;
                     move: 2
                 };
                 var mode = DRAG_MODES.newBox;
-                this._dragInteraction.onDragStart(function (s) {
-                    resizingEdges = _this._getResizingEdges(s);
+                this._dragInteraction.onDragStart(function (startPoint) {
+                    resizingEdges = _this._getResizingEdges(startPoint);
                     var bounds = _this.bounds();
-                    var isInsideBox = bounds.topLeft.x <= s.x && s.x <= bounds.bottomRight.x &&
-                        bounds.topLeft.y <= s.y && s.y <= bounds.bottomRight.y;
+                    var isInsideBox = bounds.topLeft.x <= startPoint.x && startPoint.x <= bounds.bottomRight.x &&
+                        bounds.topLeft.y <= startPoint.y && startPoint.y <= bounds.bottomRight.y;
                     if (_this.boxVisible() && (resizingEdges.top || resizingEdges.bottom || resizingEdges.left || resizingEdges.right)) {
                         mode = DRAG_MODES.resize;
                     }
@@ -10505,8 +10505,8 @@ var Plottable;
                     else {
                         mode = DRAG_MODES.newBox;
                         _this.bounds({
-                            topLeft: s,
-                            bottomRight: s
+                            topLeft: startPoint,
+                            bottomRight: startPoint
                         });
                     }
                     _this.boxVisible(true);
@@ -10514,36 +10514,38 @@ var Plottable;
                     // copy points so changes to topLeft and bottomRight don't mutate bounds
                     topLeft = { x: bounds.topLeft.x, y: bounds.topLeft.y };
                     bottomRight = { x: bounds.bottomRight.x, y: bounds.bottomRight.y };
-                    lastEndPoint = s;
+                    lastEndPoint = startPoint;
                     _this._dragStartCallbacks.callCallbacks(bounds);
                 });
-                this._dragInteraction.onDrag(function (s, e) {
-                    if (mode === DRAG_MODES.newBox) {
-                        bottomRight.x = e.x;
-                        bottomRight.y = e.y;
-                    }
-                    else if (mode === DRAG_MODES.resize) {
-                        if (resizingEdges.bottom) {
-                            bottomRight.y = e.y;
-                        }
-                        else if (resizingEdges.top) {
-                            topLeft.y = e.y;
-                        }
-                        if (resizingEdges.right) {
-                            bottomRight.x = e.x;
-                        }
-                        else if (resizingEdges.left) {
-                            topLeft.x = e.x;
-                        }
-                    }
-                    else {
-                        var dx = e.x - lastEndPoint.x;
-                        var dy = e.y - lastEndPoint.y;
-                        topLeft.x += dx;
-                        topLeft.y += dy;
-                        bottomRight.x += dx;
-                        bottomRight.y += dy;
-                        lastEndPoint = e;
+                this._dragInteraction.onDrag(function (startPoint, endPoint) {
+                    switch (mode) {
+                        case DRAG_MODES.newBox:
+                            bottomRight.x = endPoint.x;
+                            bottomRight.y = endPoint.y;
+                            break;
+                        case DRAG_MODES.resize:
+                            if (resizingEdges.bottom) {
+                                bottomRight.y = endPoint.y;
+                            }
+                            else if (resizingEdges.top) {
+                                topLeft.y = endPoint.y;
+                            }
+                            if (resizingEdges.right) {
+                                bottomRight.x = endPoint.x;
+                            }
+                            else if (resizingEdges.left) {
+                                topLeft.x = endPoint.x;
+                            }
+                            break;
+                        case DRAG_MODES.move:
+                            var dx = endPoint.x - lastEndPoint.x;
+                            var dy = endPoint.y - lastEndPoint.y;
+                            topLeft.x += dx;
+                            topLeft.y += dy;
+                            bottomRight.x += dx;
+                            bottomRight.y += dy;
+                            lastEndPoint = endPoint;
+                            break;
                     }
                     _this.bounds({
                         topLeft: topLeft,
@@ -10551,8 +10553,8 @@ var Plottable;
                     });
                     _this._dragCallbacks.callCallbacks(_this.bounds());
                 });
-                this._dragInteraction.onDragEnd(function (s, e) {
-                    if (mode === DRAG_MODES.newBox && s.x === e.x && s.y === e.y) {
+                this._dragInteraction.onDragEnd(function (startPoint, endPoint) {
+                    if (mode === DRAG_MODES.newBox && startPoint.x === endPoint.x && startPoint.y === endPoint.y) {
                         _this.boxVisible(false);
                     }
                     _this._dragEndCallbacks.callCallbacks(_this.bounds());

--- a/plottable.js
+++ b/plottable.js
@@ -10649,6 +10649,8 @@ var Plottable;
                     this.removeClass("y-resizable");
                 }
             };
+            DragBoxLayer.prototype.movable = function (movable) {
+            };
             /**
              * Sets the callback to be called when dragging starts.
              *

--- a/src/components/dragBoxLayer.ts
+++ b/src/components/dragBoxLayer.ts
@@ -272,6 +272,11 @@ export module Components {
       }
     }
 
+    public movable(): boolean;
+    public movable(movable: boolean): DragBoxLayer;
+    public movable(movable?: boolean): any {
+    }
+
     /**
      * Sets the callback to be called when dragging starts.
      *

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -506,8 +506,6 @@ describe("Interactive Components", () => {
         assert.strictEqual(dbl.movable(true), dbl, "setter mode returns DragBoxLayer");
         assert.isTrue(dbl.movable(), "set to true");
         assert.isTrue(dbl.hasClass("movable"), "\"movable\" CSS class is applied");
-        // assert.isTrue(dbl.hasClass("x-movable"), "\"x-movable\" CSS class is applied");
-        // assert.isTrue(dbl.hasClass("y-movable"), "\"y-movable\" CSS class is applied");
         svg.remove();
       });
 

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -475,5 +475,138 @@ describe("Interactive Components", () => {
         svg.remove();
       });
     });
+
+    describe("moving", () => {
+      var svg: d3.Selection<void>;
+      var dbl: Plottable.Components.DragBoxLayer;
+      var target: d3.Selection<void>;
+      var midPoint = {
+        x: SVG_WIDTH / 2,
+        y: SVG_HEIGHT / 2
+      };
+      var dragDistance = 10;
+      var initialBounds: Plottable.Bounds;
+
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        dbl = new Plottable.Components.DragBoxLayer();
+        dbl.renderTo(svg);
+
+        target = dbl.background();
+        dbl.bounds({
+          topLeft: { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4},
+          bottomRight: { x: SVG_WIDTH * 3 / 4, y: SVG_HEIGHT * 3 / 4}
+        });
+        dbl.boxVisible(true);
+        initialBounds = dbl.bounds();
+      });
+
+      it("get and set movable()", () => {
+        assert.isFalse(dbl.movable(), "defaults to false");
+        assert.strictEqual(dbl.movable(true), dbl, "setter mode returns DragBoxLayer");
+        assert.isTrue(dbl.movable(), "set to true");
+        assert.isTrue(dbl.hasClass("movable"), "\"movable\" CSS class is applied");
+        // assert.isTrue(dbl.hasClass("x-movable"), "\"x-movable\" CSS class is applied");
+        // assert.isTrue(dbl.hasClass("y-movable"), "\"y-movable\" CSS class is applied");
+        svg.remove();
+      });
+
+      it("move left", () => {
+        dbl.movable(true);
+        TestMethods.triggerFakeDragSequence(target,
+          { x: midPoint.x, y: midPoint.y },
+          { x: midPoint.x - dragDistance, y: midPoint.y }
+        );
+        var bounds = dbl.bounds();
+        assert.strictEqual(bounds.topLeft.x, initialBounds.topLeft.x - dragDistance, "left edge moved");
+        assert.strictEqual(bounds.bottomRight.x, initialBounds.bottomRight.x - dragDistance, "right edge moved");
+        assert.strictEqual(bounds.topLeft.y, initialBounds.topLeft.y, "top edge did not move");
+        assert.strictEqual(bounds.bottomRight.y, initialBounds.bottomRight.y, "bottom edge did not move");
+        svg.remove();
+      });
+
+      it("move right", () => {
+        dbl.movable(true);
+        TestMethods.triggerFakeDragSequence(target,
+          { x: midPoint.x, y: midPoint.y },
+          { x: midPoint.x + dragDistance, y: midPoint.y }
+        );
+        var bounds = dbl.bounds();
+        assert.strictEqual(bounds.topLeft.x, initialBounds.topLeft.x + dragDistance, "left edge moved");
+        assert.strictEqual(bounds.bottomRight.x, initialBounds.bottomRight.x + dragDistance, "right edge moved");
+        assert.strictEqual(bounds.topLeft.y, initialBounds.topLeft.y, "top edge did not move");
+        assert.strictEqual(bounds.bottomRight.y, initialBounds.bottomRight.y, "bottom edge did not move");
+        svg.remove();
+      });
+
+      it("move up", () => {
+        dbl.movable(true);
+        TestMethods.triggerFakeDragSequence(target,
+          { x: midPoint.x, y: midPoint.y },
+          { x: midPoint.x, y: midPoint.y - dragDistance }
+        );
+        var bounds = dbl.bounds();
+        assert.strictEqual(bounds.topLeft.x, initialBounds.topLeft.x, "left edge did not move");
+        assert.strictEqual(bounds.bottomRight.x, initialBounds.bottomRight.x, "right edge did not move");
+        assert.strictEqual(bounds.topLeft.y, initialBounds.topLeft.y - dragDistance, "top edge moved");
+        assert.strictEqual(bounds.bottomRight.y, initialBounds.bottomRight.y - dragDistance, "bottom edge moved");
+        svg.remove();
+      });
+
+      it("move down", () => {
+        dbl.movable(true);
+        TestMethods.triggerFakeDragSequence(target,
+          { x: midPoint.x, y: midPoint.y },
+          { x: midPoint.x, y: midPoint.y + dragDistance }
+        );
+        var bounds = dbl.bounds();
+        assert.strictEqual(bounds.topLeft.x, initialBounds.topLeft.x, "left edge did not move");
+        assert.strictEqual(bounds.bottomRight.x, initialBounds.bottomRight.x, "right edge did not move");
+        assert.strictEqual(bounds.topLeft.y, initialBounds.topLeft.y + dragDistance, "top edge moved");
+        assert.strictEqual(bounds.bottomRight.y, initialBounds.bottomRight.y + dragDistance, "bottom edge moved");
+        svg.remove();
+      });
+
+      it("does not move if grabbed within detectionRadius() while resizable()", () => {
+        dbl.movable(true);
+        dbl.resizable(true);
+        TestMethods.triggerFakeDragSequence(target,
+          { x: initialBounds.bottomRight.x, y: midPoint.y },
+          { x: SVG_WIDTH, y: midPoint.y }
+        );
+        var bounds = dbl.bounds();
+        assert.strictEqual(bounds.topLeft.y, initialBounds.topLeft.y, "top edge was not moved");
+        assert.strictEqual(bounds.bottomRight.y, initialBounds.bottomRight.y, "bottom edge was not moved");
+        assert.strictEqual(bounds.topLeft.x, initialBounds.topLeft.x, "left edge was not moved");
+        assert.strictEqual(bounds.bottomRight.x, SVG_WIDTH, "right edge was repositioned");
+        svg.remove();
+      });
+
+      it("doesn't dismiss on no-op move", () => {
+        dbl.movable(true);
+        TestMethods.triggerFakeDragSequence(target,
+          { x: midPoint.x, y: midPoint.y },
+          { x: midPoint.x, y: midPoint.y }
+        );
+        assert.isTrue(dbl.boxVisible(), "box remains visible");
+        var bounds = dbl.bounds();
+        assert.deepEqual(bounds, initialBounds, "bounds did not change");
+        svg.remove();
+      });
+
+      it("starts new box if hidden instead of moving", () => {
+        dbl.movable(true);
+        dbl.boxVisible(false);
+        TestMethods.triggerFakeDragSequence(target,
+          { x: midPoint.x, y: midPoint.y },
+          { x: midPoint.x, y: midPoint.y + dragDistance }
+        );
+        var bounds = dbl.bounds();
+        assert.strictEqual(bounds.topLeft.x, midPoint.x, "new box was started at the drag start position (x)");
+        assert.strictEqual(bounds.topLeft.y, midPoint.y, "new box was started at the drag start position (y)");
+
+        svg.remove();
+      });
+    });
   });
 });

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -503,6 +503,7 @@ describe("Interactive Components", () => {
 
       it("get and set movable()", () => {
         assert.isFalse(dbl.movable(), "defaults to false");
+        assert.isFalse(dbl.hasClass("movable"), "initially does not have \"movable\" CSS class");
         assert.strictEqual(dbl.movable(true), dbl, "setter mode returns DragBoxLayer");
         assert.isTrue(dbl.movable(), "set to true");
         assert.isTrue(dbl.hasClass("movable"), "\"movable\" CSS class is applied");
@@ -589,6 +590,14 @@ describe("Interactive Components", () => {
         assert.isTrue(dbl.boxVisible(), "box remains visible");
         var bounds = dbl.bounds();
         assert.deepEqual(bounds, initialBounds, "bounds did not change");
+        svg.remove();
+      });
+
+      it("dismisses on click outside of box", () => {
+        dbl.movable(true);
+        var origin = { x: 0, y: 0 };
+        TestMethods.triggerFakeDragSequence(target, origin, origin);
+        assert.isFalse(dbl.boxVisible(), "box is no longer visible");
         svg.remove();
       });
 

--- a/test/components/xDragBoxLayerTests.ts
+++ b/test/components/xDragBoxLayerTests.ts
@@ -62,8 +62,7 @@ describe("Interactive Components", () => {
         x: SVG_WIDTH * 3 / 4,
         y: SVG_HEIGHT / 2
       };
-      var target = dbl.background();
-      TestMethods.triggerFakeDragSequence(target, actualBounds.bottomRight, dragTo);
+      TestMethods.triggerFakeDragSequence(dbl.background(), actualBounds.bottomRight, dragTo);
       actualBounds = dbl.bounds();
       assert.strictEqual(actualBounds.bottomRight.x, dragTo.x, "resized in x");
       assert.strictEqual(actualBounds.topLeft.y, 0, "box still starts at top");
@@ -129,8 +128,7 @@ describe("Interactive Components", () => {
 
       var boundsBefore = dbl.bounds();
       var dragDistance = 10;
-      var target = dbl.background();
-      TestMethods.triggerFakeDragSequence(target,
+      TestMethods.triggerFakeDragSequence(dbl.background(),
         { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 },
         { x: SVG_WIDTH / 2 + dragDistance, y: SVG_HEIGHT / 2 + dragDistance }
       );

--- a/test/components/xDragBoxLayerTests.ts
+++ b/test/components/xDragBoxLayerTests.ts
@@ -105,5 +105,43 @@ describe("Interactive Components", () => {
       assert.strictEqual(boundsAfter.bottomRight.y, dbl.height(), "box still ends at bottom");
       svg.remove();
     });
+
+    it("moves only in x", () => {
+      var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      var dbl = new Plottable.Components.XDragBoxLayer();
+      dbl.boxVisible(true);
+      dbl.movable(true);
+      dbl.renderTo(svg);
+
+      var topLeft = {
+        x: SVG_WIDTH / 4,
+        y: SVG_HEIGHT / 4
+      };
+      var bottomRight = {
+        x: SVG_WIDTH * 3 / 4,
+        y: SVG_HEIGHT * 3 / 4
+      };
+
+      dbl.bounds({
+        topLeft: topLeft,
+        bottomRight: bottomRight
+      });
+
+      var boundsBefore = dbl.bounds();
+      var dragDistance = 10;
+      var target = dbl.background();
+      TestMethods.triggerFakeDragSequence(target,
+        { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 },
+        { x: SVG_WIDTH / 2 + dragDistance, y: SVG_HEIGHT / 2 + dragDistance }
+      );
+
+      var boundsAfter = dbl.bounds();
+      assert.strictEqual(boundsAfter.topLeft.x, boundsBefore.topLeft.x + dragDistance, "left edge moved");
+      assert.strictEqual(boundsAfter.topLeft.y, 0, "box still starts at top");
+      assert.strictEqual(boundsAfter.bottomRight.x, boundsBefore.bottomRight.x + dragDistance, "right edge moved");
+      assert.strictEqual(boundsAfter.bottomRight.y, dbl.height(), "box still ends at bottom");
+
+      svg.remove();
+    });
   });
 });

--- a/test/components/yDragBoxLayerTests.ts
+++ b/test/components/yDragBoxLayerTests.ts
@@ -105,5 +105,43 @@ describe("Interactive Components", () => {
       assert.strictEqual(boundsAfter.bottomRight.y, boundsBefore.bottomRight.y, "box keeps same bottom edge");
       svg.remove();
     });
+
+    it("moves only in y", () => {
+      var svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      var dbl = new Plottable.Components.YDragBoxLayer();
+      dbl.boxVisible(true);
+      dbl.movable(true);
+      dbl.renderTo(svg);
+
+      var topLeft = {
+        x: SVG_WIDTH / 4,
+        y: SVG_HEIGHT / 4
+      };
+      var bottomRight = {
+        x: SVG_WIDTH * 3 / 4,
+        y: SVG_HEIGHT * 3 / 4
+      };
+
+      dbl.bounds({
+        topLeft: topLeft,
+        bottomRight: bottomRight
+      });
+
+      var boundsBefore = dbl.bounds();
+      var dragDistance = 10;
+      var target = dbl.background();
+      TestMethods.triggerFakeDragSequence(target,
+        { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 },
+        { x: SVG_WIDTH / 2 + dragDistance, y: SVG_HEIGHT / 2 + dragDistance }
+      );
+
+      var boundsAfter = dbl.bounds();
+      assert.strictEqual(boundsAfter.topLeft.x, 0, "box still starts at left");
+      assert.strictEqual(boundsAfter.topLeft.y, boundsBefore.topLeft.y + dragDistance, "top edge moved");
+      assert.strictEqual(boundsAfter.bottomRight.x, dbl.width(), "box still ends at right");
+      assert.strictEqual(boundsAfter.bottomRight.y, boundsBefore.bottomRight.y + dragDistance, "bottom edge moved");
+
+      svg.remove();
+    });
   });
 });

--- a/test/components/yDragBoxLayerTests.ts
+++ b/test/components/yDragBoxLayerTests.ts
@@ -62,8 +62,7 @@ describe("Interactive Components", () => {
         x: SVG_WIDTH / 2,
         y: SVG_HEIGHT * 3 / 4
       };
-      var target = dbl.background();
-      TestMethods.triggerFakeDragSequence(target, actualBounds.bottomRight, dragTo);
+      TestMethods.triggerFakeDragSequence(dbl.background(), actualBounds.bottomRight, dragTo);
       actualBounds = dbl.bounds();
       assert.strictEqual(actualBounds.topLeft.x, 0, "box still starts at left");
       assert.strictEqual(actualBounds.bottomRight.x, dbl.width(), "box still ends at right");
@@ -129,8 +128,7 @@ describe("Interactive Components", () => {
 
       var boundsBefore = dbl.bounds();
       var dragDistance = 10;
-      var target = dbl.background();
-      TestMethods.triggerFakeDragSequence(target,
+      TestMethods.triggerFakeDragSequence(dbl.background(),
         { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 },
         { x: SVG_WIDTH / 2 + dragDistance, y: SVG_HEIGHT / 2 + dragDistance }
       );

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -157,6 +157,21 @@ module TestMethods {
 
   export function triggerFakeDragSequence(target: d3.Selection<void>, start: Plottable.Point, end: Plottable.Point) {
     triggerFakeMouseEvent("mousedown", target, start.x, start.y);
+    var numSteps = 10;
+    // var steps: Plottable.Point[] = [];
+    for (var i = 0; i < numSteps; i++) {
+      // steps.push({
+      //   x: start.x + (end.x - start.x) * i / numSteps,
+      //   y: start.y + (end.y - start.y) * i / numSteps
+      // });
+      triggerFakeMouseEvent(
+        "mousemove",
+        target,
+        start.x + (end.x - start.x) * i / numSteps,
+        start.y + (end.y - start.y) * i / numSteps
+      );
+    }
+    // triggerFakeMouseEvent("mousemove", target, (end.x + start.x) / 2, (end.y + start.y) / 2);
     triggerFakeMouseEvent("mousemove", target, end.x, end.y);
     triggerFakeMouseEvent("mouseup", target, end.x, end.y);
   }

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -155,15 +155,9 @@ module TestMethods {
     target.node().dispatchEvent(e);
   }
 
-  export function triggerFakeDragSequence(target: d3.Selection<void>, start: Plottable.Point, end: Plottable.Point) {
+  export function triggerFakeDragSequence(target: d3.Selection<void>, start: Plottable.Point, end: Plottable.Point, numSteps = 2) {
     triggerFakeMouseEvent("mousedown", target, start.x, start.y);
-    var numSteps = 10;
-    // var steps: Plottable.Point[] = [];
-    for (var i = 0; i < numSteps; i++) {
-      // steps.push({
-      //   x: start.x + (end.x - start.x) * i / numSteps,
-      //   y: start.y + (end.y - start.y) * i / numSteps
-      // });
+    for (var i = 1; i < numSteps; i++) {
       triggerFakeMouseEvent(
         "mousemove",
         target,
@@ -171,7 +165,6 @@ module TestMethods {
         start.y + (end.y - start.y) * i / numSteps
       );
     }
-    // triggerFakeMouseEvent("mousemove", target, (end.x + start.x) / 2, (end.y + start.y) / 2);
     triggerFakeMouseEvent("mousemove", target, end.x, end.y);
     triggerFakeMouseEvent("mouseup", target, end.x, end.y);
   }


### PR DESCRIPTION
Added the ability to move drag boxes by clicking and dragging on the inside of the box. The functionality is accessed via the `movable()` API point on `DragBoxLayer`:

```Typescript
/**
 * Gets whether or not the drag box is movable.
 */
movable(): boolean;
/**
 * Sets whether or not the drag box is movable.
 *
 * @param {boolean} movable
 * @return {DragBoxLayer} The calling DragBoxLayer.
 */
movable(movable: boolean): DragBoxLayer;
```

Example: http://jsfiddle.net/qr5t8754/
More complicated example: http://jsfiddle.net/657jg26g/

Close #365.