### PR TITLE
[GlobalInitialization] - assert variable defined in only one place

### DIFF
--- a/test/animators/easingAnimatorTests.ts
+++ b/test/animators/easingAnimatorTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Animators", () => {
   describe("EasingAnimator", () => {
     describe("Time computations", () => {

--- a/test/axes/baseAxisTests.ts
+++ b/test/axes/baseAxisTests.ts
@@ -1,5 +1,4 @@
 ///<reference path="../testReference.ts" />
-var assert = chai.assert;
 
 describe("BaseAxis", () => {
   it("orientation", () => {

--- a/test/axes/categoryAxisTests.ts
+++ b/test/axes/categoryAxisTests.ts
@@ -1,6 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
 describe("Category Axes", () => {
   it("re-renders appropriately when data is changed", () => {
     var svg = TestMethods.generateSVG(400, 400);

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("NumericAxis", () => {
   function boxIsInside(inner: ClientRect, outer: ClientRect, epsilon = 0) {
     if (inner.left < outer.left - epsilon) { return false; }

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("TimeAxis", () => {
   var scale: Plottable.Scales.Time;
   var axis: Plottable.Axes.Time;

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 function assertComponentXY(component: Plottable.Component, x: number, y: number, message: string) {
   // use <any> to examine the private variables
   var translate = d3.transform((<any> component)._element.attr("transform")).translate;

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Interactive Components", () => {
   describe("DragBoxLayer", () => {
     var SVG_WIDTH = 400;

--- a/test/components/gridlinesTests.ts
+++ b/test/components/gridlinesTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Gridlines", () => {
   it("Gridlines and axis tick marks align", () => {
     var svg = TestMethods.generateSVG(640, 480);

--- a/test/components/groupTests.ts
+++ b/test/components/groupTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("ComponentGroups", () => {
   it("append()", () => {
     var componentGroup = new Plottable.Components.Group();

--- a/test/components/interpolatedColorLegendTests.ts
+++ b/test/components/interpolatedColorLegendTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("InterpolatedColorLegend", () => {
   var svg: d3.Selection<void>;
   var colorScale: Plottable.Scales.InterpolatedColor;

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Labels", () => {
 
   it("Standard text title label generates properly", () => {

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Legend", () => {
   var svg: d3.Selection<void>;
   var color: Plottable.Scales.Color;

--- a/test/components/selectionBoxLayerTests.ts
+++ b/test/components/selectionBoxLayerTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("SelectionBoxLayer", () => {
   it("boxVisible()", () => {
     var svg = TestMethods.generateSVG();

--- a/test/components/tableTests.ts
+++ b/test/components/tableTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 function generateBasicTable(nRows: number, nCols: number) {
   // makes a table with exactly nRows * nCols children in a regular grid, with each
   // child being a basic component

--- a/test/components/xDragBoxLayerTests.ts
+++ b/test/components/xDragBoxLayerTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Interactive Components", () => {
   describe("XDragBoxLayer", () => {
     var SVG_WIDTH = 400;

--- a/test/components/yDragBoxLayerTests.ts
+++ b/test/components/yDragBoxLayerTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Interactive Components", () => {
   describe("YDragBoxLayer", () => {
     var SVG_WIDTH = 400;

--- a/test/core/datasetTests.ts
+++ b/test/core/datasetTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Dataset", () => {
   it("Updates listeners when the data is changed", () => {
     var ds = new Plottable.Dataset();

--- a/test/core/formattersTests.ts
+++ b/test/core/formattersTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Formatters", () => {
   describe("fixed", () => {
     it("shows exactly [precision] digits", () => {

--- a/test/core/metadataTests.ts
+++ b/test/core/metadataTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Metadata", () => {
   var xScale: Plottable.Scales.Linear;
   var yScale: Plottable.Scales.Linear;

--- a/test/core/renderControllerTests.ts
+++ b/test/core/renderControllerTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("RenderController", () => {
   // HACKHACK: #2083
   it.skip("Components whose render() is triggered by another Component's render() will be drawn", () => {

--- a/test/dispatchers/dispatcherTests.ts
+++ b/test/dispatchers/dispatcherTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Dispatchers", () => {
   describe("Dispatcher", () => {
     it("_connect() and _disconnect()", () => {

--- a/test/dispatchers/keyDispatcherTests.ts
+++ b/test/dispatchers/keyDispatcherTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Dispatchers", () => {
   describe("Key Dispatcher", () => {
     it("triggers callback on mousedown", () => {

--- a/test/dispatchers/mouseDispatcherTests.ts
+++ b/test/dispatchers/mouseDispatcherTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Dispatchers", () => {
   describe("Mouse Dispatcher", () => {
 

--- a/test/dispatchers/touchDispatcherTests.ts
+++ b/test/dispatchers/touchDispatcherTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Dispatchers", () => {
   describe("Touch Dispatcher", () => {
     it("getDispatcher() creates only one Dispatcher.Touch per <svg>", () => {

--- a/test/globalInitialization.ts
+++ b/test/globalInitialization.ts
@@ -5,6 +5,8 @@ interface Window {
   Pixel_CloseTo_Requirement: number;
 }
 
+var assert = chai.assert;
+
 before(() => {
   // Set the render policy to immediate to make sure ETE tests can check DOM change immediately
   Plottable.RenderController.renderPolicy("immediate");

--- a/test/interactions/clickInteractionTests.ts
+++ b/test/interactions/clickInteractionTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Interactions", () => {
   describe("Click", () => {
     var SVG_WIDTH = 400;

--- a/test/interactions/doubleClickInteractionTests.ts
+++ b/test/interactions/doubleClickInteractionTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Interactions", () => {
   describe("DoubleClick", () => {
     var SVG_WIDTH = 400;

--- a/test/interactions/dragInteractionTests.ts
+++ b/test/interactions/dragInteractionTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Interactions", () => {
   describe("Drag", () => {
     var SVG_WIDTH = 400;

--- a/test/interactions/interactionTests.ts
+++ b/test/interactions/interactionTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Interactions", () => {
   describe("Interaction", () => {
     var SVG_WIDTH = 400;

--- a/test/interactions/keyInteractionTests.ts
+++ b/test/interactions/keyInteractionTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Interactions", () => {
   describe("KeyInteraction", () => {
     it("Triggers appropriate callback for the key pressed", () => {

--- a/test/interactions/panZoomInteractionTests.ts
+++ b/test/interactions/panZoomInteractionTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Interactions", () => {
   describe("PanZoomInteraction", () => {
     var svg: d3.Selection<void>;

--- a/test/interactions/pointerInteractionTests.ts
+++ b/test/interactions/pointerInteractionTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Interactions", () => {
   describe("Pointer", () => {
     var SVG_WIDTH = 400;

--- a/test/plots/areaPlotTests.ts
+++ b/test/plots/areaPlotTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Plots", () => {
   describe("AreaPlot", () => {
     // HACKHACK #1798: beforeEach being used below

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Plots", () => {
   describe("Bar Plot", () => {
 

--- a/test/plots/clusteredBarPlotTests.ts
+++ b/test/plots/clusteredBarPlotTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Plots", () => {
   describe("Clustered Bar Plot", () => {
     var svg: d3.Selection<void>;

--- a/test/plots/linePlotTests.ts
+++ b/test/plots/linePlotTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Plots", () => {
   // HACKHACK #1798: beforeEach being used below
   describe("LinePlot", () => {

--- a/test/plots/piePlotTests.ts
+++ b/test/plots/piePlotTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Plots", () => {
   describe("PiePlot", () => {
     // HACKHACK #1798: beforeEach being used below

--- a/test/plots/plotTests.ts
+++ b/test/plots/plotTests.ts
@@ -1,6 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
 class CountingPlot extends Plottable.Plot {
   public renders: number = 0;
 

--- a/test/plots/rectanglePlotTests.ts
+++ b/test/plots/rectanglePlotTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Plots", () => {
   describe("RectanglePlot", () => {
     var SVG_WIDTH = 300;

--- a/test/plots/scatterPlotTests.ts
+++ b/test/plots/scatterPlotTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Plots", () => {
   describe("ScatterPlot", () => {
     it("renders correctly with no data", () => {

--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Plots", () => {
   describe("SegmentPlot", () => {
     var svg: d3.Selection<void>;

--- a/test/plots/stackedAreaPlotTests.ts
+++ b/test/plots/stackedAreaPlotTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Plots", () => {
   describe("Stacked Area Plot", () => {
     var svg: d3.Selection<void>;

--- a/test/plots/stackedBarPlotTests.ts
+++ b/test/plots/stackedBarPlotTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Plots", () => {
   describe("Stacked Bar Plot", () => {
     var svg: d3.Selection<void>;

--- a/test/plots/stackedPlotTests.ts
+++ b/test/plots/stackedPlotTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Plots", () => {
 
   describe("StackedBar Plot Stacking", () => {

--- a/test/plots/waterfallPlotTests.ts
+++ b/test/plots/waterfallPlotTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Plots", () => {
   describe("Waterfall Plot", () => {
     var svg: d3.Selection<void>;

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -1,5 +1,4 @@
 ///<reference path="../testReference.ts" />
-var assert = chai.assert;
 
 describe("Plots", () => {
   describe("XY Plot", () => {

--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Scales", () => {
   describe("Linear Scales", () => {
     it("extentOfValues() filters out invalid numbers", () => {

--- a/test/scales/modifiedLogScaleTests.ts
+++ b/test/scales/modifiedLogScaleTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Scales", () => {
   describe("Modified Log Scale", () => {
     var scale: Plottable.Scales.ModifiedLog;

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Scales", () => {
   it("Scale alerts listeners when its domain is updated", () => {
     var scale = new Plottable.Scale();

--- a/test/scales/tickGeneratorsTests.ts
+++ b/test/scales/tickGeneratorsTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Tick generators", () => {
   describe("interval", () => {
     it("generate ticks within domain", () => {

--- a/test/scales/timeScaleTests.ts
+++ b/test/scales/timeScaleTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("TimeScale tests", () => {
     it.skip("extentOfValues() filters out invalid Dates", () => {
       var scale = new Plottable.Scales.Time();

--- a/test/utils/arrayUtilsTests.ts
+++ b/test/utils/arrayUtilsTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Utils", () => {
   describe("ArrayUtils", () => {
 

--- a/test/utils/callbackSetTests.ts
+++ b/test/utils/callbackSetTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Utils", () => {
   describe("CallbackSet", () => {
     it("callCallbacks()", () => {

--- a/test/utils/clientToSVGTranslatorTests.ts
+++ b/test/utils/clientToSVGTranslatorTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("ClientToSVGTranslator", () => {
   it("getTranslator() creates only one ClientToSVGTranslator per <svg>", () => {
     var svg = TestMethods.generateSVG();

--- a/test/utils/colorUtilsTests.ts
+++ b/test/utils/colorUtilsTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Utils.Color", () => {
   it("lightenColor()", () => {
     var colorHex = "#12fced";

--- a/test/utils/domUtilsTests.ts
+++ b/test/utils/domUtilsTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Utils.DOM", () => {
 
   it("getBBox works properly", () => {

--- a/test/utils/mapTests.ts
+++ b/test/utils/mapTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Map", () => {
   it("set() and get()", () => {
     var map = new Plottable.Utils.Map<string, string>();

--- a/test/utils/mathUtilsTests.ts
+++ b/test/utils/mathUtilsTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Utils.Methods", () => {
   it("inRange()", () => {
     assert.isTrue(Plottable.Utils.Math.inRange(0, -1, 1), "basic functionality works");

--- a/test/utils/setTests.ts
+++ b/test/utils/setTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Utils", () => {
   describe("Set", () => {
     it("add()", () => {

--- a/test/utils/stackingUtilsTests.ts
+++ b/test/utils/stackingUtilsTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Utils", () => {
   describe("StackingUtils", () => {
 

--- a/test/utils/windowUtilsTests.ts
+++ b/test/utils/windowUtilsTests.ts
@@ -1,7 +1,5 @@
 ///<reference path="../testReference.ts" />
 
-var assert = chai.assert;
-
 describe("Utils.Window", () => {
   describe("deprecated()", () => {
 


### PR DESCRIPTION
In playing around with the variables, I found that we actually redefine the `assert` variable for every test file we make... which seems incredibly silly.  We should instead put this in globalInitialization.ts since that is a global initialization file.

From a practical standpoint, removing this redundancy reduces the overhead in creating a new test file.