### PR TITLE
[Axis.Category] - correct values for computedWidth and computedHeight

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -4765,8 +4765,8 @@ var Plottable;
                 return this.redraw();
             };
             Category.prototype.requestedSpace = function (offeredWidth, offeredHeight) {
-                var widthRequiredByTicks = this._isHorizontal() ? 0 : this._maxLabelTickLength() + this.tickLabelPadding() + this.margin();
-                var heightRequiredByTicks = this._isHorizontal() ? this._maxLabelTickLength() + this.tickLabelPadding() + this.margin() : 0;
+                var widthRequiredByTicks = this._isHorizontal() ? 0 : this._maxLabelTickLength() + this.tickLabelPadding();
+                var heightRequiredByTicks = this._isHorizontal() ? this._maxLabelTickLength() + this.tickLabelPadding() : 0;
                 if (this._scale.domain().length === 0) {
                     return {
                         minWidth: 0,
@@ -4778,8 +4778,8 @@ var Plottable;
                 this._computedWidth = measureResult.usedWidth + widthRequiredByTicks;
                 this._computedHeight = measureResult.usedHeight + heightRequiredByTicks;
                 return {
-                    minWidth: this._computedWidth,
-                    minHeight: this._computedHeight
+                    minWidth: this._isHorizontal() ? this._computedWidth : this._computedWidth + this.margin(),
+                    minHeight: this._isHorizontal() ? this._computedHeight + this.margin() : this._computedHeight
                 };
             };
             Category.prototype._getTickValues = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -4775,9 +4775,11 @@ var Plottable;
                 }
                 var categoryScale = this._scale;
                 var measureResult = this._measureTicks(offeredWidth, offeredHeight, categoryScale, categoryScale.domain());
+                this._computedWidth = measureResult.usedWidth + widthRequiredByTicks;
+                this._computedHeight = measureResult.usedHeight + heightRequiredByTicks;
                 return {
-                    minWidth: measureResult.usedWidth + widthRequiredByTicks,
-                    minHeight: measureResult.usedHeight + heightRequiredByTicks
+                    minWidth: this._computedWidth,
+                    minHeight: this._computedHeight
                 };
             };
             Category.prototype._getTickValues = function () {
@@ -4868,9 +4870,6 @@ var Plottable;
                 // HACKHACK: https://github.com/palantir/svg-typewriter/issues/25
                 var widthFn = (this._isHorizontal() && this._tickLabelAngle === 0) ? d3.sum : Plottable.Utils.Math.max;
                 var heightFn = (this._isHorizontal() && this._tickLabelAngle === 0) ? Plottable.Utils.Math.max : d3.sum;
-                var textFits = wrappingResults.every(function (t) {
-                    return !SVGTypewriter.Utils.StringMethods.isNotEmptyString(t.truncatedText) && t.noLines === 1;
-                });
                 var usedWidth = widthFn(wrappingResults, function (t) { return _this._measurer.measure(t.wrappedText).width; }, 0);
                 var usedHeight = heightFn(wrappingResults, function (t) { return _this._measurer.measure(t.wrappedText).height; }, 0);
                 // If the tick labels are rotated, reverse usedWidth and usedHeight
@@ -4881,7 +4880,6 @@ var Plottable;
                     usedWidth = tempHeight;
                 }
                 return {
-                    textFits: textFits,
                     usedWidth: usedWidth,
                     usedHeight: usedHeight
                 };

--- a/plottable.js
+++ b/plottable.js
@@ -4870,6 +4870,9 @@ var Plottable;
                 // HACKHACK: https://github.com/palantir/svg-typewriter/issues/25
                 var widthFn = (this._isHorizontal() && this._tickLabelAngle === 0) ? d3.sum : Plottable.Utils.Math.max;
                 var heightFn = (this._isHorizontal() && this._tickLabelAngle === 0) ? Plottable.Utils.Math.max : d3.sum;
+                var textFits = wrappingResults.every(function (t) {
+                    return !SVGTypewriter.Utils.StringMethods.isNotEmptyString(t.truncatedText) && t.noLines === 1;
+                });
                 var usedWidth = widthFn(wrappingResults, function (t) { return _this._measurer.measure(t.wrappedText).width; }, 0);
                 var usedHeight = heightFn(wrappingResults, function (t) { return _this._measurer.measure(t.wrappedText).height; }, 0);
                 // If the tick labels are rotated, reverse usedWidth and usedHeight
@@ -4880,6 +4883,7 @@ var Plottable;
                     usedWidth = tempHeight;
                 }
                 return {
+                    textFits: textFits,
                     usedWidth: usedWidth,
                     usedHeight: usedHeight
                 };

--- a/src/axes/categoryAxis.ts
+++ b/src/axes/categoryAxis.ts
@@ -163,6 +163,8 @@ export module Axes {
       let widthFn = (this._isHorizontal() && this._tickLabelAngle === 0) ? d3.sum : Utils.Math.max;
       let heightFn = (this._isHorizontal() && this._tickLabelAngle === 0) ? Utils.Math.max : d3.sum;
 
+      let textFits = wrappingResults.every((t: SVGTypewriter.Wrappers.WrappingResult) =>
+                    !SVGTypewriter.Utils.StringMethods.isNotEmptyString(t.truncatedText) && t.noLines === 1);
       let usedWidth = widthFn<SVGTypewriter.Wrappers.WrappingResult, number>(wrappingResults,
                       (t: SVGTypewriter.Wrappers.WrappingResult) => this._measurer.measure(t.wrappedText).width, 0);
       let usedHeight = heightFn<SVGTypewriter.Wrappers.WrappingResult, number>(wrappingResults,
@@ -177,6 +179,7 @@ export module Axes {
       }
 
       return {
+        textFits: textFits,
         usedWidth: usedWidth,
         usedHeight: usedHeight
       };

--- a/src/axes/categoryAxis.ts
+++ b/src/axes/categoryAxis.ts
@@ -34,8 +34,8 @@ export module Axes {
     }
 
     public requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest {
-      let widthRequiredByTicks = this._isHorizontal() ? 0 : this._maxLabelTickLength() + this.tickLabelPadding() + this.margin();
-      let heightRequiredByTicks = this._isHorizontal() ? this._maxLabelTickLength() + this.tickLabelPadding() + this.margin() : 0;
+      let widthRequiredByTicks = this._isHorizontal() ? 0 : this._maxLabelTickLength() + this.tickLabelPadding();
+      let heightRequiredByTicks = this._isHorizontal() ? this._maxLabelTickLength() + this.tickLabelPadding() : 0;
 
       if (this._scale.domain().length === 0) {
         return {
@@ -50,8 +50,8 @@ export module Axes {
       this._computedHeight = measureResult.usedHeight + heightRequiredByTicks;
 
       return {
-        minWidth: this._computedWidth,
-        minHeight: this._computedHeight
+        minWidth: this._isHorizontal() ? this._computedWidth : this._computedWidth + this.margin(),
+        minHeight: this._isHorizontal() ? this._computedHeight + this.margin() : this._computedHeight
       };
     }
 

--- a/src/axes/categoryAxis.ts
+++ b/src/axes/categoryAxis.ts
@@ -46,10 +46,12 @@ export module Axes {
 
       let categoryScale = <Scales.Category> this._scale;
       let measureResult = this._measureTicks(offeredWidth, offeredHeight, categoryScale, categoryScale.domain());
+      this._computedWidth = measureResult.usedWidth + widthRequiredByTicks;
+      this._computedHeight = measureResult.usedHeight + heightRequiredByTicks;
 
       return {
-        minWidth: measureResult.usedWidth + widthRequiredByTicks,
-        minHeight: measureResult.usedHeight + heightRequiredByTicks
+        minWidth: this._computedWidth,
+        minHeight: this._computedHeight
       };
     }
 
@@ -161,8 +163,6 @@ export module Axes {
       let widthFn = (this._isHorizontal() && this._tickLabelAngle === 0) ? d3.sum : Utils.Math.max;
       let heightFn = (this._isHorizontal() && this._tickLabelAngle === 0) ? Utils.Math.max : d3.sum;
 
-      let textFits = wrappingResults.every((t: SVGTypewriter.Wrappers.WrappingResult) =>
-                    !SVGTypewriter.Utils.StringMethods.isNotEmptyString(t.truncatedText) && t.noLines === 1);
       let usedWidth = widthFn<SVGTypewriter.Wrappers.WrappingResult, number>(wrappingResults,
                       (t: SVGTypewriter.Wrappers.WrappingResult) => this._measurer.measure(t.wrappedText).width, 0);
       let usedHeight = heightFn<SVGTypewriter.Wrappers.WrappingResult, number>(wrappingResults,
@@ -177,7 +177,6 @@ export module Axes {
       }
 
       return {
-        textFits: textFits,
         usedWidth: usedWidth,
         usedHeight: usedHeight
       };

--- a/test/axes/categoryAxisTests.ts
+++ b/test/axes/categoryAxisTests.ts
@@ -179,15 +179,16 @@ describe("Category Axes", () => {
   });
 
   it("_computed space variables should be set on requestedSpace", () => {
-    let svg = TestMethods.generateSVG(300, 300);
+    let svgWidth = 300;
+    let svgHeight = 300;
+    let svg = TestMethods.generateSVG(svgWidth, svgHeight);
     let labels = ["label1", "label2", "label100"];
     let scale = new Plottable.Scales.Category().domain(labels);
     let axis = new Plottable.Axes.Category(scale, "bottom");
     axis.anchor(svg);
-    axis.requestedSpace(300, 300);
+    axis.computeLayout({ x: 0, y: 0 }, svgWidth, svgHeight);
 
-    assert.isNotNull((<any> axis)._computedWidth, "computed width variable should be set to a value");
-    assert.isNotNull((<any> axis)._computedHeight, "computed height variable should be a set to a value");
+    assert.strictEqual((<any> axis)._computedHeight, axis.height() - axis.margin(), "computed height should be height without margin");
 
     svg.remove();
   });

--- a/test/axes/categoryAxisTests.ts
+++ b/test/axes/categoryAxisTests.ts
@@ -178,7 +178,7 @@ describe("Category Axes", () => {
     svg.remove();
   });
 
-  it("_computed space variables should be set on requestedSpace", () => {
+  it("_computedHeight should be set to height without margin", () => {
     let svgWidth = 300;
     let svgHeight = 300;
     let svg = TestMethods.generateSVG(svgWidth, svgHeight);

--- a/test/axes/categoryAxisTests.ts
+++ b/test/axes/categoryAxisTests.ts
@@ -177,4 +177,18 @@ describe("Category Axes", () => {
 
     svg.remove();
   });
+
+  it("_computed space variables should be set on requestedSpace", () => {
+    let svg = TestMethods.generateSVG(300, 300);
+    let labels = ["label1", "label2", "label100"];
+    let scale = new Plottable.Scales.Category().domain(labels);
+    let axis = new Plottable.Axes.Category(scale, "bottom");
+    axis.anchor(svg);
+    axis.requestedSpace(300, 300);
+
+    assert.isNotNull((<any> axis)._computedWidth, "computed width variable should be set to a value");
+    assert.isNotNull((<any> axis)._computedHeight, "computed height variable should be a set to a value");
+
+    svg.remove();
+  });
 });


### PR DESCRIPTION
QE:  This is a fix on a protected variable and should not have any effect on user-expected behavior.  Regression pass should be fine.

The protected variables `_computedWidth` and `_computedHeight` were not properly set correctly.  Thankfully, while `Axis.Category` routes around this, this means that accessing these variables can lead to errors.  Note that developers are the main user of these variables.

This is mainly a temporary band-aid for #2641 as #2620 is blocked on a reliable way to get the width/height of the axis disregarding the margin.

This affects only protected variables, which we should have probably thought about more carefully when `Axis.Category` overwrote the behavior.
