### PR TITLE
label.text() only accepts strings

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -4967,7 +4967,7 @@ var Plottable;
                 this.text(this._text);
             };
             Label.prototype.text = function (displayText) {
-                if (displayText === undefined) {
+                if (displayText === undefined || displayText == null) {
                     return this._text;
                 }
                 else {

--- a/plottable.js
+++ b/plottable.js
@@ -4971,6 +4971,9 @@ var Plottable;
                     return this._text;
                 }
                 else {
+                    if (typeof displayText !== "string") {
+                        throw new Error("Label.text() only takes strings as input");
+                    }
                     this._text = displayText;
                     this.redraw();
                     return this;

--- a/plottable.js
+++ b/plottable.js
@@ -4967,7 +4967,7 @@ var Plottable;
                 this.text(this._text);
             };
             Label.prototype.text = function (displayText) {
-                if (displayText === undefined || displayText == null) {
+                if (displayText == null) {
                     return this._text;
                 }
                 else {

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -62,9 +62,12 @@ export module Components {
       if (displayText === undefined) {
         return this._text;
       } else {
-        this._text = displayText;
-        this.redraw();
-        return this;
+        if (typeof displayText === "string") {
+          this._text = displayText;
+          this.redraw();
+          return this;
+        }
+        throw new Error("Label.text() only takes strings as input");
       }
     }
 

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -62,12 +62,12 @@ export module Components {
       if (displayText === undefined) {
         return this._text;
       } else {
-        if (typeof displayText === "string") {
-          this._text = displayText;
-          this.redraw();
-          return this;
+        if (typeof displayText !== "string") {
+          throw new Error("Label.text() only takes strings as input");
         }
-        throw new Error("Label.text() only takes strings as input");
+        this._text = displayText;
+        this.redraw();
+        return this;
       }
     }
 

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -59,7 +59,7 @@ export module Components {
      */
     public text(displayText: string): Label;
     public text(displayText?: string): any {
-      if (displayText === undefined || displayText == null) {
+      if (displayText == null) {
         return this._text;
       } else {
         if (typeof displayText !== "string") {

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -59,7 +59,7 @@ export module Components {
      */
     public text(displayText: string): Label;
     public text(displayText?: string): any {
-      if (displayText === undefined) {
+      if (displayText === undefined || displayText === null) {
         return this._text;
       } else {
         if (typeof displayText !== "string") {

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -59,7 +59,7 @@ export module Components {
      */
     public text(displayText: string): Label;
     public text(displayText?: string): any {
-      if (displayText === undefined || displayText === null) {
+      if (displayText === undefined || displayText == null) {
         return this._text;
       } else {
         if (typeof displayText !== "string") {

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -2,6 +2,12 @@
 
 describe("Labels", () => {
 
+  it("text() only accepts strings", () => {
+    assert.throws(() => new Plottable.Components.Label(<any> 23), Error);
+    assert.throws(() => new Plottable.Components.Label(<any> new Date()), Error);
+    assert.doesNotThrow(() => new Plottable.Components.Label("string"), Error, "accepts strings");
+  });
+
   it("Standard text title label generates properly", () => {
     var svg = TestMethods.generateSVG(400, 80);
     var label = new Plottable.Components.TitleLabel("A CHART TITLE");

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -3,9 +3,10 @@
 describe("Labels", () => {
 
   it("text() only accepts strings", () => {
-    assert.throws(() => new Plottable.Components.Label(<any> 23), Error);
-    assert.throws(() => new Plottable.Components.Label(<any> new Date()), Error);
-    assert.doesNotThrow(() => new Plottable.Components.Label("string"), Error, "accepts strings");
+    var label = new Plottable.Components.Label();
+    assert.throws(() => label.text(<any> 23), Error);
+    assert.throws(() => label.text(<any> new Date()), Error);
+    assert.doesNotThrow(() => label.text("string"), Error, "text() accepts strings");
   });
 
   it("Standard text title label generates properly", () => {

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -7,6 +7,7 @@ describe("Labels", () => {
     assert.throws(() => label.text(<any> 23), Error);
     assert.throws(() => label.text(<any> new Date()), Error);
     assert.doesNotThrow(() => label.text("string"), Error, "text() accepts strings");
+    assert.strictEqual(label.text(null), "string", "text(null) returns a string");
   });
 
   it("Standard text title label generates properly", () => {


### PR DESCRIPTION
fixes #2140 

Labels used to accept all types, now they will throw an error on any type that isn't a string.