### PR TITLE
The batch datasets setter dispatches updates at the end in batch

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1340,6 +1340,16 @@ declare module Plottable {
 
 declare module Plottable {
     module Drawers {
+        class ArcOutline extends Drawer {
+            constructor(dataset: Dataset);
+            protected _applyDefaultAttributes(selection: d3.Selection<any>): void;
+        }
+    }
+}
+
+
+declare module Plottable {
+    module Drawers {
         class Symbol extends Drawer {
             constructor(dataset: Dataset);
         }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3093,7 +3093,7 @@ declare module Plottable {
             addDataset(dataset: Dataset): Bar<X, Y>;
             protected _addDataset(dataset: Dataset): Bar<X, Y>;
             removeDataset(dataset: Dataset): Bar<X, Y>;
-            _removeDataset(dataset: Dataset): Bar<X, Y>;
+            protected _removeDataset(dataset: Dataset): Bar<X, Y>;
             /**
              * Get whether bar labels are enabled.
              *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2521,13 +2521,6 @@ declare module Plottable {
         anchor(selection: d3.Selection<void>): Plot;
         protected _setup(): void;
         destroy(): void;
-        /**
-         * Adds a Dataset to the Plot.
-         *
-         * @param {Dataset} dataset
-         * @returns {Plot} The calling Plot.
-         */
-        addDataset(dataset: Dataset): Plot;
         protected _createNodesForDataset(dataset: Dataset): Drawer;
         protected _createDrawer(dataset: Dataset): Drawer;
         protected _getAnimator(key: string): Animator;
@@ -2593,12 +2586,21 @@ declare module Plottable {
          */
         animator(animatorKey: string, animator: Animator): Plot;
         /**
+         * Adds a Dataset to the Plot.
+         *
+         * @param {Dataset} dataset
+         * @returns {Plot} The calling Plot.
+         */
+        addDataset(dataset: Dataset): void;
+        _addDataset(dataset: Dataset, withUpdate: boolean): Plot;
+        /**
          * Removes a Dataset from the Plot.
          *
          * @param {Dataset} dataset
          * @returns {Plot} The calling Plot.
          */
         removeDataset(dataset: Dataset): Plot;
+        _removeDataset(dataset: Dataset, withUpdate: boolean): Plot;
         protected _removeDatasetNodes(dataset: Dataset): void;
         datasets(): Dataset[];
         datasets(datasets: Dataset[]): Plot;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2592,6 +2592,7 @@ declare module Plottable {
          * @returns {Plot} The calling Plot.
          */
         addDataset(dataset: Dataset): Plot;
+        protected _addDataset(dataset: Dataset): Plot;
         /**
          * Removes a Dataset from the Plot.
          *
@@ -3262,7 +3263,7 @@ declare module Plottable {
              */
             y0(y0: number | Accessor<number>): Area<X>;
             protected _onDatasetUpdate(): void;
-            addDataset(dataset: Dataset): Area<X>;
+            protected _addDataset(dataset: Dataset): Area<X>;
             protected _removeDatasetNodes(dataset: Dataset): void;
             protected _additionalPaint(): void;
             protected _createDrawer(dataset: Dataset): Drawers.Area;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2600,6 +2600,7 @@ declare module Plottable {
          * @returns {Plot} The calling Plot.
          */
         removeDataset(dataset: Dataset): Plot;
+        protected _removeDataset(dataset: Dataset): Plot;
         protected _removeDatasetNodes(dataset: Dataset): void;
         datasets(): Dataset[];
         datasets(datasets: Dataset[]): Plot;
@@ -2650,8 +2651,8 @@ declare module Plottable {
              */
             constructor();
             computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Pie;
-            addDataset(dataset: Dataset): Pie;
-            removeDataset(dataset: Dataset): Pie;
+            protected _addDataset(dataset: Dataset): Pie;
+            protected _removeDataset(dataset: Dataset): Pie;
             protected _onDatasetUpdate(): void;
             protected _createDrawer(dataset: Dataset): Drawers.Arc;
             entities(datasets?: Dataset[]): PlotEntity[];
@@ -3090,7 +3091,9 @@ declare module Plottable {
              */
             baselineValue(value: X | Y): Bar<X, Y>;
             addDataset(dataset: Dataset): Bar<X, Y>;
+            protected _addDataset(dataset: Dataset): Bar<X, Y>;
             removeDataset(dataset: Dataset): Bar<X, Y>;
+            _removeDataset(dataset: Dataset): Bar<X, Y>;
             /**
              * Get whether bar labels are enabled.
              *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2592,7 +2592,6 @@ declare module Plottable {
          * @returns {Plot} The calling Plot.
          */
         addDataset(dataset: Dataset): Plot;
-        _addDataset(dataset: Dataset, withUpdate: boolean): Plot;
         /**
          * Removes a Dataset from the Plot.
          *
@@ -2600,7 +2599,6 @@ declare module Plottable {
          * @returns {Plot} The calling Plot.
          */
         removeDataset(dataset: Dataset): Plot;
-        _removeDataset(dataset: Dataset, withUpdate: boolean): Plot;
         protected _removeDatasetNodes(dataset: Dataset): void;
         datasets(): Dataset[];
         datasets(datasets: Dataset[]): Plot;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1340,16 +1340,6 @@ declare module Plottable {
 
 declare module Plottable {
     module Drawers {
-        class ArcOutline extends Drawer {
-            constructor(dataset: Dataset);
-            protected _applyDefaultAttributes(selection: d3.Selection<any>): void;
-        }
-    }
-}
-
-
-declare module Plottable {
-    module Drawers {
         class Symbol extends Drawer {
             constructor(dataset: Dataset);
         }
@@ -2671,7 +2661,9 @@ declare module Plottable {
             constructor();
             protected _setup(): void;
             computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Pie;
+            addDataset(dataset: Dataset): Pie;
             protected _addDataset(dataset: Dataset): Pie;
+            removeDataset(dataset: Dataset): Pie;
             protected _removeDatasetNodes(dataset: Dataset): void;
             protected _removeDataset(dataset: Dataset): Pie;
             selections(datasets?: Dataset[]): d3.Selection<any>;
@@ -3338,6 +3330,7 @@ declare module Plottable {
              */
             y0(y0: number | Accessor<number>): Area<X>;
             protected _onDatasetUpdate(): void;
+            addDataset(dataset: Dataset): Area<X>;
             protected _addDataset(dataset: Dataset): Area<X>;
             protected _removeDatasetNodes(dataset: Dataset): void;
             protected _additionalPaint(): void;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2591,7 +2591,7 @@ declare module Plottable {
          * @param {Dataset} dataset
          * @returns {Plot} The calling Plot.
          */
-        addDataset(dataset: Dataset): void;
+        addDataset(dataset: Dataset): Plot;
         _addDataset(dataset: Dataset, withUpdate: boolean): Plot;
         /**
          * Removes a Dataset from the Plot.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3144,6 +3144,8 @@ declare module Plottable {
             protected _addDataset(dataset: Dataset): Bar<X, Y>;
             removeDataset(dataset: Dataset): Bar<X, Y>;
             protected _removeDataset(dataset: Dataset): Bar<X, Y>;
+            datasets(): Dataset[];
+            datasets(datasets: Dataset[]): Plot;
             /**
              * Get whether bar labels are enabled.
              *

--- a/plottable.js
+++ b/plottable.js
@@ -6413,7 +6413,7 @@ var Plottable;
             var _this = this;
             _super.prototype.destroy.call(this);
             this._scales().forEach(function (scale) { return scale.offUpdate(_this._renderCallback); });
-            this.datasets().forEach(function (dataset) { return _this._removeDataset(dataset, false); });
+            this.datasets().forEach(function (dataset) { return _this._removeDataset(dataset); });
             this._onDatasetUpdate();
         };
         Plot.prototype._createNodesForDataset = function (dataset) {
@@ -6606,19 +6606,18 @@ var Plottable;
          * @returns {Plot} The calling Plot.
          */
         Plot.prototype.addDataset = function (dataset) {
-            return this._addDataset(dataset, true);
+            this._addDataset(dataset);
+            this._onDatasetUpdate();
+            return this;
         };
-        Plot.prototype._addDataset = function (dataset, dispatchUpdate) {
-            this._removeDataset(dataset, false);
+        Plot.prototype._addDataset = function (dataset) {
+            this._removeDataset(dataset);
             var drawer = this._createDrawer(dataset);
             this._datasetToDrawer.set(dataset, drawer);
             if (this._isSetup) {
                 this._createNodesForDataset(dataset);
             }
             dataset.onUpdate(this._onDatasetUpdateCallback);
-            if (dispatchUpdate) {
-                this._onDatasetUpdate();
-            }
             return this;
         };
         /**
@@ -6628,18 +6627,17 @@ var Plottable;
          * @returns {Plot} The calling Plot.
          */
         Plot.prototype.removeDataset = function (dataset) {
-            return this._removeDataset(dataset, true);
+            this._removeDataset(dataset);
+            this._onDatasetUpdate();
+            return this;
         };
-        Plot.prototype._removeDataset = function (dataset, dispatchUpdate) {
+        Plot.prototype._removeDataset = function (dataset) {
             if (this.datasets().indexOf(dataset) === -1) {
                 return this;
             }
             this._removeDatasetNodes(dataset);
             dataset.offUpdate(this._onDatasetUpdateCallback);
             this._datasetToDrawer.delete(dataset);
-            if (dispatchUpdate) {
-                this._onDatasetUpdate();
-            }
             return this;
         };
         Plot.prototype._removeDatasetNodes = function (dataset) {
@@ -6653,8 +6651,8 @@ var Plottable;
             if (datasets == null) {
                 return currentDatasets;
             }
-            currentDatasets.forEach(function (dataset) { return _this._removeDataset(dataset, false); });
-            datasets.forEach(function (dataset) { return _this._addDataset(dataset, false); });
+            currentDatasets.forEach(function (dataset) { return _this._removeDataset(dataset); });
+            datasets.forEach(function (dataset) { return _this._addDataset(dataset); });
             this._onDatasetUpdate();
             return this;
         };

--- a/plottable.js
+++ b/plottable.js
@@ -6607,17 +6607,15 @@ var Plottable;
         Plot.prototype.addDataset = function (dataset) {
             return this._addDataset(dataset, true);
         };
-        Plot.prototype._addDataset = function (dataset, withUpdate) {
-            // if (this.datasets().indexOf(dataset) > -1) {
+        Plot.prototype._addDataset = function (dataset, dispatchUpdate) {
             this._removeDataset(dataset, false);
-            // };
             var drawer = this._createDrawer(dataset);
             this._datasetToDrawer.set(dataset, drawer);
             if (this._isSetup) {
                 this._createNodesForDataset(dataset);
             }
             dataset.onUpdate(this._onDatasetUpdateCallback);
-            if (withUpdate) {
+            if (dispatchUpdate) {
                 this._onDatasetUpdate();
             }
             return this;
@@ -6631,14 +6629,14 @@ var Plottable;
         Plot.prototype.removeDataset = function (dataset) {
             return this._removeDataset(dataset, true);
         };
-        Plot.prototype._removeDataset = function (dataset, withUpdate) {
+        Plot.prototype._removeDataset = function (dataset, dispatchUpdate) {
             if (this.datasets().indexOf(dataset) === -1) {
                 return this;
             }
             this._removeDatasetNodes(dataset);
             dataset.offUpdate(this._onDatasetUpdateCallback);
             this._datasetToDrawer.delete(dataset);
-            if (withUpdate) {
+            if (dispatchUpdate) {
                 this._onDatasetUpdate();
             }
             return this;

--- a/plottable.js
+++ b/plottable.js
@@ -6413,7 +6413,8 @@ var Plottable;
             var _this = this;
             _super.prototype.destroy.call(this);
             this._scales().forEach(function (scale) { return scale.offUpdate(_this._renderCallback); });
-            this.datasets().forEach(function (dataset) { return _this.removeDataset(dataset); });
+            this.datasets().forEach(function (dataset) { return _this._removeDataset(dataset, false); });
+            this._onDatasetUpdate();
         };
         Plot.prototype._createNodesForDataset = function (dataset) {
             var drawer = this._datasetToDrawer.get(dataset);

--- a/plottable.js
+++ b/plottable.js
@@ -2892,6 +2892,34 @@ var Plottable;
 (function (Plottable) {
     var Drawers;
     (function (Drawers) {
+        var ArcOutline = (function (_super) {
+            __extends(ArcOutline, _super);
+            function ArcOutline(dataset) {
+                _super.call(this, dataset);
+                this._className = "arc outline";
+                this._svgElementName = "path";
+            }
+            ArcOutline.prototype._applyDefaultAttributes = function (selection) {
+                _super.prototype._applyDefaultAttributes.call(this, selection);
+                selection.style("fill", "none");
+            };
+            return ArcOutline;
+        })(Plottable.Drawer);
+        Drawers.ArcOutline = ArcOutline;
+    })(Drawers = Plottable.Drawers || (Plottable.Drawers = {}));
+})(Plottable || (Plottable = {}));
+
+///<reference path="../reference.ts" />
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    __.prototype = b.prototype;
+    d.prototype = new __();
+};
+var Plottable;
+(function (Plottable) {
+    var Drawers;
+    (function (Drawers) {
         var Symbol = (function (_super) {
             __extends(Symbol, _super);
             function Symbol(dataset) {

--- a/plottable.js
+++ b/plottable.js
@@ -6413,8 +6413,7 @@ var Plottable;
             var _this = this;
             _super.prototype.destroy.call(this);
             this._scales().forEach(function (scale) { return scale.offUpdate(_this._renderCallback); });
-            this.datasets().forEach(function (dataset) { return _this._removeDataset(dataset); });
-            this._onDatasetUpdate();
+            this.datasets([]);
         };
         Plot.prototype._createNodesForDataset = function (dataset) {
             var drawer = this._datasetToDrawer.get(dataset);

--- a/plottable.js
+++ b/plottable.js
@@ -6848,17 +6848,17 @@ var Plottable;
                 }
                 return this;
             };
-            Pie.prototype.addDataset = function (dataset) {
+            Pie.prototype._addDataset = function (dataset) {
                 if (this.datasets().length === 1) {
                     Plottable.Utils.Window.warn("Only one dataset is supported in Pie plots");
                     return this;
                 }
                 this._updatePieAngles();
-                _super.prototype.addDataset.call(this, dataset);
+                _super.prototype._addDataset.call(this, dataset);
                 return this;
             };
-            Pie.prototype.removeDataset = function (dataset) {
-                _super.prototype.removeDataset.call(this, dataset);
+            Pie.prototype._removeDataset = function (dataset) {
+                _super.prototype._removeDataset.call(this, dataset);
                 this._startAngles = [];
                 this._endAngles = [];
                 return this;
@@ -7905,15 +7905,24 @@ var Plottable;
                 return this;
             };
             Bar.prototype.addDataset = function (dataset) {
-                dataset.onUpdate(this._updateBarPixelWidthCallback);
                 _super.prototype.addDataset.call(this, dataset);
                 this._updateBarPixelWidth();
+                return this;
+            };
+            Bar.prototype._addDataset = function (dataset) {
+                dataset.onUpdate(this._updateBarPixelWidthCallback);
+                _super.prototype._addDataset.call(this, dataset);
                 return this;
             };
             Bar.prototype.removeDataset = function (dataset) {
                 dataset.offUpdate(this._updateBarPixelWidthCallback);
                 _super.prototype.removeDataset.call(this, dataset);
                 this._updateBarPixelWidth();
+                return this;
+            };
+            Bar.prototype._removeDataset = function (dataset) {
+                dataset.offUpdate(this._updateBarPixelWidthCallback);
+                _super.prototype._removeDataset.call(this, dataset);
                 return this;
             };
             Bar.prototype.labelsEnabled = function (enabled) {

--- a/plottable.js
+++ b/plottable.js
@@ -8549,13 +8549,13 @@ var Plottable;
                 _super.prototype._onDatasetUpdate.call(this);
                 this._updateYScale();
             };
-            Area.prototype.addDataset = function (dataset) {
+            Area.prototype._addDataset = function (dataset) {
                 var lineDrawer = new Plottable.Drawers.Line(dataset);
                 if (this._isSetup) {
                     lineDrawer.renderArea(this._renderArea.append("g"));
                 }
                 this._lineDrawers.set(dataset, lineDrawer);
-                _super.prototype.addDataset.call(this, dataset);
+                _super.prototype._addDataset.call(this, dataset);
                 return this;
             };
             Area.prototype._removeDatasetNodes = function (dataset) {

--- a/plottable.js
+++ b/plottable.js
@@ -6605,7 +6605,7 @@ var Plottable;
          * @returns {Plot} The calling Plot.
          */
         Plot.prototype.addDataset = function (dataset) {
-            this._addDataset(dataset, true);
+            return this._addDataset(dataset, true);
         };
         Plot.prototype._addDataset = function (dataset, withUpdate) {
             // if (this.datasets().indexOf(dataset) > -1) {

--- a/plottable.js
+++ b/plottable.js
@@ -6415,26 +6415,6 @@ var Plottable;
             this._scales().forEach(function (scale) { return scale.offUpdate(_this._renderCallback); });
             this.datasets().forEach(function (dataset) { return _this.removeDataset(dataset); });
         };
-        /**
-         * Adds a Dataset to the Plot.
-         *
-         * @param {Dataset} dataset
-         * @returns {Plot} The calling Plot.
-         */
-        Plot.prototype.addDataset = function (dataset) {
-            if (this.datasets().indexOf(dataset) > -1) {
-                this.removeDataset(dataset);
-            }
-            ;
-            var drawer = this._createDrawer(dataset);
-            this._datasetToDrawer.set(dataset, drawer);
-            if (this._isSetup) {
-                this._createNodesForDataset(dataset);
-            }
-            dataset.onUpdate(this._onDatasetUpdateCallback);
-            this._onDatasetUpdate();
-            return this;
-        };
         Plot.prototype._createNodesForDataset = function (dataset) {
             var drawer = this._datasetToDrawer.get(dataset);
             drawer.renderArea(this._renderArea.append("g"));
@@ -6619,16 +6599,46 @@ var Plottable;
             }
         };
         /**
+         * Adds a Dataset to the Plot.
+         *
+         * @param {Dataset} dataset
+         * @returns {Plot} The calling Plot.
+         */
+        Plot.prototype.addDataset = function (dataset) {
+            this._addDataset(dataset, true);
+        };
+        Plot.prototype._addDataset = function (dataset, withUpdate) {
+            // if (this.datasets().indexOf(dataset) > -1) {
+            this._removeDataset(dataset, false);
+            // };
+            var drawer = this._createDrawer(dataset);
+            this._datasetToDrawer.set(dataset, drawer);
+            if (this._isSetup) {
+                this._createNodesForDataset(dataset);
+            }
+            dataset.onUpdate(this._onDatasetUpdateCallback);
+            if (withUpdate) {
+                this._onDatasetUpdate();
+            }
+            return this;
+        };
+        /**
          * Removes a Dataset from the Plot.
          *
          * @param {Dataset} dataset
          * @returns {Plot} The calling Plot.
          */
         Plot.prototype.removeDataset = function (dataset) {
-            if (this.datasets().indexOf(dataset) > -1) {
-                this._removeDatasetNodes(dataset);
-                dataset.offUpdate(this._onDatasetUpdateCallback);
-                this._datasetToDrawer.delete(dataset);
+            return this._removeDataset(dataset, true);
+        };
+        Plot.prototype._removeDataset = function (dataset, withUpdate) {
+            if (this.datasets().indexOf(dataset) === -1) {
+                return this;
+            }
+            this._removeDatasetNodes(dataset);
+            dataset.offUpdate(this._onDatasetUpdateCallback);
+            this._datasetToDrawer.delete(dataset);
+            if (withUpdate) {
                 this._onDatasetUpdate();
             }
             return this;
@@ -6644,8 +6654,9 @@ var Plottable;
             if (datasets == null) {
                 return currentDatasets;
             }
-            currentDatasets.forEach(function (dataset) { return _this.removeDataset(dataset); });
-            datasets.forEach(function (dataset) { return _this.addDataset(dataset); });
+            currentDatasets.forEach(function (dataset) { return _this._removeDataset(dataset, false); });
+            datasets.forEach(function (dataset) { return _this._addDataset(dataset, false); });
+            this._onDatasetUpdate();
             return this;
         };
         Plot.prototype._getDrawersInOrder = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -8098,6 +8098,14 @@ var Plottable;
                 _super.prototype._removeDataset.call(this, dataset);
                 return this;
             };
+            Bar.prototype.datasets = function (datasets) {
+                if (datasets == null) {
+                    return _super.prototype.datasets.call(this);
+                }
+                _super.prototype.datasets.call(this, datasets);
+                this._updateBarPixelWidth();
+                return this;
+            };
             Bar.prototype.labelsEnabled = function (enabled) {
                 if (enabled == null) {
                     return this._labelsEnabled;

--- a/plottable.js
+++ b/plottable.js
@@ -2892,34 +2892,6 @@ var Plottable;
 (function (Plottable) {
     var Drawers;
     (function (Drawers) {
-        var ArcOutline = (function (_super) {
-            __extends(ArcOutline, _super);
-            function ArcOutline(dataset) {
-                _super.call(this, dataset);
-                this._className = "arc outline";
-                this._svgElementName = "path";
-            }
-            ArcOutline.prototype._applyDefaultAttributes = function (selection) {
-                _super.prototype._applyDefaultAttributes.call(this, selection);
-                selection.style("fill", "none");
-            };
-            return ArcOutline;
-        })(Plottable.Drawer);
-        Drawers.ArcOutline = ArcOutline;
-    })(Drawers = Plottable.Drawers || (Plottable.Drawers = {}));
-})(Plottable || (Plottable = {}));
-
-///<reference path="../reference.ts" />
-var __extends = (this && this.__extends) || function (d, b) {
-    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
-    function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
-};
-var Plottable;
-(function (Plottable) {
-    var Drawers;
-    (function (Drawers) {
         var Symbol = (function (_super) {
             __extends(Symbol, _super);
             function Symbol(dataset) {
@@ -6898,6 +6870,10 @@ var Plottable;
                 }
                 return this;
             };
+            Pie.prototype.addDataset = function (dataset) {
+                _super.prototype.addDataset.call(this, dataset);
+                return this;
+            };
             Pie.prototype._addDataset = function (dataset) {
                 if (this.datasets().length === 1) {
                     Plottable.Utils.Window.warn("Only one dataset is supported in Pie plots");
@@ -6910,6 +6886,10 @@ var Plottable;
                 }
                 this._strokeDrawers.set(dataset, strokeDrawer);
                 _super.prototype._addDataset.call(this, dataset);
+                return this;
+            };
+            Pie.prototype.removeDataset = function (dataset) {
+                _super.prototype.removeDataset.call(this, dataset);
                 return this;
             };
             Pie.prototype._removeDatasetNodes = function (dataset) {
@@ -8889,6 +8869,10 @@ var Plottable;
             Area.prototype._onDatasetUpdate = function () {
                 _super.prototype._onDatasetUpdate.call(this);
                 this._updateYScale();
+            };
+            Area.prototype.addDataset = function (dataset) {
+                _super.prototype.addDataset.call(this, dataset);
+                return this;
             };
             Area.prototype._addDataset = function (dataset) {
                 var lineDrawer = new Plottable.Drawers.Line(dataset);

--- a/src/plots/areaPlot.ts
+++ b/src/plots/areaPlot.ts
@@ -80,13 +80,13 @@ export module Plots {
       this._updateYScale();
     }
 
-    public addDataset(dataset: Dataset) {
+    protected _addDataset(dataset: Dataset) {
       let lineDrawer = new Drawers.Line(dataset);
       if (this._isSetup) {
         lineDrawer.renderArea(this._renderArea.append("g"));
       }
       this._lineDrawers.set(dataset, lineDrawer);
-      super.addDataset(dataset);
+      super._addDataset(dataset);
       return this;
     }
 

--- a/src/plots/areaPlot.ts
+++ b/src/plots/areaPlot.ts
@@ -80,6 +80,11 @@ export module Plots {
       this._updateYScale();
     }
 
+    public addDataset(dataset: Dataset) {
+      super.addDataset(dataset);
+      return this;
+    }
+
     protected _addDataset(dataset: Dataset) {
       let lineDrawer = new Drawers.Line(dataset);
       if (this._isSetup) {

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -178,6 +178,18 @@ export module Plots {
       return this;
     }
 
+    public datasets(): Dataset[];
+    public datasets(datasets: Dataset[]): Plot;
+    public datasets(datasets?: Dataset[]): any {
+      if (datasets == null) {
+        return super.datasets();
+      }
+
+      super.datasets(datasets);
+      this._updateBarPixelWidth();
+      return this;
+    }
+
     /**
      * Get whether bar labels are enabled.
      *

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -172,7 +172,7 @@ export module Plots {
       return this;
     }
 
-    public _removeDataset(dataset: Dataset) {
+    protected _removeDataset(dataset: Dataset) {
       dataset.offUpdate(this._updateBarPixelWidthCallback);
       super._removeDataset(dataset);
       return this;

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -154,9 +154,14 @@ export module Plots {
     }
 
     public addDataset(dataset: Dataset) {
-      dataset.onUpdate(this._updateBarPixelWidthCallback);
       super.addDataset(dataset);
       this._updateBarPixelWidth();
+      return this;
+    }
+
+    protected _addDataset(dataset: Dataset) {
+      dataset.onUpdate(this._updateBarPixelWidthCallback);
+      super._addDataset(dataset);
       return this;
     }
 
@@ -164,6 +169,12 @@ export module Plots {
       dataset.offUpdate(this._updateBarPixelWidthCallback);
       super.removeDataset(dataset);
       this._updateBarPixelWidth();
+      return this;
+    }
+
+    public _removeDataset(dataset: Dataset) {
+      dataset.offUpdate(this._updateBarPixelWidthCallback);
+      super._removeDataset(dataset);
       return this;
     }
 

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -36,18 +36,18 @@ export module Plots {
       return this;
     }
 
-    public addDataset(dataset: Dataset) {
+    protected _addDataset(dataset: Dataset) {
       if (this.datasets().length === 1) {
         Utils.Window.warn("Only one dataset is supported in Pie plots");
         return this;
       }
       this._updatePieAngles();
-      super.addDataset(dataset);
+      super._addDataset(dataset);
       return this;
     }
 
-    public removeDataset(dataset: Dataset) {
-      super.removeDataset(dataset);
+    protected _removeDataset(dataset: Dataset) {
+      super._removeDataset(dataset);
       this._startAngles = [];
       this._endAngles = [];
       return this;

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -44,6 +44,11 @@ export module Plots {
       return this;
     }
 
+    public addDataset(dataset: Dataset) {
+      super.addDataset(dataset);
+      return this;
+    }
+
     protected _addDataset(dataset: Dataset) {
       if (this.datasets().length === 1) {
         Utils.Window.warn("Only one dataset is supported in Pie plots");
@@ -56,6 +61,11 @@ export module Plots {
       }
       this._strokeDrawers.set(dataset, strokeDrawer);
       super._addDataset(dataset);
+      return this;
+    }
+
+    public removeDataset(dataset: Dataset) {
+      super.removeDataset(dataset);
       return this;
     }
 

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -93,7 +93,8 @@ export class Plot extends Component {
   public destroy() {
     super.destroy();
     this._scales().forEach((scale) => scale.offUpdate(this._renderCallback));
-    this.datasets().forEach((dataset) => this.removeDataset(dataset));
+    this.datasets().forEach((dataset) => this._removeDataset(dataset, false));
+    this._onDatasetUpdate();
   }
 
   protected _createNodesForDataset(dataset: Dataset) {

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -385,7 +385,7 @@ export class Plot extends Component {
    */
   public removeDataset(dataset: Dataset): Plot {
     this._removeDataset(dataset);
-    this._onDatasetUpdate()
+    this._onDatasetUpdate();
     return this;
   }
 

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -361,10 +361,8 @@ export class Plot extends Component {
     return this._addDataset(dataset, true);
   }
 
-  public _addDataset(dataset: Dataset, withUpdate: boolean) {
-    // if (this.datasets().indexOf(dataset) > -1) {
-      this._removeDataset(dataset, false);
-    // };
+  private _addDataset(dataset: Dataset, dispatchUpdate: boolean) {
+    this._removeDataset(dataset, false);
     let drawer = this._createDrawer(dataset);
     this._datasetToDrawer.set(dataset, drawer);
 
@@ -373,7 +371,7 @@ export class Plot extends Component {
     }
 
     dataset.onUpdate(this._onDatasetUpdateCallback);
-    if (withUpdate) {
+    if (dispatchUpdate) {
       this._onDatasetUpdate();
     }
     return this;
@@ -389,7 +387,7 @@ export class Plot extends Component {
     return this._removeDataset(dataset, true);
   }
 
-  public _removeDataset(dataset: Dataset, withUpdate: boolean) {
+  private _removeDataset(dataset: Dataset, dispatchUpdate: boolean) {
     if (this.datasets().indexOf(dataset) === -1) {
       return this;
     }
@@ -397,7 +395,7 @@ export class Plot extends Component {
     this._removeDatasetNodes(dataset);
     dataset.offUpdate(this._onDatasetUpdateCallback);
     this._datasetToDrawer.delete(dataset);
-    if (withUpdate) {
+    if (dispatchUpdate) {
       this._onDatasetUpdate();
     }
     return this;

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -93,8 +93,7 @@ export class Plot extends Component {
   public destroy() {
     super.destroy();
     this._scales().forEach((scale) => scale.offUpdate(this._renderCallback));
-    this.datasets().forEach((dataset) => this._removeDataset(dataset));
-    this._onDatasetUpdate();
+    this.datasets([]);
   }
 
   protected _createNodesForDataset(dataset: Dataset) {

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -363,7 +363,7 @@ export class Plot extends Component {
     return this;
   }
 
-  private _addDataset(dataset: Dataset) {
+  protected _addDataset(dataset: Dataset) {
     this._removeDataset(dataset);
     let drawer = this._createDrawer(dataset);
     this._datasetToDrawer.set(dataset, drawer);

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -388,7 +388,7 @@ export class Plot extends Component {
     return this;
   }
 
-  private _removeDataset(dataset: Dataset) {
+  protected _removeDataset(dataset: Dataset) {
     if (this.datasets().indexOf(dataset) === -1) {
       return this;
     }

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -358,7 +358,7 @@ export class Plot extends Component {
    * @returns {Plot} The calling Plot.
    */
   public addDataset(dataset: Dataset) {
-    this._addDataset(dataset, true);
+    return this._addDataset(dataset, true);
   }
 
   public _addDataset(dataset: Dataset, withUpdate: boolean) {

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -93,7 +93,7 @@ export class Plot extends Component {
   public destroy() {
     super.destroy();
     this._scales().forEach((scale) => scale.offUpdate(this._renderCallback));
-    this.datasets().forEach((dataset) => this._removeDataset(dataset, false));
+    this.datasets().forEach((dataset) => this._removeDataset(dataset));
     this._onDatasetUpdate();
   }
 
@@ -359,11 +359,13 @@ export class Plot extends Component {
    * @returns {Plot} The calling Plot.
    */
   public addDataset(dataset: Dataset) {
-    return this._addDataset(dataset, true);
+    this._addDataset(dataset);
+    this._onDatasetUpdate();
+    return this;
   }
 
-  private _addDataset(dataset: Dataset, dispatchUpdate: boolean) {
-    this._removeDataset(dataset, false);
+  private _addDataset(dataset: Dataset) {
+    this._removeDataset(dataset);
     let drawer = this._createDrawer(dataset);
     this._datasetToDrawer.set(dataset, drawer);
 
@@ -372,9 +374,6 @@ export class Plot extends Component {
     }
 
     dataset.onUpdate(this._onDatasetUpdateCallback);
-    if (dispatchUpdate) {
-      this._onDatasetUpdate();
-    }
     return this;
   }
 
@@ -385,10 +384,12 @@ export class Plot extends Component {
    * @returns {Plot} The calling Plot.
    */
   public removeDataset(dataset: Dataset): Plot {
-    return this._removeDataset(dataset, true);
+    this._removeDataset(dataset);
+    this._onDatasetUpdate()
+    return this;
   }
 
-  private _removeDataset(dataset: Dataset, dispatchUpdate: boolean) {
+  private _removeDataset(dataset: Dataset) {
     if (this.datasets().indexOf(dataset) === -1) {
       return this;
     }
@@ -396,9 +397,6 @@ export class Plot extends Component {
     this._removeDatasetNodes(dataset);
     dataset.offUpdate(this._onDatasetUpdateCallback);
     this._datasetToDrawer.delete(dataset);
-    if (dispatchUpdate) {
-      this._onDatasetUpdate();
-    }
     return this;
   }
 
@@ -416,8 +414,8 @@ export class Plot extends Component {
       return currentDatasets;
     }
 
-    currentDatasets.forEach((dataset) => this._removeDataset(dataset, false));
-    datasets.forEach((dataset) => this._addDataset(dataset, false));
+    currentDatasets.forEach((dataset) => this._removeDataset(dataset));
+    datasets.forEach((dataset) => this._addDataset(dataset));
     this._onDatasetUpdate();
     return this;
   }

--- a/test/plots/piePlotTests.ts
+++ b/test/plots/piePlotTests.ts
@@ -187,7 +187,8 @@ describe("Plots", () => {
           { value: 5000 },
           { value: 5000 }];
         let dataset = new Plottable.Dataset(data);
-        piePlot.addDataset(dataset).outerRadius(500);
+        piePlot.addDataset(dataset)
+        piePlot.outerRadius(500);
         piePlot.renderTo(svg);
 
         let texts = svg.selectAll("text");

--- a/test/plots/piePlotTests.ts
+++ b/test/plots/piePlotTests.ts
@@ -232,8 +232,7 @@ describe("Plots", () => {
           { value: 5000 },
           { value: 5000 }];
         let dataset = new Plottable.Dataset(data);
-        piePlot.addDataset(dataset);
-        piePlot.outerRadius(500);
+        piePlot.addDataset(dataset).outerRadius(500);
         piePlot.renderTo(svg);
 
         let texts = svg.selectAll("text");

--- a/test/plots/piePlotTests.ts
+++ b/test/plots/piePlotTests.ts
@@ -187,7 +187,7 @@ describe("Plots", () => {
           { value: 5000 },
           { value: 5000 }];
         let dataset = new Plottable.Dataset(data);
-        piePlot.addDataset(dataset)
+        piePlot.addDataset(dataset);
         piePlot.outerRadius(500);
         piePlot.renderTo(svg);
 

--- a/test/plots/plotTests.ts
+++ b/test/plots/plotTests.ts
@@ -82,6 +82,9 @@ describe("Plots", () => {
 
       plot.removeDataset(dataset1);
       assert.deepEqual(plot.datasets(), [dataset2, dataset3], "removing a Dataset leaves the remainder in the same order");
+
+      plot.datasets([]);
+      assert.deepEqual(plot.datasets(), [], "the datasets() call first removes all the datasets");
     });
 
     it("Updates its projectors when the Dataset is changed", () => {


### PR DESCRIPTION
Part of #2418 

Suggested improvements will come as separate PRs

150 Datasets (as requested) - Speedup `100x`
Before: http://jsfiddle.net/cn9x2p5j/2/ - `3300 ms`
After: http://jsfiddle.net/cn9x2p5j/3/ - `36 ms`

Affected (perf wise):
- Plot.datasets(). This method should be preferred for multiple datasets additions

Unaffected (perf wise):
- Plot.addDataset()
- Plot.removeDataset()

QE notes - affected points:
- Plot.datasets()
- Plot.destroy()
- Plot.addDataset()
- Plot.removeDataset()

QE notes - regression: 
- Everything should behave exactly the same

QE notes - performance: 
- Plot.datasets() should be 100x faster.
- Plot.destroy() should be faster
- Everything else should be exactly the same