### PR TITLE
API endpoint to specify opacity of legend (take 2)

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2133,15 +2133,15 @@ declare module Plottable {
              */
             symbol(symbol: (datum: any, index: number) => SymbolFactory): Legend;
             /**
-             * Gets the function determining the opacity of the symbols of the Legend.
+             * Gets the opacity of the symbols of the Legend.
              *
              * @returns {(datum: any, index: number) => number}
              */
             symbolOpacity(): (datum: any, index: number) => number;
             /**
-             * Sets the function determining the opacity of the symbols of the Legend.
+             * Sets the opacity of the symbols of the Legend.
              *
-             * @param {(datum: any, index: number) => number} opacityFunction
+             * @param {number | ((datum: any, index: number) => number)} symbolOpacity
              * @returns {Legend} The calling Legend
              */
             symbolOpacity(symbolOpacity: number | ((datum: any, index: number) => number)): Legend;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2132,6 +2132,26 @@ declare module Plottable {
              * @returns {Legend} The calling Legend
              */
             symbol(symbol: (datum: any, index: number) => SymbolFactory): Legend;
+            /**
+             * Gets the function determining the opacity of the symbols of the Legend.
+             *
+             * @returns {(datum: any, index: number) => number}
+             */
+            symbolOpacity(): (datum: any, index: number) => number;
+            /**
+             * Sets the function determining the symbols of the Legend.
+             *
+             * @param {(datum: any, index: number) => number} opacityFunction
+             * @returns {Legend} The calling Legend
+             */
+            symbolOpacity(opacityFunction: (datum: any, index: number) => number): Legend;
+            /**
+             * Sets the function determining the symbols of the Legend.
+             *
+             * @param {number} constantOpacity
+             * @returns {Legend} The calling Legend
+             */
+            symbolOpacity(constantOpacity: number): Legend;
             fixedWidth(): boolean;
             fixedHeight(): boolean;
         }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2139,19 +2139,12 @@ declare module Plottable {
              */
             symbolOpacity(): (datum: any, index: number) => number;
             /**
-             * Sets the function determining the symbols of the Legend.
+             * Sets the function determining the opacity of the symbols of the Legend.
              *
              * @param {(datum: any, index: number) => number} opacityFunction
              * @returns {Legend} The calling Legend
              */
-            symbolOpacity(opacityFunction: (datum: any, index: number) => number): Legend;
-            /**
-             * Sets the function determining the symbols of the Legend.
-             *
-             * @param {number} constantOpacity
-             * @returns {Legend} The calling Legend
-             */
-            symbolOpacity(constantOpacity: number): Legend;
+            symbolOpacity(symbolOpacity: number | ((datum: any, index: number) => number)): Legend;
             fixedWidth(): boolean;
             fixedHeight(): boolean;
         }

--- a/plottable.js
+++ b/plottable.js
@@ -5310,15 +5310,18 @@ var Plottable;
                     return this;
                 }
             };
-            Legend.prototype.symbolOpacity = function (opacity) {
-                if (opacity == null) {
+            Legend.prototype.symbolOpacity = function (symbolOpacity) {
+                if (symbolOpacity == null) {
                     return this._symbolOpacityAccessor;
                 }
-                else {
-                    this._symbolOpacityAccessor = d3.functor(opacity);
-                    this.render();
-                    return this;
+                else if (typeof symbolOpacity === "number") {
+                    this._symbolOpacityAccessor = function () { return symbolOpacity; };
                 }
+                else {
+                    this._symbolOpacityAccessor = symbolOpacity;
+                }
+                this.render();
+                return this;
             };
             Legend.prototype.fixedWidth = function () {
                 return true;

--- a/plottable.js
+++ b/plottable.js
@@ -5279,7 +5279,7 @@ var Plottable;
                 entries.select("path").attr("d", function (d, i, j) { return _this.symbol()(d, j)(layout.textHeight * 0.6); })
                     .attr("transform", "translate(" + (layout.textHeight / 2) + "," + layout.textHeight / 2 + ")")
                     .attr("fill", function (value) { return _this._colorScale.scale(value); })
-                    .attr("opacity", function (d, i) { return _this.symbolOpacity()(d, i); })
+                    .attr("opacity", function (d, i, j) { return _this.symbolOpacity()(d, j); })
                     .classed(Legend.LEGEND_SYMBOL_CLASS, true);
                 var padding = this._padding;
                 var textContainers = entries.select("g.text-container");
@@ -5314,14 +5314,11 @@ var Plottable;
                 if (opacity == null) {
                     return this._symbolOpacityAccessor;
                 }
-                else if (typeof opacity === "number") {
-                    this._symbolOpacityAccessor = function () { return opacity; };
-                }
                 else {
-                    this._symbolOpacityAccessor = opacity;
+                    this._symbolOpacityAccessor = d3.functor(opacity);
+                    this.render();
+                    return this;
                 }
-                this.render();
-                return this;
             };
             Legend.prototype.fixedWidth = function () {
                 return true;

--- a/plottable.js
+++ b/plottable.js
@@ -5107,6 +5107,7 @@ var Plottable;
                 this.xAlignment("right").yAlignment("top");
                 this.comparator(function (a, b) { return _this._colorScale.domain().indexOf(a) - _this._colorScale.domain().indexOf(b); });
                 this._symbolFactoryAccessor = function () { return Plottable.SymbolFactories.circle(); };
+                this._symbolOpacityAccessor = function () { return 1; };
             }
             Legend.prototype._setup = function () {
                 _super.prototype._setup.call(this);
@@ -5278,6 +5279,7 @@ var Plottable;
                 entries.select("path").attr("d", function (d, i, j) { return _this.symbol()(d, j)(layout.textHeight * 0.6); })
                     .attr("transform", "translate(" + (layout.textHeight / 2) + "," + layout.textHeight / 2 + ")")
                     .attr("fill", function (value) { return _this._colorScale.scale(value); })
+                    .attr("opacity", function (d, i) { return _this.symbolOpacity()(d, i); })
                     .classed(Legend.LEGEND_SYMBOL_CLASS, true);
                 var padding = this._padding;
                 var textContainers = entries.select("g.text-container");
@@ -5307,6 +5309,19 @@ var Plottable;
                     this.render();
                     return this;
                 }
+            };
+            Legend.prototype.symbolOpacity = function (opacity) {
+                if (opacity == null) {
+                    return this._symbolOpacityAccessor;
+                }
+                else if (typeof opacity === "number") {
+                    this._symbolOpacityAccessor = function () { return opacity; };
+                }
+                else {
+                    this._symbolOpacityAccessor = opacity;
+                }
+                this.render();
+                return this;
             };
             Legend.prototype.fixedWidth = function () {
                 return true;

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -24,6 +24,7 @@ export module Components {
     private _wrapper: SVGTypewriter.Wrappers.Wrapper;
     private _writer: SVGTypewriter.Writers.Writer;
     private _symbolFactoryAccessor: (datum: any, index: number) => SymbolFactory;
+    private _symbolOpacityAccessor: (datum: any, index: number) => number;
     private _redrawCallback: ScaleCallback<Scales.Color>;
 
     /**
@@ -48,6 +49,7 @@ export module Components {
       this.xAlignment("right").yAlignment("top");
       this.comparator((a: string, b: string) => this._colorScale.domain().indexOf(a) - this._colorScale.domain().indexOf(b));
       this._symbolFactoryAccessor = () => SymbolFactories.circle();
+      this._symbolOpacityAccessor = () => 1;
     }
 
     protected _setup() {
@@ -280,6 +282,7 @@ export module Components {
       entries.select("path").attr("d", (d: any, i: number, j: number) => this.symbol()(d, j)(layout.textHeight * 0.6))
                             .attr("transform", "translate(" + (layout.textHeight / 2) + "," + layout.textHeight / 2 + ")")
                             .attr("fill", (value: string) => this._colorScale.scale(value))
+                            .attr("opacity", (d: any, i: number) => this.symbolOpacity()(d, i))
                             .classed(Legend.LEGEND_SYMBOL_CLASS, true);
 
       var padding = this._padding;
@@ -324,6 +327,38 @@ export module Components {
         this.render();
         return this;
       }
+    }
+
+    /**
+     * Gets the function determining the opacity of the symbols of the Legend.
+     *
+     * @returns {(datum: any, index: number) => number}
+     */
+    public symbolOpacity(): (datum: any, index: number) => number;
+    /**
+     * Sets the function determining the symbols of the Legend.
+     *
+     * @param {(datum: any, index: number) => number} opacityFunction
+     * @returns {Legend} The calling Legend
+     */
+    public symbolOpacity(opacityFunction: (datum: any, index: number) => number): Legend;
+    /**
+     * Sets the function determining the symbols of the Legend.
+     *
+     * @param {number} constantOpacity
+     * @returns {Legend} The calling Legend
+     */
+    public symbolOpacity(constantOpacity: number): Legend;
+    public symbolOpacity(opacity?: number|((datum: any, index: number) => number)): any {
+      if (opacity == null) {
+        return this._symbolOpacityAccessor;
+      } else if (typeof opacity === "number") {
+        this._symbolOpacityAccessor = () => opacity;
+      } else {
+        this._symbolOpacityAccessor = opacity;
+      }
+      this.render();
+      return this;
     }
 
     public fixedWidth() {

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -336,26 +336,19 @@ export module Components {
      */
     public symbolOpacity(): (datum: any, index: number) => number;
     /**
-     * Sets the function determining the symbols of the Legend.
+     * Sets the function determining the opacity of the symbols of the Legend.
      *
      * @param {(datum: any, index: number) => number} opacityFunction
      * @returns {Legend} The calling Legend
      */
-    public symbolOpacity(opacityFunction: (datum: any, index: number) => number): Legend;
-    /**
-     * Sets the function determining the symbols of the Legend.
-     *
-     * @param {number} constantOpacity
-     * @returns {Legend} The calling Legend
-     */
-    public symbolOpacity(constantOpacity: number): Legend;
-    public symbolOpacity(opacity?: number | ((datum: any, index: number) => number)): any {
-      if (opacity == null) {
+    public symbolOpacity(symbolOpacity: number | ((datum: any, index: number) => number)): Legend;
+    public symbolOpacity(symbolOpacity?: number | ((datum: any, index: number) => number)): any {
+      if (symbolOpacity == null) {
         return this._symbolOpacityAccessor;
-      } else if (typeof opacity === "number") {
-        this._symbolOpacityAccessor = () => opacity;
+      } else if (typeof symbolOpacity === "number") {
+        this._symbolOpacityAccessor = () => symbolOpacity;
       } else {
-        this._symbolOpacityAccessor = opacity;
+        this._symbolOpacityAccessor = symbolOpacity;
       }
       this.render();
       return this;

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -282,7 +282,7 @@ export module Components {
       entries.select("path").attr("d", (d: any, i: number, j: number) => this.symbol()(d, j)(layout.textHeight * 0.6))
                             .attr("transform", "translate(" + (layout.textHeight / 2) + "," + layout.textHeight / 2 + ")")
                             .attr("fill", (value: string) => this._colorScale.scale(value))
-                            .attr("opacity", (d: any, i: number) => this.symbolOpacity()(d, i))
+                            .attr("opacity", (d: any, i: number, j: number) => this.symbolOpacity()(d, j))
                             .classed(Legend.LEGEND_SYMBOL_CLASS, true);
 
       var padding = this._padding;
@@ -349,7 +349,7 @@ export module Components {
      * @returns {Legend} The calling Legend
      */
     public symbolOpacity(constantOpacity: number): Legend;
-    public symbolOpacity(opacity?: number|((datum: any, index: number) => number)): any {
+    public symbolOpacity(opacity?: number | ((datum: any, index: number) => number)): any {
       if (opacity == null) {
         return this._symbolOpacityAccessor;
       } else if (typeof opacity === "number") {

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -330,15 +330,15 @@ export module Components {
     }
 
     /**
-     * Gets the function determining the opacity of the symbols of the Legend.
+     * Gets the opacity of the symbols of the Legend.
      *
      * @returns {(datum: any, index: number) => number}
      */
     public symbolOpacity(): (datum: any, index: number) => number;
     /**
-     * Sets the function determining the opacity of the symbols of the Legend.
+     * Sets the opacity of the symbols of the Legend.
      *
-     * @param {(datum: any, index: number) => number} opacityFunction
+     * @param {number | ((datum: any, index: number) => number)} symbolOpacity
      * @returns {Legend} The calling Legend
      */
     public symbolOpacity(symbolOpacity: number | ((datum: any, index: number) => number)): Legend;

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -28,6 +28,7 @@ describe("Legend", () => {
       assert.strictEqual(text, d, "the text node has correct text");
       var symbol = d3this.select("." + Plottable.Components.Legend.LEGEND_SYMBOL_CLASS);
       assert.strictEqual(symbol.attr("fill"), color.scale(d), "the symbol's fill is set properly");
+      assert.strictEqual(symbol.attr("opacity"), "1", "the symbol's opacity is set by default to 1");
     });
     svg.remove();
   });
@@ -120,6 +121,33 @@ describe("Legend", () => {
       assert.strictEqual(fill, newColorScale.scale(d), "the fill was set properly");
     });
 
+    svg.remove();
+  });
+
+  it("renders with correct opacity for each symbol when specified", () => {
+    color.domain(["foo", "bar", "baz"]);
+    legend.symbolOpacity(0.5);
+    legend.renderTo(svg);
+
+    var rows = (<any> legend)._content.selectAll(entrySelector);
+
+    rows.each(function(d: any, i: number) {
+      var d3this = d3.select(this);
+      var symbol = d3this.select("." + Plottable.Components.Legend.LEGEND_SYMBOL_CLASS);
+      assert.strictEqual(symbol.attr("opacity"), "0.5", "the symbol's opacity is set to a constant");
+    });
+
+    var opacityFunction = (d: any, i: number) => {
+      return (d === "foo") ? 0.2 : 0.8;
+    };
+    legend.symbolOpacity(opacityFunction).redraw();
+    rows = (<any> legend)._content.selectAll(entrySelector);
+
+    rows.each(function(d: any, i: number) {
+      var d3this = d3.select(this);
+      var symbol = d3this.select("." + Plottable.Components.Legend.LEGEND_SYMBOL_CLASS);
+      assert.strictEqual(symbol.attr("opacity"), String(opacityFunction(d, i)), "the symbol's opacity follows the provided function.");
+    });
     svg.remove();
   });
 

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -397,4 +397,20 @@ describe("Legend", () => {
     legend.renderTo(svg);
     svg.remove();
   });
+
+  it("symbolOpacity() passes index correctly", () => {
+    var domain = ["AA", "BB", "CC"];
+    color.domain(domain);
+
+    var expectedIndex = 0;
+    var symbolOpacityChecker = (d: any, index: number) => {
+      assert.strictEqual(index, expectedIndex, "index passed in is correct");
+      expectedIndex++;
+      return 0.5;
+    };
+    legend.symbolOpacity(symbolOpacityChecker);
+
+    legend.renderTo(svg);
+    svg.remove();
+  });
 });


### PR DESCRIPTION
Follow-up from PR #2461 and addresses issue #2434 

Currently there is no way to update the opacity of symbols in the legend in an API-endorsed way. This is desirable if you, for example, built a scatter plot of various datasets with varying colors and opacities, and would like the opacity in the legend to match.

This PR provides the following API endpoints on `Legend`:
```typescript
/**
 * Gets the opacity of the symbols of the Legend.
 *
 * @returns {(datum: any, index: number) => number}
 */
symbolOpacity(): (datum: any, index: number) => number;

/**
 * Sets the opacity of the symbols of the Legend.
 *
 * @param {number | ((datum: any, index: number) => number)} symbolOpacity
 * @returns {Legend} The calling Legend
 */
symbolOpacity(symbolOpacity: number | ((datum: any, index: number) => number)): Legend;
```

See http://plnkr.co/edit/nyEuE8L7rekfoftjeOSt?p=preview for demo.