### PR TITLE
Add GuideLineLayer

### DIFF
--- a/plottable.css
+++ b/plottable.css
@@ -158,6 +158,11 @@ svg.plottable {
 }
 /* /DragBoxLayer */
 
+.plottable .guide-line-layer line.guide-line {
+  stroke: #CCC;
+  stroke-width: 1px;
+}
+
 .plottable .legend text {
   fill: #32313F;
   font-family: "Helvetica Neue", sans-serif;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2437,19 +2437,20 @@ declare module Plottable {
             /**
              * Sets the QuantitativeScale on the GuideLineLayer.
              * If value() has been set, pixelPosition() will be updated according to the new scale.
+             * Otherwise, if pixelPosition() has been set but value() has not, value() will be set.
              *
              * @param {QuantitativeScale<D>} scale
              * @return {GuideLineLayer<D>} The calling GuideLineLayer.
              */
             scale(scale: QuantitativeScale<D>): GuideLineLayer<D>;
             /**
-             * Gets the position of the guide line in data-space.
+             * Gets the value of the guide line in data-space.
              *
              * @return {D}
              */
             value(): D;
             /**
-             * Sets the position of the guide line in data-space.
+             * Sets the value of the guide line in data-space.
              * If the GuideLineLayer has a scale, pixelPosition() will be updated.
              *
              * @param {D} value

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2470,6 +2470,7 @@ declare module Plottable {
              * @return {GuideLineLayer<D>} The calling GuideLineLayer.
              */
             pixelPosition(pixelPosition: number): GuideLineLayer<D>;
+            destroy(): void;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2428,11 +2428,50 @@ declare module Plottable {
             fixedWidth(): boolean;
             fixedHeight(): boolean;
             renderImmediately(): GuideLineLayer<D>;
+            /**
+             * Gets the QuantitativeScale on the GuideLineLayer.
+             *
+             * @return {QuantitativeScale<D>}
+             */
             scale(): QuantitativeScale<D>;
+            /**
+             * Sets the QuantitativeScale on the GuideLineLayer.
+             * If the value of the guide line in data-space has been set,
+             * the position of the guide line in pixel-space will be updated.
+             *
+             * @param {QuantitativeScale<D>} scale
+             * @return {GuideLineLayer<D>} The calling GuideLineLayer.
+             */
             scale(scale: QuantitativeScale<D>): GuideLineLayer<D>;
+            /**
+             * Gets the position of the guide line in data-space.
+             *
+             * @return {D}
+             */
             value(): D;
+            /**
+             * Sets the position of the guide line in data-space.
+             * If the GuideLineLayer has a scale, the position of the line
+             * in pixel-space will be updated accordingly.
+             *
+             * @param {D} value
+             * @return {GuideLineLayer<D>} The calling GuideLineLayer.
+             */
             value(value: D): GuideLineLayer<D>;
+            /**
+             * Gets the position of the guide line in pixel-space.
+             *
+             * @return {number}
+             */
             pixelPosition(): number;
+            /**
+             * Sets the position of the guide line in pixel-space.
+             * If the GuideLineLayer has a scale, the position of the line
+             * in data-space will be updated accordingly.
+             *
+             * @param {number} pixelPosition
+             * @return {GuideLineLayer<D>} The calling GuideLineLayer.
+             */
             pixelPosition(pixelPosition: number): GuideLineLayer<D>;
         }
     }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2427,6 +2427,7 @@ declare module Plottable {
             };
             fixedWidth(): boolean;
             fixedHeight(): boolean;
+            computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): GuideLineLayer<D>;
             renderImmediately(): GuideLineLayer<D>;
             /**
              * Gets the QuantitativeScale on the GuideLineLayer.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2417,7 +2417,17 @@ declare module Plottable {
 declare module Plottable {
     module Components {
         class GuideLineLayer<D> extends Component {
+            static ORIENTATION_VERTICAL: string;
+            static ORIENTATION_HORIZONTAL: string;
             constructor(orientation: string);
+            protected _setup(): void;
+            protected _sizeFromOffer(availableWidth: number, availableHeight: number): {
+                width: number;
+                height: number;
+            };
+            fixedWidth(): boolean;
+            fixedHeight(): boolean;
+            renderImmediately(): GuideLineLayer<D>;
             scale(): QuantitativeScale<D>;
             scale(scale: QuantitativeScale<D>): GuideLineLayer<D>;
             value(): D;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2436,8 +2436,7 @@ declare module Plottable {
             scale(): QuantitativeScale<D>;
             /**
              * Sets the QuantitativeScale on the GuideLineLayer.
-             * If the value of the guide line in data-space has been set,
-             * the position of the guide line in pixel-space will be updated.
+             * If value() has been set, pixelPosition() will be updated according to the new scale.
              *
              * @param {QuantitativeScale<D>} scale
              * @return {GuideLineLayer<D>} The calling GuideLineLayer.
@@ -2451,8 +2450,7 @@ declare module Plottable {
             value(): D;
             /**
              * Sets the position of the guide line in data-space.
-             * If the GuideLineLayer has a scale, the position of the line
-             * in pixel-space will be updated accordingly.
+             * If the GuideLineLayer has a scale, pixelPosition() will be updated.
              *
              * @param {D} value
              * @return {GuideLineLayer<D>} The calling GuideLineLayer.
@@ -2466,8 +2464,7 @@ declare module Plottable {
             pixelPosition(): number;
             /**
              * Sets the position of the guide line in pixel-space.
-             * If the GuideLineLayer has a scale, the position of the line
-             * in data-space will be updated accordingly.
+             * If the GuideLineLayer has a scale, the value() will be updated.
              *
              * @param {number} pixelPosition
              * @return {GuideLineLayer<D>} The calling GuideLineLayer.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2437,8 +2437,8 @@ declare module Plottable {
             scale(): QuantitativeScale<D>;
             /**
              * Sets the QuantitativeScale on the GuideLineLayer.
-             * If value() has been set, pixelPosition() will be updated according to the new scale.
-             * Otherwise, if pixelPosition() has been set but value() has not, value() will be set.
+             * If value() was the last property set, pixelPosition() will be updated according to the new scale.
+             * If pixelPosition() was the last property set, value() will be updated according to the new scale.
              *
              * @param {QuantitativeScale<D>} scale
              * @return {GuideLineLayer<D>} The calling GuideLineLayer.
@@ -2452,7 +2452,7 @@ declare module Plottable {
             value(): D;
             /**
              * Sets the value of the guide line in data-space.
-             * If the GuideLineLayer has a scale, pixelPosition() will be updated.
+             * If the GuideLineLayer has a scale, pixelPosition() will be updated now and whenever the scale updates.
              *
              * @param {D} value
              * @return {GuideLineLayer<D>} The calling GuideLineLayer.
@@ -2466,7 +2466,7 @@ declare module Plottable {
             pixelPosition(): number;
             /**
              * Sets the position of the guide line in pixel-space.
-             * If the GuideLineLayer has a scale, the value() will be updated.
+             * If the GuideLineLayer has a scale, the value() will be updated now and whenever the scale updates.
              *
              * @param {number} pixelPosition
              * @return {GuideLineLayer<D>} The calling GuideLineLayer.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2415,6 +2415,21 @@ declare module Plottable {
 
 
 declare module Plottable {
+    module Components {
+        class GuideLineLayer<D> extends Component {
+            constructor(orientation: string);
+            scale(): QuantitativeScale<D>;
+            scale(scale: QuantitativeScale<D>): GuideLineLayer<D>;
+            value(): D;
+            value(value: D): GuideLineLayer<D>;
+            pixelPosition(): number;
+            pixelPosition(pixelPosition: number): GuideLineLayer<D>;
+        }
+    }
+}
+
+
+declare module Plottable {
     module Plots {
         interface PlotEntity extends Entity<Plot> {
             dataset: Dataset;

--- a/plottable.js
+++ b/plottable.js
@@ -6207,16 +6207,16 @@ var Plottable;
             function GuideLineLayer(orientation) {
                 var _this = this;
                 _super.call(this);
-                this._scaleUpdateCallback = function () {
-                    _this._updatePixelPosition();
-                    _this.render();
-                };
                 if (orientation !== GuideLineLayer.ORIENTATION_VERTICAL && orientation !== GuideLineLayer.ORIENTATION_HORIZONTAL) {
                     throw new Error(orientation + " is not a valid orientation for GuideLineLayer");
                 }
                 this._orientation = orientation;
                 this._clipPathEnabled = true;
                 this.addClass("guide-line-layer");
+                this._scaleUpdateCallback = function () {
+                    _this._updatePixelPosition();
+                    _this.render();
+                };
             }
             GuideLineLayer.prototype._setup = function () {
                 _super.prototype._setup.call(this);

--- a/plottable.js
+++ b/plottable.js
@@ -6237,6 +6237,18 @@ var Plottable;
             GuideLineLayer.prototype.fixedHeight = function () {
                 return true;
             };
+            GuideLineLayer.prototype.computeLayout = function (origin, availableWidth, availableHeight) {
+                _super.prototype.computeLayout.call(this, origin, availableWidth, availableHeight);
+                if (this.scale() != null) {
+                    if (this._isVertical()) {
+                        this.scale().range([0, this.width()]);
+                    }
+                    else {
+                        this.scale().range([this.height(), 0]);
+                    }
+                }
+                return this;
+            };
             GuideLineLayer.prototype.renderImmediately = function () {
                 _super.prototype.renderImmediately.call(this);
                 this._syncValueAndPixelPosition();
@@ -6269,7 +6281,7 @@ var Plottable;
                 this._scale = scale;
                 this._scale.onUpdate(this._scaleUpdateCallback);
                 this._syncValueAndPixelPosition();
-                this.render();
+                this.redraw();
                 return this;
             };
             GuideLineLayer.prototype.value = function (value) {

--- a/plottable.js
+++ b/plottable.js
@@ -6204,8 +6204,8 @@ var Plottable;
     (function (Components) {
         var PropertyMode;
         (function (PropertyMode) {
-            PropertyMode[PropertyMode["value"] = 0] = "value";
-            PropertyMode[PropertyMode["pixel"] = 1] = "pixel";
+            PropertyMode[PropertyMode["VALUE"] = 0] = "VALUE";
+            PropertyMode[PropertyMode["PIXEL"] = 1] = "PIXEL";
         })(PropertyMode || (PropertyMode = {}));
         ;
         var GuideLineLayer = (function (_super) {
@@ -6213,7 +6213,7 @@ var Plottable;
             function GuideLineLayer(orientation) {
                 var _this = this;
                 _super.call(this);
-                this._mode = PropertyMode.value;
+                this._mode = PropertyMode.VALUE;
                 if (orientation !== GuideLineLayer.ORIENTATION_VERTICAL && orientation !== GuideLineLayer.ORIENTATION_HORIZONTAL) {
                     throw new Error(orientation + " is not a valid orientation for GuideLineLayer");
                 }
@@ -6272,10 +6272,10 @@ var Plottable;
                 if (this.scale() == null) {
                     return;
                 }
-                if (this._mode === PropertyMode.value && this.value() != null) {
+                if (this._mode === PropertyMode.VALUE && this.value() != null) {
                     this._pixelPosition = this.scale().scale(this.value());
                 }
-                else if (this._mode === PropertyMode.pixel && this.pixelPosition() != null) {
+                else if (this._mode === PropertyMode.PIXEL && this.pixelPosition() != null) {
                     this._value = this.scale().invert(this.pixelPosition());
                 }
             };
@@ -6298,7 +6298,7 @@ var Plottable;
                     return this._value;
                 }
                 this._value = value;
-                this._mode = PropertyMode.value;
+                this._mode = PropertyMode.VALUE;
                 this._syncPixelPositionAndValue();
                 this.render();
                 return this;
@@ -6308,7 +6308,7 @@ var Plottable;
                     return this._pixelPosition;
                 }
                 this._pixelPosition = pixelPosition;
-                this._mode = PropertyMode.pixel;
+                this._mode = PropertyMode.PIXEL;
                 this._syncPixelPositionAndValue();
                 this.render();
                 return this;

--- a/plottable.js
+++ b/plottable.js
@@ -6202,12 +6202,18 @@ var Plottable;
 (function (Plottable) {
     var Components;
     (function (Components) {
+        var PropertyMode;
+        (function (PropertyMode) {
+            PropertyMode[PropertyMode["value"] = 0] = "value";
+            PropertyMode[PropertyMode["pixel"] = 1] = "pixel";
+        })(PropertyMode || (PropertyMode = {}));
+        ;
         var GuideLineLayer = (function (_super) {
             __extends(GuideLineLayer, _super);
             function GuideLineLayer(orientation) {
                 var _this = this;
                 _super.call(this);
-                this._primaryProperty = "value";
+                this._mode = PropertyMode.value;
                 if (orientation !== GuideLineLayer.ORIENTATION_VERTICAL && orientation !== GuideLineLayer.ORIENTATION_HORIZONTAL) {
                     throw new Error(orientation + " is not a valid orientation for GuideLineLayer");
                 }
@@ -6266,10 +6272,10 @@ var Plottable;
                 if (this.scale() == null) {
                     return;
                 }
-                if (this._primaryProperty === "value" && this.value() != null) {
+                if (this._mode === PropertyMode.value && this.value() != null) {
                     this._pixelPosition = this.scale().scale(this.value());
                 }
-                else if (this._primaryProperty === "pixelPosition" && this.pixelPosition() != null) {
+                else if (this._mode === PropertyMode.pixel && this.pixelPosition() != null) {
                     this._value = this.scale().invert(this.pixelPosition());
                 }
             };
@@ -6292,7 +6298,7 @@ var Plottable;
                     return this._value;
                 }
                 this._value = value;
-                this._primaryProperty = "value";
+                this._mode = PropertyMode.value;
                 this._syncPixelPositionAndValue();
                 this.render();
                 return this;
@@ -6302,7 +6308,7 @@ var Plottable;
                     return this._pixelPosition;
                 }
                 this._pixelPosition = pixelPosition;
-                this._primaryProperty = "pixelPosition";
+                this._mode = PropertyMode.pixel;
                 this._syncPixelPositionAndValue();
                 this.render();
                 return this;

--- a/plottable.js
+++ b/plottable.js
@@ -6207,7 +6207,10 @@ var Plottable;
             function GuideLineLayer(orientation) {
                 var _this = this;
                 _super.call(this);
-                this._scaleUpdateCallback = function () { return _this._updatePixelPosition(); };
+                this._scaleUpdateCallback = function () {
+                    _this._updatePixelPosition();
+                    _this.render();
+                };
                 if (orientation !== GuideLineLayer.ORIENTATION_VERTICAL && orientation !== GuideLineLayer.ORIENTATION_HORIZONTAL) {
                     throw new Error(orientation + " is not a valid orientation for GuideLineLayer");
                 }

--- a/plottable.js
+++ b/plottable.js
@@ -6290,6 +6290,12 @@ var Plottable;
                 this.render();
                 return this;
             };
+            GuideLineLayer.prototype.destroy = function () {
+                _super.prototype.destroy.call(this);
+                if (this.scale() != null) {
+                    this.scale().offUpdate(this._scaleUpdateCallback);
+                }
+            };
             GuideLineLayer.ORIENTATION_VERTICAL = "vertical";
             GuideLineLayer.ORIENTATION_HORIZONTAL = "horizontal";
             return GuideLineLayer;

--- a/plottable.js
+++ b/plottable.js
@@ -6200,6 +6200,37 @@ var __extends = (this && this.__extends) || function (d, b) {
 };
 var Plottable;
 (function (Plottable) {
+    var Components;
+    (function (Components) {
+        var GuideLineLayer = (function (_super) {
+            __extends(GuideLineLayer, _super);
+            function GuideLineLayer(orientation) {
+                _super.call(this);
+            }
+            GuideLineLayer.prototype.scale = function (scale) {
+                return;
+            };
+            GuideLineLayer.prototype.value = function (value) {
+                return;
+            };
+            GuideLineLayer.prototype.pixelPosition = function (pixelPosition) {
+                return;
+            };
+            return GuideLineLayer;
+        })(Plottable.Component);
+        Components.GuideLineLayer = GuideLineLayer;
+    })(Components = Plottable.Components || (Plottable.Components = {}));
+})(Plottable || (Plottable = {}));
+
+///<reference path="../reference.ts" />
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    __.prototype = b.prototype;
+    d.prototype = new __();
+};
+var Plottable;
+(function (Plottable) {
     var Plots;
     (function (Plots) {
         var Animator;

--- a/plottable.js
+++ b/plottable.js
@@ -6220,7 +6220,7 @@ var Plottable;
             }
             GuideLineLayer.prototype._setup = function () {
                 _super.prototype._setup.call(this);
-                this._line = this.content().append("line").classed("guide-line", true);
+                this._guideLine = this.content().append("line").classed("guide-line", true);
             };
             GuideLineLayer.prototype._sizeFromOffer = function (availableWidth, availableHeight) {
                 return {
@@ -6240,7 +6240,7 @@ var Plottable;
             GuideLineLayer.prototype.renderImmediately = function () {
                 _super.prototype.renderImmediately.call(this);
                 this._updatePixelPosition();
-                this._line.attr({
+                this._guideLine.attr({
                     x1: this._isVertical() ? this.pixelPosition() : 0,
                     y1: this._isVertical() ? 0 : this.pixelPosition(),
                     x2: this._isVertical() ? this.pixelPosition() : this.width(),

--- a/plottable.js
+++ b/plottable.js
@@ -6214,7 +6214,7 @@ var Plottable;
                 this._clipPathEnabled = true;
                 this.addClass("guide-line-layer");
                 this._scaleUpdateCallback = function () {
-                    _this._syncValueAndPixelPosition();
+                    _this._setPixelPositionFromValue();
                     _this.render();
                 };
             }
@@ -6251,7 +6251,7 @@ var Plottable;
             };
             GuideLineLayer.prototype.renderImmediately = function () {
                 _super.prototype.renderImmediately.call(this);
-                this._syncValueAndPixelPosition();
+                this._setPixelPositionFromValue();
                 this._guideLine.attr({
                     x1: this._isVertical() ? this.pixelPosition() : 0,
                     y1: this._isVertical() ? 0 : this.pixelPosition(),
@@ -6260,14 +6260,14 @@ var Plottable;
                 });
                 return this;
             };
-            GuideLineLayer.prototype._syncValueAndPixelPosition = function () {
-                if (this.scale() != null) {
-                    if (this.value() != null) {
-                        this._pixelPosition = this.scale().scale(this.value());
-                    }
-                    else if (this.pixelPosition() != null) {
-                        this._value = this.scale().invert(this.pixelPosition());
-                    }
+            GuideLineLayer.prototype._setPixelPositionFromValue = function () {
+                if (this.scale() != null && this.value() != null) {
+                    this._pixelPosition = this.scale().scale(this.value());
+                }
+            };
+            GuideLineLayer.prototype._setValueFromPixelPosition = function () {
+                if (this.scale() != null && this.pixelPosition() != null) {
+                    this._value = this.scale().invert(this.pixelPosition());
                 }
             };
             GuideLineLayer.prototype.scale = function (scale) {
@@ -6280,7 +6280,8 @@ var Plottable;
                 }
                 this._scale = scale;
                 this._scale.onUpdate(this._scaleUpdateCallback);
-                this._syncValueAndPixelPosition();
+                this._setPixelPositionFromValue();
+                this._setValueFromPixelPosition();
                 this.redraw();
                 return this;
             };
@@ -6289,7 +6290,7 @@ var Plottable;
                     return this._value;
                 }
                 this._value = value;
-                this._syncValueAndPixelPosition();
+                this._setPixelPositionFromValue();
                 this.render();
                 return this;
             };
@@ -6298,7 +6299,7 @@ var Plottable;
                     return this._pixelPosition;
                 }
                 this._pixelPosition = pixelPosition;
-                this._syncValueAndPixelPosition();
+                this._setValueFromPixelPosition();
                 this.render();
                 return this;
             };

--- a/plottable.js
+++ b/plottable.js
@@ -6307,6 +6307,9 @@ var Plottable;
                 if (pixelPosition == null) {
                     return this._pixelPosition;
                 }
+                if (!Plottable.Utils.Math.isValidNumber(pixelPosition)) {
+                    throw new Error("pixelPosition must be a finite number");
+                }
                 this._pixelPosition = pixelPosition;
                 this._mode = PropertyMode.PIXEL;
                 this._syncPixelPositionAndValue();

--- a/plottable.js
+++ b/plottable.js
@@ -6214,7 +6214,7 @@ var Plottable;
                 this._clipPathEnabled = true;
                 this.addClass("guide-line-layer");
                 this._scaleUpdateCallback = function () {
-                    _this._updatePixelPosition();
+                    _this._syncValueAndPixelPosition();
                     _this.render();
                 };
             }
@@ -6239,7 +6239,7 @@ var Plottable;
             };
             GuideLineLayer.prototype.renderImmediately = function () {
                 _super.prototype.renderImmediately.call(this);
-                this._updatePixelPosition();
+                this._syncValueAndPixelPosition();
                 this._guideLine.attr({
                     x1: this._isVertical() ? this.pixelPosition() : 0,
                     y1: this._isVertical() ? 0 : this.pixelPosition(),
@@ -6248,9 +6248,14 @@ var Plottable;
                 });
                 return this;
             };
-            GuideLineLayer.prototype._updatePixelPosition = function () {
-                if (this.scale() != null && this.value() != null) {
-                    this._pixelPosition = this.scale().scale(this.value());
+            GuideLineLayer.prototype._syncValueAndPixelPosition = function () {
+                if (this.scale() != null) {
+                    if (this.value() != null) {
+                        this._pixelPosition = this.scale().scale(this.value());
+                    }
+                    else if (this.pixelPosition() != null) {
+                        this._value = this.scale().invert(this.pixelPosition());
+                    }
                 }
             };
             GuideLineLayer.prototype.scale = function (scale) {
@@ -6263,7 +6268,7 @@ var Plottable;
                 }
                 this._scale = scale;
                 this._scale.onUpdate(this._scaleUpdateCallback);
-                this._updatePixelPosition();
+                this._syncValueAndPixelPosition();
                 this.render();
                 return this;
             };
@@ -6272,7 +6277,7 @@ var Plottable;
                     return this._value;
                 }
                 this._value = value;
-                this._updatePixelPosition();
+                this._syncValueAndPixelPosition();
                 this.render();
                 return this;
             };
@@ -6281,9 +6286,7 @@ var Plottable;
                     return this._pixelPosition;
                 }
                 this._pixelPosition = pixelPosition;
-                if (this.scale() != null) {
-                    this._value = this.scale().invert(pixelPosition);
-                }
+                this._syncValueAndPixelPosition();
                 this.render();
                 return this;
             };

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -10,7 +10,10 @@ export module Components {
     private _value: D;
     private _scale: QuantitativeScale<D>;
     private _pixelPosition: number;
-    private _scaleUpdateCallback = () => this._updatePixelPosition();
+    private _scaleUpdateCallback = () => {
+      this._updatePixelPosition();
+      this.render();
+    };
     private _line: d3.Selection<void>;
 
     constructor(orientation: string) {

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -10,10 +10,7 @@ export module Components {
     private _value: D;
     private _scale: QuantitativeScale<D>;
     private _pixelPosition: number;
-    private _scaleUpdateCallback = () => {
-      this._updatePixelPosition();
-      this.render();
-    };
+    private _scaleUpdateCallback: ScaleCallback<QuantitativeScale<D>>;
     private _line: d3.Selection<void>;
 
     constructor(orientation: string) {
@@ -24,6 +21,10 @@ export module Components {
       this._orientation = orientation;
       this._clipPathEnabled = true;
       this.addClass("guide-line-layer");
+      this._scaleUpdateCallback = () => {
+        this._updatePixelPosition();
+        this.render();
+      };
     }
 
     protected _setup() {

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -22,7 +22,7 @@ export module Components {
       this._clipPathEnabled = true;
       this.addClass("guide-line-layer");
       this._scaleUpdateCallback = () => {
-        this._updatePixelPosition();
+        this._syncValueAndPixelPosition();
         this.render();
       };
     }
@@ -53,7 +53,7 @@ export module Components {
 
     public renderImmediately() {
       super.renderImmediately();
-      this._updatePixelPosition();
+      this._syncValueAndPixelPosition();
       this._guideLine.attr({
         x1: this._isVertical() ? this.pixelPosition() : 0,
         y1: this._isVertical() ? 0 : this.pixelPosition(),
@@ -63,9 +63,13 @@ export module Components {
       return this;
     }
 
-    private _updatePixelPosition() {
-      if (this.scale() != null && this.value() != null) {
-        this._pixelPosition = this.scale().scale(this.value());
+    private _syncValueAndPixelPosition() {
+      if (this.scale() != null) {
+        if (this.value() != null) {
+          this._pixelPosition = this.scale().scale(this.value());
+        } else if (this.pixelPosition() != null) {
+          this._value = this.scale().invert(this.pixelPosition());
+        }
       }
     }
 
@@ -93,7 +97,7 @@ export module Components {
       }
       this._scale = scale;
       this._scale.onUpdate(this._scaleUpdateCallback);
-      this._updatePixelPosition();
+      this._syncValueAndPixelPosition();
       this.render();
       return this;
     }
@@ -117,7 +121,7 @@ export module Components {
         return this._value;
       }
       this._value = value;
-      this._updatePixelPosition();
+      this._syncValueAndPixelPosition();
       this.render();
       return this;
     }
@@ -141,9 +145,7 @@ export module Components {
         return this._pixelPosition;
       }
       this._pixelPosition = pixelPosition;
-      if (this.scale() != null) {
-        this._value = this.scale().invert(pixelPosition);
-      }
+      this._syncValueAndPixelPosition();
       this.render();
       return this;
     }

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -1,0 +1,30 @@
+///<reference path="../reference.ts" />
+
+module Plottable {
+export module Components {
+  export class GuideLineLayer<D> extends Component {
+
+    constructor(orientation: string) {
+      super();
+    }
+
+    public scale(): QuantitativeScale<D>;
+    public scale(scale: QuantitativeScale<D>): GuideLineLayer<D>;
+    public scale(scale?: QuantitativeScale<D>): any {
+      return;
+    }
+
+    public value(): D;
+    public value(value: D): GuideLineLayer<D>;
+    public value(value?: D): any {
+      return;
+    }
+
+    public pixelPosition(): number;
+    public pixelPosition(pixelPosition: number): GuideLineLayer<D>;
+    public pixelPosition(pixelPosition?: number): any {
+      return;
+    }
+  }
+}
+}

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -22,7 +22,7 @@ export module Components {
       this._clipPathEnabled = true;
       this.addClass("guide-line-layer");
       this._scaleUpdateCallback = () => {
-        this._syncValueAndPixelPosition();
+        this._setPixelPositionFromValue();
         this.render();
       };
     }
@@ -65,7 +65,7 @@ export module Components {
 
     public renderImmediately() {
       super.renderImmediately();
-      this._syncValueAndPixelPosition();
+      this._setPixelPositionFromValue();
       this._guideLine.attr({
         x1: this._isVertical() ? this.pixelPosition() : 0,
         y1: this._isVertical() ? 0 : this.pixelPosition(),
@@ -75,13 +75,15 @@ export module Components {
       return this;
     }
 
-    private _syncValueAndPixelPosition() {
-      if (this.scale() != null) {
-        if (this.value() != null) {
-          this._pixelPosition = this.scale().scale(this.value());
-        } else if (this.pixelPosition() != null) {
-          this._value = this.scale().invert(this.pixelPosition());
-        }
+    private _setPixelPositionFromValue() {
+      if (this.scale() != null && this.value() != null) {
+        this._pixelPosition = this.scale().scale(this.value());
+      }
+    }
+
+    private _setValueFromPixelPosition() {
+      if (this.scale() != null && this.pixelPosition() != null) {
+        this._value = this.scale().invert(this.pixelPosition());
       }
     }
 
@@ -110,7 +112,8 @@ export module Components {
       }
       this._scale = scale;
       this._scale.onUpdate(this._scaleUpdateCallback);
-      this._syncValueAndPixelPosition();
+      this._setPixelPositionFromValue();
+      this._setValueFromPixelPosition();
       this.redraw();
       return this;
     }
@@ -134,7 +137,7 @@ export module Components {
         return this._value;
       }
       this._value = value;
-      this._syncValueAndPixelPosition();
+      this._setPixelPositionFromValue();
       this.render();
       return this;
     }
@@ -158,7 +161,7 @@ export module Components {
         return this._pixelPosition;
       }
       this._pixelPosition = pixelPosition;
-      this._syncValueAndPixelPosition();
+      this._setValueFromPixelPosition();
       this.render();
       return this;
     }

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -51,6 +51,18 @@ export module Components {
       return true;
     }
 
+    public computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number) {
+      super.computeLayout(origin, availableWidth, availableHeight);
+      if (this.scale() != null) {
+        if (this._isVertical()) {
+          this.scale().range([0, this.width()]);
+        } else {
+          this.scale().range([this.height(), 0]);
+        }
+      }
+      return this;
+    }
+
     public renderImmediately() {
       super.renderImmediately();
       this._syncValueAndPixelPosition();
@@ -99,7 +111,7 @@ export module Components {
       this._scale = scale;
       this._scale.onUpdate(this._scaleUpdateCallback);
       this._syncValueAndPixelPosition();
-      this.render();
+      this.redraw();
       return this;
     }
 

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -162,6 +162,9 @@ export module Components {
       if (pixelPosition == null) {
         return this._pixelPosition;
       }
+      if (!Utils.Math.isValidNumber(pixelPosition)) {
+        throw new Error("pixelPosition must be a finite number");
+      }
       this._pixelPosition = pixelPosition;
       this._mode = PropertyMode.PIXEL;
       this._syncPixelPositionAndValue();

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -82,6 +82,7 @@ export module Components {
     /**
      * Sets the QuantitativeScale on the GuideLineLayer.
      * If value() has been set, pixelPosition() will be updated according to the new scale.
+     * Otherwise, if pixelPosition() has been set but value() has not, value() will be set.
      *
      * @param {QuantitativeScale<D>} scale
      * @return {GuideLineLayer<D>} The calling GuideLineLayer.
@@ -103,13 +104,13 @@ export module Components {
     }
 
     /**
-     * Gets the position of the guide line in data-space.
+     * Gets the value of the guide line in data-space.
      *
      * @return {D}
      */
     public value(): D;
     /**
-     * Sets the position of the guide line in data-space.
+     * Sets the value of the guide line in data-space.
      * If the GuideLineLayer has a scale, pixelPosition() will be updated.
      *
      * @param {D} value

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -11,7 +11,7 @@ export module Components {
     private _scale: QuantitativeScale<D>;
     private _pixelPosition: number;
     private _scaleUpdateCallback: ScaleCallback<QuantitativeScale<D>>;
-    private _line: d3.Selection<void>;
+    private _guideLine: d3.Selection<void>;
 
     constructor(orientation: string) {
       super();
@@ -29,7 +29,7 @@ export module Components {
 
     protected _setup() {
       super._setup();
-      this._line = this.content().append("line").classed("guide-line", true);
+      this._guideLine = this.content().append("line").classed("guide-line", true);
     }
 
     protected _sizeFromOffer(availableWidth: number, availableHeight: number) {
@@ -54,7 +54,7 @@ export module Components {
     public renderImmediately() {
       super.renderImmediately();
       this._updatePixelPosition();
-      this._line.attr({
+      this._guideLine.attr({
         x1: this._isVertical() ? this.pixelPosition() : 0,
         y1: this._isVertical() ? 0 : this.pixelPosition(),
         x2: this._isVertical() ? this.pixelPosition() : this.width(),
@@ -77,8 +77,7 @@ export module Components {
     public scale(): QuantitativeScale<D>;
     /**
      * Sets the QuantitativeScale on the GuideLineLayer.
-     * If the value of the guide line in data-space has been set,
-     * the position of the guide line in pixel-space will be updated.
+     * If value() has been set, pixelPosition() will be updated according to the new scale.
      *
      * @param {QuantitativeScale<D>} scale
      * @return {GuideLineLayer<D>} The calling GuideLineLayer.
@@ -107,8 +106,7 @@ export module Components {
     public value(): D;
     /**
      * Sets the position of the guide line in data-space.
-     * If the GuideLineLayer has a scale, the position of the line
-     * in pixel-space will be updated accordingly.
+     * If the GuideLineLayer has a scale, pixelPosition() will be updated.
      *
      * @param {D} value
      * @return {GuideLineLayer<D>} The calling GuideLineLayer.
@@ -132,8 +130,7 @@ export module Components {
     public pixelPosition(): number;
     /**
      * Sets the position of the guide line in pixel-space.
-     * If the GuideLineLayer has a scale, the position of the line
-     * in data-space will be updated accordingly.
+     * If the GuideLineLayer has a scale, the value() will be updated.
      *
      * @param {number} pixelPosition
      * @return {GuideLineLayer<D>} The calling GuideLineLayer.

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -2,6 +2,7 @@
 
 module Plottable {
 export module Components {
+  enum PropertyMode { value, pixel };
   export class GuideLineLayer<D> extends Component {
     public static ORIENTATION_VERTICAL = "vertical";
     public static ORIENTATION_HORIZONTAL = "horizontal";
@@ -12,7 +13,7 @@ export module Components {
     private _pixelPosition: number;
     private _scaleUpdateCallback: ScaleCallback<QuantitativeScale<D>>;
     private _guideLine: d3.Selection<void>;
-    private _primaryProperty = "value";
+    private _mode = PropertyMode.value;
 
     constructor(orientation: string) {
       super();
@@ -81,9 +82,9 @@ export module Components {
       if (this.scale() == null) {
         return;
       }
-      if (this._primaryProperty === "value" && this.value() != null) {
+      if (this._mode === PropertyMode.value && this.value() != null) {
         this._pixelPosition = this.scale().scale(this.value());
-      } else if (this._primaryProperty === "pixelPosition" && this.pixelPosition() != null) {
+      } else if (this._mode === PropertyMode.pixel && this.pixelPosition() != null) {
         this._value = this.scale().invert(this.pixelPosition());
       }
     }
@@ -137,7 +138,7 @@ export module Components {
         return this._value;
       }
       this._value = value;
-      this._primaryProperty = "value";
+      this._mode = PropertyMode.value;
       this._syncPixelPositionAndValue();
       this.render();
       return this;
@@ -162,7 +163,7 @@ export module Components {
         return this._pixelPosition;
       }
       this._pixelPosition = pixelPosition;
-      this._primaryProperty = "pixelPosition";
+      this._mode = PropertyMode.pixel;
       this._syncPixelPositionAndValue();
       this.render();
       return this;

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -3,27 +3,109 @@
 module Plottable {
 export module Components {
   export class GuideLineLayer<D> extends Component {
+    public static ORIENTATION_VERTICAL = "vertical";
+    public static ORIENTATION_HORIZONTAL = "horizontal";
+
+    private _orientation: string;
+    private _value: D;
+    private _scale: QuantitativeScale<D>;
+    private _pixelPosition: number;
+    private _scaleUpdateCallback = () => this._updatePixelPosition();
+    private _line: d3.Selection<void>;
 
     constructor(orientation: string) {
       super();
+      if (orientation !== GuideLineLayer.ORIENTATION_VERTICAL && orientation !== GuideLineLayer.ORIENTATION_HORIZONTAL) {
+        throw new Error(orientation + " is not a valid orientation for GuideLineLayer");
+      }
+      this._orientation = orientation;
+      this._clipPathEnabled = true;
+      this.addClass("guide-line-layer");
+    }
+
+    protected _setup() {
+      super._setup();
+      this._line = this.content().append("line").classed("guide-line", true);
+    }
+
+    protected _sizeFromOffer(availableWidth: number, availableHeight: number) {
+      return {
+        width: availableWidth,
+        height: availableHeight
+      };
+    }
+
+    private _isVertical() {
+      return this._orientation === GuideLineLayer.ORIENTATION_VERTICAL;
+    }
+
+    public fixedWidth() {
+      return true;
+    }
+
+    public fixedHeight() {
+      return true;
+    }
+
+    public renderImmediately() {
+      super.renderImmediately();
+      this._updatePixelPosition();
+      this._line.attr({
+        x1: this._isVertical() ? this.pixelPosition() : 0,
+        y1: this._isVertical() ? 0 : this.pixelPosition(),
+        x2: this._isVertical() ? this.pixelPosition() : this.width(),
+        y2: this._isVertical() ? this.height() : this.pixelPosition()
+      });
+      return this;
+    }
+
+    private _updatePixelPosition() {
+      if (this.scale() != null && this.value() != null) {
+        this._pixelPosition = this.scale().scale(this.value());
+      }
     }
 
     public scale(): QuantitativeScale<D>;
     public scale(scale: QuantitativeScale<D>): GuideLineLayer<D>;
     public scale(scale?: QuantitativeScale<D>): any {
-      return;
+      if (scale == null) {
+        return this._scale;
+      }
+      let previousScale = this._scale;
+      if (previousScale != null) {
+        previousScale.offUpdate(this._scaleUpdateCallback);
+      }
+      this._scale = scale;
+      this._scale.onUpdate(this._scaleUpdateCallback);
+      this._updatePixelPosition();
+      this.render();
+      return this;
     }
 
     public value(): D;
     public value(value: D): GuideLineLayer<D>;
     public value(value?: D): any {
-      return;
+      if (value == null) {
+        return this._value;
+      }
+      this._value = value;
+      this._updatePixelPosition();
+      this.render();
+      return this;
     }
 
     public pixelPosition(): number;
     public pixelPosition(pixelPosition: number): GuideLineLayer<D>;
     public pixelPosition(pixelPosition?: number): any {
-      return;
+      if (pixelPosition == null) {
+        return this._pixelPosition;
+      }
+      this._pixelPosition = pixelPosition;
+      if (this.scale() != null) {
+        this._value = this.scale().invert(pixelPosition);
+      }
+      this.render();
+      return this;
     }
   }
 }

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -2,7 +2,7 @@
 
 module Plottable {
 export module Components {
-  enum PropertyMode { value, pixel };
+  enum PropertyMode { VALUE, PIXEL };
   export class GuideLineLayer<D> extends Component {
     public static ORIENTATION_VERTICAL = "vertical";
     public static ORIENTATION_HORIZONTAL = "horizontal";
@@ -13,7 +13,7 @@ export module Components {
     private _pixelPosition: number;
     private _scaleUpdateCallback: ScaleCallback<QuantitativeScale<D>>;
     private _guideLine: d3.Selection<void>;
-    private _mode = PropertyMode.value;
+    private _mode = PropertyMode.VALUE;
 
     constructor(orientation: string) {
       super();
@@ -82,9 +82,9 @@ export module Components {
       if (this.scale() == null) {
         return;
       }
-      if (this._mode === PropertyMode.value && this.value() != null) {
+      if (this._mode === PropertyMode.VALUE && this.value() != null) {
         this._pixelPosition = this.scale().scale(this.value());
-      } else if (this._mode === PropertyMode.pixel && this.pixelPosition() != null) {
+      } else if (this._mode === PropertyMode.PIXEL && this.pixelPosition() != null) {
         this._value = this.scale().invert(this.pixelPosition());
       }
     }
@@ -138,7 +138,7 @@ export module Components {
         return this._value;
       }
       this._value = value;
-      this._mode = PropertyMode.value;
+      this._mode = PropertyMode.VALUE;
       this._syncPixelPositionAndValue();
       this.render();
       return this;
@@ -163,7 +163,7 @@ export module Components {
         return this._pixelPosition;
       }
       this._pixelPosition = pixelPosition;
-      this._mode = PropertyMode.pixel;
+      this._mode = PropertyMode.PIXEL;
       this._syncPixelPositionAndValue();
       this.render();
       return this;

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -149,6 +149,13 @@ export module Components {
       this.render();
       return this;
     }
+
+    public destroy() {
+      super.destroy();
+      if (this.scale() != null) {
+        this.scale().offUpdate(this._scaleUpdateCallback);
+      }
+    }
   }
 }
 }

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -65,7 +65,20 @@ export module Components {
       }
     }
 
+    /**
+     * Gets the QuantitativeScale on the GuideLineLayer.
+     *
+     * @return {QuantitativeScale<D>}
+     */
     public scale(): QuantitativeScale<D>;
+    /**
+     * Sets the QuantitativeScale on the GuideLineLayer.
+     * If the value of the guide line in data-space has been set,
+     * the position of the guide line in pixel-space will be updated.
+     *
+     * @param {QuantitativeScale<D>} scale
+     * @return {GuideLineLayer<D>} The calling GuideLineLayer.
+     */
     public scale(scale: QuantitativeScale<D>): GuideLineLayer<D>;
     public scale(scale?: QuantitativeScale<D>): any {
       if (scale == null) {
@@ -82,7 +95,20 @@ export module Components {
       return this;
     }
 
+    /**
+     * Gets the position of the guide line in data-space.
+     *
+     * @return {D}
+     */
     public value(): D;
+    /**
+     * Sets the position of the guide line in data-space.
+     * If the GuideLineLayer has a scale, the position of the line
+     * in pixel-space will be updated accordingly.
+     *
+     * @param {D} value
+     * @return {GuideLineLayer<D>} The calling GuideLineLayer.
+     */
     public value(value: D): GuideLineLayer<D>;
     public value(value?: D): any {
       if (value == null) {
@@ -94,7 +120,20 @@ export module Components {
       return this;
     }
 
+    /**
+     * Gets the position of the guide line in pixel-space.
+     *
+     * @return {number}
+     */
     public pixelPosition(): number;
+    /**
+     * Sets the position of the guide line in pixel-space.
+     * If the GuideLineLayer has a scale, the position of the line
+     * in data-space will be updated accordingly.
+     *
+     * @param {number} pixelPosition
+     * @return {GuideLineLayer<D>} The calling GuideLineLayer.
+     */
     public pixelPosition(pixelPosition: number): GuideLineLayer<D>;
     public pixelPosition(pixelPosition?: number): any {
       if (pixelPosition == null) {

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -56,6 +56,7 @@
 /// <reference path="components/gridlines.ts" />
 /// <reference path="components/table.ts" />
 /// <reference path="components/selectionBoxLayer.ts" />
+/// <reference path="components/guideLineLayer.ts" />
 
 /// <reference path="plots/plot.ts" />
 /// <reference path="plots/piePlot.ts" />

--- a/test/components/guideLineLayerTests.ts
+++ b/test/components/guideLineLayerTests.ts
@@ -210,6 +210,15 @@ describe("GuideLineLayer", () => {
       };
       TestMethods.assertLineAttrs(line, expectedAttrs1, "the line was drawn at the correct position");
 
+      scale1.domain([0, 20]);
+      let expectedAttrs1b = {
+        x1: scale1.scale(value),
+        x2: scale1.scale(value),
+        y1: 0,
+        y2: SVG_HEIGHT
+      };
+      TestMethods.assertLineAttrs(line, expectedAttrs1b, "the line was redrawn at the correct position on domain change");
+
       let scale2 = new Plottable.Scales.Linear();
       scale2.domain([0, 100]);
       gll.scale(scale2);
@@ -341,6 +350,15 @@ describe("GuideLineLayer", () => {
         y2: scale1.scale(value)
       };
       TestMethods.assertLineAttrs(line, expectedAttrs1, "the line was drawn at the correct position");
+
+      scale1.domain([0, 20]);
+      let expectedAttrs1b = {
+        x1: 0,
+        x2: SVG_WIDTH,
+        y1: scale1.scale(value),
+        y2: scale1.scale(value)
+      };
+      TestMethods.assertLineAttrs(line, expectedAttrs1b, "the line was redrawn at the correct position on domain change");
 
       let scale2 = new Plottable.Scales.Linear();
       scale2.domain([0, 100]);

--- a/test/components/guideLineLayerTests.ts
+++ b/test/components/guideLineLayerTests.ts
@@ -94,11 +94,38 @@ describe("GuideLineLayer", () => {
     assert.throws(() => new Plottable.Components.GuideLineLayer<number>("blargh"), Error);
   });
 
-  it("has fixed height if vertical, fixed width if horizontal", () => {
-    let verticalGLL = new Plottable.Components.GuideLineLayer<number>("vertical");
-    assert.strictEqual(verticalGLL.fixedHeight(), true, "fixed height if vertical");
-    let horizontalGLL = new Plottable.Components.GuideLineLayer<number>("horizontal");
-    assert.strictEqual(horizontalGLL.fixedWidth(), true, "fixed width if horizontal");
+  it("has an effective size of 0, but will occupy all offered space (vertical)", () => {
+    let SVG_WIDTH = 400;
+    let SVG_HEIGHT = 300;
+    let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
+    let request = gll.requestedSpace(SVG_WIDTH, SVG_HEIGHT);
+    TestMethods.verifySpaceRequest(request, 0, 0, "does not request any space");
+    assert.isTrue(gll.fixedWidth(), "fixed width");
+    assert.isTrue(gll.fixedHeight(), "fixed height");
+
+    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+    gll.anchor(svg);
+    gll.computeLayout({x: 0, y: 0}, SVG_WIDTH, SVG_HEIGHT);
+    assert.strictEqual(gll.width(), SVG_WIDTH, "accepted all offered width");
+    assert.strictEqual(gll.height(), SVG_HEIGHT, "accepted all offered height");
+    svg.remove();
+  });
+
+  it("has an effective size of 0, but will occupy all offered space (horizontal)", () => {
+    let SVG_WIDTH = 300;
+    let SVG_HEIGHT = 400;
+    let gll = new Plottable.Components.GuideLineLayer<number>("horizontal");
+    let request = gll.requestedSpace(SVG_WIDTH, SVG_HEIGHT);
+    TestMethods.verifySpaceRequest(request, 0, 0, "does not request any space");
+    assert.isTrue(gll.fixedWidth(), "fixed width");
+    assert.isTrue(gll.fixedHeight(), "fixed height");
+
+    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+    gll.anchor(svg);
+    gll.computeLayout({x: 0, y: 0}, SVG_WIDTH, SVG_HEIGHT);
+    assert.strictEqual(gll.width(), SVG_WIDTH, "accepted all offered width");
+    assert.strictEqual(gll.height(), SVG_HEIGHT, "accepted all offered height");
+    svg.remove();
   });
 
   describe("rendering (vertical)", () => {

--- a/test/components/guideLineLayerTests.ts
+++ b/test/components/guideLineLayerTests.ts
@@ -70,7 +70,7 @@ describe("GuideLineLayer", () => {
       let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
       let value = 0.5;
       gll.value(value);
-      var setPosition = -999;
+      let setPosition = -999;
       gll.pixelPosition(setPosition);
       let expectedPosition = linearScale.scale(value);
       gll.scale(linearScale);

--- a/test/components/guideLineLayerTests.ts
+++ b/test/components/guideLineLayerTests.ts
@@ -121,7 +121,7 @@ describe("GuideLineLayer", () => {
     let SVG_WIDTH = 400;
     let SVG_HEIGHT = 300;
 
-    it("has an effective size of 0, but will occupy all offered space", () => {
+    it("requests no space, but will occupy all offered space", () => {
       let gll = new Plottable.Components.GuideLineLayer<void>("vertical");
       let request = gll.requestedSpace(SVG_WIDTH, SVG_HEIGHT);
       TestMethods.verifySpaceRequest(request, 0, 0, "does not request any space");
@@ -154,8 +154,8 @@ describe("GuideLineLayer", () => {
       gll.pixelPosition(expectedPosition1);
       gll.renderTo(svg);
 
-      assert.strictEqual(gll.content().selectAll("line").size(), 1, "exactly one line is drawn");
-      let line = gll.content().select("line");
+      assert.strictEqual(gll.content().selectAll(".guide-line").size(), 1, "exactly one line is drawn");
+      let line = gll.content().select(".guide-line");
       let expectedAttrs1 = {
         x1: expectedPosition1,
         x2: expectedPosition1,
@@ -166,8 +166,8 @@ describe("GuideLineLayer", () => {
 
       let expectedPosition2 = SVG_WIDTH * 3 / 4;
       gll.pixelPosition(expectedPosition2);
-      assert.strictEqual(gll.content().selectAll("line").size(), 1, "exactly one line is drawn");
-      line = gll.content().select("line");
+      assert.strictEqual(gll.content().selectAll(".guide-line").size(), 1, "exactly one line is drawn");
+      line = gll.content().select(".guide-line");
       let expectedAttrs2 = {
         x1: expectedPosition2,
         x2: expectedPosition2,
@@ -189,8 +189,8 @@ describe("GuideLineLayer", () => {
 
       let value1 = 5;
       gll.value(value1);
-      assert.strictEqual(gll.content().selectAll("line").size(), 1, "exactly one line is drawn");
-      let line = gll.content().select("line");
+      assert.strictEqual(gll.content().selectAll(".guide-line").size(), 1, "exactly one line is drawn");
+      let line = gll.content().select(".guide-line");
       let expectedAttrs1 = {
         x1: scale.scale(value1),
         x2: scale.scale(value1),
@@ -201,8 +201,8 @@ describe("GuideLineLayer", () => {
 
       let value2 = 8;
       gll.value(value2);
-      assert.strictEqual(gll.content().selectAll("line").size(), 1, "exactly one line is drawn");
-      line = gll.content().select("line");
+      assert.strictEqual(gll.content().selectAll(".guide-line").size(), 1, "exactly one line is drawn");
+      line = gll.content().select(".guide-line");
       let expectedAttrs2 = {
         x1: scale.scale(value2),
         x2: scale.scale(value2),
@@ -224,7 +224,7 @@ describe("GuideLineLayer", () => {
       let scale1 = new Plottable.Scales.Linear();
       scale1.domain([0, 10]);
       gll.scale(scale1);
-      let line = gll.content().select("line");
+      let line = gll.content().select(".guide-line");
       let expectedAttrs1 = {
         x1: scale1.scale(value),
         x2: scale1.scale(value),
@@ -245,7 +245,7 @@ describe("GuideLineLayer", () => {
       let scale2 = new Plottable.Scales.Linear();
       scale2.domain([0, 100]);
       gll.scale(scale2);
-      line = gll.content().select("line");
+      line = gll.content().select(".guide-line");
       let expectedAttrs2 = {
         x1: scale2.scale(value),
         x2: scale2.scale(value),
@@ -262,7 +262,7 @@ describe("GuideLineLayer", () => {
     let SVG_WIDTH = 300;
     let SVG_HEIGHT = 400;
 
-    it("has an effective size of 0, but will occupy all offered space", () => {
+    it("requests no space, but will occupy all offered space", () => {
       let gll = new Plottable.Components.GuideLineLayer<void>("horizontal");
       let request = gll.requestedSpace(SVG_WIDTH, SVG_HEIGHT);
       TestMethods.verifySpaceRequest(request, 0, 0, "does not request any space");
@@ -295,8 +295,8 @@ describe("GuideLineLayer", () => {
       gll.pixelPosition(expectedPosition1);
       gll.renderTo(svg);
 
-      assert.strictEqual(gll.content().selectAll("line").size(), 1, "exactly one line is drawn");
-      let line = gll.content().select("line");
+      assert.strictEqual(gll.content().selectAll(".guide-line").size(), 1, "exactly one line is drawn");
+      let line = gll.content().select(".guide-line");
       let expectedAttrs1 = {
         x1: 0,
         x2: SVG_WIDTH,
@@ -307,8 +307,8 @@ describe("GuideLineLayer", () => {
 
       let expectedPosition2 = SVG_WIDTH * 3 / 4;
       gll.pixelPosition(expectedPosition2);
-      assert.strictEqual(gll.content().selectAll("line").size(), 1, "exactly one line is drawn");
-      line = gll.content().select("line");
+      assert.strictEqual(gll.content().selectAll(".guide-line").size(), 1, "exactly one line is drawn");
+      line = gll.content().select(".guide-line");
       let expectedAttrs2 = {
         x1: 0,
         x2: SVG_WIDTH,
@@ -330,8 +330,8 @@ describe("GuideLineLayer", () => {
 
       let value1 = 5;
       gll.value(value1);
-      assert.strictEqual(gll.content().selectAll("line").size(), 1, "exactly one line is drawn");
-      let line = gll.content().select("line");
+      assert.strictEqual(gll.content().selectAll(".guide-line").size(), 1, "exactly one line is drawn");
+      let line = gll.content().select(".guide-line");
       let expectedAttrs1 = {
         x1: 0,
         x2: SVG_WIDTH,
@@ -342,8 +342,8 @@ describe("GuideLineLayer", () => {
 
       let value2 = 8;
       gll.value(value2);
-      assert.strictEqual(gll.content().selectAll("line").size(), 1, "exactly one line is drawn");
-      line = gll.content().select("line");
+      assert.strictEqual(gll.content().selectAll(".guide-line").size(), 1, "exactly one line is drawn");
+      line = gll.content().select(".guide-line");
       let expectedAttrs2 = {
         x1: 0,
         x2: SVG_WIDTH,
@@ -365,7 +365,7 @@ describe("GuideLineLayer", () => {
       let scale1 = new Plottable.Scales.Linear();
       scale1.domain([0, 10]);
       gll.scale(scale1);
-      let line = gll.content().select("line");
+      let line = gll.content().select(".guide-line");
       let expectedAttrs1 = {
         x1: 0,
         x2: SVG_WIDTH,
@@ -386,7 +386,7 @@ describe("GuideLineLayer", () => {
       let scale2 = new Plottable.Scales.Linear();
       scale2.domain([0, 100]);
       gll.scale(scale2);
-      line = gll.content().select("line");
+      line = gll.content().select(".guide-line");
       let expectedAttrs2 = {
         x1: 0,
         x2: SVG_WIDTH,

--- a/test/components/guideLineLayerTests.ts
+++ b/test/components/guideLineLayerTests.ts
@@ -94,43 +94,35 @@ describe("GuideLineLayer", () => {
     assert.throws(() => new Plottable.Components.GuideLineLayer<number>("blargh"), Error);
   });
 
-  it("has an effective size of 0, but will occupy all offered space (vertical)", () => {
-    let SVG_WIDTH = 400;
-    let SVG_HEIGHT = 300;
-    let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
-    let request = gll.requestedSpace(SVG_WIDTH, SVG_HEIGHT);
-    TestMethods.verifySpaceRequest(request, 0, 0, "does not request any space");
-    assert.isTrue(gll.fixedWidth(), "fixed width");
-    assert.isTrue(gll.fixedHeight(), "fixed height");
-
-    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-    gll.anchor(svg);
-    gll.computeLayout({x: 0, y: 0}, SVG_WIDTH, SVG_HEIGHT);
-    assert.strictEqual(gll.width(), SVG_WIDTH, "accepted all offered width");
-    assert.strictEqual(gll.height(), SVG_HEIGHT, "accepted all offered height");
-    svg.remove();
-  });
-
-  it("has an effective size of 0, but will occupy all offered space (horizontal)", () => {
-    let SVG_WIDTH = 300;
-    let SVG_HEIGHT = 400;
-    let gll = new Plottable.Components.GuideLineLayer<number>("horizontal");
-    let request = gll.requestedSpace(SVG_WIDTH, SVG_HEIGHT);
-    TestMethods.verifySpaceRequest(request, 0, 0, "does not request any space");
-    assert.isTrue(gll.fixedWidth(), "fixed width");
-    assert.isTrue(gll.fixedHeight(), "fixed height");
-
-    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-    gll.anchor(svg);
-    gll.computeLayout({x: 0, y: 0}, SVG_WIDTH, SVG_HEIGHT);
-    assert.strictEqual(gll.width(), SVG_WIDTH, "accepted all offered width");
-    assert.strictEqual(gll.height(), SVG_HEIGHT, "accepted all offered height");
-    svg.remove();
-  });
-
   describe("rendering (vertical)", () => {
     let SVG_WIDTH = 400;
     let SVG_HEIGHT = 400;
+
+    it("has an effective size of 0, but will occupy all offered space", () => {
+      let gll = new Plottable.Components.GuideLineLayer<void>("vertical");
+      let request = gll.requestedSpace(SVG_WIDTH, SVG_HEIGHT);
+      TestMethods.verifySpaceRequest(request, 0, 0, "does not request any space");
+      assert.isTrue(gll.fixedWidth(), "fixed width");
+      assert.isTrue(gll.fixedHeight(), "fixed height");
+
+      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      gll.anchor(svg);
+      gll.computeLayout({x: 0, y: 0}, SVG_WIDTH, SVG_HEIGHT);
+      assert.strictEqual(gll.width(), SVG_WIDTH, "accepted all offered width");
+      assert.strictEqual(gll.height(), SVG_HEIGHT, "accepted all offered height");
+      svg.remove();
+    });
+
+    it("clipPath enabled", () => {
+      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      let gll = new Plottable.Components.GuideLineLayer<void>("vertical");
+      gll.renderTo(svg);
+      TestMethods.verifyClipPath(gll);
+      let clipRect = (<any> gll)._boxContainer.select(".clip-rect");
+      assert.strictEqual(TestMethods.numAttr(clipRect, "width"), SVG_WIDTH, "the clipRect has an appropriate width");
+      assert.strictEqual(TestMethods.numAttr(clipRect, "height"), SVG_HEIGHT, "the clipRect has an appropriate height");
+      svg.remove();
+    });
 
     it("renders correctly given a pixel position", () => {
       let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
@@ -237,6 +229,32 @@ describe("GuideLineLayer", () => {
   describe("rendering (horizontal)", () => {
     let SVG_WIDTH = 400;
     let SVG_HEIGHT = 400;
+
+    it("has an effective size of 0, but will occupy all offered space", () => {
+      let gll = new Plottable.Components.GuideLineLayer<void>("horizontal");
+      let request = gll.requestedSpace(SVG_WIDTH, SVG_HEIGHT);
+      TestMethods.verifySpaceRequest(request, 0, 0, "does not request any space");
+      assert.isTrue(gll.fixedWidth(), "fixed width");
+      assert.isTrue(gll.fixedHeight(), "fixed height");
+
+      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      gll.anchor(svg);
+      gll.computeLayout({x: 0, y: 0}, SVG_WIDTH, SVG_HEIGHT);
+      assert.strictEqual(gll.width(), SVG_WIDTH, "accepted all offered width");
+      assert.strictEqual(gll.height(), SVG_HEIGHT, "accepted all offered height");
+      svg.remove();
+    });
+
+    it("clipPath enabled", () => {
+      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      let gll = new Plottable.Components.GuideLineLayer<void>("horizontal");
+      gll.renderTo(svg);
+      TestMethods.verifyClipPath(gll);
+      let clipRect = (<any> gll)._boxContainer.select(".clip-rect");
+      assert.strictEqual(TestMethods.numAttr(clipRect, "width"), SVG_WIDTH, "the clipRect has an appropriate width");
+      assert.strictEqual(TestMethods.numAttr(clipRect, "height"), SVG_HEIGHT, "the clipRect has an appropriate height");
+      svg.remove();
+    });
 
     it("renders correctly given a pixel position", () => {
       let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);

--- a/test/components/guideLineLayerTests.ts
+++ b/test/components/guideLineLayerTests.ts
@@ -22,6 +22,11 @@ describe("GuideLineLayer", () => {
     assert.isUndefined(gll.pixelPosition(), "returns undefined before any pixel position is set");
     assert.strictEqual(gll.pixelPosition(expectedPosition), gll, "setter returns the calling GuideLineLayer");
     assert.strictEqual(gll.pixelPosition(), expectedPosition, "getter returns the set pixel position");
+    // HACKHACK #2614: chai-assert.d.ts has the wrong signature
+    (<any> assert).throws(() => gll.pixelPosition(NaN), Error, "", "Rejects NaN");
+    (<any> assert).throws(() => gll.pixelPosition(Infinity), Error, "", "Rejects Infinity");
+    (<any> assert).throws(() => gll.pixelPosition(-Infinity), Error, "", "Rejects -Infinity");
+    (<any> assert).throws(() => gll.pixelPosition(<any> "5"), Error, "", "Rejects stringy numbers");
   });
 
   it("destroy() disconnects from scale safely", () => {

--- a/test/components/guideLineLayerTests.ts
+++ b/test/components/guideLineLayerTests.ts
@@ -25,7 +25,7 @@ describe("GuideLineLayer", () => {
   });
 
   describe("coordination between scale(), value(), and pixelPosition()", () => {
-    it("changing value() updates pixelPosition()", () => {
+    it("changing value() updates pixelPosition() if scale() is set", () => {
       let linearScale = new Plottable.Scales.Linear();
       linearScale.domain([0, 1]);
       linearScale.range([0, 100]);
@@ -37,7 +37,7 @@ describe("GuideLineLayer", () => {
       assert.strictEqual(gll.pixelPosition(), expectedPosition, "pixel position was updated to match the set value");
     });
 
-    it("changing pixelPosition() updates value()", () => {
+    it("changing pixelPosition() updates value() if scale() is set", () => {
       let linearScale = new Plottable.Scales.Linear();
       linearScale.domain([0, 1]);
       linearScale.range([0, 100]);
@@ -71,7 +71,7 @@ describe("GuideLineLayer", () => {
       let value = 0.5;
       gll.value(value);
       var setPosition = -999;
-      gll.position(setPosition);
+      gll.pixelPosition(setPosition);
       let expectedPosition = linearScale.scale(value);
       gll.scale(linearScale);
       assert.strictEqual(gll.pixelPosition(), expectedPosition, "setting the scale updates the pixel position");

--- a/test/components/guideLineLayerTests.ts
+++ b/test/components/guideLineLayerTests.ts
@@ -1,0 +1,315 @@
+///<reference path="../testReference.ts" />
+
+describe("GuideLineLayer", () => {
+  it("scale()", () => {
+    let gll = new Plottable.Components.GuideLineLayer<Date>("vertical");
+    let timeScale = new Plottable.Scales.Time();
+    assert.strictEqual(gll.scale(timeScale), gll, "setter returns the calling GuideLineLayer");
+    assert.strictEqual(gll.scale(), timeScale, "getter returns the set Scale");
+  });
+
+  it("value()", () => {
+    let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
+    let expectedValue = 5;
+    assert.isUndefined(gll.value(), "returns undefined before any value is set");
+    assert.strictEqual(gll.value(expectedValue), gll, "setter returns the calling GuideLineLayer");
+    assert.strictEqual(gll.value(), expectedValue, "getter returns the set value");
+  });
+
+  it("pixelPosition()", () => {
+    let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
+    let expectedPosition = 5;
+    assert.isUndefined(gll.pixelPosition(), "returns undefined before any pixel position is set");
+    assert.strictEqual(gll.pixelPosition(expectedPosition), gll, "setter returns the calling GuideLineLayer");
+    assert.strictEqual(gll.pixelPosition(), expectedPosition, "getter returns the set pixel position");
+  });
+
+  describe("coordination between scale(), value(), and pixelPosition()", () => {
+    it("changing value() updates pixelPosition()", () => {
+      let linearScale = new Plottable.Scales.Linear();
+      linearScale.domain([0, 1]);
+      linearScale.range([0, 100]);
+      let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
+      gll.scale(linearScale);
+      let value = 0.5;
+      let expectedPosition = linearScale.scale(value);
+      gll.value(value);
+      assert.strictEqual(gll.pixelPosition(), expectedPosition, "pixel position was updated to match the set value");
+    });
+
+    it("changing pixelPosition() updates value()", () => {
+      let linearScale = new Plottable.Scales.Linear();
+      linearScale.domain([0, 1]);
+      linearScale.range([0, 100]);
+      let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
+      gll.scale(linearScale);
+      let position = 50;
+      let expectedValue = linearScale.invert(position);
+      gll.pixelPosition(position);
+      assert.strictEqual(gll.value(), expectedValue, "value was updated to match the set pixel position");
+    });
+
+    it("updating the scale's domain updates pixelPosition() to match the existing value()", () => {
+      let linearScale = new Plottable.Scales.Linear();
+      linearScale.domain([0, 1]);
+      linearScale.range([0, 100]);
+      let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
+      gll.scale(linearScale);
+      let value = 0.5;
+      gll.value(value);
+      assert.strictEqual(gll.pixelPosition(), linearScale.scale(value), "pixel position matches set value");
+      linearScale.domain([0, 2]);
+      assert.strictEqual(gll.pixelPosition(), linearScale.scale(value), "pixel position was updated when scale updated");
+    });
+
+    it("changing the scale updates pixelPosition() to match the existing value()", () => {
+      let linearScale = new Plottable.Scales.Linear();
+      linearScale.domain([0, 1]);
+      linearScale.range([0, 100]);
+
+      let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
+      let value = 0.5;
+      gll.value(value);
+      let expectedPosition = linearScale.scale(value);
+      gll.scale(linearScale);
+      assert.strictEqual(gll.pixelPosition(), expectedPosition, "setting the scale updates the pixel position");
+
+      let linearScaleB = new Plottable.Scales.Linear();
+      linearScaleB.domain([0, 1]);
+      linearScaleB.range([0, 200]);
+      let expectedPositionB = linearScaleB.scale(value);
+      gll.scale(linearScaleB);
+      assert.strictEqual(gll.pixelPosition(), expectedPositionB, "changing the scale updates the pixel position");
+
+      linearScaleB.range([0, 400]); // range changes are non-updating
+      assert.strictEqual(gll.pixelPosition(), expectedPositionB, "range() updates don't normally affect GuideLineLayer");
+      linearScale.domain([0, 2]);
+      assert.strictEqual(gll.pixelPosition(), expectedPositionB, "changing the old scale does not trigger updates");
+    });
+  });
+
+  it("rejects invalid orientations", () => {
+    assert.doesNotThrow(() => new Plottable.Components.GuideLineLayer<number>("vertical"), Error, "accepts \"vertical\"");
+    assert.doesNotThrow(() => new Plottable.Components.GuideLineLayer<number>("horizontal"), Error, "accepts \"horizontal\"");
+    assert.throws(() => new Plottable.Components.GuideLineLayer<number>("blargh"), Error);
+  });
+
+  it("has fixed height if vertical, fixed width if horizontal", () => {
+    let verticalGLL = new Plottable.Components.GuideLineLayer<number>("vertical");
+    assert.strictEqual(verticalGLL.fixedHeight(), true, "fixed height if vertical");
+    let horizontalGLL = new Plottable.Components.GuideLineLayer<number>("horizontal");
+    assert.strictEqual(horizontalGLL.fixedWidth(), true, "fixed width if horizontal");
+  });
+
+  describe("rendering (vertical)", () => {
+    let SVG_WIDTH = 400;
+    let SVG_HEIGHT = 400;
+
+    it("renders correctly given a pixel position", () => {
+      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      let expectedPosition1 = SVG_WIDTH / 2;
+      let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
+      gll.pixelPosition(expectedPosition1);
+      gll.renderTo(svg);
+
+      assert.strictEqual(gll.content().selectAll("line").size(), 1, "exactly one line is drawn");
+      let line = gll.content().select("line");
+      let expectedAttrs1 = {
+        x1: expectedPosition1,
+        x2: expectedPosition1,
+        y1: 0,
+        y2: SVG_HEIGHT
+      };
+      TestMethods.assertLineAttrs(line, expectedAttrs1, "the line was drawn at the specified position");
+
+      let expectedPosition2 = SVG_WIDTH * 3 / 4;
+      gll.pixelPosition(expectedPosition2);
+      assert.strictEqual(gll.content().selectAll("line").size(), 1, "exactly one line is drawn");
+      line = gll.content().select("line");
+      let expectedAttrs2 = {
+        x1: expectedPosition2,
+        x2: expectedPosition2,
+        y1: 0,
+        y2: SVG_HEIGHT
+      };
+      TestMethods.assertLineAttrs(line, expectedAttrs2, "the line was drawn at the updated position");
+
+      svg.remove();
+    });
+
+    it("renders correctly given a value and scale", () => {
+      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
+      gll.renderTo(svg);
+      let scale = new Plottable.Scales.Linear();
+      scale.domain([0, 10]);
+      gll.scale(scale);
+
+      let value1 = 5;
+      gll.value(value1);
+      assert.strictEqual(gll.content().selectAll("line").size(), 1, "exactly one line is drawn");
+      let line = gll.content().select("line");
+      let expectedAttrs1 = {
+        x1: scale.scale(value1),
+        x2: scale.scale(value1),
+        y1: 0,
+        y2: SVG_HEIGHT
+      };
+      TestMethods.assertLineAttrs(line, expectedAttrs1, "the line was drawn at the correct position");
+
+      let value2 = 8;
+      gll.value(value2);
+      assert.strictEqual(gll.content().selectAll("line").size(), 1, "exactly one line is drawn");
+      line = gll.content().select("line");
+      let expectedAttrs2 = {
+        x1: scale.scale(value2),
+        x2: scale.scale(value2),
+        y1: 0,
+        y2: SVG_HEIGHT
+      };
+      TestMethods.assertLineAttrs(line, expectedAttrs2, "the line was redrawn at the new position when the value was changed");
+
+      svg.remove();
+    });
+
+    it("re-renders correctly when the scale is updated", () => {
+      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
+      let value = 5;
+      gll.value(value);
+      gll.renderTo(svg);
+
+      let scale1 = new Plottable.Scales.Linear();
+      scale1.domain([0, 10]);
+      gll.scale(scale1);
+      let line = gll.content().select("line");
+      let expectedAttrs1 = {
+        x1: scale1.scale(value),
+        x2: scale1.scale(value),
+        y1: 0,
+        y2: SVG_HEIGHT
+      };
+      TestMethods.assertLineAttrs(line, expectedAttrs1, "the line was drawn at the correct position");
+
+      let scale2 = new Plottable.Scales.Linear();
+      scale2.domain([0, 100]);
+      gll.scale(scale2);
+      line = gll.content().select("line");
+      let expectedAttrs2 = {
+        x1: scale2.scale(value),
+        x2: scale2.scale(value),
+        y1: 0,
+        y2: SVG_HEIGHT
+      };
+      TestMethods.assertLineAttrs(line, expectedAttrs2, "the line was redrawn at the new position when the value was changed");
+
+      svg.remove();
+    });
+  });
+
+  describe("rendering (horizontal)", () => {
+    let SVG_WIDTH = 400;
+    let SVG_HEIGHT = 400;
+
+    it("renders correctly given a pixel position", () => {
+      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      let expectedPosition1 = SVG_WIDTH / 2;
+      let gll = new Plottable.Components.GuideLineLayer<number>("horizontal");
+      gll.pixelPosition(expectedPosition1);
+      gll.renderTo(svg);
+
+      assert.strictEqual(gll.content().selectAll("line").size(), 1, "exactly one line is drawn");
+      let line = gll.content().select("line");
+      let expectedAttrs1 = {
+        x1: 0,
+        x2: SVG_WIDTH,
+        y1: expectedPosition1,
+        y2: expectedPosition1
+      };
+      TestMethods.assertLineAttrs(line, expectedAttrs1, "the line was drawn at the specified position");
+
+      let expectedPosition2 = SVG_WIDTH * 3 / 4;
+      gll.pixelPosition(expectedPosition2);
+      assert.strictEqual(gll.content().selectAll("line").size(), 1, "exactly one line is drawn");
+      line = gll.content().select("line");
+      let expectedAttrs2 = {
+        x1: 0,
+        x2: SVG_WIDTH,
+        y1: expectedPosition2,
+        y2: expectedPosition2
+      };
+      TestMethods.assertLineAttrs(line, expectedAttrs2, "the line was drawn at the updated position");
+
+      svg.remove();
+    });
+
+    it("renders correctly given a value and scale", () => {
+      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      let gll = new Plottable.Components.GuideLineLayer<number>("horizontal");
+      gll.renderTo(svg);
+      let scale = new Plottable.Scales.Linear();
+      scale.domain([0, 10]);
+      gll.scale(scale);
+
+      let value1 = 5;
+      gll.value(value1);
+      assert.strictEqual(gll.content().selectAll("line").size(), 1, "exactly one line is drawn");
+      let line = gll.content().select("line");
+      let expectedAttrs1 = {
+        x1: 0,
+        x2: SVG_WIDTH,
+        y1: scale.scale(value1),
+        y2: scale.scale(value1)
+      };
+      TestMethods.assertLineAttrs(line, expectedAttrs1, "the line was drawn at the correct position");
+
+      let value2 = 8;
+      gll.value(value2);
+      assert.strictEqual(gll.content().selectAll("line").size(), 1, "exactly one line is drawn");
+      line = gll.content().select("line");
+      let expectedAttrs2 = {
+        x1: 0,
+        x2: SVG_WIDTH,
+        y1: scale.scale(value2),
+        y2: scale.scale(value2)
+      };
+      TestMethods.assertLineAttrs(line, expectedAttrs2, "the line was redrawn at the new position when the value was changed");
+
+      svg.remove();
+    });
+
+    it("re-renders correctly when the scale is updated", () => {
+      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      let gll = new Plottable.Components.GuideLineLayer<number>("horizontal");
+      let value = 5;
+      gll.value(value);
+      gll.renderTo(svg);
+
+      let scale1 = new Plottable.Scales.Linear();
+      scale1.domain([0, 10]);
+      gll.scale(scale1);
+      let line = gll.content().select("line");
+      let expectedAttrs1 = {
+        x1: 0,
+        x2: SVG_WIDTH,
+        y1: scale1.scale(value),
+        y2: scale1.scale(value)
+      };
+      TestMethods.assertLineAttrs(line, expectedAttrs1, "the line was drawn at the correct position");
+
+      let scale2 = new Plottable.Scales.Linear();
+      scale2.domain([0, 100]);
+      gll.scale(scale2);
+      line = gll.content().select("line");
+      let expectedAttrs2 = {
+        x1: 0,
+        x2: SVG_WIDTH,
+        y1: scale2.scale(value),
+        y2: scale2.scale(value)
+      };
+      TestMethods.assertLineAttrs(line, expectedAttrs2, "the line was redrawn at the new position when the value was changed");
+
+      svg.remove();
+    });
+  });
+});

--- a/test/components/guideLineLayerTests.ts
+++ b/test/components/guideLineLayerTests.ts
@@ -45,6 +45,11 @@ describe("GuideLineLayer", () => {
       let expectedPosition = linearScale.scale(value);
       gll.value(value);
       assert.strictEqual(gll.pixelPosition(), expectedPosition, "pixel position was updated to match the set value");
+
+      let valueB = 0.8;
+      let expectedPositionB = linearScale.scale(valueB);
+      gll.value(valueB);
+      assert.strictEqual(gll.pixelPosition(), expectedPositionB, "pixel position was updated when value was changed again");
     });
 
     it("changing pixelPosition() updates value() if scale() is set", () => {
@@ -57,6 +62,11 @@ describe("GuideLineLayer", () => {
       let expectedValue = linearScale.invert(position);
       gll.pixelPosition(position);
       assert.strictEqual(gll.value(), expectedValue, "value was updated to match the set pixel position");
+
+      let positionB = 75;
+      let expectedValueB = linearScale.invert(positionB);
+      gll.pixelPosition(positionB);
+      assert.strictEqual(gll.value(), expectedValueB, "value was updated when the position was changed again");
     });
 
     it("updating the scale's domain updates pixelPosition() to match the existing value()", () => {

--- a/test/components/guideLineLayerTests.ts
+++ b/test/components/guideLineLayerTests.ts
@@ -69,7 +69,7 @@ describe("GuideLineLayer", () => {
       assert.strictEqual(gll.value(), expectedValueB, "value was updated when the position was changed again");
     });
 
-    it("updating the scale's domain updates pixelPosition() to match the existing value()", () => {
+    it("changing the scale's domain updates pixelPositon() if value() was the last property set", () => {
       let linearScale = new Plottable.Scales.Linear();
       linearScale.domain([0, 1]);
       linearScale.range([0, 100]);
@@ -82,42 +82,77 @@ describe("GuideLineLayer", () => {
       assert.strictEqual(gll.pixelPosition(), linearScale.scale(value), "pixel position was updated when scale updated");
     });
 
-    it("changing the scale updates pixelPosition() if value() is set", () => {
+    it("changing the scale's domain updates value() if pixelPosition() was the last property set", () => {
+      let linearScale = new Plottable.Scales.Linear();
+      linearScale.domain([0, 1]);
+      linearScale.range([0, 100]);
+      let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
+      gll.scale(linearScale);
+      let pixelPosition = 50;
+      gll.pixelPosition(pixelPosition);
+      assert.strictEqual(gll.value(), linearScale.invert(pixelPosition), "value matches set pixel position");
+      linearScale.domain([0, 2]);
+      assert.strictEqual(gll.value(), linearScale.invert(pixelPosition), "value was updated when scale updated");
+    });
+
+    it("changing the scale updates pixelPosition() if value() was the last property set", () => {
       let linearScale = new Plottable.Scales.Linear();
       linearScale.domain([0, 1]);
       linearScale.range([0, 100]);
 
       let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
-      let value = 0.5;
-      gll.value(value);
-      let setPosition = -999;
+
+      let setPosition = -100;
       gll.pixelPosition(setPosition);
-      let expectedPosition = linearScale.scale(value);
+      let setValue = 0.5;
+      gll.value(setValue);
+      let expectedPosition = linearScale.scale(setValue);
+
       gll.scale(linearScale);
-      assert.strictEqual(gll.pixelPosition(), expectedPosition, "setting the scale updates the pixel position");
+      assert.strictEqual(gll.pixelPosition(), expectedPosition,
+        "setting the scale updates the pixel position if value() was the last thing set");
+      assert.strictEqual(gll.value(), setValue, "value is not changed");
       assert.notStrictEqual(gll.pixelPosition(), setPosition, "originally-set pixel position was overridden");
 
       let linearScaleB = new Plottable.Scales.Linear();
       linearScaleB.domain([0, 1]);
       linearScaleB.range([0, 200]);
-      let expectedPositionB = linearScaleB.scale(value);
+      let expectedPositionB = linearScaleB.scale(setValue);
       gll.scale(linearScaleB);
-      assert.strictEqual(gll.pixelPosition(), expectedPositionB, "changing the scale updates the pixel position");
+      assert.strictEqual(gll.pixelPosition(), expectedPositionB,
+        "changing the scale updates the pixel position if value() was the last thing set");
+      assert.strictEqual(gll.value(), setValue, "value is not changed");
       assert.strictEqual((<any>linearScale)._callbacks.size, 0, "callback was removed from the previous Scale");
     });
 
-    it("changing the scale updates value() if pixelPosition() is set but value() is not", () => {
-      let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
-      let position = 50;
-      gll.pixelPosition(position);
-
+    it("changing the scale updates value() if pixelPosition() was the last property set", () => {
       let linearScale = new Plottable.Scales.Linear();
       linearScale.domain([0, 1]);
       linearScale.range([0, 100]);
 
+      let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
+
+      let setValue = 0.5;
+      gll.value(setValue);
+      let setPosition = -100;
+      gll.pixelPosition(setPosition);
+      let expectedValue = linearScale.invert(setPosition);
+
       gll.scale(linearScale);
-      let expectedValue = linearScale.invert(position);
-      assert.strictEqual(gll.value(), expectedValue, "value was updated to match the set pixel position");
+      assert.strictEqual(gll.value(), expectedValue,
+        "setting the scale updates the value if pixelPosition() was the last thing set");
+      assert.strictEqual(gll.pixelPosition(), setPosition, "pixel position is not changed");
+      assert.notStrictEqual(gll.value(), setValue, "originally-set value was overridden");
+
+      let linearScaleB = new Plottable.Scales.Linear();
+      linearScaleB.domain([0, 1]);
+      linearScaleB.range([0, 200]);
+      let expectedValueB = linearScaleB.invert(setPosition);
+      gll.scale(linearScaleB);
+      assert.strictEqual(gll.value(), expectedValueB,
+        "changing the scale updates the value if pixelPosition() was the last thing set");
+      assert.strictEqual(gll.pixelPosition(), setPosition, "pixel position is not changed");
+      assert.strictEqual((<any>linearScale)._callbacks.size, 0, "callback was removed from the previous Scale");
     });
   });
 

--- a/test/components/guideLineLayerTests.ts
+++ b/test/components/guideLineLayerTests.ts
@@ -62,7 +62,7 @@ describe("GuideLineLayer", () => {
       assert.strictEqual(gll.pixelPosition(), linearScale.scale(value), "pixel position was updated when scale updated");
     });
 
-    it("changing the scale updates pixelPosition() to match the existing value()", () => {
+    it("changing the scale updates pixelPosition() if value() is set", () => {
       let linearScale = new Plottable.Scales.Linear();
       linearScale.domain([0, 1]);
       linearScale.range([0, 100]);
@@ -70,9 +70,12 @@ describe("GuideLineLayer", () => {
       let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
       let value = 0.5;
       gll.value(value);
+      var setPosition = -999;
+      gll.position(setPosition);
       let expectedPosition = linearScale.scale(value);
       gll.scale(linearScale);
       assert.strictEqual(gll.pixelPosition(), expectedPosition, "setting the scale updates the pixel position");
+      assert.notStrictEqual(gll.pixelPosition(), setPosition, "originally-set pixel position was overridden");
 
       let linearScaleB = new Plottable.Scales.Linear();
       linearScaleB.domain([0, 1]);
@@ -86,6 +89,20 @@ describe("GuideLineLayer", () => {
       linearScale.domain([0, 2]);
       assert.strictEqual(gll.pixelPosition(), expectedPositionB, "changing the old scale does not trigger updates");
     });
+
+    it("changing the scale updates value() if pixelPosition() is set but value() is not", () => {
+      let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
+      let position = 50;
+      gll.pixelPosition(position);
+
+      let linearScale = new Plottable.Scales.Linear();
+      linearScale.domain([0, 1]);
+      linearScale.range([0, 100]);
+
+      gll.scale(linearScale);
+      let expectedValue = linearScale.invert(position);
+      assert.strictEqual(gll.value(), expectedValue, "value was updated to match the set pixel position");
+    });
   });
 
   it("rejects invalid orientations", () => {
@@ -96,7 +113,7 @@ describe("GuideLineLayer", () => {
 
   describe("rendering (vertical)", () => {
     let SVG_WIDTH = 400;
-    let SVG_HEIGHT = 400;
+    let SVG_HEIGHT = 300;
 
     it("has an effective size of 0, but will occupy all offered space", () => {
       let gll = new Plottable.Components.GuideLineLayer<void>("vertical");
@@ -236,7 +253,7 @@ describe("GuideLineLayer", () => {
   });
 
   describe("rendering (horizontal)", () => {
-    let SVG_WIDTH = 400;
+    let SVG_WIDTH = 300;
     let SVG_HEIGHT = 400;
 
     it("has an effective size of 0, but will occupy all offered space", () => {

--- a/test/components/guideLineLayerTests.ts
+++ b/test/components/guideLineLayerTests.ts
@@ -252,7 +252,7 @@ describe("GuideLineLayer", () => {
         y1: 0,
         y2: SVG_HEIGHT
       };
-      TestMethods.assertLineAttrs(line, expectedAttrs2, "the line was redrawn at the new position when the value was changed");
+      TestMethods.assertLineAttrs(line, expectedAttrs2, "the line was redrawn at the new position when the scale was changed");
 
       svg.remove();
     });
@@ -393,7 +393,7 @@ describe("GuideLineLayer", () => {
         y1: scale2.scale(value),
         y2: scale2.scale(value)
       };
-      TestMethods.assertLineAttrs(line, expectedAttrs2, "the line was redrawn at the new position when the value was changed");
+      TestMethods.assertLineAttrs(line, expectedAttrs2, "the line was redrawn at the new position when the scale was changed");
 
       svg.remove();
     });

--- a/test/components/guideLineLayerTests.ts
+++ b/test/components/guideLineLayerTests.ts
@@ -256,6 +256,21 @@ describe("GuideLineLayer", () => {
 
       svg.remove();
     });
+
+    it("sets the scale's range based on the allocated width", () => {
+      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      let gll = new Plottable.Components.GuideLineLayer<number>("vertical");
+      let scale1 = new Plottable.Scales.Linear();
+      gll.scale(scale1);
+      gll.renderTo(svg);
+      assert.deepEqual(gll.scale().range(), [0, SVG_WIDTH], "range was set based on the allocated width");
+
+      let scale2 = new Plottable.Scales.Linear();
+      gll.scale(scale2);
+      assert.deepEqual(gll.scale().range(), [0, SVG_WIDTH], "replacement scale has its range set based on the allocated width");
+
+      svg.remove();
+    });
   });
 
   describe("rendering (horizontal)", () => {
@@ -394,6 +409,21 @@ describe("GuideLineLayer", () => {
         y2: scale2.scale(value)
       };
       TestMethods.assertLineAttrs(line, expectedAttrs2, "the line was redrawn at the new position when the scale was changed");
+
+      svg.remove();
+    });
+
+    it("sets the scale's range based on the allocated height", () => {
+      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      let gll = new Plottable.Components.GuideLineLayer<number>("horizontal");
+      let scale1 = new Plottable.Scales.Linear();
+      gll.scale(scale1);
+      gll.renderTo(svg);
+      assert.deepEqual(gll.scale().range(), [SVG_HEIGHT, 0], "range was set based on the allocated height");
+
+      let scale2 = new Plottable.Scales.Linear();
+      gll.scale(scale2);
+      assert.deepEqual(gll.scale().range(), [SVG_HEIGHT, 0], "replacement scale has its range set based on the allocated height");
 
       svg.remove();
     });

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -95,10 +95,11 @@ module TestMethods {
     line: d3.Selection<void>,
     expectedAttrs: { x1: number, y1: number, x2: number, y2: number },
     message: string) {
-    assert.strictEqual(TestMethods.numAttr(line, "x1"), expectedAttrs.x1, message + " (x1)");
-    assert.strictEqual(TestMethods.numAttr(line, "y1"), expectedAttrs.y1, message + " (y1)");
-    assert.strictEqual(TestMethods.numAttr(line, "x2"), expectedAttrs.x2, message + " (x2)");
-    assert.strictEqual(TestMethods.numAttr(line, "y2"), expectedAttrs.y2, message + " (y2)");
+    let floatingPointError = 0.000000001;
+    assert.closeTo(TestMethods.numAttr(line, "x1"), expectedAttrs.x1, floatingPointError, message + " (x1)");
+    assert.closeTo(TestMethods.numAttr(line, "y1"), expectedAttrs.y1, floatingPointError, message + " (y1)");
+    assert.closeTo(TestMethods.numAttr(line, "x2"), expectedAttrs.x2, floatingPointError, message + " (x2)");
+    assert.closeTo(TestMethods.numAttr(line, "y2"), expectedAttrs.y2, floatingPointError, message + " (y2)");
   }
 
   export function assertEntitiesEqual(

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -91,6 +91,16 @@ module TestMethods {
     assert.strictEqual(height, String(heightExpected), "height: " + message);
   }
 
+  export function assertLineAttrs(
+    line: d3.Selection<void>,
+    expectedAttrs: { x1: number, y1: number, x2: number, y2: number },
+    message: string) {
+    assert.strictEqual(TestMethods.numAttr(line, "x1"), expectedAttrs.x1, message + " (x1)");
+    assert.strictEqual(TestMethods.numAttr(line, "y1"), expectedAttrs.y1, message + " (y1)");
+    assert.strictEqual(TestMethods.numAttr(line, "x2"), expectedAttrs.x2, message + " (x2)");
+    assert.strictEqual(TestMethods.numAttr(line, "y2"), expectedAttrs.y2, message + " (y2)");
+  }
+
   export function assertEntitiesEqual(
       actual: Plottable.Entity<Plottable.Component>,
       expected: Plottable.Entity<Plottable.Component>,

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -28,6 +28,7 @@
 ///<reference path="components/groupTests.ts" />
 ///<reference path="components/componentTests.ts" />
 ///<reference path="components/tableTests.ts" />
+///<reference path="components/guideLineLayerTests.ts" />
 
 ///<reference path="plots/plotTests.ts" />
 ///<reference path="plots/xyPlotTests.ts" />


### PR DESCRIPTION
Added new class `GuideLineLayer`. This `Component` fully-occupies a cell in a `Table` (like `SelectionBoxLayer`), and draws either a vertical or horizontal line at a specified position in data- or pixel-space:

`DragLineLayer` will extend this class. This PR serves as step one towards #1640.

<img width="647" alt="screen shot 2015-08-10 at 2 58 24 pm" src="https://cloud.githubusercontent.com/assets/1440449/9185387/5084b7be-3f70-11e5-94d9-0cfdddafe5bb.png">

The class is generic on the type of value it would take in data-space:
```Typescript
class GuideLineLayer<D> extends Component {
  ...
}
```
`D` would be `number` if the `value()` of the line is a `number`, for example; it should also match the type of input to the `QuantitativeScale` used with the `GuideLineLayer`. `void` should be used if the `GuideLineLayer` is only used in pixel-space.

Features the following API points:
```Typescript
constructor(orientation: string); // "vertical" or "horizontal"

/**
 * Gets the QuantitativeScale on the GuideLineLayer.
 */
scale(): QuantitativeScale<D>;
/**
 * Sets the QuantitativeScale on the GuideLineLayer.
 * If value() was the last property set, pixelPosition() will be updated according to the new scale.
 * If pixelPosition() was the last property set, value() will be updated according to the new scale.
 */
scale(scale: QuantitativeScale<D>): GuideLineLayer<D>;

/**
 * Gets the value of the guide line in data-space.
 */
value(): D;
/**
 * Sets the value of the guide line in data-space.
 * If the GuideLineLayer has a scale, pixelPosition() will be updated now and whenever the scale updates.
 */
value(value: D): GuideLineLayer<D>;

/**
 * Gets the position of the guide line in pixel-space.
 */
pixelPosition(): number;
/**
 * Sets the position of the guide line in pixel-space.
 * If the GuideLineLayer has a scale, the value() will be updated now and whenever the scale updates.
 */
pixelPosition(pixelPosition: number): GuideLineLayer<D>;
```

CSS styles should be applied to the following element to style the line:
```CSS
.plottable .guide-line-layer line.guide-line {
  ...
}
```

Demo: http://jsfiddle.net/fza2vdcc/