### PR TITLE
[TSLint] - enforce no-var-keyword on scaleTests

### DIFF
--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -1,43 +1,42 @@
 ///<reference path="../testReference.ts" />
-/* tslint:disable: no-var-keyword */
 
 describe("Scales", () => {
   describe("Linear Scales", () => {
     it("extentOfValues() filters out invalid numbers", () => {
-      var scale = new Plottable.Scales.Linear();
-      var expectedExtent = [0, 1];
-      var arrayWithBadValues: any[] = [null, NaN, undefined, Infinity, -Infinity, "a string", 0, 1];
-      var extent = scale.extentOfValues(arrayWithBadValues);
+      const scale = new Plottable.Scales.Linear();
+      const expectedExtent = [0, 1];
+      const arrayWithBadValues: any[] = [null, NaN, undefined, Infinity, -Infinity, "a string", 0, 1];
+      const extent = scale.extentOfValues(arrayWithBadValues);
       assert.deepEqual(extent, expectedExtent, "invalid values were filtered out");
     });
 
     it("autoDomain() defaults to [0, 1]", () => {
-      var scale = new Plottable.Scales.Linear();
+      const scale = new Plottable.Scales.Linear();
       scale.autoDomain();
-      var d = scale.domain();
+      const d = scale.domain();
       assert.strictEqual(d[0], 0);
       assert.strictEqual(d[1], 1);
     });
 
     it("autoDomain() expands single value to [value - 1, value + 1]", () => {
-      var scale = new Plottable.Scales.Linear();
-      var singleValue = 15;
+      const scale = new Plottable.Scales.Linear();
+      const singleValue = 15;
       scale.addIncludedValuesProvider((scale: Plottable.Scales.Linear) => [singleValue, singleValue]);
       assert.deepEqual(scale.domain(), [singleValue - 1, singleValue + 1], "single-value extent was expanded");
     });
 
     it("domainMin()", () => {
-      var scale = new Plottable.Scales.Linear();
+      const scale = new Plottable.Scales.Linear();
       scale.padProportion(0);
-      var requestedDomain = [-5, 5];
+      const requestedDomain = [-5, 5];
       scale.addIncludedValuesProvider((scale: Plottable.Scales.Linear) => requestedDomain);
 
-      var minBelowBottom = -10;
+      const minBelowBottom = -10;
       scale.domainMin(minBelowBottom);
       assert.deepEqual(scale.domain(), [minBelowBottom, requestedDomain[1]], "lower end of domain was set by domainMin()");
       assert.strictEqual(scale.domainMin(), minBelowBottom, "returns the set minimum value");
 
-      var minInMiddle = 0;
+      const minInMiddle = 0;
       scale.domainMin(minInMiddle);
       assert.deepEqual(scale.domain(), [minInMiddle, requestedDomain[1]], "lower end was set even if requested value cuts off some data");
 
@@ -45,29 +44,29 @@ describe("Scales", () => {
       assert.deepEqual(scale.domain(), requestedDomain, "calling autoDomain() overrides domainMin()");
       assert.strictEqual(scale.domainMin(), scale.domain()[0], "returns autoDomain()-ed min value after autoDomain()-ing");
 
-      var minEqualTop = scale.domain()[1];
+      const minEqualTop = scale.domain()[1];
       scale.domainMin(minEqualTop);
       assert.deepEqual(scale.domain(), [minEqualTop, minEqualTop + 1],
         "domain is set to [min, min + 1] if the requested value is >= to autoDomain()-ed max value");
 
       scale.domainMin(minInMiddle);
-      var requestedDomain2 = [-10, 10];
+      const requestedDomain2 = [-10, 10];
       scale.addIncludedValuesProvider((scale: Plottable.Scales.Linear) => requestedDomain2);
       assert.deepEqual(scale.domain(), [minInMiddle, requestedDomain2[1]], "adding another ExtentsProvider doesn't change domainMin()");
     });
 
     it("domainMax()", () => {
-      var scale = new Plottable.Scales.Linear();
+      const scale = new Plottable.Scales.Linear();
       scale.padProportion(0);
-      var requestedDomain = [-5, 5];
+      const requestedDomain = [-5, 5];
       scale.addIncludedValuesProvider((scale: Plottable.Scales.Linear) => requestedDomain);
 
-      var maxAboveTop = 10;
+      const maxAboveTop = 10;
       scale.domainMax(maxAboveTop);
       assert.deepEqual(scale.domain(), [requestedDomain[0], maxAboveTop], "upper end of domain was set by domainMax()");
       assert.strictEqual(scale.domainMax(), maxAboveTop, "returns the set maximum value");
 
-      var maxInMiddle = 0;
+      const maxInMiddle = 0;
       scale.domainMax(maxInMiddle);
       assert.deepEqual(scale.domain(), [requestedDomain[0], maxInMiddle], "upper end was set even if requested value cuts off some data");
 
@@ -75,39 +74,39 @@ describe("Scales", () => {
       assert.deepEqual(scale.domain(), requestedDomain, "calling autoDomain() overrides domainMax()");
       assert.strictEqual(scale.domainMax(), scale.domain()[1], "returns autoDomain()-ed max value after autoDomain()-ing");
 
-      var maxEqualBottom = scale.domain()[0];
+      const maxEqualBottom = scale.domain()[0];
       scale.domainMax(maxEqualBottom);
       assert.deepEqual(scale.domain(), [maxEqualBottom - 1, maxEqualBottom],
         "domain is set to [max - 1, max] if the requested value is <= to autoDomain()-ed min value");
 
       scale.domainMax(maxInMiddle);
-      var requestedDomain2 = [-10, 10];
+      const requestedDomain2 = [-10, 10];
       scale.addIncludedValuesProvider((scale: Plottable.Scales.Linear) => requestedDomain2);
       assert.deepEqual(scale.domain(), [requestedDomain2[0], maxInMiddle], "adding another ExtentsProvider doesn't change domainMax()");
     });
 
     it("domainMin() and domainMax() together", () => {
-      var scale = new Plottable.Scales.Linear();
+      const scale = new Plottable.Scales.Linear();
       scale.padProportion(0);
-      var requestedDomain = [-5, 5];
+      const requestedDomain = [-5, 5];
       scale.addIncludedValuesProvider((scale: Plottable.Scales.Linear) => requestedDomain);
 
-      var desiredMin = -10;
-      var desiredMax = 10;
+      const desiredMin = -10;
+      const desiredMax = 10;
       scale.domainMin(desiredMin);
       scale.domainMax(desiredMax);
       assert.deepEqual(scale.domain(), [desiredMin, desiredMax], "setting domainMin() and domainMax() sets the domain");
 
       scale.autoDomain();
-      var bigMin = 10;
-      var smallMax = -10;
+      const bigMin = 10;
+      const smallMax = -10;
       scale.domainMin(bigMin);
       scale.domainMax(smallMax);
       assert.deepEqual(scale.domain(), [bigMin, smallMax], "setting both is allowed even if it reverse the domain");
     });
 
     it("domain can't include NaN or Infinity", () => {
-      var scale = new Plottable.Scales.Linear();
+      const scale = new Plottable.Scales.Linear();
       scale.domain([0, 1]);
       scale.domain([5, Infinity]);
       assert.deepEqual(scale.domain(), [0, 1], "Infinity containing domain was ignored");
@@ -120,18 +119,18 @@ describe("Scales", () => {
     });
 
     it("custom tick generator", () => {
-      var scale = new Plottable.Scales.Linear();
+      const scale = new Plottable.Scales.Linear();
       scale.domain([0, 10]);
-      var ticks = scale.ticks();
-      assert.closeTo(ticks.length, 10, 1, "ticks were generated correctly with default generator");
+      const defaultTicks = scale.ticks();
+      assert.closeTo(defaultTicks.length, 10, 1, "ticks were generated correctly with default generator");
       scale.tickGenerator((scale) => scale.defaultTicks().filter(tick => tick % 3 === 0));
-      ticks = scale.ticks();
-      assert.deepEqual(ticks, [0, 3, 6, 9], "ticks were generated correctly with custom generator");
+      const customTicks = scale.ticks();
+      assert.deepEqual(customTicks, [0, 3, 6, 9], "ticks were generated correctly with custom generator");
     });
 
     describe("Padding exceptions", () => {
       it("addPaddingExceptionsProvider() works as expected on one end", () => {
-        var scale = new Plottable.Scales.Linear();
+        const scale = new Plottable.Scales.Linear();
         scale.addIncludedValuesProvider(() => [10, 13]);
         assert.strictEqual(scale.domain()[0], 9.5, "The left side of the domain is padded");
 
@@ -143,7 +142,7 @@ describe("Scales", () => {
       });
 
       it("addPaddingExceptionsProvider() works as expected on both ends", () => {
-        var scale = new Plottable.Scales.Linear();
+        const scale = new Plottable.Scales.Linear();
         scale.addIncludedValuesProvider(() => [10, 13]);
         assert.deepEqual(scale.domain(), [9.5, 13.5], "The domain is padded");
 
@@ -158,11 +157,11 @@ describe("Scales", () => {
       });
 
       it("removePaddingExceptionsProvider() works as expected", () => {
-        var scale = new Plottable.Scales.Linear();
+        const scale = new Plottable.Scales.Linear();
         scale.addIncludedValuesProvider(() => [10, 13]);
 
-        var paddingExceptionProviderLeft = () => [10];
-        var paddingExceptionProviderBoth = () => [10, 13];
+        const paddingExceptionProviderLeft = () => [10];
+        const paddingExceptionProviderBoth = () => [10, 13];
 
         assert.deepEqual(scale.domain(), [9.5, 13.5], "The domain is padded");
 
@@ -188,9 +187,9 @@ describe("Scales", () => {
     });
 
     describe("autoranging behavior", () => {
-      var data: any[];
-      var dataset: Plottable.Dataset;
-      var scale: Plottable.Scales.Linear;
+      let data: any[];
+      let dataset: Plottable.Dataset;
+      let scale: Plottable.Scales.Linear;
       beforeEach(() => {
         data = [{foo: 2, bar: 1}, {foo: 5, bar: -20}, {foo: 0, bar: 0}];
         dataset = new Plottable.Dataset(data);
@@ -207,8 +206,8 @@ describe("Scales", () => {
       });
 
       it("scale autorange works as expected with single dataset", () => {
-        var svg = TestMethods.generateSVG(100, 100);
-        var plot = new Plottable.Plot();
+        const svg = TestMethods.generateSVG(100, 100);
+        const plot = new Plottable.Plot();
         (<any> plot)._createDrawer = (dataset: Plottable.Dataset) => createMockDrawer(dataset);
         plot.addDataset(dataset)
             .attr("x", (d) => d.foo, scale)
@@ -221,17 +220,17 @@ describe("Scales", () => {
       });
 
       it("scale reference counting works as expected", () => {
-        var svg1 = TestMethods.generateSVG(100, 100);
-        var svg2 = TestMethods.generateSVG(100, 100);
-        var renderer1 = new Plottable.Plot();
+        const svg1 = TestMethods.generateSVG(100, 100);
+        const svg2 = TestMethods.generateSVG(100, 100);
+        const renderer1 = new Plottable.Plot();
         (<any> renderer1)._createDrawer = (dataset: Plottable.Dataset) => createMockDrawer(dataset);
         renderer1.addDataset(dataset).attr("x", (d) => d.foo, scale);
         renderer1.renderTo(svg1);
-        var renderer2 = new Plottable.Plot();
+        const renderer2 = new Plottable.Plot();
         (<any> renderer2)._createDrawer = (dataset: Plottable.Dataset) => createMockDrawer(dataset);
         renderer2.addDataset(dataset).attr("x", (d) => d.foo, scale);
         renderer2.renderTo(svg2);
-        var otherScale = new Plottable.Scales.Linear();
+        const otherScale = new Plottable.Scales.Linear();
         renderer1.attr("x", (d) => d.foo, otherScale);
         dataset.data([{foo: 10}, {foo: 11}]);
         assert.deepEqual(scale.domain(), [10, 11], "scale was still listening to dataset after one perspective deregistered");
@@ -252,9 +251,9 @@ describe("Scales", () => {
       });
 
       it("removeIncludedValuesProvider()", () => {
-        var posProvider = (scale: Plottable.Scale<number, number>) => [0, 10];
+        const posProvider = (scale: Plottable.Scale<number, number>) => [0, 10];
         scale.addIncludedValuesProvider(posProvider);
-        var negProvider = (scale: Plottable.Scale<number, number>) => [-10, 0];
+        const negProvider = (scale: Plottable.Scale<number, number>) => [-10, 0];
         scale.addIncludedValuesProvider(negProvider);
         assert.deepEqual(scale.domain(), [-10, 10], "scale domain accounts for both providers");
 
@@ -263,22 +262,22 @@ describe("Scales", () => {
       });
 
       it("should resize when a plot is removed", () => {
-        var svg = TestMethods.generateSVG(400, 400);
-        var ds1 = new Plottable.Dataset([{x: 0, y: 0}, {x: 1, y: 1}]);
-        var ds2 = new Plottable.Dataset([{x: 1, y: 1}, {x: 2, y: 2}]);
-        var xScale = new Plottable.Scales.Linear();
+        const svg = TestMethods.generateSVG(400, 400);
+        const ds1 = new Plottable.Dataset([{x: 0, y: 0}, {x: 1, y: 1}]);
+        const ds2 = new Plottable.Dataset([{x: 1, y: 1}, {x: 2, y: 2}]);
+        const xScale = new Plottable.Scales.Linear();
         xScale.padProportion(0);
-        var yScale = new Plottable.Scales.Linear();
+        const yScale = new Plottable.Scales.Linear();
         yScale.padProportion(0);
-        var renderAreaD1 = new Plottable.Plots.Line();
+        const renderAreaD1 = new Plottable.Plots.Line();
         renderAreaD1.addDataset(ds1);
         renderAreaD1.x((d) => d.x, xScale);
         renderAreaD1.y((d) => d.y, yScale);
-        var renderAreaD2 = new Plottable.Plots.Line();
+        const renderAreaD2 = new Plottable.Plots.Line();
         renderAreaD2.addDataset(ds2);
         renderAreaD2.x((d) => d.x, xScale);
         renderAreaD2.y((d) => d.y, yScale);
-        var renderAreas = new Plottable.Components.Group([renderAreaD1, renderAreaD2]);
+        const renderAreas = new Plottable.Components.Group([renderAreaD1, renderAreaD2]);
         renderAreas.renderTo(svg);
         assert.deepEqual(xScale.domain(), [0, 2]);
         renderAreaD1.detach();

--- a/test/scales/modifiedLogScaleTests.ts
+++ b/test/scales/modifiedLogScaleTests.ts
@@ -1,11 +1,10 @@
 ///<reference path="../testReference.ts" />
-/* tslint:disable: no-var-keyword */
 
 describe("Scales", () => {
   describe("Modified Log Scale", () => {
-    var scale: Plottable.Scales.ModifiedLog;
-    var base = 10;
-    var epsilon = 0.00001;
+    let scale: Plottable.Scales.ModifiedLog;
+    const base = 10;
+    const epsilon = 0.00001;
     beforeEach(() => {
       scale = new Plottable.Scales.ModifiedLog(base);
     });
@@ -43,7 +42,7 @@ describe("Scales", () => {
     it("can be padded", () => {
       scale.addIncludedValuesProvider((scale: Plottable.Scales.ModifiedLog) => [0, base]);
       scale.padProportion(0);
-      var unpaddedDomain = scale.domain();
+      const unpaddedDomain = scale.domain();
       scale.padProportion(0.1);
       assert.operator(scale.domain()[0], "<", unpaddedDomain[0], "left side of domain has been padded");
       assert.operator(unpaddedDomain[1], "<", scale.domain()[1], "right side of domain has been padded");
@@ -51,7 +50,7 @@ describe("Scales", () => {
 
     it("autoDomain() expands single value correctly", () => {
       scale.padProportion(0);
-      var singleValue = 15;
+      let singleValue = 15;
       scale.addIncludedValuesProvider((scale: Plottable.Scales.ModifiedLog) => [singleValue, singleValue]);
       assert.deepEqual(scale.domain(), [singleValue / base, singleValue * base],
         "positive single-value extent was expanded to [value / base, value * base]");
@@ -66,93 +65,93 @@ describe("Scales", () => {
     });
 
     it("domainMin()", () => {
-      var scale = new Plottable.Scales.ModifiedLog(base);
+      const scale = new Plottable.Scales.ModifiedLog(base);
       scale.padProportion(0);
-      var requestedDomain = [-5, 5];
+      const requestedDomain = [-5, 5];
       scale.addIncludedValuesProvider((scale: Plottable.Scales.ModifiedLog) => requestedDomain);
 
-      var minBelowBottom = -10;
+      const minBelowBottom = -10;
       scale.domainMin(minBelowBottom);
       assert.deepEqual(scale.domain(), [minBelowBottom, requestedDomain[1]], "lower end of domain was set by domainMin()");
 
-      var minInMiddle = 0;
+      const minInMiddle = 0;
       scale.domainMin(minInMiddle);
       assert.deepEqual(scale.domain(), [minInMiddle, requestedDomain[1]], "lower end was set even if requested value cuts off some data");
 
       scale.autoDomain();
       assert.deepEqual(scale.domain(), requestedDomain, "calling autoDomain() overrides domainMin()");
 
-      var minEqualTop = scale.domain()[1];
+      const minEqualTop = scale.domain()[1];
       scale.domainMin(minEqualTop);
       assert.deepEqual(scale.domain(), [minEqualTop, minEqualTop * base],
         "domain is set to [min, min * base] if the requested value is >= autoDomain()-ed max value");
 
       scale.domainMin(minInMiddle);
-      var requestedDomain2 = [-10, 10];
+      const requestedDomain2 = [-10, 10];
       scale.addIncludedValuesProvider((scale: Plottable.Scales.ModifiedLog) => requestedDomain2);
       assert.deepEqual(scale.domain(), [minInMiddle, requestedDomain2[1]], "adding another ExtentsProvider doesn't change domainMin()");
     });
 
     it("domainMax()", () => {
-      var scale = new Plottable.Scales.ModifiedLog(base);
+      const scale = new Plottable.Scales.ModifiedLog(base);
       scale.padProportion(0);
-      var requestedDomain = [-5, 5];
+      const requestedDomain = [-5, 5];
       scale.addIncludedValuesProvider((scale: Plottable.Scales.ModifiedLog) => requestedDomain);
 
-      var maxAboveTop = 10;
+      const maxAboveTop = 10;
       scale.domainMax(maxAboveTop);
       assert.deepEqual(scale.domain(), [requestedDomain[0], maxAboveTop], "upper end of domain was set by domainMax()");
 
-      var maxInMiddle = 0;
+      const maxInMiddle = 0;
       scale.domainMax(maxInMiddle);
       assert.deepEqual(scale.domain(), [requestedDomain[0], maxInMiddle], "upper end was set even if requested value cuts off some data");
 
       scale.autoDomain();
       assert.deepEqual(scale.domain(), requestedDomain, "calling autoDomain() overrides domainMax()");
 
-      var maxEqualBottom = scale.domain()[0];
+      const maxEqualBottom = scale.domain()[0];
       scale.domainMax(maxEqualBottom);
       assert.deepEqual(scale.domain(), [maxEqualBottom * base, maxEqualBottom],
         "domain is set to [max * base, max] if the requested value is <= autoDomain()-ed min value and negative");
 
       scale.domainMax(maxInMiddle);
-      var requestedDomain2 = [-10, 10];
+      const requestedDomain2 = [-10, 10];
       scale.addIncludedValuesProvider((scale: Plottable.Scales.ModifiedLog) => requestedDomain2);
       assert.deepEqual(scale.domain(), [requestedDomain2[0], maxInMiddle], "adding another ExtentsProvider doesn't change domainMax()");
     });
 
     it("domainMin() and domainMax() together", () => {
-      var scale = new Plottable.Scales.ModifiedLog(base);
+      const scale = new Plottable.Scales.ModifiedLog(base);
       scale.padProportion(0);
-      var requestedDomain = [-5, 5];
+      const requestedDomain = [-5, 5];
       scale.addIncludedValuesProvider((scale: Plottable.Scales.ModifiedLog) => requestedDomain);
 
-      var desiredMin = -10;
-      var desiredMax = 10;
+      const desiredMin = -10;
+      const desiredMax = 10;
       scale.domainMin(desiredMin);
       scale.domainMax(desiredMax);
       assert.deepEqual(scale.domain(), [desiredMin, desiredMax], "setting domainMin() and domainMax() sets the domain");
 
       scale.autoDomain();
-      var bigMin = 10;
-      var smallMax = -10;
+      const bigMin = 10;
+      const smallMax = -10;
       scale.domainMin(bigMin);
       scale.domainMax(smallMax);
       assert.deepEqual(scale.domain(), [bigMin, smallMax], "setting both is allowed even if it reverse the domain");
     });
 
     it("gives reasonable values for ticks()", () => {
-      var providedExtents = [0, base / 2];
+      let providedExtents = [0, base / 2];
       scale.addIncludedValuesProvider((scale: Plottable.Scale<number, number>) => providedExtents);
-      var ticks = scale.ticks();
+      let ticks = scale.ticks();
       assert.operator(ticks.length, ">", 0);
 
       providedExtents = [-base * 2, base * 2];
       scale.autoDomain();
       ticks = scale.ticks();
-      var beforePivot = ticks.filter((x) => x <= -base);
-      var afterPivot = ticks.filter((x) => base <= x);
-      var betweenPivots = ticks.filter((x) => -base < x && x < base);
+      const beforePivot = ticks.filter((x) => x <= -base);
+      const afterPivot = ticks.filter((x) => base <= x);
+      const betweenPivots = ticks.filter((x) => -base < x && x < base);
       assert.operator(beforePivot.length, ">", 0, "should be ticks before -base");
       assert.operator(afterPivot.length, ">", 0, "should be ticks after base");
       assert.operator(betweenPivots.length, ">", 0, "should be ticks between -base and base");
@@ -160,20 +159,20 @@ describe("Scales", () => {
 
     it("works on inverted domain", () => {
       scale.domain([200, -100]);
-      var range = scale.range();
+      const range = scale.range();
       assert.closeTo(scale.scale(-100), range[1], epsilon);
       assert.closeTo(scale.scale(200), range[0], epsilon);
-      var a = [-100, -10, -3, 0, 1, 3.64, 50, 60, 200];
-      var b = a.map((x) => scale.scale(x));
+      const a = [-100, -10, -3, 0, 1, 3.64, 50, 60, 200];
+      const b = a.map((x) => scale.scale(x));
       // should be decreasing function; reverse is sorted
       assert.deepEqual(b.slice().reverse(), b.slice().sort((x, y) => x - y));
 
-      var ticks = scale.ticks();
+      const ticks = scale.ticks();
       assert.deepEqual(ticks, ticks.slice().sort((x, y) => x - y), "ticks should be sorted");
       assert.deepEqual(ticks, Plottable.Utils.Array.uniq(ticks), "ticks should not be repeated");
-      var beforePivot = ticks.filter((x) => x <= -base);
-      var afterPivot = ticks.filter((x) => base <= x);
-      var betweenPivots = ticks.filter((x) => -base < x && x < base);
+      const beforePivot = ticks.filter((x) => x <= -base);
+      const afterPivot = ticks.filter((x) => base <= x);
+      const betweenPivots = ticks.filter((x) => -base < x && x < base);
       assert.operator(beforePivot.length, ">", 0, "should be ticks before -base");
       assert.operator(afterPivot.length, ">", 0, "should be ticks after base");
       assert.operator(betweenPivots.length, ">", 0, "should be ticks between -base and base");
@@ -182,7 +181,7 @@ describe("Scales", () => {
     it("ticks() always has more than 2 ticks", () => {
       [null, [2, 9], [0, 1], [1, 2], [0.001, 0.01], [-0.1, 0.1], [-3, -2]].forEach((domain) => {
         scale.domain(domain);
-        var ticks = scale.ticks();
+        const ticks = scale.ticks();
         assert.operator(ticks.length, ">", 2);
       });
     });

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -1,13 +1,12 @@
 ///<reference path="../testReference.ts" />
-/* tslint:disable: no-var-keyword */
 
 describe("Scales", () => {
   it("Scale alerts listeners when its domain is updated", () => {
-    var scale = new Plottable.Scale();
+    const scale = new Plottable.Scale();
     (<any> scale)._d3Scale = d3.scale.identity();
 
-    var callbackWasCalled = false;
-    var testCallback = (listenable: Plottable.Scale<any, any>) => {
+    let callbackWasCalled = false;
+    const testCallback = (listenable: Plottable.Scale<any, any>) => {
       assert.strictEqual(listenable, scale, "Callback received the calling scale as the first argument");
       callbackWasCalled = true;
     };
@@ -18,12 +17,12 @@ describe("Scales", () => {
   });
 
   it("Scale update listeners can be turned off", () => {
-    var scale = new Plottable.Scale();
+    const scale = new Plottable.Scale();
     (<any> scale)._d3Scale = d3.scale.identity();
     (<any> scale)._setBackingScaleDomain = () => { return; };
 
-    var callbackWasCalled = false;
-    var testCallback = (listenable: Plottable.Scale<any, any>) => {
+    let callbackWasCalled = false;
+    const testCallback = (listenable: Plottable.Scale<any, any>) => {
       assert.strictEqual(listenable, scale, "Callback received the calling scale as the first argument");
       callbackWasCalled = true;
     };
@@ -39,7 +38,7 @@ describe("Scales", () => {
 
   describe("Category Scales", () => {
     it("rangeBand is updated when domain changes", () => {
-      var scale = new Plottable.Scales.Category();
+      const scale = new Plottable.Scales.Category();
       scale.range([0, 2679]);
 
       scale.domain(["1", "2", "3", "4"]);
@@ -50,28 +49,28 @@ describe("Scales", () => {
     });
 
     it("stepWidth operates normally", () => {
-      var scale = new Plottable.Scales.Category();
+      const scale = new Plottable.Scales.Category();
       scale.range([0, 3000]);
 
       scale.domain(["1", "2", "3", "4"]);
-      var widthSum = scale.rangeBand() * (1 + scale.innerPadding());
+      const widthSum = scale.rangeBand() * (1 + scale.innerPadding());
       assert.strictEqual(scale.stepWidth(), widthSum, "step width is the sum of innerPadding width and band width");
     });
   });
 
   it("CategoryScale + BarPlot combo works as expected when the data is swapped", () => {
     // This unit test taken from SLATE, see SLATE-163 a fix for SLATE-102
-    var xScale = new Plottable.Scales.Category();
-    var yScale = new Plottable.Scales.Linear();
-    var dA = {x: "A", y: 2};
-    var dB = {x: "B", y: 2};
-    var dC = {x: "C", y: 2};
-    var dataset = new Plottable.Dataset([dA, dB]);
-    var barPlot = new Plottable.Plots.Bar();
+    const xScale = new Plottable.Scales.Category();
+    const yScale = new Plottable.Scales.Linear();
+    const dA = {x: "A", y: 2};
+    const dB = {x: "B", y: 2};
+    const dC = {x: "C", y: 2};
+    const dataset = new Plottable.Dataset([dA, dB]);
+    const barPlot = new Plottable.Plots.Bar();
     barPlot.addDataset(dataset);
     barPlot.x((d: any) => d.x, xScale);
     barPlot.y((d: any) => d.y, yScale);
-    var svg = TestMethods.generateSVG();
+    const svg = TestMethods.generateSVG();
     assert.deepEqual(xScale.domain(), [], "before anchoring, the bar plot doesn't proxy data to the scale");
     barPlot.renderTo(svg);
     assert.deepEqual(xScale.domain(), ["A", "B"], "after anchoring, the bar plot's data is on the scale");
@@ -94,7 +93,7 @@ describe("Scales", () => {
 
   describe("Color Scales", () => {
     it("accepts categorical string types and Category domain", () => {
-      var scale = new Plottable.Scales.Color("10");
+      const scale = new Plottable.Scales.Color("10");
       scale.domain(["yes", "no", "maybe"]);
       assert.strictEqual("#1f77b4", scale.scale("yes"));
       assert.strictEqual("#ff7f0e", scale.scale("no"));
@@ -102,22 +101,22 @@ describe("Scales", () => {
     });
 
     it("default colors are generated", () => {
-      var scale = new Plottable.Scales.Color();
-      var colorArray = ["#5279c7", "#fd373e", "#63c261",
+      const scale = new Plottable.Scales.Color();
+      const colorArray = ["#5279c7", "#fd373e", "#63c261",
                         "#fad419", "#2c2b6f", "#ff7939",
                         "#db2e65", "#99ce50", "#962565", "#06cccc"];
       assert.deepEqual(scale.range(), colorArray);
     });
 
     it("uses altered colors if size of domain exceeds size of range", () => {
-      var scale = new Plottable.Scales.Color();
+      const scale = new Plottable.Scales.Color();
       scale.range(["#5279c7", "#fd373e"]);
       scale.domain(["a", "b", "c"]);
       assert.notEqual(scale.scale("c"), "#5279c7");
     });
 
     it("interprets named color values correctly", () => {
-      var scale = new Plottable.Scales.Color();
+      const scale = new Plottable.Scales.Color();
       scale.range(["red", "blue"]);
       scale.domain(["a", "b"]);
       assert.strictEqual(scale.scale("a"), "#ff0000");
@@ -125,16 +124,16 @@ describe("Scales", () => {
     });
 
     it("accepts CSS specified colors", () => {
-      var style = d3.select("body").append("style");
+      const style = d3.select("body").append("style");
       style.html(".plottable-colors-0 {background-color: #ff0000 !important; }");
       Plottable.Scales.Color.invalidateColorCache();
-      var scale = new Plottable.Scales.Color();
+      const scale = new Plottable.Scales.Color();
       style.remove();
       Plottable.Scales.Color.invalidateColorCache();
       assert.strictEqual(scale.range()[0], "#ff0000", "User has specified red color for first color scale color");
       assert.strictEqual(scale.range()[1], "#fd373e", "The second color of the color scale should be the same");
 
-      var defaultScale = new Plottable.Scales.Color();
+      const defaultScale = new Plottable.Scales.Color();
       assert.strictEqual(scale.range()[0], "#ff0000",
         "Unloading the CSS should not modify the first scale color (this will not be the case if we support dynamic CSS");
       assert.strictEqual(defaultScale.range()[0], "#5279c7",
@@ -142,36 +141,36 @@ describe("Scales", () => {
     });
 
      it("caches CSS specified colors unless the cache is invalidated", () => {
-      var style = d3.select("body").append("style");
+      const style = d3.select("body").append("style");
       style.html(".plottable-colors-0 {background-color: #ff0000 !important; }");
       Plottable.Scales.Color.invalidateColorCache();
-      var scale = new Plottable.Scales.Color();
+      const scale = new Plottable.Scales.Color();
       style.remove();
 
       assert.strictEqual(scale.range()[0], "#ff0000", "User has specified red color for first color scale color");
 
-      var scaleCached = new Plottable.Scales.Color();
+      const scaleCached = new Plottable.Scales.Color();
       assert.strictEqual(scaleCached.range()[0], "#ff0000", "The red color should still be cached");
 
       Plottable.Scales.Color.invalidateColorCache();
-      var scaleFresh = new Plottable.Scales.Color();
+      const scaleFresh = new Plottable.Scales.Color();
       assert.strictEqual(scaleFresh.range()[0], "#5279c7", "Invalidating the cache should reset the red color to the default");
     });
 
     it("should try to recover from malicious CSS styleseets", () => {
-      var defaultNumberOfColors = 10;
+      const defaultNumberOfColors = 10;
 
-      var initialScale = new Plottable.Scales.Color();
+      const initialScale = new Plottable.Scales.Color();
       assert.strictEqual(initialScale.range().length, defaultNumberOfColors,
         "there should initially be " + defaultNumberOfColors + " default colors");
 
-      var maliciousStyle = d3.select("body").append("style");
+      const maliciousStyle = d3.select("body").append("style");
       maliciousStyle.html("* {background-color: #fff000;}");
       Plottable.Scales.Color.invalidateColorCache();
-      var affectedScale = new Plottable.Scales.Color();
+      const affectedScale = new Plottable.Scales.Color();
       maliciousStyle.remove();
       Plottable.Scales.Color.invalidateColorCache();
-      var colorRange = affectedScale.range();
+      const colorRange = affectedScale.range();
       assert.strictEqual(colorRange.length, defaultNumberOfColors + 1,
         "it should detect the end of the given colors and the fallback to the * selector, " +
         "but should still include the last occurance of the * selector color");
@@ -184,16 +183,16 @@ describe("Scales", () => {
     });
 
     it("does not crash by malicious CSS stylesheets", () => {
-      var initialScale = new Plottable.Scales.Color();
+      const initialScale = new Plottable.Scales.Color();
       assert.strictEqual(initialScale.range().length, 10, "there should initially be 10 default colors");
 
-      var maliciousStyle = d3.select("body").append("style");
+      const maliciousStyle = d3.select("body").append("style");
       maliciousStyle.html("[class^='plottable-'] {background-color: pink;}");
       Plottable.Scales.Color.invalidateColorCache();
-      var affectedScale = new Plottable.Scales.Color();
+      const affectedScale = new Plottable.Scales.Color();
       maliciousStyle.remove();
       Plottable.Scales.Color.invalidateColorCache();
-      var maximumColorsFromCss = (<any> Plottable.Scales.Color)._MAXIMUM_COLORS_FROM_CSS;
+      const maximumColorsFromCss = (<any> Plottable.Scales.Color)._MAXIMUM_COLORS_FROM_CSS;
       assert.strictEqual(affectedScale.range().length, maximumColorsFromCss,
         "current malicious CSS countermeasure is to cap maximum number of colors to 256");
     });
@@ -202,7 +201,7 @@ describe("Scales", () => {
 
   describe("Interpolated Color Scales", () => {
     it("default scale uses reds and a linear scale type", () => {
-      var scale = new Plottable.Scales.InterpolatedColor();
+      const scale = new Plottable.Scales.InterpolatedColor();
       scale.domain([0, 16]);
       assert.strictEqual("#ffffff", scale.scale(0));
       assert.strictEqual("#feb24c", scale.scale(8));
@@ -210,14 +209,14 @@ describe("Scales", () => {
     });
 
     it("linearly interpolates colors in L*a*b color space", () => {
-      var scale = new Plottable.Scales.InterpolatedColor();
+      const scale = new Plottable.Scales.InterpolatedColor();
       scale.domain([0, 1]);
       assert.strictEqual("#b10026", scale.scale(1));
       assert.strictEqual("#d9151f", scale.scale(0.9));
     });
 
     it("accepts array types with color hex values", () => {
-      var scale = new Plottable.Scales.InterpolatedColor();
+      const scale = new Plottable.Scales.InterpolatedColor();
       scale.range(["#000", "#FFF"]);
       scale.domain([0, 16]);
       assert.strictEqual("#000000", scale.scale(0));
@@ -226,7 +225,7 @@ describe("Scales", () => {
     });
 
     it("accepts array types with color names", () => {
-      var scale = new Plottable.Scales.InterpolatedColor();
+      const scale = new Plottable.Scales.InterpolatedColor();
       scale.range(["black", "white"]);
       scale.domain([0, 16]);
       assert.strictEqual("#000000", scale.scale(0));
@@ -235,7 +234,7 @@ describe("Scales", () => {
     });
 
     it("overflow scale values clamp to range", () => {
-      var scale = new Plottable.Scales.InterpolatedColor();
+      const scale = new Plottable.Scales.InterpolatedColor();
       scale.range(["black", "white"]);
       scale.domain([0, 16]);
       assert.strictEqual("#000000", scale.scale(0));
@@ -245,7 +244,7 @@ describe("Scales", () => {
     });
 
     it("can be converted to a different range", () => {
-      var scale = new Plottable.Scales.InterpolatedColor();
+      const scale = new Plottable.Scales.InterpolatedColor();
       scale.range(["black", "white"]);
       scale.domain([0, 16]);
       assert.strictEqual("#000000", scale.scale(0));
@@ -257,46 +256,46 @@ describe("Scales", () => {
 
   describe("extent calculation", () => {
     it("categoryScale gives the unique values when domain is stringy", () => {
-      var values = ["1", "3", "2", "1"];
-      var scale = new Plottable.Scales.Category();
-      var computedExtent = scale.extentOfValues(values);
+      const values = ["1", "3", "2", "1"];
+      const scale = new Plottable.Scales.Category();
+      const computedExtent = scale.extentOfValues(values);
 
       assert.deepEqual(computedExtent, ["1", "3", "2"], "the extent is made of all the unique values in the domain");
     });
 
     it("categoryScale gives the unique values when domain is numeric", () => {
-      var values = [1, 3, 2, 1];
-      var scale = new Plottable.Scales.Category();
-      var computedExtent = scale.extentOfValues(<any>values);
+      const values = [1, 3, 2, 1];
+      const scale = new Plottable.Scales.Category();
+      const computedExtent = scale.extentOfValues(<any>values);
 
       assert.deepEqual(computedExtent, [1, 3, 2], "the extent is made of all the unique values in the domain");
     });
 
     it("quantitaveScale gives the minimum and maxiumum when the domain is stringy", () => {
-      var values = ["1", "3", "2", "1"];
-      var scale = new Plottable.QuantitativeScale();
-      var computedExtent = scale.extentOfValues(values);
+      const values = ["1", "3", "2", "1"];
+      const scale = new Plottable.QuantitativeScale();
+      const computedExtent = scale.extentOfValues(values);
 
       assert.deepEqual(computedExtent, ["1", "3"], "the extent is the miminum and the maximum value in the domain");
     });
 
     it("quantitaveScale gives the minimum and maxiumum when the domain is numeric", () => {
-      var values = [1, 3, 2, 1];
-      var scale = new Plottable.QuantitativeScale();
-      var computedExtent = scale.extentOfValues(values);
+      const values = [1, 3, 2, 1];
+      const scale = new Plottable.QuantitativeScale();
+      const computedExtent = scale.extentOfValues(values);
 
       assert.deepEqual(computedExtent, [1, 3], "the extent is the miminum and the maximum value in the domain");
     });
 
     it("timeScale extent calculation works as expected", () => {
-      var date1 = new Date(2015, 2, 25, 19, 0, 0);
-      var date2 = new Date(2015, 2, 24, 19, 0, 0);
-      var date3 = new Date(2015, 2, 25, 19, 0, 0);
-      var date4 = new Date(2015, 2, 26, 19, 0, 0);
-      var values = [date1, date2, date3, date4];
+      const date1 = new Date(2015, 2, 25, 19, 0, 0);
+      const date2 = new Date(2015, 2, 24, 19, 0, 0);
+      const date3 = new Date(2015, 2, 25, 19, 0, 0);
+      const date4 = new Date(2015, 2, 26, 19, 0, 0);
+      const values = [date1, date2, date3, date4];
 
-      var scale = new Plottable.Scales.Time();
-      var computedExtent = scale.extentOfValues(values);
+      const scale = new Plottable.Scales.Time();
+      const computedExtent = scale.extentOfValues(values);
 
       assert.deepEqual(computedExtent, [date2, date4], "The extent is the miminum and the maximum value in the domain");
     });

--- a/test/scales/tickGeneratorsTests.ts
+++ b/test/scales/tickGeneratorsTests.ts
@@ -4,34 +4,34 @@
 describe("Tick generators", () => {
   describe("interval", () => {
     it("generate ticks within domain", () => {
-      var start = 0.5, end = 4.01, interval = 1;
-      var scale = new Plottable.Scales.Linear();
+      const start = 0.5, end = 4.01, interval = 1;
+      const scale = new Plottable.Scales.Linear();
       scale.domain([start, end]);
-      var ticks = Plottable.Scales.TickGenerators.intervalTickGenerator(interval)(scale);
+      const ticks = Plottable.Scales.TickGenerators.intervalTickGenerator(interval)(scale);
       assert.deepEqual(ticks, [0.5, 1, 2, 3, 4, 4.01], "generated ticks contains all possible ticks within range");
     });
 
     it("domain crossing 0", () => {
-      var start = -1.5, end = 1, interval = 0.5;
-      var scale = new Plottable.Scales.Linear();
+      const start = -1.5, end = 1, interval = 0.5;
+      const scale = new Plottable.Scales.Linear();
       scale.domain([start, end]);
-      var ticks = Plottable.Scales.TickGenerators.intervalTickGenerator(interval)(scale);
+      const ticks = Plottable.Scales.TickGenerators.intervalTickGenerator(interval)(scale);
       assert.deepEqual(ticks, [-1.5, -1, -0.5, 0, 0.5, 1], "generated all number divisible by 0.5 in domain");
     });
 
     it("generate ticks with reversed domain", () => {
-      var start = -2.2, end = -7.6, interval = 2.5;
-      var scale = new Plottable.Scales.Linear();
+      const start = -2.2, end = -7.6, interval = 2.5;
+      const scale = new Plottable.Scales.Linear();
       scale.domain([start, end]);
-      var ticks = Plottable.Scales.TickGenerators.intervalTickGenerator(interval)(scale);
+      const ticks = Plottable.Scales.TickGenerators.intervalTickGenerator(interval)(scale);
       assert.deepEqual(ticks, [-7.6, -7.5, -5, -2.5, -2.2], "generated all ticks between lower and higher value");
     });
 
     it("passing big interval", () => {
-      var start = 0.5, end = 10.01, interval = 11;
-      var scale = new Plottable.Scales.Linear();
+      const start = 0.5, end = 10.01, interval = 11;
+      const scale = new Plottable.Scales.Linear();
       scale.domain([start, end]);
-      var ticks = Plottable.Scales.TickGenerators.intervalTickGenerator(interval)(scale);
+      const ticks = Plottable.Scales.TickGenerators.intervalTickGenerator(interval)(scale);
       assert.deepEqual(ticks, [0.5, 10.01], "no middle ticks were added");
     });
 
@@ -43,30 +43,30 @@ describe("Tick generators", () => {
 
   describe("integer", () => {
     it("normal case", () => {
-      var scale = new Plottable.Scales.Linear();
+      const scale = new Plottable.Scales.Linear();
       scale.domain([0, 4]);
-      var ticks = Plottable.Scales.TickGenerators.integerTickGenerator()(scale);
+      const ticks = Plottable.Scales.TickGenerators.integerTickGenerator()(scale);
       assert.deepEqual(ticks, [0, 1, 2, 3, 4], "only the integers are returned");
     });
 
     it("works across negative numbers", () => {
-      var scale = new Plottable.Scales.Linear();
+      const scale = new Plottable.Scales.Linear();
       scale.domain([-2, 1]);
-      var ticks = Plottable.Scales.TickGenerators.integerTickGenerator()(scale);
+      const ticks = Plottable.Scales.TickGenerators.integerTickGenerator()(scale);
       assert.deepEqual(ticks, [-2, -1, 0, 1], "only the integers are returned");
     });
 
     it("includes endticks", () => {
-      var scale = new Plottable.Scales.Linear();
+      const scale = new Plottable.Scales.Linear();
       scale.domain([-2.7, 1.5]);
-      var ticks = Plottable.Scales.TickGenerators.integerTickGenerator()(scale);
+      const ticks = Plottable.Scales.TickGenerators.integerTickGenerator()(scale);
       assert.deepEqual(ticks, [-2.5, -2, -1, 0, 1, 1.5], "end ticks are included");
     });
 
     it("all float ticks", () => {
-      var scale = new Plottable.Scales.Linear();
+      const scale = new Plottable.Scales.Linear();
       scale.domain([1.1, 1.5]);
-      var ticks = Plottable.Scales.TickGenerators.integerTickGenerator()(scale);
+      const ticks = Plottable.Scales.TickGenerators.integerTickGenerator()(scale);
       assert.deepEqual(ticks, [1.1, 1.5], "only the end ticks are returned");
     });
   });

--- a/test/scales/tickGeneratorsTests.ts
+++ b/test/scales/tickGeneratorsTests.ts
@@ -1,5 +1,4 @@
 ///<reference path="../testReference.ts" />
-/* tslint:disable: no-var-keyword */
 
 describe("Tick generators", () => {
   describe("interval", () => {

--- a/test/scales/timeScaleTests.ts
+++ b/test/scales/timeScaleTests.ts
@@ -1,5 +1,4 @@
 ///<reference path="../testReference.ts" />
-/* tslint:disable: no-var-keyword */
 
 describe("TimeScale tests", () => {
     it.skip("extentOfValues() filters out invalid Dates", () => {

--- a/test/scales/timeScaleTests.ts
+++ b/test/scales/timeScaleTests.ts
@@ -3,19 +3,19 @@
 
 describe("TimeScale tests", () => {
     it.skip("extentOfValues() filters out invalid Dates", () => {
-      var scale = new Plottable.Scales.Time();
-      var expectedExtent = [new Date("2015-06-05"), new Date("2015-06-04")];
-      var arrayWithBadValues: any[] = [null, NaN, undefined, Infinity, -Infinity, "a string",
+      const scale = new Plottable.Scales.Time();
+      const expectedExtent = [new Date("2015-06-05"), new Date("2015-06-04")];
+      const arrayWithBadValues: any[] = [null, NaN, undefined, Infinity, -Infinity, "a string",
         0, new Date("2015-06-05"), new Date("2015-06-04")];
-      var extent = scale.extentOfValues(arrayWithBadValues);
+      const extent = scale.extentOfValues(arrayWithBadValues);
       assert.strictEqual(extent[0].getTime(), expectedExtent[0].getTime(), "returned correct min");
       assert.strictEqual(extent[1].getTime(), expectedExtent[1].getTime(), "returned correct max");
     });
 
   it("can be padded", () => {
-    var scale = new Plottable.Scales.Time();
+    const scale = new Plottable.Scales.Time();
     scale.padProportion(0);
-    var unpaddedDomain = scale.domain();
+    const unpaddedDomain = scale.domain();
     scale.addIncludedValuesProvider((scale: Plottable.Scales.Time) => unpaddedDomain);
     scale.padProportion(0.1);
     assert.operator(scale.domain()[0].getTime(), "<", unpaddedDomain[0].getTime(), "left side of domain was padded");
@@ -23,9 +23,9 @@ describe("TimeScale tests", () => {
   });
 
   it("respects padding exceptions", () => {
-    var scale = new Plottable.Scales.Time();
-    var minValue = new Date(2000, 5, 4);
-    var maxValue = new Date(2000, 5, 6);
+    const scale = new Plottable.Scales.Time();
+    const minValue = new Date(2000, 5, 4);
+    const maxValue = new Date(2000, 5, 6);
     scale.addIncludedValuesProvider((scale: Plottable.Scales.Time) => [minValue, maxValue]);
     scale.padProportion(0.1);
     assert.operator(scale.domain()[0].getTime(), "<", minValue.getTime(), "left side of domain is normally padded");
@@ -37,35 +37,35 @@ describe("TimeScale tests", () => {
   });
 
   it("autoDomain() expands single value to [value - 1 day, value + 1 day]", () => {
-    var scale = new Plottable.Scales.Time();
+    const scale = new Plottable.Scales.Time();
     scale.padProportion(0);
-    var singleValue = new Date(2000, 5, 5);
-    var dayBefore = new Date(2000, 5, 4);
-    var dayAfter = new Date(2000, 5, 6);
+    const singleValue = new Date(2000, 5, 5);
+    const dayBefore = new Date(2000, 5, 4);
+    const dayAfter = new Date(2000, 5, 6);
     scale.addIncludedValuesProvider((scale: Plottable.Scales.Time) => [singleValue, singleValue]);
     scale.autoDomain();
-    var domain = scale.domain();
+    const domain = scale.domain();
     assert.strictEqual(domain[0].getTime(), dayBefore.getTime(), "left side of domain was expaded by one day");
     assert.strictEqual(domain[1].getTime(), dayAfter.getTime(), "right side of domain was expaded by one day");
   });
 
   it("can't set reversed domain", () => {
-    var scale = new Plottable.Scales.Time();
+    const scale = new Plottable.Scales.Time();
     assert.throws(() => scale.domain([new Date("1985-10-26"), new Date("1955-11-05")]), "chronological");
   });
 
   it("domainMin()", () => {
-    var scale = new Plottable.Scales.Time();
+    const scale = new Plottable.Scales.Time();
     scale.padProportion(0);
-    var requestedDomain = [new Date("2015-05-01"), new Date("2015-07-01")];
+    const requestedDomain = [new Date("2015-05-01"), new Date("2015-07-01")];
     scale.addIncludedValuesProvider((scale: Plottable.Scales.Time) => requestedDomain);
 
-    var minBelowBottom = new Date("2015-04-01");
+    const minBelowBottom = new Date("2015-04-01");
     scale.domainMin(minBelowBottom);
     assert.strictEqual(scale.domain()[0].getTime(), minBelowBottom.getTime(), "lower end of domain was set by domainMin()");
     assert.strictEqual(scale.domainMin().getTime(), minBelowBottom.getTime(), "returns the set minimum value");
 
-    var minInMiddle = new Date("2015-06-01");
+    const minInMiddle = new Date("2015-06-01");
     scale.domainMin(minInMiddle);
     assert.strictEqual(scale.domain()[0].getTime(), minInMiddle.getTime(), "lower end was set even if requested value cuts off some data");
 
@@ -74,32 +74,32 @@ describe("TimeScale tests", () => {
     assert.strictEqual(scale.domainMin().getTime(), scale.domain()[0].getTime(),
       "returns autoDomain()-ed min value after autoDomain()-ing");
 
-    var minEqualTop = new Date("2015-07-01");
-    var nextDay = new Date("2015-07-02");
+    const minEqualTop = new Date("2015-07-01");
+    const nextDay = new Date("2015-07-02");
     scale.domainMin(minEqualTop);
-    var domain = scale.domain();
+    const domain = scale.domain();
     assert.strictEqual(domain[0].getTime(), minEqualTop.getTime(),
       "lower end was set even if requested value is >= autoDomain()-ed max");
     assert.strictEqual(domain[1].getTime(), nextDay.getTime(), "upper end is set one day later");
 
     scale.domainMin(minInMiddle);
-    var requestedDomain2 = [new Date("2014-05-01"), new Date("2016-07-01")];
+    const requestedDomain2 = [new Date("2014-05-01"), new Date("2016-07-01")];
     scale.addIncludedValuesProvider((scale: Plottable.Scales.Time) => requestedDomain2);
     assert.strictEqual(scale.domain()[0].getTime(), minInMiddle.getTime(), "adding another ExtentsProvider doesn't change domainMin()");
   });
 
   it("domainMax()", () => {
-    var scale = new Plottable.Scales.Time();
+    const scale = new Plottable.Scales.Time();
     scale.padProportion(0);
-    var requestedDomain = [new Date("2015-05-01"), new Date("2015-07-01")];
+    const requestedDomain = [new Date("2015-05-01"), new Date("2015-07-01")];
     scale.addIncludedValuesProvider((scale: Plottable.Scales.Time) => requestedDomain);
 
-    var maxAboveTop = new Date("2015-08-01");
+    const maxAboveTop = new Date("2015-08-01");
     scale.domainMax(maxAboveTop);
     assert.strictEqual(scale.domain()[1].getTime(), maxAboveTop.getTime(), "upper end of domain was set by domainMax()");
     assert.strictEqual(scale.domainMax().getTime(), maxAboveTop.getTime(), "returns the set maximum value");
 
-    var maxInMiddle = new Date("2015-06-01");
+    const maxInMiddle = new Date("2015-06-01");
     scale.domainMax(maxInMiddle);
     assert.strictEqual(scale.domain()[1].getTime(), maxInMiddle.getTime(), "upper end was set even if requested value cuts off some data");
 
@@ -108,35 +108,35 @@ describe("TimeScale tests", () => {
     assert.strictEqual(scale.domainMax().getTime(), scale.domain()[1].getTime(),
       "returns autoDomain()-ed max value after autoDomain()-ing");
 
-    var maxEqualBottom = new Date("2015-05-01");
-    var dayBefore = new Date("2015-04-30");
+    const maxEqualBottom = new Date("2015-05-01");
+    const dayBefore = new Date("2015-04-30");
     scale.domainMax(maxEqualBottom);
-    var domain = scale.domain();
+    const domain = scale.domain();
     assert.strictEqual(domain[1].getTime(), maxEqualBottom.getTime(),
       "upper end was set even if requested value is <= autoDomain()-ed min");
     assert.strictEqual(domain[0].getTime(), dayBefore.getTime(), "lower end is set one day before");
 
     scale.domainMax(maxInMiddle);
-    var requestedDomain2 = [new Date("2014-05-01"), new Date("2016-07-01")];
+    const requestedDomain2 = [new Date("2014-05-01"), new Date("2016-07-01")];
     scale.addIncludedValuesProvider((scale: Plottable.Scales.Time) => requestedDomain2);
     assert.strictEqual(scale.domain()[1].getTime(), maxInMiddle.getTime(), "adding another ExtentsProvider doesn't change domainMax()");
   });
 
     it("domainMin() and domainMax() together", () => {
-      var scale = new Plottable.Scales.Time();
+      const scale = new Plottable.Scales.Time();
       scale.padProportion(0);
-    var requestedDomain = [new Date("2015-05-01"), new Date("2015-07-01")];
+    const requestedDomain = [new Date("2015-05-01"), new Date("2015-07-01")];
       scale.addIncludedValuesProvider((scale: Plottable.Scales.Time) => requestedDomain);
 
-      var desiredMin = new Date("2015-04-01");
-      var desiredMax = new Date("2015-08-01");
+      const desiredMin = new Date("2015-04-01");
+      const desiredMax = new Date("2015-08-01");
       scale.domainMin(desiredMin);
       scale.domainMax(desiredMax);
       assert.deepEqual(scale.domain(), [desiredMin, desiredMax], "setting domainMin() and domainMax() sets the domain");
 
       scale.autoDomain();
-      var bigMin = new Date("2015-08-01");
-      var smallMax = new Date("2015-04-01");
+      const bigMin = new Date("2015-08-01");
+      const smallMax = new Date("2015-04-01");
       scale.domainMin(bigMin);
       assert.throws(() => scale.domainMax(smallMax), Error);
 
@@ -146,34 +146,34 @@ describe("TimeScale tests", () => {
     });
 
   it("tickInterval produces correct number of ticks", () => {
-    var scale = new Plottable.Scales.Time();
+    const scale = new Plottable.Scales.Time();
     // 100 year span
     scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2100, 0, 1, 0, 0, 0, 0)]);
-    var ticks = scale.tickInterval(Plottable.TimeInterval.year);
-    assert.strictEqual(ticks.length, 101, "generated correct number of ticks");
+    const yearTicks = scale.tickInterval(Plottable.TimeInterval.year);
+    assert.strictEqual(yearTicks.length, 101, "generated correct number of ticks");
     // 1 year span
     scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 11, 31, 0, 0, 0, 0)]);
-    ticks = scale.tickInterval(Plottable.TimeInterval.month);
-    assert.strictEqual(ticks.length, 12, "generated correct number of ticks");
-    ticks = scale.tickInterval(Plottable.TimeInterval.month, 3);
-    assert.strictEqual(ticks.length, 4, "generated correct number of ticks");
+    const monthTicks = scale.tickInterval(Plottable.TimeInterval.month);
+    assert.strictEqual(monthTicks.length, 12, "generated correct number of ticks");
+    const threeMonthTicks = scale.tickInterval(Plottable.TimeInterval.month, 3);
+    assert.strictEqual(threeMonthTicks.length, 4, "generated correct number of ticks");
     // 1 month span
     scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 1, 1, 0, 0, 0, 0)]);
-    ticks = scale.tickInterval(Plottable.TimeInterval.day);
-    assert.strictEqual(ticks.length, 32, "generated correct number of ticks");
+    const dayTicks = scale.tickInterval(Plottable.TimeInterval.day);
+    assert.strictEqual(dayTicks.length, 32, "generated correct number of ticks");
     // 1 day span
     scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 0, 1, 23, 0, 0, 0)]);
-    ticks = scale.tickInterval(Plottable.TimeInterval.hour);
-    assert.strictEqual(ticks.length, 24, "generated correct number of ticks");
+    const hourTicks = scale.tickInterval(Plottable.TimeInterval.hour);
+    assert.strictEqual(hourTicks.length, 24, "generated correct number of ticks");
     // 1 hour span
     scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 0, 1, 1, 0, 0, 0)]);
-    ticks = scale.tickInterval(Plottable.TimeInterval.minute);
-    assert.strictEqual(ticks.length, 61, "generated correct number of ticks");
-    ticks = scale.tickInterval(Plottable.TimeInterval.minute, 10);
-    assert.strictEqual(ticks.length, 7, "generated correct number of ticks");
+    const minuteTicks = scale.tickInterval(Plottable.TimeInterval.minute);
+    assert.strictEqual(minuteTicks.length, 61, "generated correct number of ticks");
+    const tenMinuteTicks = scale.tickInterval(Plottable.TimeInterval.minute, 10);
+    assert.strictEqual(tenMinuteTicks.length, 7, "generated correct number of ticks");
     // 1 minute span
     scale.domain([new Date(2000, 0, 1, 0, 0, 0, 0), new Date(2000, 0, 1, 0, 1, 0, 0)]);
-    ticks = scale.tickInterval(Plottable.TimeInterval.second);
-    assert.strictEqual(ticks.length, 61, "generated correct number of ticks");
+    const secondTicks = scale.tickInterval(Plottable.TimeInterval.second);
+    assert.strictEqual(secondTicks.length, 61, "generated correct number of ticks");
   });
 });


### PR DESCRIPTION
Fun thing to see is that I'm trying to move towards biasing towards a `const` usage over a `let` usage and as a result some test code is a bit more precise on what its testing.