### PR TITLE
Root <svg> has pointer-events: visible.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -284,7 +284,7 @@ module.exports = function(grunt) {
         testname: "Plottable Sauce Unit Tests",
         browsers: [{
           browserName: "firefox",
-          platform: "linux"
+          platform: "WIN7"
         }, {
           browserName: "chrome",
           platform: "linux"

--- a/plottable.css
+++ b/plottable.css
@@ -41,6 +41,7 @@
 
 svg.plottable {
   display : block; /* SVGs must be block elements for width/height calculations to work in Firefox. */
+  pointer-events: visible;
 }
 
 .plottable .background-fill {

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -24,6 +24,8 @@ describe("Component behavior", () => {
       c.anchor(svg);
       assert.strictEqual((<any> c)._element.node(), svg.select("g").node(), "the component anchored to a <g> beneath the <svg>");
       assert.isTrue(svg.classed("plottable"), "<svg> was given \"plottable\" CSS class");
+      const computedStyle = window.getComputedStyle(<Element>svg.node());
+      assert.strictEqual(computedStyle.pointerEvents, "visible", "\"pointer-events\" style set to \"visible\"");
       svg.remove();
     });
 
@@ -34,6 +36,8 @@ describe("Component behavior", () => {
       c.anchor(svg2);
       assert.strictEqual((<any> c)._element.node(), svg2.select("g").node(), "the component re-achored under the second <svg>");
       assert.isTrue(svg2.classed("plottable"), "second <svg> was given \"plottable\" CSS class");
+      const computedStyle = window.getComputedStyle(<Element>svg2.node());
+      assert.strictEqual(computedStyle.pointerEvents, "visible", "second <svg>'s \"pointer-events\" style set to \"visible\"");
 
       svg.remove();
       svg2.remove();

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -144,8 +144,8 @@ module TestMethods {
 
   export function triggerFakeMouseEvent(type: string, target: d3.Selection<void>, relativeX: number, relativeY: number, button = 0) {
     var clientRect = (<Element> target.node()).getBoundingClientRect();
-    var xPos = clientRect.left + relativeX;
-    var yPos = clientRect.top + relativeY;
+    var xPos = Math.round(clientRect.left + relativeX);
+    var yPos = Math.round(clientRect.top + relativeY);
     var e = <MouseEvent> document.createEvent("MouseEvents");
     e.initMouseEvent(type, true, true, window, 1,
       xPos, yPos,
@@ -199,8 +199,8 @@ module TestMethods {
     var fakeTouchList: any = [];
 
     touchPoints.forEach(( touchPoint, i ) => {
-      var xPos = clientRect.left + touchPoint.x;
-      var yPos = clientRect.top + touchPoint.y;
+      var xPos = Math.round(clientRect.left + touchPoint.x);
+      var yPos = Math.round(clientRect.top + touchPoint.y);
       var identifier = ids[i] == null ? 0 : ids[i];
       fakeTouchList.push( {
         identifier: identifier,


### PR DESCRIPTION
Default property appears to be `"auto"` -- on Safari this doesn't behave correctly.

The root `<svg>` will now have `pointer-events` set to `"visible"`, which should be what we want:
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pointer-events

Close #2454.