### PR TITLE
[Reference.ts] - Remove reference lines

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1,4 +1,3 @@
-
 declare module Plottable {
     module Utils {
         module Math {
@@ -58,7 +57,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Utils {
         /**
@@ -75,7 +73,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Utils {
@@ -191,7 +188,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Utils {
         module Color {
@@ -220,7 +216,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Utils {
@@ -258,7 +253,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Utils {
         /**
@@ -271,7 +265,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Utils {
@@ -310,7 +303,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Utils {
         module Window {
@@ -344,7 +336,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Utils {
         class ClientToSVGTranslator {
@@ -366,7 +357,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Configs {
         /**
@@ -376,11 +366,9 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     var version: string;
 }
-
 
 declare module Plottable {
     type DatasetCallback = (dataset: Dataset) => void;
@@ -437,7 +425,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module RenderPolicies {
         /**
@@ -470,7 +457,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     /**
@@ -591,7 +577,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     type Formatter = (d: any) => string;
     /**
@@ -689,7 +674,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     /**
      * A SymbolFactory is a function that takes in a symbolSize which is the edge length of the render area
@@ -705,7 +689,6 @@ declare module Plottable {
         function triangleDown(): SymbolFactory;
     }
 }
-
 
 declare module Plottable {
     interface ScaleCallback<S extends Scale<any, any>> {
@@ -826,7 +809,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     class QuantitativeScale<D> extends Scale<D, number> {
         protected static _DEFAULT_NUM_TICKS: number;
@@ -935,7 +917,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Scales {
         class Linear extends QuantitativeScale<number> {
@@ -956,7 +937,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Scales {
@@ -995,7 +975,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Scales {
@@ -1072,7 +1051,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Scales {
         class Color extends Scale<string, string> {
@@ -1103,7 +1081,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Scales {
@@ -1142,7 +1119,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Scales {
         class InterpolatedColor extends Scale<number, string> {
@@ -1165,7 +1141,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Scales {
@@ -1197,7 +1172,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Drawers {
@@ -1271,7 +1245,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Drawers {
         class Line extends Drawer {
@@ -1281,7 +1254,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Drawers {
@@ -1293,7 +1265,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Drawers {
         class Rectangle extends Drawer {
@@ -1301,7 +1272,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Drawers {
@@ -1311,7 +1281,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Drawers {
         class Symbol extends Drawer {
@@ -1320,7 +1289,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Drawers {
         class Segment extends Drawer {
@@ -1328,7 +1296,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     type ComponentCallback = (component: Component) => void;
@@ -1562,7 +1529,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     class ComponentContainer extends Component {
         constructor();
@@ -1594,7 +1560,6 @@ declare module Plottable {
         destroy(): void;
     }
 }
-
 
 declare module Plottable {
     module Components {
@@ -1635,7 +1600,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     class Axis<D> extends Component {
@@ -1784,7 +1748,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module TimeInterval {
         var second: string;
@@ -1866,7 +1829,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Axes {
         class Numeric extends Axis<number> {
@@ -1920,7 +1882,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Axes {
         class Category extends Axis<string> {
@@ -1955,7 +1916,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Components {
@@ -2027,7 +1987,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Components {
@@ -2122,7 +2081,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Components {
         class InterpolatedColorLegend extends Component {
@@ -2173,7 +2131,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Components {
         class Gridlines extends Component {
@@ -2189,7 +2146,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Components {
@@ -2310,7 +2266,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Components {
         class SelectionBoxLayer extends Component {
@@ -2395,7 +2350,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Plots {
@@ -2547,7 +2501,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Plots {
         class Pie extends Plot {
@@ -2657,7 +2610,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     class XYPlot<X, Y> extends Plot {
         protected static _X_KEY: string;
@@ -2757,7 +2709,6 @@ declare module Plottable {
         protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
     }
 }
-
 
 declare module Plottable {
     module Plots {
@@ -2862,7 +2813,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Plots {
         class Scatter<X, Y> extends XYPlot<X, Y> {
@@ -2913,7 +2863,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Plots {
@@ -3046,7 +2995,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Plots {
         class Line<X> extends XYPlot<X, number> {
@@ -3075,7 +3023,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Plots {
@@ -3117,7 +3064,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Plots {
         class ClusteredBar<X, Y> extends Bar<X, Y> {
@@ -3137,7 +3083,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Plots {
@@ -3164,7 +3109,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Plots {
@@ -3195,7 +3139,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Plots {
@@ -3279,7 +3222,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Plots {
         class Waterfall<X, Y> extends Bar<X, number> {
@@ -3319,7 +3261,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     interface Animator {
         /**
@@ -3343,7 +3284,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Animators {
         /**
@@ -3356,7 +3296,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Animators {
@@ -3449,7 +3388,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     class Dispatcher {
         protected _eventToCallback: {
@@ -3460,7 +3398,6 @@ declare module Plottable {
         protected _unsetCallback(callbackSet: Utils.CallbackSet<Function>, callback: Function): void;
     }
 }
-
 
 declare module Plottable {
     module Dispatchers {
@@ -3561,7 +3498,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Dispatchers {
         type TouchCallback = (ids: number[], idToPoint: {
@@ -3643,7 +3579,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Dispatchers {
         type KeyCallback = (keyCode: number, event: KeyboardEvent) => void;
@@ -3678,7 +3613,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     class Interaction {
@@ -3729,7 +3663,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     type ClickCallback = (point: Point) => void;
     module Interactions {
@@ -3754,7 +3687,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Interactions {
         class DoubleClick extends Interaction {
@@ -3777,7 +3709,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     type KeyCallback = (keyCode: number) => void;
@@ -3806,7 +3737,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     type PointerCallback = (point: Point) => void;
@@ -3859,7 +3789,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Interactions {
@@ -3969,7 +3898,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     type DragCallback = (start: Point, end: Point) => void;
     module Interactions {
@@ -4044,7 +3972,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     type DragBoxCallback = (bounds: Bounds) => void;
@@ -4155,7 +4082,6 @@ declare module Plottable {
     }
 }
 
-
 declare module Plottable {
     module Components {
         class XDragBoxLayer extends DragBoxLayer {
@@ -4181,7 +4107,6 @@ declare module Plottable {
         }
     }
 }
-
 
 declare module Plottable {
     module Components {

--- a/plottable.js
+++ b/plottable.js
@@ -18,7 +18,6 @@ Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
         root['Plottable'] = factory(req, exp, mod);
     }
 }(this, function(require, exports, module) {
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Utils;
@@ -115,7 +114,6 @@ var Plottable;
     })(Utils = Plottable.Utils || (Plottable.Utils = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Utils;
@@ -201,7 +199,6 @@ var Plottable;
     })(Utils = Plottable.Utils || (Plottable.Utils = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Utils;
@@ -472,7 +469,6 @@ var Plottable;
     })(Utils = Plottable.Utils || (Plottable.Utils = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Utils;
@@ -553,7 +549,6 @@ var Plottable;
     })(Utils = Plottable.Utils || (Plottable.Utils = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Utils;
@@ -621,7 +616,6 @@ var Plottable;
     })(Utils = Plottable.Utils || (Plottable.Utils = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -659,7 +653,6 @@ var Plottable;
     })(Utils = Plottable.Utils || (Plottable.Utils = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Utils;
@@ -742,7 +735,6 @@ var Plottable;
     })(Utils = Plottable.Utils || (Plottable.Utils = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Utils;
@@ -812,7 +804,6 @@ var Plottable;
     })(Utils = Plottable.Utils || (Plottable.Utils = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Utils;
@@ -885,7 +876,6 @@ var Plottable;
     })(Utils = Plottable.Utils || (Plottable.Utils = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Configs;
@@ -897,13 +887,11 @@ var Plottable;
     })(Configs = Plottable.Configs || (Plottable.Configs = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     Plottable.version = "1.5.0";
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Dataset = (function () {
@@ -967,7 +955,6 @@ var Plottable;
     Plottable.Dataset = Dataset;
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var RenderPolicies;
@@ -1016,7 +1003,6 @@ var Plottable;
     })(RenderPolicies = Plottable.RenderPolicies || (Plottable.RenderPolicies = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     /**
@@ -1133,7 +1119,6 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     /**
@@ -1354,7 +1339,6 @@ var Plottable;
     })(Formatters = Plottable.Formatters || (Plottable.Formatters = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var SymbolFactories;
@@ -1386,7 +1370,6 @@ var Plottable;
     })(SymbolFactories = Plottable.SymbolFactories || (Plottable.SymbolFactories = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Scale = (function () {
@@ -1535,7 +1518,6 @@ var Plottable;
     Plottable.Scale = Scale;
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -1761,7 +1743,6 @@ var Plottable;
     Plottable.QuantitativeScale = QuantitativeScale;
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -1820,7 +1801,6 @@ var Plottable;
     })(Scales = Plottable.Scales || (Plottable.Scales = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -2012,7 +1992,6 @@ var Plottable;
     })(Scales = Plottable.Scales || (Plottable.Scales = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -2127,7 +2106,6 @@ var Plottable;
     })(Scales = Plottable.Scales || (Plottable.Scales = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -2246,7 +2224,6 @@ var Plottable;
     })(Scales = Plottable.Scales || (Plottable.Scales = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -2362,7 +2339,6 @@ var Plottable;
     })(Scales = Plottable.Scales || (Plottable.Scales = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -2516,7 +2492,6 @@ var Plottable;
     })(Scales = Plottable.Scales || (Plottable.Scales = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Scales;
@@ -2564,7 +2539,6 @@ var Plottable;
     })(Scales = Plottable.Scales || (Plottable.Scales = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Drawer = (function () {
@@ -2699,7 +2673,6 @@ var Plottable;
     Plottable.Drawer = Drawer;
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -2730,7 +2703,6 @@ var Plottable;
     })(Drawers = Plottable.Drawers || (Plottable.Drawers = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -2761,7 +2733,6 @@ var Plottable;
     })(Drawers = Plottable.Drawers || (Plottable.Drawers = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -2784,7 +2755,6 @@ var Plottable;
     })(Drawers = Plottable.Drawers || (Plottable.Drawers = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -2808,7 +2778,6 @@ var Plottable;
     })(Drawers = Plottable.Drawers || (Plottable.Drawers = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -2832,7 +2801,6 @@ var Plottable;
     })(Drawers = Plottable.Drawers || (Plottable.Drawers = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -2855,7 +2823,6 @@ var Plottable;
     })(Drawers = Plottable.Drawers || (Plottable.Drawers = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Components;
@@ -3365,7 +3332,6 @@ var Plottable;
     Plottable.Component = Component;
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -3447,7 +3413,6 @@ var Plottable;
     Plottable.ComponentContainer = ComponentContainer;
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -3546,7 +3511,6 @@ var Plottable;
     })(Components = Plottable.Components || (Plottable.Components = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -3874,7 +3838,6 @@ var Plottable;
     Plottable.Axis = Axis;
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -4333,7 +4296,6 @@ var Plottable;
     })(Axes = Plottable.Axes || (Plottable.Axes = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -4671,7 +4633,6 @@ var Plottable;
     })(Axes = Plottable.Axes || (Plottable.Axes = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -4865,7 +4826,6 @@ var Plottable;
     })(Axes = Plottable.Axes || (Plottable.Axes = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -5019,7 +4979,6 @@ var Plottable;
     })(Components = Plottable.Components || (Plottable.Components = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -5278,7 +5237,6 @@ var Plottable;
     })(Components = Plottable.Components || (Plottable.Components = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -5506,7 +5464,6 @@ var Plottable;
     })(Components = Plottable.Components || (Plottable.Components = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -5601,7 +5558,6 @@ var Plottable;
     })(Components = Plottable.Components || (Plottable.Components = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -5965,7 +5921,6 @@ var Plottable;
     })(Components = Plottable.Components || (Plottable.Components = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -6123,7 +6078,6 @@ var Plottable;
     })(Components = Plottable.Components || (Plottable.Components = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -6573,7 +6527,6 @@ var Plottable;
     Plottable.Plot = Plot;
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -6845,7 +6798,6 @@ var Plottable;
     })(Plots = Plottable.Plots || (Plottable.Plots = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -7136,7 +7088,6 @@ var Plottable;
     Plottable.XYPlot = XYPlot;
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -7364,7 +7315,6 @@ var Plottable;
     })(Plots = Plottable.Plots || (Plottable.Plots = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -7473,7 +7423,6 @@ var Plottable;
     })(Plots = Plottable.Plots || (Plottable.Plots = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -8014,7 +7963,6 @@ var Plottable;
     })(Plots = Plottable.Plots || (Plottable.Plots = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -8136,7 +8084,6 @@ var Plottable;
     })(Plots = Plottable.Plots || (Plottable.Plots = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -8307,7 +8254,6 @@ var Plottable;
     })(Plots = Plottable.Plots || (Plottable.Plots = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -8373,7 +8319,6 @@ var Plottable;
     })(Plots = Plottable.Plots || (Plottable.Plots = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -8540,7 +8485,6 @@ var Plottable;
     })(Plots = Plottable.Plots || (Plottable.Plots = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -8663,7 +8607,6 @@ var Plottable;
     })(Plots = Plottable.Plots || (Plottable.Plots = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -8781,7 +8724,6 @@ var Plottable;
     })(Plots = Plottable.Plots || (Plottable.Plots = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -8986,9 +8928,7 @@ var Plottable;
     })(Plots = Plottable.Plots || (Plottable.Plots = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Animators;
@@ -9012,7 +8952,6 @@ var Plottable;
     })(Animators = Plottable.Animators || (Plottable.Animators = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Animators;
@@ -9127,7 +9066,6 @@ var Plottable;
     })(Animators = Plottable.Animators || (Plottable.Animators = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Dispatcher = (function () {
@@ -9173,7 +9111,6 @@ var Plottable;
     Plottable.Dispatcher = Dispatcher;
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -9361,7 +9298,6 @@ var Plottable;
     })(Dispatchers = Plottable.Dispatchers || (Plottable.Dispatchers = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -9519,7 +9455,6 @@ var Plottable;
     })(Dispatchers = Plottable.Dispatchers || (Plottable.Dispatchers = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -9588,7 +9523,6 @@ var Plottable;
     })(Dispatchers = Plottable.Dispatchers || (Plottable.Dispatchers = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
     var Interaction = (function () {
@@ -9683,7 +9617,6 @@ var Plottable;
     Plottable.Interaction = Interaction;
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -9766,7 +9699,6 @@ var Plottable;
     })(Interactions = Plottable.Interactions || (Plottable.Interactions = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -9880,7 +9812,6 @@ var Plottable;
     })(Interactions = Plottable.Interactions || (Plottable.Interactions = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -9956,7 +9887,6 @@ var Plottable;
     })(Interactions = Plottable.Interactions || (Plottable.Interactions = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -10074,7 +10004,6 @@ var Plottable;
     })(Interactions = Plottable.Interactions || (Plottable.Interactions = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -10395,7 +10324,6 @@ var Plottable;
     })(Interactions = Plottable.Interactions || (Plottable.Interactions = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -10554,7 +10482,6 @@ var Plottable;
     })(Interactions = Plottable.Interactions || (Plottable.Interactions = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -10882,7 +10809,6 @@ var Plottable;
     })(Components = Plottable.Components || (Plottable.Components = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -10940,7 +10866,6 @@ var Plottable;
     })(Components = Plottable.Components || (Plottable.Components = {}));
 })(Plottable || (Plottable = {}));
 
-///<reference path="../reference.ts" />
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }

--- a/src/animators/animator.ts
+++ b/src/animators/animator.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 
 export interface Animator {

--- a/src/animators/easingAnimator.ts
+++ b/src/animators/easingAnimator.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Animators {
 

--- a/src/animators/nullAnimator.ts
+++ b/src/animators/nullAnimator.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Animators {
 

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export class Axis<D> extends Component {
   /**

--- a/src/axes/categoryAxis.ts
+++ b/src/axes/categoryAxis.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Axes {
   export class Category extends Axis<string> {

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Axes {
   export class Numeric extends Axis<number> {

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 
 export module TimeInterval {

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 
 export type ComponentCallback = (component: Component) => void;

--- a/src/components/componentContainer.ts
+++ b/src/components/componentContainer.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 /*
  * ComponentContainer class encapsulates Table and ComponentGroup's shared functionality.

--- a/src/components/dragBoxLayer.ts
+++ b/src/components/dragBoxLayer.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 
 export type DragBoxCallback = (bounds: Bounds) => void;

--- a/src/components/gridlines.ts
+++ b/src/components/gridlines.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Components {
   export class Gridlines extends Component {

--- a/src/components/group.ts
+++ b/src/components/group.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Components {
   export class Group extends ComponentContainer {

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Components {
   export class InterpolatedColorLegend extends Component {

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Components {
   export class Label extends Component {

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Components {
   export class Legend extends Component {

--- a/src/components/selectionBoxLayer.ts
+++ b/src/components/selectionBoxLayer.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Components {
   export class SelectionBoxLayer extends Component {

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Components {
   type _LayoutAllocation = {

--- a/src/components/xDragBoxLayer.ts
+++ b/src/components/xDragBoxLayer.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Components {
   export class XDragBoxLayer extends DragBoxLayer {

--- a/src/components/yDragBoxLayer.ts
+++ b/src/components/yDragBoxLayer.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Components {
   export class YDragBoxLayer extends DragBoxLayer {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Configs {
   /**

--- a/src/core/dataset.ts
+++ b/src/core/dataset.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 
 export type DatasetCallback = (dataset: Dataset) => void;

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 
 export type Formatter = (d: any) => string;

--- a/src/core/renderController.ts
+++ b/src/core/renderController.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 /**
  * The RenderController is responsible for enqueueing and synchronizing

--- a/src/core/renderPolicy.ts
+++ b/src/core/renderPolicy.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module RenderPolicies {
   /**

--- a/src/core/symbolFactories.ts
+++ b/src/core/symbolFactories.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 
 /**

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export var version = "@VERSION";
 }

--- a/src/dispatchers/dispatcher.ts
+++ b/src/dispatchers/dispatcher.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export class Dispatcher {
   protected _eventToCallback: { [eventName: string]: (e: Event) => any; } = {};

--- a/src/dispatchers/keyDispatcher.ts
+++ b/src/dispatchers/keyDispatcher.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Dispatchers {
   export type KeyCallback = (keyCode: number, event: KeyboardEvent) => void;

--- a/src/dispatchers/mouseDispatcher.ts
+++ b/src/dispatchers/mouseDispatcher.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Dispatchers {
   export type MouseCallback = (p: Point, event: MouseEvent) => void;

--- a/src/dispatchers/touchDispatcher.ts
+++ b/src/dispatchers/touchDispatcher.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Dispatchers {
   export type TouchCallback = (ids: number[], idToPoint: { [id: number]: Point; }, event: TouchEvent) => void;

--- a/src/drawers/arcDrawer.ts
+++ b/src/drawers/arcDrawer.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Drawers {
   export class Arc extends Drawer {

--- a/src/drawers/areaDrawer.ts
+++ b/src/drawers/areaDrawer.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Drawers {
   export class Area extends Drawer {

--- a/src/drawers/drawer.ts
+++ b/src/drawers/drawer.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Drawers {
   /**

--- a/src/drawers/lineDrawer.ts
+++ b/src/drawers/lineDrawer.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Drawers {
   export class Line extends Drawer {

--- a/src/drawers/rectangleDrawer.ts
+++ b/src/drawers/rectangleDrawer.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Drawers {
   export class Rectangle extends Drawer {

--- a/src/drawers/segmentDrawer.ts
+++ b/src/drawers/segmentDrawer.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Drawers {
   export class Segment extends Drawer {

--- a/src/drawers/symbolDrawer.ts
+++ b/src/drawers/symbolDrawer.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Drawers {
   export class Symbol extends Drawer {

--- a/src/interactions/clickInteraction.ts
+++ b/src/interactions/clickInteraction.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 
 export type ClickCallback = (point: Point) => void;

--- a/src/interactions/doubleClickInteraction.ts
+++ b/src/interactions/doubleClickInteraction.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Interactions {
   enum ClickState {NotClicked, SingleClicked, DoubleClicked};

--- a/src/interactions/dragInteraction.ts
+++ b/src/interactions/dragInteraction.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 
 export type DragCallback = (start: Point, end: Point) => void;

--- a/src/interactions/interaction.ts
+++ b/src/interactions/interaction.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export class Interaction {
   protected _componentAttachedTo: Component;

--- a/src/interactions/keyInteraction.ts
+++ b/src/interactions/keyInteraction.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export type KeyCallback = (keyCode: number) => void;
 

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Interactions {
   export class PanZoom extends Interaction {

--- a/src/interactions/pointerInteraction.ts
+++ b/src/interactions/pointerInteraction.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 
 export type PointerCallback = (point: Point) => void;

--- a/src/plots/areaPlot.ts
+++ b/src/plots/areaPlot.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Plots {
   export class Area<X> extends Line<X> {

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 
 type LabelConfig = {

--- a/src/plots/clusteredBarPlot.ts
+++ b/src/plots/clusteredBarPlot.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Plots {
   export class ClusteredBar<X, Y> extends Bar<X, Y> {

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Plots {
   export class Line<X> extends XYPlot<X, number> {

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Plots {
   export class Pie extends Plot {

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 
 export module Plots {

--- a/src/plots/rectanglePlot.ts
+++ b/src/plots/rectanglePlot.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Plots {
   export class Rectangle<X, Y> extends XYPlot<X, Y> {

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Plots {
   export class Scatter<X, Y> extends XYPlot<X, Y> {

--- a/src/plots/segmentPlot.ts
+++ b/src/plots/segmentPlot.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Plots {
   export class Segment<X, Y> extends XYPlot<X, Y> {

--- a/src/plots/stackedAreaPlot.ts
+++ b/src/plots/stackedAreaPlot.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Plots {
   export class StackedArea<X> extends Area<X> {

--- a/src/plots/stackedBarPlot.ts
+++ b/src/plots/stackedBarPlot.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Plots {
   export class StackedBar<X, Y> extends Bar<X, Y> {

--- a/src/plots/waterfallPlot.ts
+++ b/src/plots/waterfallPlot.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Plots {
   export class Waterfall<X, Y> extends Bar<X, number> {

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export class XYPlot<X, Y> extends Plot {
   protected static _X_KEY = "x";

--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Scales {
   export class Category extends Scale<string, number> {

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Scales {
   export class Color extends Scale<string, string> {

--- a/src/scales/interpolatedColorScale.ts
+++ b/src/scales/interpolatedColorScale.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Scales {
   type supportedScale = d3.scale.Linear<number, string> | d3.scale.Log<number, string> | d3.scale.Pow<number, string>;

--- a/src/scales/linearScale.ts
+++ b/src/scales/linearScale.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Scales {
   export class Linear extends QuantitativeScale<number> {

--- a/src/scales/modifiedLogScale.ts
+++ b/src/scales/modifiedLogScale.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Scales {
   export class ModifiedLog extends QuantitativeScale<number> {

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export class QuantitativeScale<D> extends Scale<D, number> {
   protected static _DEFAULT_NUM_TICKS = 10;

--- a/src/scales/scale.ts
+++ b/src/scales/scale.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export interface ScaleCallback<S extends Scale<any, any>> {
   (scale: S): any;

--- a/src/scales/tickGenerators.ts
+++ b/src/scales/tickGenerators.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Scales {
   export module TickGenerators {

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Scales {
   export class Time extends QuantitativeScale<Date> {

--- a/src/utils/arrayUtils.ts
+++ b/src/utils/arrayUtils.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Utils {
   export module Array {

--- a/src/utils/callbackSet.ts
+++ b/src/utils/callbackSet.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Utils {
   /**

--- a/src/utils/clientToSVGTranslator.ts
+++ b/src/utils/clientToSVGTranslator.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Utils {
   export class ClientToSVGTranslator {

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Utils {
   export module Color {

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -1,4 +1,3 @@
-
 module Plottable {
 export module Utils {
   export module DOM {

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Utils {
   /**

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Utils {
   export module Math {

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Utils {
   /**

--- a/src/utils/stackingUtils.ts
+++ b/src/utils/stackingUtils.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Utils {
   export module Stacking {

--- a/src/utils/windowUtils.ts
+++ b/src/utils/windowUtils.ts
@@ -1,5 +1,3 @@
-///<reference path="../reference.ts" />
-
 module Plottable {
 export module Utils {
   export module Window {

--- a/test/animators/easingAnimatorTests.ts
+++ b/test/animators/easingAnimatorTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Animators", () => {
   describe("EasingAnimator", () => {
     describe("Time computations", () => {

--- a/test/axes/baseAxisTests.ts
+++ b/test/axes/baseAxisTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("BaseAxis", () => {
   it("orientation", () => {
     var scale = new Plottable.Scales.Linear();

--- a/test/axes/categoryAxisTests.ts
+++ b/test/axes/categoryAxisTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Category Axes", () => {
   it("re-renders appropriately when data is changed", () => {
     var svg = TestMethods.generateSVG(400, 400);

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("NumericAxis", () => {
   function boxIsInside(inner: ClientRect, outer: ClientRect, epsilon = 0) {
     if (inner.left < outer.left - epsilon) { return false; }

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("TimeAxis", () => {
   var scale: Plottable.Scales.Time;
   var axis: Plottable.Axes.Time;

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 function assertComponentXY(component: Plottable.Component, x: number, y: number, message: string) {
   // use <any> to examine the private variables
   var translate = d3.transform((<any> component)._element.attr("transform")).translate;

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Interactive Components", () => {
   describe("DragBoxLayer", () => {
     var SVG_WIDTH = 400;

--- a/test/components/gridlinesTests.ts
+++ b/test/components/gridlinesTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Gridlines", () => {
   it("Gridlines and axis tick marks align", () => {
     var svg = TestMethods.generateSVG(640, 480);

--- a/test/components/groupTests.ts
+++ b/test/components/groupTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("ComponentGroups", () => {
   it("append()", () => {
     var componentGroup = new Plottable.Components.Group();

--- a/test/components/interpolatedColorLegendTests.ts
+++ b/test/components/interpolatedColorLegendTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("InterpolatedColorLegend", () => {
   var svg: d3.Selection<void>;
   var colorScale: Plottable.Scales.InterpolatedColor;

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Labels", () => {
 
   it("Standard text title label generates properly", () => {

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Legend", () => {
   var svg: d3.Selection<void>;
   var color: Plottable.Scales.Color;

--- a/test/components/selectionBoxLayerTests.ts
+++ b/test/components/selectionBoxLayerTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("SelectionBoxLayer", () => {
   it("boxVisible()", () => {
     var svg = TestMethods.generateSVG();

--- a/test/components/tableTests.ts
+++ b/test/components/tableTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 function generateBasicTable(nRows: number, nCols: number) {
   // makes a table with exactly nRows * nCols children in a regular grid, with each
   // child being a basic component

--- a/test/components/xDragBoxLayerTests.ts
+++ b/test/components/xDragBoxLayerTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Interactive Components", () => {
   describe("XDragBoxLayer", () => {
     var SVG_WIDTH = 400;

--- a/test/components/yDragBoxLayerTests.ts
+++ b/test/components/yDragBoxLayerTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Interactive Components", () => {
   describe("YDragBoxLayer", () => {
     var SVG_WIDTH = 400;

--- a/test/core/datasetTests.ts
+++ b/test/core/datasetTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Dataset", () => {
   it("Updates listeners when the data is changed", () => {
     var ds = new Plottable.Dataset();

--- a/test/core/formattersTests.ts
+++ b/test/core/formattersTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Formatters", () => {
   describe("fixed", () => {
     it("shows exactly [precision] digits", () => {

--- a/test/core/metadataTests.ts
+++ b/test/core/metadataTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Metadata", () => {
   var xScale: Plottable.Scales.Linear;
   var yScale: Plottable.Scales.Linear;

--- a/test/core/renderControllerTests.ts
+++ b/test/core/renderControllerTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("RenderController", () => {
   // HACKHACK: #2083
   it.skip("Components whose render() is triggered by another Component's render() will be drawn", () => {

--- a/test/dispatchers/dispatcherTests.ts
+++ b/test/dispatchers/dispatcherTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Dispatchers", () => {
   describe("Dispatcher", () => {
     it("_connect() and _disconnect()", () => {

--- a/test/dispatchers/keyDispatcherTests.ts
+++ b/test/dispatchers/keyDispatcherTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Dispatchers", () => {
   describe("Key Dispatcher", () => {
     it("triggers callback on mousedown", () => {

--- a/test/dispatchers/mouseDispatcherTests.ts
+++ b/test/dispatchers/mouseDispatcherTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Dispatchers", () => {
   describe("Mouse Dispatcher", () => {
 

--- a/test/dispatchers/touchDispatcherTests.ts
+++ b/test/dispatchers/touchDispatcherTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Dispatchers", () => {
   describe("Touch Dispatcher", () => {
     it("getDispatcher() creates only one Dispatcher.Touch per <svg>", () => {

--- a/test/drawers/drawerTests.ts
+++ b/test/drawers/drawerTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 class MockAnimator implements Plottable.Animator {
   private _time: number;
   private _callback: Function;

--- a/test/drawers/lineDrawerTests.ts
+++ b/test/drawers/lineDrawerTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Drawers", () => {
   describe("Line Drawer", () => {
     it("selectionForIndex()", () => {

--- a/test/globalInitialization.ts
+++ b/test/globalInitialization.ts
@@ -1,5 +1,3 @@
-///<reference path="testReference.ts" />
-
 interface Window {
   PHANTOMJS: boolean;
   Pixel_CloseTo_Requirement: number;

--- a/test/interactions/clickInteractionTests.ts
+++ b/test/interactions/clickInteractionTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Interactions", () => {
   describe("Click", () => {
     var SVG_WIDTH = 400;

--- a/test/interactions/doubleClickInteractionTests.ts
+++ b/test/interactions/doubleClickInteractionTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Interactions", () => {
   describe("DoubleClick", () => {
     var SVG_WIDTH = 400;

--- a/test/interactions/dragInteractionTests.ts
+++ b/test/interactions/dragInteractionTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Interactions", () => {
   describe("Drag", () => {
     var SVG_WIDTH = 400;

--- a/test/interactions/interactionTests.ts
+++ b/test/interactions/interactionTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Interactions", () => {
   describe("Interaction", () => {
     var SVG_WIDTH = 400;

--- a/test/interactions/keyInteractionTests.ts
+++ b/test/interactions/keyInteractionTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Interactions", () => {
   describe("KeyInteraction", () => {
     it("Triggers appropriate callback for the key pressed", () => {

--- a/test/interactions/panZoomInteractionTests.ts
+++ b/test/interactions/panZoomInteractionTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Interactions", () => {
   describe("PanZoomInteraction", () => {
     var svg: d3.Selection<void>;

--- a/test/interactions/pointerInteractionTests.ts
+++ b/test/interactions/pointerInteractionTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Interactions", () => {
   describe("Pointer", () => {
     var SVG_WIDTH = 400;

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -1,5 +1,3 @@
-///<reference path="testReference.ts" />
-
 module Mocks {
   export class FixedSizeComponent extends Plottable.Component {
     public fsWidth: number;

--- a/test/plots/areaPlotTests.ts
+++ b/test/plots/areaPlotTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Plots", () => {
   describe("AreaPlot", () => {
     // HACKHACK #1798: beforeEach being used below

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Plots", () => {
   describe("Bar Plot", () => {
 

--- a/test/plots/clusteredBarPlotTests.ts
+++ b/test/plots/clusteredBarPlotTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Plots", () => {
   describe("Clustered Bar Plot", () => {
     var svg: d3.Selection<void>;

--- a/test/plots/linePlotTests.ts
+++ b/test/plots/linePlotTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Plots", () => {
   // HACKHACK #1798: beforeEach being used below
   describe("LinePlot", () => {

--- a/test/plots/piePlotTests.ts
+++ b/test/plots/piePlotTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Plots", () => {
   describe("PiePlot", () => {
     // HACKHACK #1798: beforeEach being used below

--- a/test/plots/plotTests.ts
+++ b/test/plots/plotTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 class CountingPlot extends Plottable.Plot {
   public renders: number = 0;
 

--- a/test/plots/rectanglePlotTests.ts
+++ b/test/plots/rectanglePlotTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Plots", () => {
   describe("RectanglePlot", () => {
     var SVG_WIDTH = 300;

--- a/test/plots/scatterPlotTests.ts
+++ b/test/plots/scatterPlotTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Plots", () => {
   describe("ScatterPlot", () => {
     it("renders correctly with no data", () => {

--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Plots", () => {
   describe("SegmentPlot", () => {
     var svg: d3.Selection<void>;

--- a/test/plots/stackedAreaPlotTests.ts
+++ b/test/plots/stackedAreaPlotTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Plots", () => {
   describe("Stacked Area Plot", () => {
     var svg: d3.Selection<void>;

--- a/test/plots/stackedBarPlotTests.ts
+++ b/test/plots/stackedBarPlotTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Plots", () => {
   describe("Stacked Bar Plot", () => {
     var svg: d3.Selection<void>;

--- a/test/plots/stackedPlotTests.ts
+++ b/test/plots/stackedPlotTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Plots", () => {
 
   describe("StackedBar Plot Stacking", () => {

--- a/test/plots/waterfallPlotTests.ts
+++ b/test/plots/waterfallPlotTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Plots", () => {
   describe("Waterfall Plot", () => {
     var svg: d3.Selection<void>;

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Plots", () => {
   describe("XY Plot", () => {
     var svg: d3.Selection<void>;

--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Scales", () => {
   describe("Linear Scales", () => {
     it("extentOfValues() filters out invalid numbers", () => {

--- a/test/scales/modifiedLogScaleTests.ts
+++ b/test/scales/modifiedLogScaleTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Scales", () => {
   describe("Modified Log Scale", () => {
     var scale: Plottable.Scales.ModifiedLog;

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Scales", () => {
   it("Scale alerts listeners when its domain is updated", () => {
     var scale = new Plottable.Scale();

--- a/test/scales/tickGeneratorsTests.ts
+++ b/test/scales/tickGeneratorsTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Tick generators", () => {
   describe("interval", () => {
     it("generate ticks within domain", () => {

--- a/test/scales/timeScaleTests.ts
+++ b/test/scales/timeScaleTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("TimeScale tests", () => {
     it.skip("extentOfValues() filters out invalid Dates", () => {
       var scale = new Plottable.Scales.Time();

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -1,5 +1,3 @@
-///<reference path="testReference.ts" />
-
 module TestMethods {
 
   export function generateSVG(width = 400, height = 400): d3.Selection<void> {

--- a/test/utils/arrayUtilsTests.ts
+++ b/test/utils/arrayUtilsTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Utils", () => {
   describe("ArrayUtils", () => {
 

--- a/test/utils/callbackSetTests.ts
+++ b/test/utils/callbackSetTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Utils", () => {
   describe("CallbackSet", () => {
     it("callCallbacks()", () => {

--- a/test/utils/clientToSVGTranslatorTests.ts
+++ b/test/utils/clientToSVGTranslatorTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("ClientToSVGTranslator", () => {
   it("getTranslator() creates only one ClientToSVGTranslator per <svg>", () => {
     var svg = TestMethods.generateSVG();

--- a/test/utils/colorUtilsTests.ts
+++ b/test/utils/colorUtilsTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Utils.Color", () => {
   it("lightenColor()", () => {
     var colorHex = "#12fced";

--- a/test/utils/domUtilsTests.ts
+++ b/test/utils/domUtilsTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Utils.DOM", () => {
 
   it("getBBox works properly", () => {

--- a/test/utils/mapTests.ts
+++ b/test/utils/mapTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Map", () => {
   it("set() and get()", () => {
     var map = new Plottable.Utils.Map<string, string>();

--- a/test/utils/mathUtilsTests.ts
+++ b/test/utils/mathUtilsTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Utils.Methods", () => {
   it("inRange()", () => {
     assert.isTrue(Plottable.Utils.Math.inRange(0, -1, 1), "basic functionality works");

--- a/test/utils/setTests.ts
+++ b/test/utils/setTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Utils", () => {
   describe("Set", () => {
     it("add()", () => {

--- a/test/utils/stackingUtilsTests.ts
+++ b/test/utils/stackingUtilsTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Utils", () => {
   describe("StackingUtils", () => {
 

--- a/test/utils/windowUtilsTests.ts
+++ b/test/utils/windowUtilsTests.ts
@@ -1,5 +1,3 @@
-///<reference path="../testReference.ts" />
-
 describe("Utils.Window", () => {
   describe("deprecated()", () => {
 


### PR DESCRIPTION
Removing these lines seems to have no effect on the compiler.  My personal guess is that `reference.ts` has already defined the files that need to be compiled and that restating it is redundant?