### PR TITLE
[Plots.Scatter] - Adding `entitiesIn()` endpoint

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2926,6 +2926,21 @@ declare module Plottable {
             protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
             protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;
             protected _propertyProjectors(): AttributeToProjector;
+            /**
+             * Gets the Entities that intersect the Bounds.
+             *
+             * @param {Bounds} bounds
+             * @returns {PlotEntity[]}
+             */
+            entitiesIn(bounds: Bounds): PlotEntity[];
+            /**
+             * Gets the Entities that intersect the area defined by the ranges.
+             *
+             * @param {Range} xRange
+             * @param {Range} yRange
+             * @returns {PlotEntity[]}
+             */
+            entitiesIn(xRange: Range, yRange: Range): PlotEntity[];
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -7520,6 +7520,7 @@ var Plottable;
                 return propertyToProjectors;
             };
             Scatter.prototype.entitiesIn = function (xRangeOrBounds, yRange) {
+                var _this = this;
                 var dataXRange;
                 var dataYRange;
                 if (yRange == null) {
@@ -7531,14 +7532,12 @@ var Plottable;
                     dataXRange = xRangeOrBounds;
                     dataYRange = yRange;
                 }
-                var attrToProjector = this._generateAttrToProjector();
                 return this.entities().filter(function (entity) {
                     var datum = entity.datum;
                     var index = entity.index;
                     var dataset = entity.dataset;
-                    var translate = d3.transform(attrToProjector["transform"](datum, index, dataset)).translate;
-                    var x = translate[0];
-                    var y = translate[1];
+                    var x = Plottable.Plot._scaledAccessor(_this.x())(datum, index, dataset);
+                    var y = Plottable.Plot._scaledAccessor(_this.y())(datum, index, dataset);
                     return dataXRange.min <= x && x <= dataXRange.max && dataYRange.min <= y && y <= dataYRange.max;
                 });
             };

--- a/plottable.js
+++ b/plottable.js
@@ -7520,7 +7520,6 @@ var Plottable;
                 return propertyToProjectors;
             };
             Scatter.prototype.entitiesIn = function (xRangeOrBounds, yRange) {
-                var _this = this;
                 var dataXRange;
                 var dataYRange;
                 if (yRange == null) {
@@ -7532,12 +7531,14 @@ var Plottable;
                     dataXRange = xRangeOrBounds;
                     dataYRange = yRange;
                 }
+                var xProjector = Plottable.Plot._scaledAccessor(this.x());
+                var yProjector = Plottable.Plot._scaledAccessor(this.y());
                 return this.entities().filter(function (entity) {
                     var datum = entity.datum;
                     var index = entity.index;
                     var dataset = entity.dataset;
-                    var x = Plottable.Plot._scaledAccessor(_this.x())(datum, index, dataset);
-                    var y = Plottable.Plot._scaledAccessor(_this.y())(datum, index, dataset);
+                    var x = xProjector(datum, index, dataset);
+                    var y = yProjector(datum, index, dataset);
                     return dataXRange.min <= x && x <= dataXRange.max && dataYRange.min <= y && y <= dataYRange.max;
                 });
             };

--- a/plottable.js
+++ b/plottable.js
@@ -7519,6 +7519,29 @@ var Plottable;
                 };
                 return propertyToProjectors;
             };
+            Scatter.prototype.entitiesIn = function (xRangeOrBounds, yRange) {
+                var dataXRange;
+                var dataYRange;
+                if (yRange == null) {
+                    var bounds = xRangeOrBounds;
+                    dataXRange = { min: bounds.topLeft.x, max: bounds.bottomRight.x };
+                    dataYRange = { min: bounds.topLeft.y, max: bounds.bottomRight.y };
+                }
+                else {
+                    dataXRange = xRangeOrBounds;
+                    dataYRange = yRange;
+                }
+                var attrToProjector = this._generateAttrToProjector();
+                return this.entities().filter(function (entity) {
+                    var datum = entity.datum;
+                    var index = entity.index;
+                    var dataset = entity.dataset;
+                    var translate = d3.transform(attrToProjector["transform"](datum, index, dataset)).translate;
+                    var x = translate[0];
+                    var y = translate[1];
+                    return dataXRange.min <= x && x <= dataXRange.max && dataYRange.min <= y && y <= dataYRange.max;
+                });
+            };
             Scatter._SIZE_KEY = "size";
             Scatter._SYMBOL_KEY = "symbol";
             return Scatter;

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -169,14 +169,12 @@ export module Plots {
         dataXRange = (<Range> xRangeOrBounds);
         dataYRange = yRange;
       }
-      var attrToProjector = this._generateAttrToProjector();
       return this.entities().filter((entity) => {
         var datum = entity.datum;
         var index = entity.index;
         var dataset = entity.dataset;
-        var translate = d3.transform(attrToProjector["transform"](datum, index, dataset)).translate;
-        var x = translate[0];
-        var y = translate[1];
+        var x = Plot._scaledAccessor(this.x())(datum, index, dataset);
+        var y = Plot._scaledAccessor(this.y())(datum, index, dataset);
         return dataXRange.min <= x && x <= dataXRange.max && dataYRange.min <= y && y <= dataYRange.max;
       });
     }

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -142,6 +142,44 @@ export module Plots {
         symbolProjector(datum, index, dataset)(sizeProjector(datum, index, dataset));
       return propertyToProjectors;
     }
+
+    /**
+     * Gets the Entities that intersect the Bounds.
+     *
+     * @param {Bounds} bounds
+     * @returns {PlotEntity[]}
+     */
+    public entitiesIn(bounds: Bounds): PlotEntity[];
+    /**
+     * Gets the Entities that intersect the area defined by the ranges.
+     *
+     * @param {Range} xRange
+     * @param {Range} yRange
+     * @returns {PlotEntity[]}
+     */
+    public entitiesIn(xRange: Range, yRange: Range): PlotEntity[];
+    public entitiesIn(xRangeOrBounds: Range | Bounds, yRange?: Range): PlotEntity[] {
+      var dataXRange: Range;
+      var dataYRange: Range;
+      if (yRange == null) {
+        var bounds = (<Bounds> xRangeOrBounds);
+        dataXRange = { min: bounds.topLeft.x, max: bounds.bottomRight.x };
+        dataYRange = { min: bounds.topLeft.y, max: bounds.bottomRight.y };
+      } else {
+        dataXRange = (<Range> xRangeOrBounds);
+        dataYRange = yRange;
+      }
+      var attrToProjector = this._generateAttrToProjector();
+      return this.entities().filter((entity) => {
+        var datum = entity.datum;
+        var index = entity.index;
+        var dataset = entity.dataset;
+        var translate = d3.transform(attrToProjector["transform"](datum, index, dataset)).translate;
+        var x = translate[0];
+        var y = translate[1];
+        return dataXRange.min <= x && x <= dataXRange.max && dataYRange.min <= y && y <= dataYRange.max;
+      });
+    }
   }
 }
 }

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -169,12 +169,14 @@ export module Plots {
         dataXRange = (<Range> xRangeOrBounds);
         dataYRange = yRange;
       }
+      var xProjector = Plot._scaledAccessor(this.x());
+      var yProjector = Plot._scaledAccessor(this.y());
       return this.entities().filter((entity) => {
         var datum = entity.datum;
         var index = entity.index;
         var dataset = entity.dataset;
-        var x = Plot._scaledAccessor(this.x())(datum, index, dataset);
-        var y = Plot._scaledAccessor(this.y())(datum, index, dataset);
+        var x = xProjector(datum, index, dataset);
+        var y = yProjector(datum, index, dataset);
         return dataXRange.min <= x && x <= dataXRange.max && dataYRange.min <= y && y <= dataYRange.max;
       });
     }

--- a/test/plots/scatterPlotTests.ts
+++ b/test/plots/scatterPlotTests.ts
@@ -140,6 +140,58 @@ describe("Plots", () => {
       svg.remove();
     });
 
+    it("can retrieve entities in a certain range", () => {
+      var svg = TestMethods.generateSVG(400, 400);
+      var xScale = new Plottable.Scales.Linear();
+      var yScale = new Plottable.Scales.Linear();
+
+      var dataset = new Plottable.Dataset([{x: 0, y: 0}, {x: 1, y: 1}]);
+      var dataset2 = new Plottable.Dataset([{x: 1, y: 2}, {x: 3, y: 4}]);
+      var plot = new Plottable.Plots.Scatter();
+      plot.x((d: any) => d.x, xScale)
+          .y((d: any) => d.y, yScale)
+          .addDataset(dataset)
+          .addDataset(dataset2);
+      plot.renderTo(svg);
+
+      var entities = plot.entitiesIn({ min: xScale.scale(1), max: xScale.scale(1) },
+                                     { min: yScale.scale(1), max: yScale.scale(1) });
+
+      assert.lengthOf(entities, 1, "only one entity has been retrieved");
+      assert.deepEqual(entities[0].datum, {x: 1, y: 1}, "correct datum has been retrieved");
+
+      svg.remove();
+    });
+
+    it("can retrieve entities in a certain bounds", () => {
+      var svg = TestMethods.generateSVG(400, 400);
+      var xScale = new Plottable.Scales.Linear();
+      var yScale = new Plottable.Scales.Linear();
+
+      var dataset = new Plottable.Dataset([{x: 0, y: 0}, {x: 1, y: 1}]);
+      var dataset2 = new Plottable.Dataset([{x: 1, y: 2}, {x: 3, y: 4}]);
+      var plot = new Plottable.Plots.Scatter();
+      plot.x((d: any) => d.x, xScale)
+          .y((d: any) => d.y, yScale)
+          .addDataset(dataset)
+          .addDataset(dataset2);
+      plot.renderTo(svg);
+
+      var entities = plot.entitiesIn({ topLeft: {
+                                         x: xScale.scale(1),
+                                         y: yScale.scale(1)
+                                       },
+                                       bottomRight: {
+                                         x: xScale.scale(1),
+                                         y: yScale.scale(1)
+                                       }});
+
+      assert.lengthOf(entities, 1, "only one entity has been retrieved");
+      assert.deepEqual(entities[0].datum, {x: 1, y: 1}, "correct datum has been retrieved");
+
+      svg.remove();
+    });
+
     it("correctly handles NaN and undefined x and y values", () => {
       var svg = TestMethods.generateSVG(400, 400);
       var data = [

--- a/test/plots/scatterPlotTests.ts
+++ b/test/plots/scatterPlotTests.ts
@@ -163,7 +163,7 @@ describe("Plots", () => {
       svg.remove();
     });
 
-    it("cannot retrieve entities if range does not contain center", () => {
+    it("entities are not returned if their center lies outside the range", () => {
       var svg = TestMethods.generateSVG(400, 400);
       var xScale = new Plottable.Scales.Linear();
       var yScale = new Plottable.Scales.Linear();

--- a/test/plots/scatterPlotTests.ts
+++ b/test/plots/scatterPlotTests.ts
@@ -163,6 +163,28 @@ describe("Plots", () => {
       svg.remove();
     });
 
+    it("cannot retrieve entities if range does not contain center", () => {
+      var svg = TestMethods.generateSVG(400, 400);
+      var xScale = new Plottable.Scales.Linear();
+      var yScale = new Plottable.Scales.Linear();
+
+      var dataset = new Plottable.Dataset([{x: 0, y: 0}, {x: 1, y: 1}]);
+      var dataset2 = new Plottable.Dataset([{x: 1, y: 2}, {x: 3, y: 4}]);
+      var plot = new Plottable.Plots.Scatter();
+      plot.x((d: any) => d.x, xScale)
+          .y((d: any) => d.y, yScale)
+          .addDataset(dataset)
+          .addDataset(dataset2);
+      plot.renderTo(svg);
+
+      var entities = plot.entitiesIn({ min: xScale.scale(1.001), max: xScale.scale(1.001) },
+                                     { min: yScale.scale(1.001), max: yScale.scale(1.001) });
+
+      assert.lengthOf(entities, 0, "no entities retrieved");
+
+      svg.remove();
+    });
+
     it("can retrieve entities in a certain bounds", () => {
       var svg = TestMethods.generateSVG(400, 400);
       var xScale = new Plottable.Scales.Linear();


### PR DESCRIPTION
Similar to how `Plots.Bar` has an `entitiesIn()` endpoint, `Plots.Scatter` can now use this endpoint to find all of the entities within the given range or with the given bounds.

API Changes:
```typescript
/**
 * Gets the Entities that intersect the Bounds.
 *
 * @param {Bounds} bounds
 * @returns {PlotEntity[]}
 */
entitiesIn(bounds: Bounds): PlotEntity[];
/**
 * Gets the Entities that intersect the area defined by the ranges.
 *
 * @param {Range} xRange
 * @param {Range} yRange
 * @returns {PlotEntity[]}
 */
entitiesIn(xRange: Range, yRange: Range): PlotEntity[];
```

JSFiddle: http://jsfiddle.net/bluong63/o3s4wst5/

Closes #2519 