### PR TITLE
Safari now correctly detects events in the SVG

### DIFF
--- a/plottable.css
+++ b/plottable.css
@@ -41,7 +41,7 @@
 
 svg.plottable {
   display : block; /* SVGs must be block elements for width/height calculations to work in Firefox. */
-  pointer-events: visible;
+  pointer-events: visibleFill;
 }
 
 .plottable .background-fill {

--- a/plottable.css
+++ b/plottable.css
@@ -41,6 +41,7 @@
 
 svg.plottable {
   display : block; /* SVGs must be block elements for width/height calculations to work in Firefox. */
+  pointer-events: visible;
 }
 
 .plottable .background-fill {

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -25,7 +25,8 @@ describe("Component behavior", () => {
       assert.strictEqual((<any> c)._element.node(), svg.select("g").node(), "the component anchored to a <g> beneath the <svg>");
       assert.isTrue(svg.classed("plottable"), "<svg> was given \"plottable\" CSS class");
       const computedStyle = window.getComputedStyle(<Element>svg.node());
-      assert.strictEqual(computedStyle.pointerEvents, "visible", "\"pointer-events\" style set to \"visible\"");
+      assert.strictEqual(computedStyle.pointerEvents.toLowerCase(), "visiblefill",
+        "\"pointer-events\" style set to \"visiblefill\"");
       svg.remove();
     });
 
@@ -37,7 +38,8 @@ describe("Component behavior", () => {
       assert.strictEqual((<any> c)._element.node(), svg2.select("g").node(), "the component re-achored under the second <svg>");
       assert.isTrue(svg2.classed("plottable"), "second <svg> was given \"plottable\" CSS class");
       const computedStyle = window.getComputedStyle(<Element>svg2.node());
-      assert.strictEqual(computedStyle.pointerEvents, "visible", "second <svg>'s \"pointer-events\" style set to \"visible\"");
+      assert.strictEqual(computedStyle.pointerEvents.toLowerCase(), "visiblefill",
+        "second <svg>'s \"pointer-events\" style set to \"visiblefill\"");
 
       svg.remove();
       svg2.remove();

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -24,6 +24,8 @@ describe("Component behavior", () => {
       c.anchor(svg);
       assert.strictEqual((<any> c)._element.node(), svg.select("g").node(), "the component anchored to a <g> beneath the <svg>");
       assert.isTrue(svg.classed("plottable"), "<svg> was given \"plottable\" CSS class");
+      const computedStyle = window.getComputedStyle(<Element>svg.node());
+      assert.strictEqual(computedStyle.pointerEvents, "visible", "\"pointer-events\" style set to \"visible\"");
       svg.remove();
     });
 
@@ -34,6 +36,8 @@ describe("Component behavior", () => {
       c.anchor(svg2);
       assert.strictEqual((<any> c)._element.node(), svg2.select("g").node(), "the component re-achored under the second <svg>");
       assert.isTrue(svg2.classed("plottable"), "second <svg> was given \"plottable\" CSS class");
+      const computedStyle = window.getComputedStyle(<Element>svg2.node());
+      assert.strictEqual(computedStyle.pointerEvents, "visible", "second <svg>'s \"pointer-events\" style set to \"visible\"");
 
       svg.remove();
       svg2.remove();


### PR DESCRIPTION
Safari now correctly responds to `Click` and `Drag` `Interaction`s that start in the `<svg>`.

Close #2454.

---
### Long-winded explanation
Set the `pointer-events` property to "`visibleFill`". Default property is `"auto"`, which on `<svg>`s should behave the same as `"visiblePainted"`, which says:

>The element can only be the target of a mouse event when the visibility attribute is set to visible and when the mouse cursor is over the interior (i.e., 'fill') of the element and the fill attribute is set to a value other than none, or when the mouse cursor is over the perimeter (i.e., 'stroke') of the element and the stroke attribute is set to a value other than none.

However, on non-Safari browsers, `"auto"` appears to behave like `"all"`, whereas in Safari it appears to behave as `"none"`. `"visibleFill"` seems closer to what we're looking for:

>SVG only. The element can only be the target of a mouse event when the visibility property is set to visible and when the mouse cursor is over the interior (i.e., fill) of the element. The value of the fill property does not effect event processing.

([citation](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pointer-events))

We can't use `"visible"` because in Firefox setting the `pointer-events` property affects size measurements:

>
```
  // Our "visual" overflow rect needs to be valid for building display lists
  // for hit testing, which means that for certain values of 'pointer-events'
  // it needs to include the geometry of the fill or stroke even when the fill/
  // stroke don't actually render (e.g. when stroke="none" or
  // stroke-opacity="0"). GetHitTestFlags() accounts for 'pointer-events'.
```

([source](https://dxr.mozilla.org/mozilla-central/source/layout/svg/nsSVGPathGeometryFrame.cpp#374))