### PR TITLE
DragBoxLayer doesn't show resize/move cursors if not enabled.

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -10992,7 +10992,7 @@ var Plottable;
             };
             // Sets resizable classes. Overridden by subclasses that only resize in one dimension.
             DragBoxLayer.prototype._setResizableClasses = function (canResize) {
-                if (canResize) {
+                if (canResize && this.enabled()) {
                     this.addClass("x-resizable");
                     this.addClass("y-resizable");
                 }
@@ -11006,13 +11006,16 @@ var Plottable;
                     return this._movable;
                 }
                 this._movable = movable;
-                if (movable) {
+                this._setMovableClass();
+                return this;
+            };
+            DragBoxLayer.prototype._setMovableClass = function () {
+                if (this.movable() && this.enabled()) {
                     this.addClass("movable");
                 }
                 else {
                     this.removeClass("movable");
                 }
-                return this;
             };
             /**
              * Sets the callback to be called when dragging starts.
@@ -11085,6 +11088,8 @@ var Plottable;
                     return this._dragInteraction.enabled();
                 }
                 this._dragInteraction.enabled(enabled);
+                this._setResizableClasses(this.resizable());
+                this._setMovableClass();
                 return this;
             };
             return DragBoxLayer;
@@ -11129,7 +11134,7 @@ var Plottable;
                 });
             };
             XDragBoxLayer.prototype._setResizableClasses = function (canResize) {
-                if (canResize) {
+                if (canResize && this.enabled()) {
                     this.addClass("x-resizable");
                 }
                 else {
@@ -11187,7 +11192,7 @@ var Plottable;
                 });
             };
             YDragBoxLayer.prototype._setResizableClasses = function (canResize) {
-                if (canResize) {
+                if (canResize && this.enabled()) {
                     this.addClass("y-resizable");
                 }
                 else {

--- a/src/components/dragBoxLayer.ts
+++ b/src/components/dragBoxLayer.ts
@@ -289,7 +289,7 @@ export module Components {
 
     // Sets resizable classes. Overridden by subclasses that only resize in one dimension.
     protected _setResizableClasses(canResize: boolean) {
-      if (canResize) {
+      if (canResize && this.enabled()) {
         this.addClass("x-resizable");
         this.addClass("y-resizable");
       } else {
@@ -314,12 +314,16 @@ export module Components {
         return this._movable;
       }
       this._movable = movable;
-      if (movable) {
+      this._setMovableClass();
+      return this;
+    }
+
+    private _setMovableClass() {
+      if (this.movable() && this.enabled()) {
         this.addClass("movable");
       } else {
         this.removeClass("movable");
       }
-      return this;
     }
 
     /**
@@ -408,6 +412,8 @@ export module Components {
         return this._dragInteraction.enabled();
       }
       this._dragInteraction.enabled(enabled);
+      this._setResizableClasses(this.resizable());
+      this._setMovableClass();
       return this;
     }
   }

--- a/src/components/xDragBoxLayer.ts
+++ b/src/components/xDragBoxLayer.ts
@@ -29,7 +29,7 @@ export module Components {
     }
 
     protected _setResizableClasses(canResize: boolean) {
-      if (canResize) {
+      if (canResize && this.enabled()) {
         this.addClass("x-resizable");
       } else {
         this.removeClass("x-resizable");

--- a/src/components/yDragBoxLayer.ts
+++ b/src/components/yDragBoxLayer.ts
@@ -29,7 +29,7 @@ export module Components {
     }
 
     protected _setResizableClasses(canResize: boolean) {
-      if (canResize) {
+      if (canResize && this.enabled()) {
         this.addClass("y-resizable");
       } else {
         this.removeClass("y-resizable");

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -301,6 +301,31 @@ describe("Interactive Components", () => {
         assert.isTrue(dbl.boxVisible(), "box is shown when enabled");
         svg.remove();
       });
+
+      it("does not have resizable CSS classes when enabled(false)", () => {
+        let dbl = new Plottable.Components.DragBoxLayer();
+        dbl.resizable(true);
+        assert.isTrue(dbl.hasClass("x-resizable"), "carries \"x-resizable\" class if resizable");
+        assert.isTrue(dbl.hasClass("y-resizable"), "carries \"y-resizable\" class if resizable");
+        dbl.enabled(false);
+        assert.isFalse(dbl.hasClass("x-resizable"), "does not carry \"x-resizable\" class if resizable, but not enabled");
+        assert.isFalse(dbl.hasClass("y-resizable"), "does not carry \"y-resizable\" class if resizable, but not enabled");
+        dbl.resizable(false);
+        dbl.enabled(true);
+        assert.isFalse(dbl.hasClass("x-resizable"), "does not carry \"x-resizable\" class if enabled, but not resizable");
+        assert.isFalse(dbl.hasClass("y-resizable"), "does not carry \"y-resizable\" class if enabled, but not resizable");
+      });
+
+      it("does not have movable CSS classe when enabled(false)", () => {
+        let dbl = new Plottable.Components.DragBoxLayer();
+        dbl.movable(true);
+        assert.isTrue(dbl.hasClass("movable"), "carries \"movable\" class if movable");
+        dbl.enabled(false);
+        assert.isFalse(dbl.hasClass("movable"), "does not carry \"movable\" class if movable, but not enabled");
+        dbl.movable(false);
+        dbl.enabled(true);
+        assert.isFalse(dbl.hasClass("movable"), "does not carry \"movable\" class if enabled, but not movable");
+      });
     });
 
     describe("resizing", () => {

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -30,40 +30,6 @@ describe("Interactive Components", () => {
       svg.remove();
     });
 
-    it("enabled(boolean) properly modifies the state", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.DragBoxLayer();
-      assert.isTrue(dbl.enabled(), "drag box layer is enabled by default");
-      assert.strictEqual(dbl.enabled(false), dbl, "enabled(boolean) returns itself");
-      assert.isFalse(dbl.enabled(), "drag box layer reports when it is disabled");
-      svg.remove();
-    });
-
-    it("disables box when enabled(false)", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.DragBoxLayer();
-      dbl.enabled(false);
-      dbl.renderTo(svg);
-      assert.isFalse(dbl.boxVisible(), "box is hidden initially");
-
-      let startPoint = {
-        x: SVG_WIDTH / 4,
-        y: SVG_HEIGHT / 4
-      };
-      let endPoint = {
-        x: SVG_WIDTH / 2,
-        y: SVG_HEIGHT / 2
-      };
-
-      let target = dbl.background();
-      TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
-      assert.isFalse(dbl.boxVisible(), "box is not shown when disabled");
-      dbl.enabled(true);
-      TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
-      assert.isTrue(dbl.boxVisible(), "box is shown when enabled");
-      svg.remove();
-    });
-
     it("dismisses on click", () => {
       let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       let dbl = new Plottable.Components.DragBoxLayer();
@@ -299,6 +265,42 @@ describe("Interactive Components", () => {
       assert.isTrue(callbackDragEnd2Called, "the callback 2 for drag end is still connected");
 
       svg.remove();
+    });
+
+    describe("enabling/disabling", () => {
+      it("enabled(boolean) properly modifies the state", () => {
+        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        let dbl = new Plottable.Components.DragBoxLayer();
+        assert.isTrue(dbl.enabled(), "drag box layer is enabled by default");
+        assert.strictEqual(dbl.enabled(false), dbl, "enabled(boolean) returns itself");
+        assert.isFalse(dbl.enabled(), "drag box layer reports when it is disabled");
+        svg.remove();
+      });
+
+      it("disables box when enabled(false)", () => {
+        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        let dbl = new Plottable.Components.DragBoxLayer();
+        dbl.enabled(false);
+        dbl.renderTo(svg);
+        assert.isFalse(dbl.boxVisible(), "box is hidden initially");
+
+        let startPoint = {
+          x: SVG_WIDTH / 4,
+          y: SVG_HEIGHT / 4
+        };
+        let endPoint = {
+          x: SVG_WIDTH / 2,
+          y: SVG_HEIGHT / 2
+        };
+
+        let target = dbl.background();
+        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+        assert.isFalse(dbl.boxVisible(), "box is not shown when disabled");
+        dbl.enabled(true);
+        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+        assert.isTrue(dbl.boxVisible(), "box is shown when enabled");
+        svg.remove();
+      });
     });
 
     describe("resizing", () => {

--- a/test/components/xDragBoxLayerTests.ts
+++ b/test/components/xDragBoxLayerTests.ts
@@ -155,6 +155,17 @@ describe("Interactive Components", () => {
       svg.remove();
     });
 
+    it("does not have resizable CSS class when enabled(false)", () => {
+      let xdbl = new Plottable.Components.XDragBoxLayer();
+      xdbl.resizable(true);
+      assert.isTrue(xdbl.hasClass("x-resizable"), "carries \"x-resizable\" class if resizable");
+      xdbl.enabled(false);
+      assert.isFalse(xdbl.hasClass("x-resizable"), "does not carry \"x-resizable\" class if resizable, but not enabled");
+      xdbl.resizable(false);
+      xdbl.enabled(true);
+      assert.isFalse(xdbl.hasClass("x-resizable"), "does not carry \"x-resizable\" class if enabled, but not resizable");
+    });
+
     it("destroy() does not error if scales are not inputted", () => {
       let svg = TestMethods.generateSVG();
       let sbl = new Plottable.Components.XDragBoxLayer();

--- a/test/components/yDragBoxLayerTests.ts
+++ b/test/components/yDragBoxLayerTests.ts
@@ -155,6 +155,17 @@ describe("Interactive Components", () => {
       svg.remove();
     });
 
+    it("does not have resizable CSS class when enabled(false)", () => {
+      let ydbl = new Plottable.Components.YDragBoxLayer();
+      ydbl.resizable(true);
+      assert.isTrue(ydbl.hasClass("y-resizable"), "carries \"y-resizable\" class if resizable");
+      ydbl.enabled(false);
+      assert.isFalse(ydbl.hasClass("y-resizable"), "does not carry \"y-resizable\" class if resizable, but not enabled");
+      ydbl.resizable(false);
+      ydbl.enabled(true);
+      assert.isFalse(ydbl.hasClass("y-resizable"), "does not carry \"y-resizable\" class if enabled, but not resizable");
+    });
+
     it("destroy() does not error if scales are not inputted", () => {
       let svg = TestMethods.generateSVG();
       let sbl = new Plottable.Components.YDragBoxLayer();


### PR DESCRIPTION
The CSS classes for resizing (`x-resizable`, `y-resizable`, `movable`) are no longer applied if the `DragBoxLayer` is disabled.

With the fix: http://jsfiddle.net/uhpevd7n/1/
On **`develop`**: http://jsfiddle.net/uhpevd7n/

Closes #2542.