### PR TITLE
trigger keypress callback only once when the key was pressed

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -10061,7 +10061,7 @@ var Plottable;
                 this._keyReleaseCallbacks = {};
                 this._mouseMoveCallback = function (point) { return false; }; // HACKHACK: registering a listener
                 this._downedKeys = new Plottable.Utils.Set();
-                this._keyDownCallback = function (keyCode) { return _this._handleKeyDownEvent(keyCode); };
+                this._keyDownCallback = function (keyCode, event) { return _this._handleKeyDownEvent(keyCode, event); };
                 this._keyUpCallback = function (keyCode) { return _this._handleKeyUpEvent(keyCode); };
             }
             Key.prototype._anchor = function (component) {
@@ -10080,9 +10080,9 @@ var Plottable;
                 this._keyDispatcher.offKeyUp(this._keyUpCallback);
                 this._keyDispatcher = null;
             };
-            Key.prototype._handleKeyDownEvent = function (keyCode) {
+            Key.prototype._handleKeyDownEvent = function (keyCode, event) {
                 var p = this._translateToComponentSpace(this._positionDispatcher.lastMousePosition());
-                if (this._isInsideComponent(p)) {
+                if (this._isInsideComponent(p) && !event.repeat) {
                     if (this._keyPressCallbacks[keyCode]) {
                         this._keyPressCallbacks[keyCode].callCallbacks(keyCode);
                     }

--- a/src/interactions/keyInteraction.ts
+++ b/src/interactions/keyInteraction.ts
@@ -16,7 +16,7 @@ export module Interactions {
 
     private _mouseMoveCallback = (point: Point) => false; // HACKHACK: registering a listener
     private _downedKeys = new Plottable.Utils.Set();
-    private _keyDownCallback = (keyCode: number) => this._handleKeyDownEvent(keyCode);
+    private _keyDownCallback = (keyCode: number, event: KeyboardEvent) => this._handleKeyDownEvent(keyCode, event);
     private _keyUpCallback = (keyCode: number) => this._handleKeyUpEvent(keyCode);
 
     protected _anchor(component: Component) {
@@ -41,9 +41,9 @@ export module Interactions {
       this._keyDispatcher = null;
     }
 
-    private _handleKeyDownEvent(keyCode: number) {
+    private _handleKeyDownEvent(keyCode: number, event: KeyboardEvent) {
       let p = this._translateToComponentSpace(this._positionDispatcher.lastMousePosition());
-      if (this._isInsideComponent(p)) {
+      if (this._isInsideComponent(p) && !event.repeat) {
         if (this._keyPressCallbacks[keyCode]) {
           this._keyPressCallbacks[keyCode].callCallbacks(keyCode);
         }

--- a/test/interactions/keyInteractionTests.ts
+++ b/test/interactions/keyInteractionTests.ts
@@ -196,6 +196,12 @@ describe("Interactions", () => {
         TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
         assert.isFalse(aCallbackCalled, "callback for \"a\" was not called when \"a\" key was released");
 
+        TestMethods.triggerFakeMouseEvent("mouseout", component.background(), -100, -100);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
+        TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode, { repeat : true });
+        assert.isFalse(aCallbackCalled, "callback for \"a\" was not called when \"a\" key was released");
         keyInteraction.offKeyRelease(aCode, aCallback);
         svg.remove();
       });

--- a/test/interactions/keyInteractionTests.ts
+++ b/test/interactions/keyInteractionTests.ts
@@ -116,6 +116,36 @@ describe("Interactions", () => {
         keyInteraction.offKeyPress(aCode, aCallback2);
         svg.remove();
       });
+
+      it("is only triggered once when the key is pressed", () => {
+        keyInteraction.onKeyPress(aCode, aCallback);
+        keyInteraction.attachTo(component);
+
+        TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
+        assert.isTrue(aCallbackCalled, "callback for \"a\" was called when \"a\" key was pressed");
+
+        aCallbackCalled = false;
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode, { repeat : true });
+        assert.isFalse(aCallbackCalled, "callback for \"a\" was not called when keydown was fired the second time");
+
+        keyInteraction.offKeyPress(aCode, aCallback);
+        svg.remove();
+      });
+
+      it("does not fire callback pressing the key when mouse was outside and moved inside", () => {
+        keyInteraction.onKeyPress(aCode, aCallback);
+        keyInteraction.attachTo(component);
+
+        TestMethods.triggerFakeMouseEvent("mouseout", component.background(), -100, -100);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
+        TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode, { repeat : true });
+        assert.isFalse(aCallbackCalled, "callback for \"a\" was not called");
+
+        keyInteraction.offKeyPress(aCode, aCallback);
+        svg.remove();
+      });
     });
 
     describe("onKeyRelease", () => {
@@ -196,12 +226,6 @@ describe("Interactions", () => {
         TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
         assert.isFalse(aCallbackCalled, "callback for \"a\" was not called when \"a\" key was released");
 
-        TestMethods.triggerFakeMouseEvent("mouseout", component.background(), -100, -100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode, { repeat : true });
-        assert.isFalse(aCallbackCalled, "callback for \"a\" was not called when \"a\" key was released");
         keyInteraction.offKeyRelease(aCode, aCallback);
         svg.remove();
       });

--- a/test/interactions/keyInteractionTests.ts
+++ b/test/interactions/keyInteractionTests.ts
@@ -133,7 +133,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("does not fire callback pressing the key when mouse was outside and moved inside", () => {
+      it("does not fire the callback if the key is pressed and held down outside, then the mouse moved inside", () => {
         keyInteraction.onKeyPress(aCode, aCallback);
         keyInteraction.attachTo(component);
 

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -225,12 +225,18 @@ module TestMethods {
     target.node().dispatchEvent(e);
   }
 
-  export function triggerFakeKeyboardEvent(type: string, target: d3.Selection<void>, keyCode: number) {
+  export function triggerFakeKeyboardEvent(type: string, target: d3.Selection<void>, keyCode: number, options?: {[key: string]: any}) {
     let event = <KeyboardEvent> document.createEvent("Events");
     event.initEvent(type, true, true);
     event.keyCode = keyCode;
+    if (options != null ) {
+      for (var key in options) {
+        if (options.hasOwnProperty(key)) {
+          (<any> event)[key] = options[key];
+        }
+      }
+    }
     target.node().dispatchEvent(event);
-    return event;
   }
 
   export function assertAreaPathCloseTo(actualPath: string, expectedPath: string, precision: number, msg: string) {

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -230,11 +230,7 @@ module TestMethods {
     event.initEvent(type, true, true);
     event.keyCode = keyCode;
     if (options != null ) {
-      for (var key in options) {
-        if (options.hasOwnProperty(key)) {
-          (<any> event)[key] = options[key];
-        }
-      }
+      Object.keys(options).forEach((key) => (<any> event)[key] = options[key] );
     }
     target.node().dispatchEvent(event);
   }


### PR DESCRIPTION
closes #2499 
demo: http://jsfiddle.net/sqa7dw6c/4/

EDIT: talked offline; since there's a use case requiring the functionality, will fix the auto-repeating behavior.  Will add ```onKeydown```/revise ```OnKeyPress``` if there's new feature requests 