### PR TITLE
[Axes.Time] - includes the margin in its height

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -4063,9 +4063,10 @@ var Plottable;
                 // Makes sure that the size it requires is a multiple of tier sizes, such that
                 // we have no leftover tiers
                 var size = _super.prototype._sizeFromOffer.call(this, availableWidth, availableHeight);
-                size.height = this._tierHeights.reduce(function (prevValue, currValue, index, arr) {
+                var tierHeights = this._tierHeights.reduce(function (prevValue, currValue, index, arr) {
                     return (prevValue + currValue > size.height) ? prevValue : (prevValue + currValue);
                 });
+                size.height = Math.min(size.height, tierHeights + this.margin());
                 return size;
             };
             Time.prototype._setup = function () {
@@ -4222,7 +4223,7 @@ var Plottable;
             };
             Time.prototype._hideOverflowingTiers = function () {
                 var _this = this;
-                var availableHeight = this.height();
+                var availableHeight = this.height() - this.margin();
                 var usedHeight = 0;
                 this.content()
                     .selectAll("." + Time.TIME_AXIS_TIER_CLASS)

--- a/plottable.js
+++ b/plottable.js
@@ -4223,7 +4223,7 @@ var Plottable;
             };
             Time.prototype._hideOverflowingTiers = function () {
                 var _this = this;
-                var availableHeight = this.height() - this.margin();
+                var availableHeight = this.height();
                 var usedHeight = 0;
                 this.content()
                     .selectAll("." + Time.TIME_AXIS_TIER_CLASS)

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -309,9 +309,10 @@ export module Axes {
       // we have no leftover tiers
 
       let size = super._sizeFromOffer(availableWidth, availableHeight);
-      size.height = this._tierHeights.reduce((prevValue, currValue, index, arr) => {
+      let tierHeights = this._tierHeights.reduce((prevValue, currValue, index, arr) => {
         return (prevValue + currValue > size.height) ? prevValue : (prevValue + currValue);
       });
+      size.height = Math.min(size.height, tierHeights + this.margin());
       return size;
     }
 
@@ -491,7 +492,7 @@ export module Axes {
     }
 
     private _hideOverflowingTiers() {
-      let availableHeight = this.height();
+      let availableHeight = this.height() - this.margin();
       let usedHeight = 0;
 
       this.content()

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -492,7 +492,7 @@ export module Axes {
     }
 
     private _hideOverflowingTiers() {
-      let availableHeight = this.height() - this.margin();
+      let availableHeight = this.height();
       let usedHeight = 0;
 
       this.content()

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -231,6 +231,7 @@ describe("TimeAxis", () => {
     let xScale = new Plottable.Scales.Time();
     xScale.domain([new Date("2013-03-23 12:00"), new Date("2013-04-03 0:00")]);
     let xAxis = new Plottable.Axes.Time(xScale, "bottom");
+    xAxis.margin(0);
 
     let tiersToCreate = 15;
     let configuration = Array.apply(null, Array(tiersToCreate)).map(() => {
@@ -279,6 +280,17 @@ describe("TimeAxis", () => {
       return "visible";
     }
 
+  });
+
+  it("height includes margin, label padding, and tick length", () => {
+    let svg = TestMethods.generateSVG(400, 400);
+    let xScale = new Plottable.Scales.Time();
+    let xAxis = new Plottable.Axes.Time(xScale, "bottom");
+    xAxis.margin(100);
+    xAxis.renderTo(svg);
+    let minimumHeight = xAxis.tickLabelPadding() + xAxis.margin() + xAxis.innerTickLength();
+    assert.operator(xAxis.height(), ">=", minimumHeight, "height includes all relevant pieces");
+    svg.remove();
   });
 
 });

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -282,7 +282,7 @@ describe("TimeAxis", () => {
 
   });
 
-  it("height includes margin, label padding, and tick length", () => {
+  it("occupied space includes margin, label padding, and tick length", () => {
     let svg = TestMethods.generateSVG(400, 400);
     let xScale = new Plottable.Scales.Time();
     let xAxis = new Plottable.Axes.Time(xScale, "bottom");

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -287,7 +287,8 @@ describe("TimeAxis", () => {
     let xScale = new Plottable.Scales.Time();
     let xAxis = new Plottable.Axes.Time(xScale, "bottom");
     xAxis.margin(100);
-    xAxis.renderTo(svg);
+    xAxis.anchor(svg);
+    xAxis.computeLayout({ x: 0, y: 0}, 400, 400);
     let minimumHeight = xAxis.tickLabelPadding() + xAxis.margin() + xAxis.innerTickLength();
     assert.operator(xAxis.height(), ">=", minimumHeight, "height includes all relevant pieces");
     svg.remove();


### PR DESCRIPTION
`Axes.Time` now appropriately includes the margin in its space usage.

This means that if `Axes.Time` is given enough space to include the tiers as well as the margin, the margin is included in the height for the axis.

Fixes #2042 