### PR TITLE
adding no-var-keyword rule

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -19,6 +19,7 @@ Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
     }
 }(this, function(require, exports, module) {
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     var Utils;
@@ -116,6 +117,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     var Utils;
@@ -202,6 +204,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     var Utils;
@@ -269,6 +272,7 @@ var Plottable;
     })(Utils = Plottable.Utils || (Plottable.Utils = {}));
 })(Plottable || (Plottable = {}));
 
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     var Utils;
@@ -473,6 +477,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     var Utils;
@@ -554,6 +559,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     var Utils;
@@ -660,6 +666,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     var Utils;
@@ -813,6 +820,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     var Utils;
@@ -1017,6 +1025,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     /**
@@ -1134,6 +1143,7 @@ var Plottable;
 
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     /**
@@ -1387,6 +1397,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     var Scale = (function () {
@@ -1536,6 +1547,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -1821,6 +1833,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -2013,6 +2026,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -2128,6 +2142,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -2247,6 +2262,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -2363,6 +2379,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -2517,6 +2534,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     var Scales;
@@ -2565,6 +2583,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     var Drawer = (function () {
@@ -2856,6 +2875,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     var Components;
@@ -3448,6 +3468,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -3547,6 +3568,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -3875,6 +3897,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -4334,6 +4357,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -4672,6 +4696,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -4866,6 +4891,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -5020,6 +5046,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -5279,6 +5306,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -5507,6 +5535,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -5602,6 +5631,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -5966,6 +5996,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -6124,6 +6155,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -6574,6 +6606,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -6846,6 +6879,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -7137,6 +7171,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -7365,6 +7400,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -7474,6 +7510,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -8015,6 +8052,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -8137,6 +8175,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -8308,6 +8347,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -8374,6 +8414,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -8541,6 +8582,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -8664,6 +8706,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -8782,6 +8825,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -9013,6 +9057,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     var Animators;
@@ -9128,6 +9173,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     var Dispatcher = (function () {
@@ -9174,6 +9220,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -9362,6 +9409,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -9520,6 +9568,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -9589,6 +9638,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var Plottable;
 (function (Plottable) {
     var Interaction = (function () {
@@ -9684,6 +9734,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -9767,6 +9818,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -9881,6 +9933,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -9957,6 +10010,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -10075,6 +10129,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -10396,6 +10451,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
@@ -10555,6 +10611,7 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }

--- a/src/animators/easingAnimator.ts
+++ b/src/animators/easingAnimator.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Animators {

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export class Axis<D> extends Component {

--- a/src/axes/categoryAxis.ts
+++ b/src/axes/categoryAxis.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Axes {

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Axes {

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 

--- a/src/components/dragBoxLayer.ts
+++ b/src/components/dragBoxLayer.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 

--- a/src/components/gridlines.ts
+++ b/src/components/gridlines.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Components {

--- a/src/components/group.ts
+++ b/src/components/group.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Components {

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Components {

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Components {

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Components {

--- a/src/components/selectionBoxLayer.ts
+++ b/src/components/selectionBoxLayer.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Components {

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Components {

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 

--- a/src/core/renderController.ts
+++ b/src/core/renderController.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 /**

--- a/src/dispatchers/dispatcher.ts
+++ b/src/dispatchers/dispatcher.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export class Dispatcher {

--- a/src/dispatchers/keyDispatcher.ts
+++ b/src/dispatchers/keyDispatcher.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Dispatchers {

--- a/src/dispatchers/mouseDispatcher.ts
+++ b/src/dispatchers/mouseDispatcher.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Dispatchers {

--- a/src/dispatchers/touchDispatcher.ts
+++ b/src/dispatchers/touchDispatcher.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Dispatchers {

--- a/src/drawers/drawer.ts
+++ b/src/drawers/drawer.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Drawers {

--- a/src/interactions/clickInteraction.ts
+++ b/src/interactions/clickInteraction.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 

--- a/src/interactions/doubleClickInteraction.ts
+++ b/src/interactions/doubleClickInteraction.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Interactions {

--- a/src/interactions/dragInteraction.ts
+++ b/src/interactions/dragInteraction.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 

--- a/src/interactions/interaction.ts
+++ b/src/interactions/interaction.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export class Interaction {

--- a/src/interactions/keyInteraction.ts
+++ b/src/interactions/keyInteraction.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export type KeyCallback = (keyCode: number) => void;

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Interactions {

--- a/src/interactions/pointerInteraction.ts
+++ b/src/interactions/pointerInteraction.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 

--- a/src/plots/areaPlot.ts
+++ b/src/plots/areaPlot.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Plots {

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 

--- a/src/plots/clusteredBarPlot.ts
+++ b/src/plots/clusteredBarPlot.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Plots {

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Plots {

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Plots {

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 

--- a/src/plots/rectanglePlot.ts
+++ b/src/plots/rectanglePlot.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Plots {

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Plots {

--- a/src/plots/segmentPlot.ts
+++ b/src/plots/segmentPlot.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Plots {

--- a/src/plots/stackedAreaPlot.ts
+++ b/src/plots/stackedAreaPlot.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Plots {

--- a/src/plots/stackedBarPlot.ts
+++ b/src/plots/stackedBarPlot.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Plots {

--- a/src/plots/waterfallPlot.ts
+++ b/src/plots/waterfallPlot.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Plots {

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export class XYPlot<X, Y> extends Plot {

--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Scales {

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Scales {

--- a/src/scales/interpolatedColorScale.ts
+++ b/src/scales/interpolatedColorScale.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Scales {

--- a/src/scales/modifiedLogScale.ts
+++ b/src/scales/modifiedLogScale.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Scales {

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export class QuantitativeScale<D> extends Scale<D, number> {

--- a/src/scales/scale.ts
+++ b/src/scales/scale.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export interface ScaleCallback<S extends Scale<any, any>> {

--- a/src/scales/tickGenerators.ts
+++ b/src/scales/tickGenerators.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Scales {

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Scales {

--- a/src/utils/arrayUtils.ts
+++ b/src/utils/arrayUtils.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Utils {

--- a/src/utils/clientToSVGTranslator.ts
+++ b/src/utils/clientToSVGTranslator.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Utils {

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Utils {

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -1,3 +1,4 @@
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Utils {

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Utils {

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Utils {

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Utils {

--- a/src/utils/stackingUtils.ts
+++ b/src/utils/stackingUtils.ts
@@ -1,4 +1,5 @@
 ///<reference path="../reference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module Plottable {
 export module Utils {

--- a/test/animators/easingAnimatorTests.ts
+++ b/test/animators/easingAnimatorTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Animators", () => {
   describe("EasingAnimator", () => {

--- a/test/axes/baseAxisTests.ts
+++ b/test/axes/baseAxisTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("BaseAxis", () => {
   it("orientation", () => {

--- a/test/axes/categoryAxisTests.ts
+++ b/test/axes/categoryAxisTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Category Axes", () => {
   it("re-renders appropriately when data is changed", () => {

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("NumericAxis", () => {
   function boxIsInside(inner: ClientRect, outer: ClientRect, epsilon = 0) {

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("TimeAxis", () => {
   var scale: Plottable.Scales.Time;

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 function assertComponentXY(component: Plottable.Component, x: number, y: number, message: string) {
   // use <any> to examine the private variables

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Interactive Components", () => {
   describe("DragBoxLayer", () => {

--- a/test/components/gridlinesTests.ts
+++ b/test/components/gridlinesTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Gridlines", () => {
   it("Gridlines and axis tick marks align", () => {

--- a/test/components/groupTests.ts
+++ b/test/components/groupTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("ComponentGroups", () => {
   it("append()", () => {

--- a/test/components/interpolatedColorLegendTests.ts
+++ b/test/components/interpolatedColorLegendTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("InterpolatedColorLegend", () => {
   var svg: d3.Selection<void>;

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Labels", () => {
 

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Legend", () => {
   var svg: d3.Selection<void>;

--- a/test/components/selectionBoxLayerTests.ts
+++ b/test/components/selectionBoxLayerTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("SelectionBoxLayer", () => {
   it("boxVisible()", () => {

--- a/test/components/tableTests.ts
+++ b/test/components/tableTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 function generateBasicTable(nRows: number, nCols: number) {
   // makes a table with exactly nRows * nCols children in a regular grid, with each

--- a/test/components/xDragBoxLayerTests.ts
+++ b/test/components/xDragBoxLayerTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Interactive Components", () => {
   describe("XDragBoxLayer", () => {

--- a/test/components/yDragBoxLayerTests.ts
+++ b/test/components/yDragBoxLayerTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Interactive Components", () => {
   describe("YDragBoxLayer", () => {

--- a/test/core/datasetTests.ts
+++ b/test/core/datasetTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Dataset", () => {
   it("Updates listeners when the data is changed", () => {

--- a/test/core/formattersTests.ts
+++ b/test/core/formattersTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Formatters", () => {
   describe("fixed", () => {

--- a/test/core/metadataTests.ts
+++ b/test/core/metadataTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Metadata", () => {
   var xScale: Plottable.Scales.Linear;

--- a/test/core/renderControllerTests.ts
+++ b/test/core/renderControllerTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("RenderController", () => {
   // HACKHACK: #2083

--- a/test/dispatchers/dispatcherTests.ts
+++ b/test/dispatchers/dispatcherTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Dispatchers", () => {
   describe("Dispatcher", () => {

--- a/test/dispatchers/keyDispatcherTests.ts
+++ b/test/dispatchers/keyDispatcherTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Dispatchers", () => {
   describe("Key Dispatcher", () => {

--- a/test/dispatchers/mouseDispatcherTests.ts
+++ b/test/dispatchers/mouseDispatcherTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Dispatchers", () => {
   describe("Mouse Dispatcher", () => {

--- a/test/dispatchers/touchDispatcherTests.ts
+++ b/test/dispatchers/touchDispatcherTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Dispatchers", () => {
   describe("Touch Dispatcher", () => {

--- a/test/drawers/drawerTests.ts
+++ b/test/drawers/drawerTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 class MockAnimator implements Plottable.Animator {
   private _time: number;

--- a/test/drawers/lineDrawerTests.ts
+++ b/test/drawers/lineDrawerTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Drawers", () => {
   describe("Line Drawer", () => {

--- a/test/globalInitialization.ts
+++ b/test/globalInitialization.ts
@@ -1,4 +1,5 @@
 ///<reference path="testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 interface Window {
   PHANTOMJS: boolean;

--- a/test/interactions/clickInteractionTests.ts
+++ b/test/interactions/clickInteractionTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Interactions", () => {
   describe("Click", () => {

--- a/test/interactions/doubleClickInteractionTests.ts
+++ b/test/interactions/doubleClickInteractionTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Interactions", () => {
   describe("DoubleClick", () => {

--- a/test/interactions/dragInteractionTests.ts
+++ b/test/interactions/dragInteractionTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Interactions", () => {
   describe("Drag", () => {

--- a/test/interactions/interactionTests.ts
+++ b/test/interactions/interactionTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Interactions", () => {
   describe("Interaction", () => {

--- a/test/interactions/keyInteractionTests.ts
+++ b/test/interactions/keyInteractionTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Interactions", () => {
   describe("KeyInteraction", () => {

--- a/test/interactions/panZoomInteractionTests.ts
+++ b/test/interactions/panZoomInteractionTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Interactions", () => {
   describe("PanZoomInteraction", () => {

--- a/test/interactions/pointerInteractionTests.ts
+++ b/test/interactions/pointerInteractionTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Interactions", () => {
   describe("Pointer", () => {

--- a/test/plots/areaPlotTests.ts
+++ b/test/plots/areaPlotTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Plots", () => {
   describe("AreaPlot", () => {

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Plots", () => {
   describe("Bar Plot", () => {

--- a/test/plots/clusteredBarPlotTests.ts
+++ b/test/plots/clusteredBarPlotTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Plots", () => {
   describe("Clustered Bar Plot", () => {

--- a/test/plots/linePlotTests.ts
+++ b/test/plots/linePlotTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Plots", () => {
   // HACKHACK #1798: beforeEach being used below

--- a/test/plots/piePlotTests.ts
+++ b/test/plots/piePlotTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Plots", () => {
   describe("PiePlot", () => {

--- a/test/plots/plotTests.ts
+++ b/test/plots/plotTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 class CountingPlot extends Plottable.Plot {
   public renders: number = 0;

--- a/test/plots/rectanglePlotTests.ts
+++ b/test/plots/rectanglePlotTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Plots", () => {
   describe("RectanglePlot", () => {

--- a/test/plots/scatterPlotTests.ts
+++ b/test/plots/scatterPlotTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Plots", () => {
   describe("ScatterPlot", () => {

--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Plots", () => {
   describe("SegmentPlot", () => {

--- a/test/plots/stackedAreaPlotTests.ts
+++ b/test/plots/stackedAreaPlotTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Plots", () => {
   describe("Stacked Area Plot", () => {

--- a/test/plots/stackedBarPlotTests.ts
+++ b/test/plots/stackedBarPlotTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Plots", () => {
   describe("Stacked Bar Plot", () => {

--- a/test/plots/stackedPlotTests.ts
+++ b/test/plots/stackedPlotTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Plots", () => {
 

--- a/test/plots/waterfallPlotTests.ts
+++ b/test/plots/waterfallPlotTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Plots", () => {
   describe("Waterfall Plot", () => {

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Plots", () => {
   describe("XY Plot", () => {

--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Scales", () => {
   describe("Linear Scales", () => {

--- a/test/scales/modifiedLogScaleTests.ts
+++ b/test/scales/modifiedLogScaleTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Scales", () => {
   describe("Modified Log Scale", () => {

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Scales", () => {
   it("Scale alerts listeners when its domain is updated", () => {

--- a/test/scales/tickGeneratorsTests.ts
+++ b/test/scales/tickGeneratorsTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Tick generators", () => {
   describe("interval", () => {

--- a/test/scales/timeScaleTests.ts
+++ b/test/scales/timeScaleTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("TimeScale tests", () => {
     it.skip("extentOfValues() filters out invalid Dates", () => {

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -1,4 +1,5 @@
 ///<reference path="testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 module TestMethods {
 

--- a/test/utils/arrayUtilsTests.ts
+++ b/test/utils/arrayUtilsTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Utils", () => {
   describe("ArrayUtils", () => {

--- a/test/utils/callbackSetTests.ts
+++ b/test/utils/callbackSetTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Utils", () => {
   describe("CallbackSet", () => {

--- a/test/utils/clientToSVGTranslatorTests.ts
+++ b/test/utils/clientToSVGTranslatorTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("ClientToSVGTranslator", () => {
   it("getTranslator() creates only one ClientToSVGTranslator per <svg>", () => {

--- a/test/utils/colorUtilsTests.ts
+++ b/test/utils/colorUtilsTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Utils.Color", () => {
   it("lightenColor()", () => {

--- a/test/utils/domUtilsTests.ts
+++ b/test/utils/domUtilsTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Utils.DOM", () => {
 

--- a/test/utils/mapTests.ts
+++ b/test/utils/mapTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Map", () => {
   it("set() and get()", () => {

--- a/test/utils/mathUtilsTests.ts
+++ b/test/utils/mathUtilsTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Utils.Methods", () => {
   it("inRange()", () => {

--- a/test/utils/setTests.ts
+++ b/test/utils/setTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Utils", () => {
   describe("Set", () => {

--- a/test/utils/stackingUtilsTests.ts
+++ b/test/utils/stackingUtilsTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Utils", () => {
   describe("StackingUtils", () => {

--- a/test/utils/windowUtilsTests.ts
+++ b/test/utils/windowUtilsTests.ts
@@ -1,4 +1,5 @@
 ///<reference path="../testReference.ts" />
+/* tslint:disable: no-var-keyword */
 
 describe("Utils.Window", () => {
   describe("deprecated()", () => {

--- a/tslint.json
+++ b/tslint.json
@@ -41,6 +41,7 @@
     "no-unused-expression": true,
     "no-unused-variable": true,
     "no-use-before-declare": true,
+    "no-var-keyword": true,
     "one-line": [true,
         "check-catch",
         "check-else",


### PR DESCRIPTION
Will iteratively work on converting `var`s to `let`s and `const`s on a side branch