### PR TITLE
Apply the correct pointer-events styles on DragBoxLayer edges/corners.

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -10890,7 +10890,8 @@ var Plottable;
                 _super.prototype._setup.call(this);
                 var createLine = function () { return _this._box.append("line").style({
                     "opacity": 0,
-                    "stroke": "pink"
+                    "stroke": "pink",
+                    "pointer-events": "visibleStroke"
                 }); };
                 this._detectionEdgeT = createLine().classed("drag-edge-tb", true);
                 this._detectionEdgeB = createLine().classed("drag-edge-tb", true);
@@ -10900,7 +10901,8 @@ var Plottable;
                     var createCorner = function () { return _this._box.append("circle")
                         .style({
                         "opacity": 0,
-                        "fill": "pink"
+                        "fill": "pink",
+                        "pointer-events": "visibleFill"
                     }); };
                     this._detectionCornerTL = createCorner().classed("drag-corner-tl", true);
                     this._detectionCornerTR = createCorner().classed("drag-corner-tr", true);

--- a/src/components/dragBoxLayer.ts
+++ b/src/components/dragBoxLayer.ts
@@ -154,7 +154,8 @@ export module Components {
 
       let createLine = () => this._box.append("line").style({
                                "opacity": 0,
-                               "stroke": "pink"
+                               "stroke": "pink",
+                               "pointer-events": "visibleStroke"
                              });
       this._detectionEdgeT = createLine().classed("drag-edge-tb", true);
       this._detectionEdgeB = createLine().classed("drag-edge-tb", true);
@@ -165,7 +166,8 @@ export module Components {
         let createCorner = () => this._box.append("circle")
                                      .style({
                                        "opacity": 0,
-                                       "fill": "pink"
+                                       "fill": "pink",
+                                       "pointer-events": "visibleFill"
                                      });
         this._detectionCornerTL = createCorner().classed("drag-corner-tl", true);
         this._detectionCornerTR = createCorner().classed("drag-corner-tr", true);

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -332,8 +332,25 @@ describe("Interactive Components", () => {
         resetBox();
       });
 
-      it("resizable() defaults to false", () => {
+      it("resizable() getter/setter", () => {
         assert.isFalse(dbl.resizable(), "defaults to false");
+        assert.strictEqual(dbl.resizable(true), dbl, "returns DragBoxLayer when invoked as setter");
+        assert.isTrue(dbl.resizable(), "successfully set to true");
+        svg.remove();
+      });
+
+      it("resizable() correctly sets pointer-events", () => {
+        dbl.resizable(true);
+        let edges = dbl.content().selectAll("line");
+        edges[0].forEach((edge) => {
+          let computedStyle = window.getComputedStyle(<Element> edge);
+          assert.strictEqual(computedStyle.pointerEvents.toLowerCase(), "visiblestroke", "pointer-events set correctly on edges");
+        });
+        let corners = dbl.content().selectAll("circle");
+        corners[0].forEach((corner) => {
+          let computedStyle = window.getComputedStyle(<Element> corner);
+          assert.strictEqual(computedStyle.pointerEvents.toLowerCase(), "visiblefill", "pointer-events set correctly on corners");
+        });
         svg.remove();
       });
 


### PR DESCRIPTION
Because functional CSS properties (in this case `pointer-events`) were not being set directly on the elements, the resize cursors weren't showing.

On this branch: http://jsfiddle.net/5tw5efp9/
On **`develop`**: http://jsfiddle.net/36euzLjv/