### PR TITLE
[Gridlines] - Allow to be rendered on its own

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2202,6 +2202,7 @@ declare module Plottable {
             destroy(): Gridlines;
             protected _setup(): void;
             renderImmediately(): Gridlines;
+            computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Gridlines;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -5619,6 +5619,16 @@ var Plottable;
                 this._redrawYLines();
                 return this;
             };
+            Gridlines.prototype.computeLayout = function (origin, availableWidth, availableHeight) {
+                _super.prototype.computeLayout.call(this, origin, availableWidth, availableHeight);
+                if (this._xScale != null) {
+                    this._xScale.range([0, this.width()]);
+                }
+                if (this._yScale != null) {
+                    this._yScale.range([this.height(), 0]);
+                }
+                return this;
+            };
             Gridlines.prototype._redrawXLines = function () {
                 var _this = this;
                 if (this._xScale) {

--- a/src/components/gridlines.ts
+++ b/src/components/gridlines.ts
@@ -59,6 +59,17 @@ export module Components {
       return this;
     }
 
+    public computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number) {
+      super.computeLayout(origin, availableWidth, availableHeight);
+      if (this._xScale != null) {
+        this._xScale.range([0, this.width()]);
+      }
+      if (this._yScale != null) {
+        this._yScale.range([this.height(), 0]);
+      }
+      return this;
+    }
+
     private _redrawXLines() {
       if (this._xScale) {
         var xTicks = this._xScale.ticks();

--- a/test/components/gridlinesTests.ts
+++ b/test/components/gridlinesTests.ts
@@ -1,6 +1,24 @@
 ///<reference path="../testReference.ts" />
 
 describe("Gridlines", () => {
+
+  it("Scale ranges are set to the Gridlines dimensions when layout is computed", () => {
+    var svg = TestMethods.generateSVG(640, 480);
+    var xScale = new Plottable.Scales.Linear();
+    xScale.domain([0, 10]);
+
+    var yScale = new Plottable.Scales.Linear();
+    yScale.domain([0, 10]);
+
+    var gridlines = new Plottable.Components.Gridlines(xScale, yScale);
+    gridlines.renderTo(svg);
+
+    assert.deepEqual(xScale.range(), [0, 640], "x scale range extends to the width of the svg");
+    assert.deepEqual(yScale.range(), [480, 0], "y scale range extends to the height of the svg");
+
+    svg.remove();
+  });
+
   it("Gridlines and axis tick marks align", () => {
     var svg = TestMethods.generateSVG(640, 480);
     var xScale = new Plottable.Scales.Linear();


### PR DESCRIPTION
Currently, `Gridline`s are only able to render to our expectations when it is grouped with something like a `Plots.Scatter` or similar.  However, it would be nice if we could render these `Gridline`s by themselves without heavy reliance on a grouped component.

JSFiddle: http://jsfiddle.net/bluong63/z1pnmgL2/

Fixes #2532 