### PR TITLE
[HOTFIX] detach() callbacks should called even if not anchored()

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -3292,9 +3292,9 @@ var Plottable;
             this.parent(null);
             if (this._isAnchored) {
                 this._element.remove();
-                this._isAnchored = false;
-                this._onDetachCallbacks.callCallbacks(this);
             }
+            this._isAnchored = false;
+            this._onDetachCallbacks.callCallbacks(this);
             return this;
         };
         /**

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -450,9 +450,9 @@ export class Component {
 
     if (this._isAnchored) {
       this._element.remove();
-      this._isAnchored = false;
-      this._onDetachCallbacks.callCallbacks(this);
     }
+    this._isAnchored = false;
+    this._onDetachCallbacks.callCallbacks(this);
 
     return this;
   }

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -110,7 +110,18 @@ describe("Component behavior", () => {
 
     it("components can be detach()-ed even if not anchor()-ed", () => {
       var c = new Plottable.Component();
-      c.detach(); // no error thrown
+
+      var callbackCalled = false;
+      var passedComponent: Plottable.Component;
+      var callback = (component: Plottable.Component) => {
+        callbackCalled = true;
+        passedComponent = component;
+      };
+      c.onDetach(callback);
+
+      assert.doesNotThrow(() => c.detach(), Error, "does not throw error if detach() called before anchor()");
+      assert.isTrue(callbackCalled, "detach() callback was still called");
+      assert.strictEqual(passedComponent, c, "callback was passed the Component that detach()-ed");
       svg.remove();
     });
 
@@ -128,30 +139,6 @@ describe("Component behavior", () => {
       c.detach();
       assert.isTrue(callbackCalled, "callback was called when the Component was detach()-ed");
       assert.strictEqual(passedComponent, c, "callback was passed the Component that detach()-ed");
-      svg.remove();
-    });
-
-    it("callbacks on detach() not called unless the component is anchored", () => {
-      c = new Plottable.Component();
-
-      var callbackCalled = false;
-      var callback = (component: Plottable.Component) => callbackCalled = true;
-      c.onDetach(callback);
-
-      callbackCalled = false;
-      c.detach();
-      assert.isFalse(callbackCalled, "callback was not called because the Component is not rendered yet");
-
-      c.renderTo(svg);
-
-      callbackCalled = false;
-      c.detach();
-      assert.isTrue(callbackCalled, "callback was called when the Component was detach()-ed");
-
-      callbackCalled = false;
-      c.detach();
-      assert.isFalse(callbackCalled, "callback was not called because the Component was detached already");
-
       svg.remove();
     });
   });

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -139,6 +139,12 @@ describe("Component behavior", () => {
       c.detach();
       assert.isTrue(callbackCalled, "callback was called when the Component was detach()-ed");
       assert.strictEqual(passedComponent, c, "callback was passed the Component that detach()-ed");
+
+      callbackCalled = false;
+      c.detach();
+      assert.isTrue(callbackCalled, "callback called even if already detach()-ed");
+      assert.strictEqual(passedComponent, c, "callback was passed the Component that detach()-ed");
+
       svg.remove();
     });
   });

--- a/test/components/groupTests.ts
+++ b/test/components/groupTests.ts
@@ -71,12 +71,9 @@ describe("ComponentGroups", () => {
   it("detach()-ing a Component that is in the Group removes it from the Group", () => {
     var c0 = new Plottable.Component();
     var componentGroup = new Plottable.Components.Group([c0]);
-    var svg = TestMethods.generateSVG();
-    componentGroup.renderTo(svg);
     c0.detach();
     assert.lengthOf(componentGroup.components(), 0, "Component is no longer in the Group");
     assert.isNull(c0.parent(), "Component disconnected from Group");
-    svg.remove();
   });
 
   it("can move components to other groups after anchoring", () => {

--- a/test/components/tableTests.ts
+++ b/test/components/tableTests.ts
@@ -80,7 +80,7 @@ describe("Tables", () => {
       assert.throw(() => t.add(null, 0, 0), "Cannot add null to a table cell");
     });
 
-    it("add()-ing a Component to the Group should detach() it from its current location", () => {
+    it("add()-ing a Component to the Table should detach() it from its current location", () => {
       var c1 = new Plottable.Component;
       var svg = TestMethods.generateSVG();
       c1.renderTo(svg);
@@ -319,21 +319,19 @@ describe("Tables", () => {
 
     it("detach()-ing a Component removes it from the Table", () => {
       table = new Plottable.Components.Table([[c1]]);
-      var svg = TestMethods.generateSVG();
-      table.renderTo(svg);
       c1.detach();
       assert.deepEqual((<any> table)._rows, [[null]], "calling detach() on the Component removed it from the Table");
-      svg.remove();
+      assert.isNull(c1.parent(), "Component disconnected from the Table");
     });
   });
 
   it("has()", () => {
     var c0 = new Plottable.Component();
-    var componentGroup = new Plottable.Components.Table([[c0]]);
-    assert.isTrue(componentGroup.has(c0), "correctly checks that Component is in the Table");
-    componentGroup.remove(c0);
-    assert.isFalse(componentGroup.has(c0), "correctly checks that Component is no longer in the Table");
-    componentGroup.add(c0, 1, 1);
-    assert.isTrue(componentGroup.has(c0), "correctly checks that Component is in the Table again");
+    var table = new Plottable.Components.Table([[c0]]);
+    assert.isTrue(table.has(c0), "correctly checks that Component is in the Table");
+    table.remove(c0);
+    assert.isFalse(table.has(c0), "correctly checks that Component is no longer in the Table");
+    table.add(c0, 1, 1);
+    assert.isTrue(table.has(c0), "correctly checks that Component is in the Table again");
   });
 });


### PR DESCRIPTION
`detach()` callbacks should be called whenever `detach()` is called, to make sure that the `Component` and its parent correctly disassociate.

#### Testing Notes
The bug manifested when `detach()`-ing `Component`s that were in a `Group` or `Table` before the `Group` or `Table` was rendered.