### PR TITLE
Deferred Rendering fix

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -6894,6 +6894,8 @@ var Plottable;
                     _this._cachedDomainY = _lastSeenDomainY;
                     _deltaX = 0;
                     _deltaY = 0;
+                    _scalingX = 1;
+                    _scalingY = 1;
                     _this.render();
                     _this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
                 }, _deferredRenderingTimeout);

--- a/plottable.js
+++ b/plottable.js
@@ -3238,9 +3238,9 @@ var Plottable;
             this.parent(null);
             if (this._isAnchored) {
                 this._element.remove();
+                this._isAnchored = false;
+                this._onDetachCallbacks.callCallbacks(this);
             }
-            this._isAnchored = false;
-            this._onDetachCallbacks.callCallbacks(this);
             return this;
         };
         /**
@@ -6936,7 +6936,7 @@ var Plottable;
             if (deferredRendering == null) {
                 return this._deferredRendering;
             }
-            if (deferredRendering) {
+            if (deferredRendering && this._isAnchored) {
                 if (this.x() && this.x().scale) {
                     this._cachedDomainX = this.x().scale.domain();
                 }

--- a/plottable.js
+++ b/plottable.js
@@ -6878,8 +6878,8 @@ var Plottable;
             var _deltaY = 0;
             var _scalingX = 1;
             var _scalingY = 1;
-            var _lastSeenDomainX = null;
-            var _lastSeenDomainY = null;
+            var _lastSeenDomainX = [null, null];
+            var _lastSeenDomainY = [null, null];
             var _timeoutReference = 0;
             var _deferredRenderingTimeout = 500;
             var _registerDeferredRendering = function () {
@@ -6911,6 +6911,7 @@ var Plottable;
                 _registerDeferredRendering();
             };
             var _lazyDomainChangeCallbackY = function (scale) {
+                console.log("cached domain Y", _this._cachedDomainY);
                 if (!_this._isAnchored) {
                     return;
                 }

--- a/plottable.js
+++ b/plottable.js
@@ -1,5 +1,5 @@
 /*!
-Plottable 1.5.0 (https://github.com/palantir/plottable)
+Plottable 1.5.2 (https://github.com/palantir/plottable)
 Copyright 2014-2015 Palantir Technologies
 Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
 */
@@ -900,7 +900,7 @@ var Plottable;
 ///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
-    Plottable.version = "1.5.0";
+    Plottable.version = "1.5.2";
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />

--- a/plottable.js
+++ b/plottable.js
@@ -6911,7 +6911,6 @@ var Plottable;
                 _registerDeferredRendering();
             };
             var _lazyDomainChangeCallbackY = function (scale) {
-                console.log("cached domain Y", _this._cachedDomainY);
                 if (!_this._isAnchored) {
                     return;
                 }

--- a/plottable.js
+++ b/plottable.js
@@ -1,5 +1,5 @@
 /*!
-Plottable 1.5.2 (https://github.com/palantir/plottable)
+Plottable 1.5.0 (https://github.com/palantir/plottable)
 Copyright 2014-2015 Palantir Technologies
 Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
 */
@@ -900,7 +900,7 @@ var Plottable;
 ///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
-    Plottable.version = "1.5.2";
+    Plottable.version = "1.5.0";
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -450,10 +450,10 @@ export class Component {
 
     if (this._isAnchored) {
       this._element.remove();
+      this._isAnchored = false;
+      this._onDetachCallbacks.callCallbacks(this);
     }
-    this._isAnchored = false;
 
-    this._onDetachCallbacks.callCallbacks(this);
     return this;
   }
 

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -31,8 +31,8 @@ export class XYPlot<X, Y> extends Plot {
     var _deltaY = 0;
     var _scalingX = 1;
     var _scalingY = 1;
-    var _lastSeenDomainX: X[] = null;
-    var _lastSeenDomainY: Y[] = null;
+    var _lastSeenDomainX: X[] = [null, null];
+    var _lastSeenDomainY: Y[] = [null, null];
     var _timeoutReference = 0;
     var _deferredRenderingTimeout = 500;
 
@@ -69,6 +69,9 @@ export class XYPlot<X, Y> extends Plot {
     };
 
     var _lazyDomainChangeCallbackY = (scale: Scale<Y, any>) => {
+      console.log("cached domain Y", this._cachedDomainY);
+
+
       if (!this._isAnchored) {
         return;
       }

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -49,6 +49,8 @@ export class XYPlot<X, Y> extends Plot {
         this._cachedDomainY = _lastSeenDomainY;
         _deltaX = 0;
         _deltaY = 0;
+        _scalingX = 1;
+        _scalingY = 1;
         this.render();
         this._renderArea.attr("transform", "translate(0, 0) scale(1, 1)");
       }, _deferredRenderingTimeout);

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -111,7 +111,7 @@ export class XYPlot<X, Y> extends Plot {
       return this._deferredRendering;
     }
 
-    if (deferredRendering) {
+    if (deferredRendering && this._isAnchored) {
       if (this.x() && this.x().scale) {
         this._cachedDomainX = this.x().scale.domain();
       }

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -69,9 +69,6 @@ export class XYPlot<X, Y> extends Plot {
     };
 
     var _lazyDomainChangeCallbackY = (scale: Scale<Y, any>) => {
-      console.log("cached domain Y", this._cachedDomainY);
-
-
       if (!this._isAnchored) {
         return;
       }

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -124,6 +124,30 @@ describe("Component behavior", () => {
       assert.strictEqual(passedComponent, c, "callback was passed the Component that detach()-ed");
       svg.remove();
     });
+
+    it("callbacks on detach() not called unless the component is anchored", () => {
+      c = new Plottable.Component();
+
+      var callbackCalled = false;
+      var callback = (component: Plottable.Component) => callbackCalled = true;
+      c.onDetach(callback);
+
+      callbackCalled = false;
+      c.detach();
+      assert.isFalse(callbackCalled, "callback was not called because the Component is not rendered yet");
+
+      c.renderTo(svg);
+
+      callbackCalled = false;
+      c.detach();
+      assert.isTrue(callbackCalled, "callback was called when the Component was detach()-ed");
+
+      callbackCalled = false;
+      c.detach();
+      assert.isFalse(callbackCalled, "callback was not called because the Component was detached already");
+
+      svg.remove();
+    });
   });
 
   it("parent()", () => {

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -168,52 +168,33 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      // it("deferredRendering() caches domains properly when setup before rendering", function() {
-      //   // this.timeout(0);
-      //   xScale.domain([5, 6]);
-      //   yScale.domain([6, 7]);
-      //   plot.x((d) => d.x, xScale);
-      //   plot.y((d) => d.y, yScale);
-      //   plot.deferredRendering(true);
-      //   var oldRender = (<any>plot)._renderCallback;
-      //   (<any>plot).renderCallback = function() {
-      //     var ret = oldRender();
-      //     console.log("The custom one was called");
+      it("deferredRendering() caches domains properly when setup before rendering", function() {
+        xScale.domain([5, 6]);
+        yScale.domain([6, 7]);
+        plot.x((d) => d.x, xScale);
+        plot.y((d) => d.y, yScale);
+        plot.deferredRendering(true);
+        plot.renderTo(svg);
 
-      //     assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The correct x domain is cached");
-      //     assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The correct y domain is cached");
-      //     return ret;
-      //   }
-      //   plot.renderTo(svg);
+        assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "The x domain is still not cached until the timeout expires");
+        assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "The y domain is still not cached until the timeout expires");
 
-      //   assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "The x domain is still not cached until the timeout expires");
-      //   assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "The y domain is still not cached until the timeout expires");
+        svg.remove();
+      });
 
+      it("deferredRendering() caches domains properly setup before scales", () => {
+        xScale.domain([5, 6]);
+        yScale.domain([6, 7]);
+        plot.deferredRendering(true);
+        plot.x((d) => d.x, xScale);
+        plot.y((d) => d.y, yScale);
+        plot.renderTo(svg);
 
-      //   svg.remove();
-      // });
+        assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "The x domain is still not cached until the timeout expires");
+        assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "The y domain is still not cached until the timeout expires");
 
-      // it("deferredRendering() caches domains properly setup before scales", () => {
-      //   xScale.domain([5, 6]);
-      //   yScale.domain([6, 7]);
-      //   plot.deferredRendering(true);
-      //   plot.x((d) => d.x, xScale);
-      //   plot.y((d) => d.y, yScale);
-      //   var oldRender = plot.render;
-      //   plot.render = function() {
-      //     var ret = oldRender();
-      //     assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The correct x domain is cached");
-      //     assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The correct y domain is cached");
-      //     return ret;
-      //   }
-      //   plot.renderTo(svg);
-
-      //   assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "The x domain is still not cached until the timeout expires");
-      //   assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "The y domain is still not cached until the timeout expires");
-
-
-      //   svg.remove();
-      // });
+        svg.remove();
+      });
 
     });
 

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -142,25 +142,49 @@ describe("Plots", () => {
         (<any> plot)._createDrawer = (dataset: Plottable.Dataset) => createMockDrawer(dataset);
       });
 
-      it("deferredRendering() setter/getter", () => {
-        assert.strictEqual(plot.deferredRendering(), false, "deferred rendering is false by default");
-        assert.strictEqual(plot.deferredRendering(true), plot, "setting the deferred rendering option returns the plot");
-        assert.strictEqual(plot.deferredRendering(), true, "deferred rendering can be turned on");
-        plot.deferredRendering(false);
-        assert.strictEqual(plot.deferredRendering(), false, "deferred rendering can be turned off");
+      // it("deferredRendering() setter/getter", () => {
+      //   assert.strictEqual(plot.deferredRendering(), false, "deferred rendering is false by default");
+      //   assert.strictEqual(plot.deferredRendering(true), plot, "setting the deferred rendering option returns the plot");
+      //   assert.strictEqual(plot.deferredRendering(), true, "deferred rendering can be turned on");
+      //   plot.deferredRendering(false);
+      //   assert.strictEqual(plot.deferredRendering(), false, "deferred rendering can be turned off");
 
-        svg.remove();
-      });
+      //   svg.remove();
+      // });
 
-      it("deferredRendering() caches domains properly", () => {
+      // it("deferredRendering() caches domains properly", () => {
+      //   xScale.domain([5, 6]);
+      //   yScale.domain([6, 7]);
+      //   plot.x((d) => d.x, xScale);
+      //   plot.y((d) => d.y, yScale);
+      //   plot.renderTo(svg);
+      //   assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "the x domain is not cached when deferredRendering is disabled");
+      //   assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "the y domain is not cached when deferredRendering is disabled");
+      //   plot.deferredRendering(true);
+
+      //   assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The correct x domain is cached");
+      //   assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The correct y domain is cached");
+
+      //   svg.remove();
+      // });
+
+      it("deferredRendering() caches domains properly when setup before rendering", () => {
+
+
+        var oldTimeout = (<any>window).setTimeout;
+        (<any>window).setTimeout = function (fn, time) {
+          fn.call(this);
+        }
+
         xScale.domain([5, 6]);
         yScale.domain([6, 7]);
         plot.x((d) => d.x, xScale);
         plot.y((d) => d.y, yScale);
-        plot.renderTo(svg);
-        assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "the x domain is not cached when deferredRendering is disabled");
-        assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "the y domain is not cached when deferredRendering is disabled");
         plot.deferredRendering(true);
+        assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "The x domain is still not cached until the timeout expires");
+        assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "The y domain is still not cached until the timeout expires");
+
+        plot.renderTo(svg);
 
         assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The correct x domain is cached");
         assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The correct y domain is cached");
@@ -168,33 +192,19 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("deferredRendering() caches domains properly when setup before rendering", () => {
-        xScale.domain([5, 6]);
-        yScale.domain([6, 7]);
-        plot.x((d) => d.x, xScale);
-        plot.y((d) => d.y, yScale);
-        plot.deferredRendering(true);
-        plot.renderTo(svg);
+      // it("deferredRendering() caches domains properly setup before scales", () => {
+      //   xScale.domain([5, 6]);
+      //   yScale.domain([6, 7]);
+      //   plot.deferredRendering(true);
+      //   plot.x((d) => d.x, xScale);
+      //   plot.y((d) => d.y, yScale);
+      //   plot.renderTo(svg);
 
-        assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "The x domain is still not cached until the timeout expires");
-        assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "The y domain is still not cached until the timeout expires");
+      //   assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "The x domain is still not cached until the timeout expires");
+      //   assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "The y domain is still not cached until the timeout expires");
 
-        svg.remove();
-      });
-
-      it("deferredRendering() caches domains properly setup before scales", () => {
-        xScale.domain([5, 6]);
-        yScale.domain([6, 7]);
-        plot.deferredRendering(true);
-        plot.x((d) => d.x, xScale);
-        plot.y((d) => d.y, yScale);
-        plot.renderTo(svg);
-
-        assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "The x domain is still not cached until the timeout expires");
-        assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "The y domain is still not cached until the timeout expires");
-
-        svg.remove();
-      });
+      //   svg.remove();
+      // });
 
     });
 

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -152,7 +152,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("deferredRendering() caches domains properly", function() {
+      it("deferredRendering() caches domains properly", () => {
         xScale.domain([5, 6]);
         yScale.domain([6, 7]);
         plot.x((d) => d.x, xScale);
@@ -168,7 +168,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("deferredRendering() caches domains properly when setup before rendering", function() {
+      it("deferredRendering() caches domains properly when setup before rendering", () => {
         xScale.domain([5, 6]);
         yScale.domain([6, 7]);
         plot.x((d) => d.x, xScale);

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -152,7 +152,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("deferredRendering() caches domains properly", () => {
+      it("deferredRendering() caches domains properly", function() {
         xScale.domain([5, 6]);
         yScale.domain([6, 7]);
         plot.x((d) => d.x, xScale);
@@ -168,39 +168,52 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("deferredRendering() caches domains properly when setup before rendering", () => {
-        xScale.domain([5, 6]);
-        yScale.domain([6, 7]);
-        plot.x((d) => d.x, xScale);
-        plot.y((d) => d.y, yScale);
-        plot.deferredRendering(true);
-        assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "the x domain is not cached until the plot is rendered");
-        assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "the y domain is not cached until the plot is rendered");
-        plot.renderTo(svg);
+      // it("deferredRendering() caches domains properly when setup before rendering", function() {
+      //   // this.timeout(0);
+      //   xScale.domain([5, 6]);
+      //   yScale.domain([6, 7]);
+      //   plot.x((d) => d.x, xScale);
+      //   plot.y((d) => d.y, yScale);
+      //   plot.deferredRendering(true);
+      //   var oldRender = (<any>plot)._renderCallback;
+      //   (<any>plot).renderCallback = function() {
+      //     var ret = oldRender();
+      //     console.log("The custom one was called");
 
-        assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The correct x domain is cached");
-        assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The correct y domain is cached");
+      //     assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The correct x domain is cached");
+      //     assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The correct y domain is cached");
+      //     return ret;
+      //   }
+      //   plot.renderTo(svg);
 
-        svg.remove();
-      });
+      //   assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "The x domain is still not cached until the timeout expires");
+      //   assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "The y domain is still not cached until the timeout expires");
 
-      it("deferredRendering() caches domains properly setup before scales", () => {
-        xScale.domain([5, 6]);
-        yScale.domain([6, 7]);
-        plot.deferredRendering(true);
-        assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "the x domain is not cached until the plot is rendered");
-        assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "the y domain is not cached until the plot is rendered");
-        plot.x((d) => d.x, xScale);
-        plot.y((d) => d.y, yScale);
-        assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "the x domain is not cached until the plot is rendered");
-        assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "the y domain is not cached until the plot is rendered");
-        plot.renderTo(svg);
 
-        assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The correct x domain is cached");
-        assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The correct y domain is cached");
+      //   svg.remove();
+      // });
 
-        svg.remove();
-      });
+      // it("deferredRendering() caches domains properly setup before scales", () => {
+      //   xScale.domain([5, 6]);
+      //   yScale.domain([6, 7]);
+      //   plot.deferredRendering(true);
+      //   plot.x((d) => d.x, xScale);
+      //   plot.y((d) => d.y, yScale);
+      //   var oldRender = plot.render;
+      //   plot.render = function() {
+      //     var ret = oldRender();
+      //     assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The correct x domain is cached");
+      //     assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The correct y domain is cached");
+      //     return ret;
+      //   }
+      //   plot.renderTo(svg);
+
+      //   assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "The x domain is still not cached until the timeout expires");
+      //   assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "The y domain is still not cached until the timeout expires");
+
+
+      //   svg.remove();
+      // });
 
     });
 

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -134,7 +134,7 @@ describe("Plots", () => {
       var yScale: Plottable.Scales.Linear;
       var plot: Plottable.XYPlot<number, number>;
 
-      var oldTimeout: any;
+      var nativeTimeout: Function;
 
       beforeEach(() => {
         svg = TestMethods.generateSVG(500, 500);
@@ -143,14 +143,16 @@ describe("Plots", () => {
         plot = new Plottable.XYPlot<number, number>();
         (<any> plot)._createDrawer = (dataset: Plottable.Dataset) => createMockDrawer(dataset);
 
-        oldTimeout = (<any>window).setTimeout;
-        (<any>window).setTimeout = function (fn, time) {
+        // Replacing timeout with instant invocation to avoid waiting for the deferred rendering
+        nativeTimeout = (<any>window).setTimeout;
+        (<any>window).setTimeout = function(fn: Function) {
           fn.call(this);
-        }
+        };
       });
 
       afterEach(() => {
-        (<any>window).setTimeout = oldTimeout;
+        (<any>window).setTimeout = nativeTimeout;
+        svg.remove();
       });
 
       it("deferredRendering() setter/getter", () => {
@@ -159,8 +161,6 @@ describe("Plots", () => {
         assert.strictEqual(plot.deferredRendering(), true, "deferred rendering can be turned on");
         plot.deferredRendering(false);
         assert.strictEqual(plot.deferredRendering(), false, "deferred rendering can be turned off");
-
-        svg.remove();
       });
 
       it("deferredRendering() caches domains properly", () => {
@@ -175,8 +175,6 @@ describe("Plots", () => {
 
         assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The correct x domain is cached");
         assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The correct y domain is cached");
-
-        svg.remove();
       });
 
       it("deferredRendering() caches domains properly when setup before rendering", () => {
@@ -193,8 +191,6 @@ describe("Plots", () => {
 
         assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The correct x domain is cached");
         assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The correct y domain is cached");
-
-        svg.remove();
       });
 
       it("deferredRendering() caches domains properly setup before scales", () => {
@@ -205,15 +201,13 @@ describe("Plots", () => {
         plot.y((d) => d.y, yScale);
         assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "The x domain is still not cached until the timeout expires");
         assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "The y domain is still not cached until the timeout expires");
+
         plot.renderTo(svg);
 
         assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The x domain is still not cached until the timeout expires");
         assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The y domain is still not cached until the timeout expires");
-
-        svg.remove();
       });
 
     });
-
   });
 });

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -133,14 +133,6 @@ describe("Plots", () => {
       var xScale: Plottable.Scales.Linear;
       var yScale: Plottable.Scales.Linear;
       var plot: Plottable.XYPlot<number, number>;
-      var simpleDataset = new Plottable.Dataset([
-        { a: -6, b: 6 },
-        { a: -2, b: 2 },
-        { a: 2, b: -2 },
-        { a: 6, b: -6 }
-      ]);
-      var xAccessor = (d: any) => d.a;
-      var yAccessor = (d: any) => d.b;
 
       beforeEach(() => {
         svg = TestMethods.generateSVG(500, 500);

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -134,47 +134,52 @@ describe("Plots", () => {
       var yScale: Plottable.Scales.Linear;
       var plot: Plottable.XYPlot<number, number>;
 
+      var oldTimeout: any;
+
       beforeEach(() => {
         svg = TestMethods.generateSVG(500, 500);
         xScale = new Plottable.Scales.Linear();
         yScale = new Plottable.Scales.Linear();
         plot = new Plottable.XYPlot<number, number>();
         (<any> plot)._createDrawer = (dataset: Plottable.Dataset) => createMockDrawer(dataset);
-      });
 
-      // it("deferredRendering() setter/getter", () => {
-      //   assert.strictEqual(plot.deferredRendering(), false, "deferred rendering is false by default");
-      //   assert.strictEqual(plot.deferredRendering(true), plot, "setting the deferred rendering option returns the plot");
-      //   assert.strictEqual(plot.deferredRendering(), true, "deferred rendering can be turned on");
-      //   plot.deferredRendering(false);
-      //   assert.strictEqual(plot.deferredRendering(), false, "deferred rendering can be turned off");
-
-      //   svg.remove();
-      // });
-
-      // it("deferredRendering() caches domains properly", () => {
-      //   xScale.domain([5, 6]);
-      //   yScale.domain([6, 7]);
-      //   plot.x((d) => d.x, xScale);
-      //   plot.y((d) => d.y, yScale);
-      //   plot.renderTo(svg);
-      //   assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "the x domain is not cached when deferredRendering is disabled");
-      //   assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "the y domain is not cached when deferredRendering is disabled");
-      //   plot.deferredRendering(true);
-
-      //   assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The correct x domain is cached");
-      //   assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The correct y domain is cached");
-
-      //   svg.remove();
-      // });
-
-      it("deferredRendering() caches domains properly when setup before rendering", () => {
-
-
-        var oldTimeout = (<any>window).setTimeout;
+        oldTimeout = (<any>window).setTimeout;
         (<any>window).setTimeout = function (fn, time) {
           fn.call(this);
         }
+      });
+
+      afterEach(() => {
+        (<any>window).setTimeout = oldTimeout;
+      });
+
+      it("deferredRendering() setter/getter", () => {
+        assert.strictEqual(plot.deferredRendering(), false, "deferred rendering is false by default");
+        assert.strictEqual(plot.deferredRendering(true), plot, "setting the deferred rendering option returns the plot");
+        assert.strictEqual(plot.deferredRendering(), true, "deferred rendering can be turned on");
+        plot.deferredRendering(false);
+        assert.strictEqual(plot.deferredRendering(), false, "deferred rendering can be turned off");
+
+        svg.remove();
+      });
+
+      it("deferredRendering() caches domains properly", () => {
+        xScale.domain([5, 6]);
+        yScale.domain([6, 7]);
+        plot.x((d) => d.x, xScale);
+        plot.y((d) => d.y, yScale);
+        plot.renderTo(svg);
+        assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "the x domain is not cached when deferredRendering is disabled");
+        assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "the y domain is not cached when deferredRendering is disabled");
+        plot.deferredRendering(true);
+
+        assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The correct x domain is cached");
+        assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The correct y domain is cached");
+
+        svg.remove();
+      });
+
+      it("deferredRendering() caches domains properly when setup before rendering", () => {
 
         xScale.domain([5, 6]);
         yScale.domain([6, 7]);
@@ -192,19 +197,21 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      // it("deferredRendering() caches domains properly setup before scales", () => {
-      //   xScale.domain([5, 6]);
-      //   yScale.domain([6, 7]);
-      //   plot.deferredRendering(true);
-      //   plot.x((d) => d.x, xScale);
-      //   plot.y((d) => d.y, yScale);
-      //   plot.renderTo(svg);
+      it("deferredRendering() caches domains properly setup before scales", () => {
+        xScale.domain([5, 6]);
+        yScale.domain([6, 7]);
+        plot.deferredRendering(true);
+        plot.x((d) => d.x, xScale);
+        plot.y((d) => d.y, yScale);
+        assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "The x domain is still not cached until the timeout expires");
+        assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "The y domain is still not cached until the timeout expires");
+        plot.renderTo(svg);
 
-      //   assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "The x domain is still not cached until the timeout expires");
-      //   assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "The y domain is still not cached until the timeout expires");
+        assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The x domain is still not cached until the timeout expires");
+        assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The y domain is still not cached until the timeout expires");
 
-      //   svg.remove();
-      // });
+        svg.remove();
+      });
 
     });
 

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -178,7 +178,6 @@ describe("Plots", () => {
       });
 
       it("deferredRendering() caches domains properly when setup before rendering", () => {
-
         xScale.domain([5, 6]);
         yScale.domain([6, 7]);
         plot.x((d) => d.x, xScale);

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -2,128 +2,215 @@
 
 describe("Plots", () => {
   describe("XY Plot", () => {
-    var svg: d3.Selection<void>;
-    var xScale: Plottable.Scales.Linear;
-    var yScale: Plottable.Scales.Linear;
-    var plot: Plottable.XYPlot<number, number>;
-    var simpleDataset = new Plottable.Dataset([
-      { a: -6, b: 6 },
-      { a: -2, b: 2 },
-      { a: 2, b: -2 },
-      { a: 6, b: -6 }
-    ]);
-    var xAccessor = (d: any) => d.a;
-    var yAccessor = (d: any) => d.b;
+    describe("Basic functionality", () => {
+      var svg: d3.Selection<void>;
+      var xScale: Plottable.Scales.Linear;
+      var yScale: Plottable.Scales.Linear;
+      var plot: Plottable.XYPlot<number, number>;
+      var simpleDataset = new Plottable.Dataset([
+        { a: -6, b: 6 },
+        { a: -2, b: 2 },
+        { a: 2, b: -2 },
+        { a: 6, b: -6 }
+      ]);
+      var xAccessor = (d: any) => d.a;
+      var yAccessor = (d: any) => d.b;
 
-    beforeEach(() => {
-      svg = TestMethods.generateSVG(500, 500);
-      xScale = new Plottable.Scales.Linear();
-      yScale = new Plottable.Scales.Linear();
-      plot = new Plottable.XYPlot<number, number>();
-      (<any> plot)._createDrawer = (dataset: Plottable.Dataset) => createMockDrawer(dataset);
-      plot.addDataset(simpleDataset);
-      plot.x(xAccessor, xScale)
-          .y(yAccessor, yScale)
-          .renderTo(svg);
-    });
-
-    it("autorangeMode() getter", () => {
-      assert.strictEqual(plot.autorangeMode(), "none");
-      assert.strictEqual(plot.autorangeMode("x"), plot, "autorangeMode() setter did not return the original object");
-      assert.strictEqual(plot.autorangeMode(), "x");
-      plot.autorangeMode("y");
-      assert.strictEqual(plot.autorangeMode(), "y");
-      plot.autorangeMode("none");
-      assert.strictEqual(plot.autorangeMode(), "none");
-      svg.remove();
-    });
-
-    it("autorangeMode() invalid inputs", () => {
-      assert.throws(() => {
-        plot.autorangeMode("foobar");
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(500, 500);
+        xScale = new Plottable.Scales.Linear();
+        yScale = new Plottable.Scales.Linear();
+        plot = new Plottable.XYPlot<number, number>();
+        (<any> plot)._createDrawer = (dataset: Plottable.Dataset) => createMockDrawer(dataset);
+        plot.addDataset(simpleDataset);
+        plot.x(xAccessor, xScale)
+            .y(yAccessor, yScale)
+            .renderTo(svg);
       });
-      svg.remove();
+
+      it("autorangeMode() getter", () => {
+        assert.strictEqual(plot.autorangeMode(), "none");
+        assert.strictEqual(plot.autorangeMode("x"), plot, "autorangeMode() setter did not return the original object");
+        assert.strictEqual(plot.autorangeMode(), "x");
+        plot.autorangeMode("y");
+        assert.strictEqual(plot.autorangeMode(), "y");
+        plot.autorangeMode("none");
+        assert.strictEqual(plot.autorangeMode(), "none");
+        svg.remove();
+      });
+
+      it("autorangeMode() invalid inputs", () => {
+        assert.throws(() => {
+          plot.autorangeMode("foobar");
+        });
+        svg.remove();
+      });
+
+      it("automatically adjusting Y domain over visible points", () => {
+        xScale.domain([-3, 3]);
+        assert.deepEqual(yScale.domain(), [-7, 7], "domain has not been adjusted to visible points");
+        plot.autorangeMode("y");
+        assert.deepEqual(yScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points");
+        plot.autorangeMode("none");
+        svg.remove();
+      });
+
+      it("automatically adjusting Y domain when no points are visible", () => {
+        plot.autorangeMode("y");
+        xScale.domain([-0.5, 0.5]);
+        assert.deepEqual(yScale.domain(), [0, 1], "scale uses default domain");
+        svg.remove();
+      });
+
+      it("automatically adjusting Y domain when X scale is replaced", () => {
+        plot.autorangeMode("y");
+        var newXScale = new Plottable.Scales.Linear().domain([-3, 3]);
+        plot.x(xAccessor, newXScale);
+        assert.deepEqual(yScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points on new X scale domain");
+        xScale.domain([-2, 2]);
+        assert.deepEqual(yScale.domain(), [-2.5, 2.5], "changing domain of original X scale doesn't affect Y scale's domain");
+        svg.remove();
+      });
+
+      it("automatically adjusting X domain over visible points", () => {
+        yScale.domain([-3, 3]);
+        assert.deepEqual(xScale.domain(), [-7, 7], "domain has not been adjusted to visible points");
+        plot.autorangeMode("x");
+        assert.deepEqual(xScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points");
+        plot.autorangeMode("none");
+        svg.remove();
+      });
+
+      it("automatically adjusting X domain when no points are visible", () => {
+        plot.autorangeMode("x");
+        yScale.domain([-0.5, 0.5]);
+        assert.deepEqual(xScale.domain(), [0, 1], "scale uses default domain");
+        svg.remove();
+      });
+
+      it("automatically adjusting X domain when Y scale is replaced", () => {
+        plot.autorangeMode("x");
+        var newYScale = new Plottable.Scales.Linear().domain([-3, 3]);
+        plot.y(yAccessor, newYScale);
+        assert.deepEqual(xScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points on new Y scale domain");
+        yScale.domain([-2, 2]);
+        assert.deepEqual(xScale.domain(), [-2.5, 2.5], "changing domain of original Y scale doesn't affect X scale's domain");
+        svg.remove();
+      });
+
+      it("showAllData()", () => {
+        plot.autorangeMode("y");
+        xScale.domain([-0.5, 0.5]);
+        plot.showAllData();
+        assert.deepEqual(yScale.domain(), [-7, 7], "domain has been adjusted to show all data");
+        assert.deepEqual(xScale.domain(), [-7, 7], "domain has been adjusted to show all data");
+        svg.remove();
+      });
+
+      it("show all data without auto adjust domain", () => {
+        plot.autorangeMode("y");
+        xScale.domain([-0.5, 0.5]);
+        plot.autorangeMode("none");
+        plot.showAllData();
+        assert.deepEqual(yScale.domain(), [-7, 7], "domain has been adjusted to show all data");
+        assert.deepEqual(xScale.domain(), [-7, 7], "domain has been adjusted to show all data");
+        svg.remove();
+      });
+
+      it("listeners are deregistered after removal", () => {
+        plot.autorangeMode("y");
+        plot.destroy();
+
+        assert.strictEqual((<any> xScale)._callbacks.size, 0, "the plot is no longer attached to xScale");
+        assert.strictEqual((<any> yScale)._callbacks.size, 0, "the plot is no longer attached to yScale");
+
+        svg.remove();
+      });
     });
 
-    it("automatically adjusting Y domain over visible points", () => {
-      xScale.domain([-3, 3]);
-      assert.deepEqual(yScale.domain(), [-7, 7], "domain has not been adjusted to visible points");
-      plot.autorangeMode("y");
-      assert.deepEqual(yScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points");
-      plot.autorangeMode("none");
-      svg.remove();
+    describe("Deferred Rendering", () => {
+      var svg: d3.Selection<void>;
+      var xScale: Plottable.Scales.Linear;
+      var yScale: Plottable.Scales.Linear;
+      var plot: Plottable.XYPlot<number, number>;
+      var simpleDataset = new Plottable.Dataset([
+        { a: -6, b: 6 },
+        { a: -2, b: 2 },
+        { a: 2, b: -2 },
+        { a: 6, b: -6 }
+      ]);
+      var xAccessor = (d: any) => d.a;
+      var yAccessor = (d: any) => d.b;
+
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(500, 500);
+        xScale = new Plottable.Scales.Linear();
+        yScale = new Plottable.Scales.Linear();
+        plot = new Plottable.XYPlot<number, number>();
+        (<any> plot)._createDrawer = (dataset: Plottable.Dataset) => createMockDrawer(dataset);
+      });
+
+      it("deferredRendering() setter/getter", () => {
+        assert.strictEqual(plot.deferredRendering(), false, "deferred rendering is false by default");
+        assert.strictEqual(plot.deferredRendering(true), plot, "setting the deferred rendering option returns the plot");
+        assert.strictEqual(plot.deferredRendering(), true, "deferred rendering can be turned on");
+        plot.deferredRendering(false);
+        assert.strictEqual(plot.deferredRendering(), false, "deferred rendering can be turned off");
+
+        svg.remove();
+      });
+
+      it("deferredRendering() caches domains properly", () => {
+        xScale.domain([5, 6]);
+        yScale.domain([6, 7]);
+        plot.x((d) => d.x, xScale);
+        plot.y((d) => d.y, yScale);
+        plot.renderTo(svg);
+        assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "the x domain is not cached when deferredRendering is disabled");
+        assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "the y domain is not cached when deferredRendering is disabled");
+        plot.deferredRendering(true);
+
+        assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The correct x domain is cached");
+        assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The correct y domain is cached");
+
+        svg.remove();
+      });
+
+      it("deferredRendering() caches domains properly when setup before rendering", () => {
+        xScale.domain([5, 6]);
+        yScale.domain([6, 7]);
+        plot.x((d) => d.x, xScale);
+        plot.y((d) => d.y, yScale);
+        plot.deferredRendering(true);
+        assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "the x domain is not cached until the plot is rendered");
+        assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "the y domain is not cached until the plot is rendered");
+        plot.renderTo(svg);
+
+        assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The correct x domain is cached");
+        assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The correct y domain is cached");
+
+        svg.remove();
+      });
+
+      it("deferredRendering() caches domains properly setup before scales", () => {
+        xScale.domain([5, 6]);
+        yScale.domain([6, 7]);
+        plot.deferredRendering(true);
+        assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "the x domain is not cached until the plot is rendered");
+        assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "the y domain is not cached until the plot is rendered");
+        plot.x((d) => d.x, xScale);
+        plot.y((d) => d.y, yScale);
+        assert.deepEqual((<any>plot)._cachedDomainX, [null, null], "the x domain is not cached until the plot is rendered");
+        assert.deepEqual((<any>plot)._cachedDomainY, [null, null], "the y domain is not cached until the plot is rendered");
+        plot.renderTo(svg);
+
+        assert.deepEqual((<any>plot)._cachedDomainX, [5, 6], "The correct x domain is cached");
+        assert.deepEqual((<any>plot)._cachedDomainY, [6, 7], "The correct y domain is cached");
+
+        svg.remove();
+      });
+
     });
 
-    it("automatically adjusting Y domain when no points are visible", () => {
-      plot.autorangeMode("y");
-      xScale.domain([-0.5, 0.5]);
-      assert.deepEqual(yScale.domain(), [0, 1], "scale uses default domain");
-      svg.remove();
-    });
-
-    it("automatically adjusting Y domain when X scale is replaced", () => {
-      plot.autorangeMode("y");
-      var newXScale = new Plottable.Scales.Linear().domain([-3, 3]);
-      plot.x(xAccessor, newXScale);
-      assert.deepEqual(yScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points on new X scale domain");
-      xScale.domain([-2, 2]);
-      assert.deepEqual(yScale.domain(), [-2.5, 2.5], "changing domain of original X scale doesn't affect Y scale's domain");
-      svg.remove();
-    });
-
-    it("automatically adjusting X domain over visible points", () => {
-      yScale.domain([-3, 3]);
-      assert.deepEqual(xScale.domain(), [-7, 7], "domain has not been adjusted to visible points");
-      plot.autorangeMode("x");
-      assert.deepEqual(xScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points");
-      plot.autorangeMode("none");
-      svg.remove();
-    });
-
-    it("automatically adjusting X domain when no points are visible", () => {
-      plot.autorangeMode("x");
-      yScale.domain([-0.5, 0.5]);
-      assert.deepEqual(xScale.domain(), [0, 1], "scale uses default domain");
-      svg.remove();
-    });
-
-    it("automatically adjusting X domain when Y scale is replaced", () => {
-      plot.autorangeMode("x");
-      var newYScale = new Plottable.Scales.Linear().domain([-3, 3]);
-      plot.y(yAccessor, newYScale);
-      assert.deepEqual(xScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points on new Y scale domain");
-      yScale.domain([-2, 2]);
-      assert.deepEqual(xScale.domain(), [-2.5, 2.5], "changing domain of original Y scale doesn't affect X scale's domain");
-      svg.remove();
-    });
-
-    it("showAllData()", () => {
-      plot.autorangeMode("y");
-      xScale.domain([-0.5, 0.5]);
-      plot.showAllData();
-      assert.deepEqual(yScale.domain(), [-7, 7], "domain has been adjusted to show all data");
-      assert.deepEqual(xScale.domain(), [-7, 7], "domain has been adjusted to show all data");
-      svg.remove();
-    });
-
-    it("show all data without auto adjust domain", () => {
-      plot.autorangeMode("y");
-      xScale.domain([-0.5, 0.5]);
-      plot.autorangeMode("none");
-      plot.showAllData();
-      assert.deepEqual(yScale.domain(), [-7, 7], "domain has been adjusted to show all data");
-      assert.deepEqual(xScale.domain(), [-7, 7], "domain has been adjusted to show all data");
-      svg.remove();
-    });
-
-    it("listeners are deregistered after removal", () => {
-      plot.autorangeMode("y");
-      plot.destroy();
-
-      assert.strictEqual((<any> xScale)._callbacks.size, 0, "the plot is no longer attached to xScale");
-      assert.strictEqual((<any> yScale)._callbacks.size, 0, "the plot is no longer attached to yScale");
-
-      svg.remove();
-    });
   });
 });


### PR DESCRIPTION
Closes #2538

Before: http://jsfiddle.net/ys358yxy/2/
After: http://jsfiddle.net/ys358yxy/1/

The issue was that an unanchored plot is not setting up the scale correctly (because it does not know how much space it has in the SVG) and we were not taking that into account. With this fix will only cache domains for anchored plots

Also as part of this PR: 
- Added tests for deferredRendering
- Fixed more issues caught by the tests and not observed through manual inspection
- `onDetachCallbacks` on the component are not called unless the component was already anchored
- added tests for the item above
- Rearranged the test file for XYPlot. I did not like that the beforeEach was doing way too much for the basic use cases of the XYPlot. Also, I did not like creating a new XYPlot category, so I added 1 more level of nesting to allow my DeferredRendering to live under the XYPlot tag
