### PR TITLE
Refactor segment plot tests

### DIFF
--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -45,8 +45,8 @@ describe("Plots", () => {
         plot.addDataset(new Plottable.Dataset(data));
         plot.renderTo(svg);
 
-        plot.content().selectAll("line")[0].forEach((line) => {
-          let lineSelection = d3.select(line);
+        plot.content().selectAll("line").each(function() {
+          let lineSelection = d3.select(this);
           assert.strictEqual(lineSelection.attr("x1"), lineSelection.attr("x2"), "line is vertical");
         });
         svg.remove();
@@ -60,8 +60,8 @@ describe("Plots", () => {
         plot.addDataset(new Plottable.Dataset(data));
         plot.renderTo(svg);
 
-        plot.content().selectAll("line")[0].forEach((line) => {
-          let lineSelection = d3.select(line);
+        plot.content().selectAll("line").each(function() {
+          let lineSelection = d3.select(this);
           assert.strictEqual(lineSelection.attr("y1"), lineSelection.attr("y2"), "line is horizontal");
         });
         svg.remove();

--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -19,10 +19,6 @@ describe("Plots", () => {
         yScale = new Plottable.Scales.Linear();
       });
 
-      afterEach(() => {
-        svg.remove();
-      });
-
       it("renders a line properly", () => {
         let plot = new Plottable.Plots.Segment();
         plot.x((d) => d.x, xScale);
@@ -38,6 +34,7 @@ describe("Plots", () => {
         assert.strictEqual(+line.attr("x2"), 437.5, "x2 is correct");
         assert.strictEqual(+line.attr("y1"), 437.5, "y1 is correct");
         assert.strictEqual(+line.attr("y2"), 62.5, "y2 is correct");
+        svg.remove();
       });
 
       it("renders vertical lines when x2 is not set", () => {
@@ -52,6 +49,7 @@ describe("Plots", () => {
           let lineSelection = d3.select(line);
           assert.strictEqual(lineSelection.attr("x1"), lineSelection.attr("x2"), "line is vertical");
         });
+        svg.remove();
       });
 
       it("renders horizontal lines when y2 is not set", () => {
@@ -66,6 +64,7 @@ describe("Plots", () => {
           let lineSelection = d3.select(line);
           assert.strictEqual(lineSelection.attr("y1"), lineSelection.attr("y2"), "line is horizontal");
         });
+        svg.remove();
       });
 
       it("autorangeMode(\"x\")", () => {
@@ -91,6 +90,7 @@ describe("Plots", () => {
 
         yScale.domain([0.5, 1.5]);
         assert.deepEqual(xScale.domain(), [1, 2], "x domain includes only the visible segment (second)");
+        svg.remove();
       });
 
       it("autorangeMode(\"y\")", () => {
@@ -116,6 +116,7 @@ describe("Plots", () => {
 
         xScale.domain([0.5, 1.5]);
         assert.deepEqual(yScale.domain(), [1, 2], "y domain includes only the visible segment (second)");
+        svg.remove();
       });
     });
 
@@ -141,10 +142,6 @@ describe("Plots", () => {
         plot.addDataset(new Plottable.Dataset(data)).renderTo(svg);
       });
 
-      afterEach(() => {
-        svg.remove();
-      });
-
       it("retrieves the entities that intersect with the bounding box", () => {
         let entities = plot.entitiesIn({
           topLeft: { x: xScale.scale(0), y: yScale.scale(4.5) },
@@ -152,6 +149,7 @@ describe("Plots", () => {
         assert.lengthOf(entities, 2, "retrieved 2 entities intersect with the box");
         assert.strictEqual(entities[0].index, 0, "the entity of index 0 is retrieved");
         assert.strictEqual(entities[1].index, 1, "the entity of index 1 is retrieved");
+        svg.remove();
       });
 
       it("retrieves the entities that intersect with given ranges", () => {
@@ -161,6 +159,7 @@ describe("Plots", () => {
         assert.lengthOf(entities, 2, "retrieved 2 entities intersect with the ranges");
         assert.strictEqual(entities[0].index, 1, "the entity of index 1 is retrieved");
         assert.strictEqual(entities[1].index, 2, "the entity of index 2 is retrieved");
+        svg.remove();
       });
 
       it("retrieves the entity if exactly one of its endpoints is in the ranges", () => {
@@ -179,6 +178,7 @@ describe("Plots", () => {
         // horizontal segment
         checkEntitiesInRange(plot, 3, 1.5, 2.5, 1.5, 0.5);
         checkEntitiesInRange(plot, 3, 3.5, 4.5, 1.5, 0.5);
+        svg.remove();
       });
 
       it("retrieves the entity if both of its endpoints are in the ranges", () => {
@@ -193,6 +193,7 @@ describe("Plots", () => {
 
         // horizontal segment
         checkEntitiesInRange(plot, 3, 1.5, 4.5, 1.5, 0.5);
+        svg.remove();
       });
 
       it("retrieves the entity if it intersects with the ranges with no endpoints inside", () => {
@@ -207,6 +208,7 @@ describe("Plots", () => {
 
         // horizontal segment
         checkEntitiesInRange(plot, 3, 2.5, 3.5, 1.5, 0.5);
+        svg.remove();
       });
 
       it("returns empty array when no entities intersect with the ranges", () => {
@@ -214,6 +216,7 @@ describe("Plots", () => {
           { min: xScale.scale(1.5), max: xScale.scale(2.5) },
           { min: yScale.scale(2.5), max: yScale.scale(1.5) });
         assert.lengthOf(entities, 0, "no entities intersects with the ranges");
+        svg.remove();
       });
 
       function checkEntitiesInRange(plot: Plottable.Plots.Segment<any, any>, index: number,

--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -129,11 +129,16 @@ describe("Plots", () => {
       let svg: d3.Selection<void>;
       let xScale: Plottable.Scales.Linear;
       let yScale: Plottable.Scales.Linear;
+      let plot: Plottable.Plots.Segment<number, number>;
 
       beforeEach(() => {
         svg = TestMethods.generateSVG(500, 500);
         xScale = new Plottable.Scales.Linear();
         yScale = new Plottable.Scales.Linear();
+        plot = new Plottable.Plots.Segment<number, number>()
+          .x((d) => d.x, xScale).x2((d) => d.x2)
+          .y((d) => d.y, yScale).y2((d) => d.y2);
+        plot.addDataset(new Plottable.Dataset(data)).renderTo(svg);
       });
 
       afterEach(() => {
@@ -141,10 +146,6 @@ describe("Plots", () => {
       });
 
       it("retrieves the entities that intersect with the bounding box", () => {
-        let plot = new Plottable.Plots.Segment()
-          .x((d) => d.x, xScale).x2((d) => d.x2)
-          .y((d) => d.y, yScale).y2((d) => d.y2);
-        plot.addDataset(new Plottable.Dataset(data)).renderTo(svg);
         let entities = plot.entitiesIn({
           topLeft: { x: xScale.scale(0), y: yScale.scale(4.5) },
           bottomRight: { x: xScale.scale(2.5), y: yScale.scale(3) } });
@@ -154,10 +155,6 @@ describe("Plots", () => {
       });
 
       it("retrieves the entities that intersect with given ranges", () => {
-        let plot = new Plottable.Plots.Segment()
-          .x((d) => d.x, xScale).x2((d) => d.x2)
-          .y((d) => d.y, yScale).y2((d) => d.y2);
-        plot.addDataset(new Plottable.Dataset(data)).renderTo(svg);
         let entities = plot.entitiesIn(
           { min: xScale.scale(2.5), max: xScale.scale(4.5) },
           { min: yScale.scale(4.5), max: yScale.scale(2.5) });
@@ -167,11 +164,6 @@ describe("Plots", () => {
       });
 
       it("retrieves the entity if exactly one of its endpoints is in the ranges", () => {
-        let plot = new Plottable.Plots.Segment()
-          .x((d) => d.x, xScale).x2((d) => d.x2)
-          .y((d) => d.y, yScale).y2((d) => d.y2);
-        plot.addDataset(new Plottable.Dataset(data)).renderTo(svg);
-
         // vertial segment
         checkEntitiesInRange(plot, 0, 0.5, 1.5, 1.5, 0.5);
         checkEntitiesInRange(plot, 0, 0.5, 1.5, 4.5, 3.5);
@@ -190,11 +182,6 @@ describe("Plots", () => {
       });
 
       it("retrieves the entity if both of its endpoints are in the ranges", () => {
-        let plot = new Plottable.Plots.Segment()
-          .x((d) => d.x, xScale).x2((d) => d.x2)
-          .y((d) => d.y, yScale).y2((d) => d.y2);
-        plot.addDataset(new Plottable.Dataset(data)).renderTo(svg);
-
         // vertial segment
         checkEntitiesInRange(plot, 0, 0.5, 1.5, 4.5, 0.5);
 
@@ -209,11 +196,6 @@ describe("Plots", () => {
       });
 
       it("retrieves the entity if it intersects with the ranges with no endpoints inside", () => {
-        let plot = new Plottable.Plots.Segment()
-          .x((d) => d.x, xScale).x2((d) => d.x2)
-          .y((d) => d.y, yScale).y2((d) => d.y2);
-        plot.addDataset(new Plottable.Dataset(data)).renderTo(svg);
-
         // vertial segment
         checkEntitiesInRange(plot, 0, 0.5, 1.5, 3.5, 1.5);
 
@@ -228,11 +210,6 @@ describe("Plots", () => {
       });
 
       it("returns empty array when no entities intersect with the ranges", () => {
-        let plot = new Plottable.Plots.Segment()
-          .x((d) => d.x, xScale).x2((d) => d.x2)
-          .y((d) => d.y, yScale).y2((d) => d.y2);
-        plot.addDataset(new Plottable.Dataset(data)).renderTo(svg);
-
         let entities = plot.entitiesIn(
           { min: xScale.scale(1.5), max: xScale.scale(2.5) },
           { min: yScale.scale(2.5), max: yScale.scale(1.5) });

--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -2,116 +2,124 @@
 
 describe("Plots", () => {
   describe("SegmentPlot", () => {
-    let svg: d3.Selection<void>;
-    let xScale: Plottable.Scales.Linear;
-    let yScale: Plottable.Scales.Linear;
-    let renderArea: d3.Selection<void>;
-    let data = [
-      { x: 1, y: 1, x2: 4, y2: 4 },
-      { x: 2, y: 2, x2: 3, y2: 5 },
-      { x: 3, y: 3, x2: 5, y2: 2 }
-    ];
 
-    beforeEach(() => {
-      svg = TestMethods.generateSVG(500, 500);
-      xScale = new Plottable.Scales.Linear();
-      yScale = new Plottable.Scales.Linear();
-    });
-
-    it("renders a line properly", () => {
-      let plot = new Plottable.Plots.Segment();
-      plot.x(function(d) { return d.x; }, xScale);
-      plot.x2(function(d) { return d.x2; });
-      plot.y(function(d) { return d.y; }, yScale);
-      plot.y2(function(d) { return d.y2; });
-      plot.addDataset(new Plottable.Dataset([data[0]])).renderTo(svg);
-      renderArea = (<any> plot)._renderArea;
-      let lineSelection = d3.select(renderArea.selectAll("line")[0][0]);
-      assert.strictEqual(+lineSelection.attr("x1"), 62.5, "x1 is correct");
-      assert.strictEqual(+lineSelection.attr("x2"), 437.5, "x2 is correct");
-      assert.strictEqual(+lineSelection.attr("y1"), 437.5, "y1 is correct");
-      assert.strictEqual(+lineSelection.attr("y2"), 62.5, "y2 is correct");
-      svg.remove();
-    });
-
-    it("renders vertical lines when x2 is not set", () => {
-      let plot = new Plottable.Plots.Segment();
-      plot.x(function(d) { return d.x; }, xScale);
-      plot.y(function(d) { return d.y; }, yScale);
-      plot.y2(function(d) { return d.y2; });
-      plot.addDataset(new Plottable.Dataset(data)).renderTo(svg);
-      renderArea = (<any> plot)._renderArea;
-      renderArea.selectAll("line")[0].forEach((line) => {
-      let lineSelection = d3.select(line);
-      assert.strictEqual(lineSelection.attr("x1"), lineSelection.attr("x2"), "line is vertical");
-      });
-      svg.remove();
-    });
-
-    it("renders horizontal lines when y2 is not set", () => {
-      let plot = new Plottable.Plots.Segment();
-      plot.x(function(d) { return d.x; }, xScale);
-      plot.x2(function(d) { return d.x2; });
-      plot.y(function(d) { return d.y; }, yScale);
-      plot.addDataset(new Plottable.Dataset(data)).renderTo(svg);
-      renderArea = (<any> plot)._renderArea;
-      renderArea.selectAll("line")[0].forEach((line) => {
-      let lineSelection = d3.select(line);
-      assert.strictEqual(lineSelection.attr("y1"), lineSelection.attr("y2"), "line is horizontal");
-      });
-      svg.remove();
-    });
-
-    it("autorangeMode(\"x\")", () => {
-      let staggeredData = [
-        { y: 0, x: 0, x2: 1 },
-        { y: 1, x: 1, x2: 2 }
+    describe("SegmentPlot - basics", () => {
+      let svg: d3.Selection<void>;
+      let xScale: Plottable.Scales.Linear;
+      let yScale: Plottable.Scales.Linear;
+      let renderArea: d3.Selection<void>;
+      let data = [
+        { x: 1, y: 1, x2: 4, y2: 4 },
+        { x: 2, y: 2, x2: 3, y2: 5 },
+        { x: 3, y: 3, x2: 5, y2: 2 }
       ];
-      xScale.padProportion(0);
 
-      let plot = new Plottable.Plots.Segment();
-      plot.x(function(d) { return d.x; }, xScale);
-      plot.x2(function(d) { return d.x2; });
-      plot.y(function(d) { return d.y; }, yScale);
-      plot.addDataset(new Plottable.Dataset(staggeredData));
-      plot.autorangeMode("x");
-      plot.renderTo(svg);
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(500, 500);
+        xScale = new Plottable.Scales.Linear();
+        yScale = new Plottable.Scales.Linear();
+      });
 
-      assert.deepEqual(xScale.domain(), [0, 2], "y domain includes both visible segments");
+      it("renders a line properly", () => {
+        let plot = new Plottable.Plots.Segment();
+        plot.x((d) => d.x, xScale);
+        plot.x2((d) => d.x2);
+        plot.y((d) => d.y, yScale);
+        plot.y2((d) => d.y2);
+        plot.addDataset(new Plottable.Dataset([data[0]]))
+        plot.renderTo(svg);
+        renderArea = (<any> plot)._renderArea;
+        let lineSelection = d3.select(renderArea.selectAll("line")[0][0]);
+        assert.strictEqual(+lineSelection.attr("x1"), 62.5, "x1 is correct");
+        assert.strictEqual(+lineSelection.attr("x2"), 437.5, "x2 is correct");
+        assert.strictEqual(+lineSelection.attr("y1"), 437.5, "y1 is correct");
+        assert.strictEqual(+lineSelection.attr("y2"), 62.5, "y2 is correct");
+        svg.remove();
+      });
 
-      yScale.domain([-0.5, 0.5]);
-      assert.deepEqual(xScale.domain(), [0, 1], "y domain includes only the visible segment (first)");
+      it("renders vertical lines when x2 is not set", () => {
+        let plot = new Plottable.Plots.Segment();
+        plot.x((d) => d.x, xScale);
+        plot.y((d) => d.y, yScale);
+        plot.y2((d) => d.y2);
+        plot.addDataset(new Plottable.Dataset(data))
+        plot.renderTo(svg);
+        renderArea = (<any> plot)._renderArea;
+        renderArea.selectAll("line")[0].forEach((line) => {
+        let lineSelection = d3.select(line);
+        assert.strictEqual(lineSelection.attr("x1"), lineSelection.attr("x2"), "line is vertical");
+        });
+        svg.remove();
+      });
 
-      yScale.domain([0.5, 1.5]);
-      assert.deepEqual(xScale.domain(), [1, 2], "y domain includes only the visible segment (second)");
+      it("renders horizontal lines when y2 is not set", () => {
+        let plot = new Plottable.Plots.Segment();
+        plot.x((d) => d.x, xScale);
+        plot.x2((d) => d.x2);
+        plot.y((d) => d.y, yScale);
+        plot.addDataset(new Plottable.Dataset(data))
+        plot.renderTo(svg);
+        renderArea = (<any> plot)._renderArea;
+        renderArea.selectAll("line")[0].forEach((line) => {
+        let lineSelection = d3.select(line);
+        assert.strictEqual(lineSelection.attr("y1"), lineSelection.attr("y2"), "line is horizontal");
+        });
+        svg.remove();
+      });
 
-      svg.remove();
-    });
+      it("autorangeMode(\"x\")", () => {
+        let staggeredData = [
+          { y: 0, x: 0, x2: 1 },
+          { y: 1, x: 1, x2: 2 }
+        ];
+        xScale.padProportion(0);
 
-    it("autorangeMode(\"y\")", () => {
-      let staggeredData = [
-        { x: 0, y: 0, y2: 1 },
-        { x: 1, y: 1, y2: 2 }
-      ];
-      yScale.padProportion(0);
+        let plot = new Plottable.Plots.Segment();
+        plot.x((d) => d.x, xScale);
+        plot.x2((d) => d.x2);
+        plot.y((d) => d.y, yScale);
+        plot.addDataset(new Plottable.Dataset(staggeredData));
+        plot.autorangeMode("x");
 
-      let plot = new Plottable.Plots.Segment();
-      plot.x(function(d) { return d.x; }, xScale);
-      plot.y(function(d) { return d.y; }, yScale);
-      plot.y2(function(d) { return d.y2; });
-      plot.addDataset(new Plottable.Dataset(staggeredData));
-      plot.autorangeMode("y");
-      plot.renderTo(svg);
+        plot.renderTo(svg);
 
-      assert.deepEqual(yScale.domain(), [0, 2], "y domain includes both visible segments");
+        assert.deepEqual(xScale.domain(), [0, 2], "y domain includes both visible segments");
 
-      xScale.domain([-0.5, 0.5]);
-      assert.deepEqual(yScale.domain(), [0, 1], "y domain includes only the visible segment (first)");
+        yScale.domain([-0.5, 0.5]);
+        assert.deepEqual(xScale.domain(), [0, 1], "y domain includes only the visible segment (first)");
 
-      xScale.domain([0.5, 1.5]);
-      assert.deepEqual(yScale.domain(), [1, 2], "y domain includes only the visible segment (second)");
+        yScale.domain([0.5, 1.5]);
+        assert.deepEqual(xScale.domain(), [1, 2], "y domain includes only the visible segment (second)");
 
-      svg.remove();
+        svg.remove();
+      });
+
+      it("autorangeMode(\"y\")", () => {
+        let staggeredData = [
+          { x: 0, y: 0, y2: 1 },
+          { x: 1, y: 1, y2: 2 }
+        ];
+        yScale.padProportion(0);
+
+        let plot = new Plottable.Plots.Segment();
+        plot.x((d) => d.x, xScale);
+        plot.y((d) => d.y, yScale);
+        plot.y2((d) => d.y2);
+        plot.addDataset(new Plottable.Dataset(staggeredData));
+        plot.autorangeMode("y");
+
+        plot.renderTo(svg);
+
+        assert.deepEqual(yScale.domain(), [0, 2], "y domain includes both visible segments");
+
+        xScale.domain([-0.5, 0.5]);
+        assert.deepEqual(yScale.domain(), [0, 1], "y domain includes only the visible segment (first)");
+
+        xScale.domain([0.5, 1.5]);
+        assert.deepEqual(yScale.domain(), [1, 2], "y domain includes only the visible segment (second)");
+
+        svg.remove();
+      });
     });
 
     describe("entitiesIn() returns segments that intersect with the given constraints", () => {
@@ -120,6 +128,16 @@ describe("Plots", () => {
         { x: 2, x2: 3, y: 4, y2: 3 },
         { x: 4, x2: 5, y: 2, y2: 4 },
         { x: 2, x2: 4, y: 1, y2: 1 }];
+
+      let svg: d3.Selection<void>;
+      let xScale: Plottable.Scales.Linear;
+      let yScale: Plottable.Scales.Linear;
+
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(500, 500);
+        xScale = new Plottable.Scales.Linear();
+        yScale = new Plottable.Scales.Linear();
+      });
 
       it("retrieves the entities that intersect with the bounding box", () => {
         let plot = new Plottable.Plots.Segment()

--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -141,7 +141,8 @@ describe("Plots", () => {
         { x: 1, x2: 1, y: 1, y2: 4 },
         { x: 2, x2: 3, y: 4, y2: 3 },
         { x: 4, x2: 5, y: 2, y2: 4 },
-        { x: 2, x2: 4, y: 1, y2: 1 }];
+        { x: 2, x2: 4, y: 1, y2: 1 }
+      ];
 
       let svg: d3.Selection<void>;
       let xScale: Plottable.Scales.Linear;
@@ -161,7 +162,8 @@ describe("Plots", () => {
       it("retrieves the entities that intersect with the bounding box", () => {
         let entities = plot.entitiesIn({
           topLeft: { x: xScale.scale(0), y: yScale.scale(4.5) },
-          bottomRight: { x: xScale.scale(2.5), y: yScale.scale(3) } });
+          bottomRight: { x: xScale.scale(2.5), y: yScale.scale(3) }
+        });
         assert.lengthOf(entities, 2, "retrieved 2 entities intersect with the box");
         assert.strictEqual(entities[0].index, 0, "the entity of index 0 is retrieved");
         assert.strictEqual(entities[1].index, 1, "the entity of index 1 is retrieved");
@@ -171,7 +173,8 @@ describe("Plots", () => {
       it("retrieves the entities that intersect with given ranges", () => {
         let entities = plot.entitiesIn(
           { min: xScale.scale(2.5), max: xScale.scale(4.5) },
-          { min: yScale.scale(4.5), max: yScale.scale(2.5) });
+          { min: yScale.scale(4.5), max: yScale.scale(2.5) }
+        );
         assert.lengthOf(entities, 2, "retrieved 2 entities intersect with the ranges");
         assert.strictEqual(entities[0].index, 1, "the entity of index 1 is retrieved");
         assert.strictEqual(entities[1].index, 2, "the entity of index 2 is retrieved");
@@ -230,7 +233,8 @@ describe("Plots", () => {
       it("returns empty array when no entities intersect with the ranges", () => {
         let entities = plot.entitiesIn(
           { min: xScale.scale(1.5), max: xScale.scale(2.5) },
-          { min: yScale.scale(2.5), max: yScale.scale(1.5) });
+          { min: yScale.scale(2.5), max: yScale.scale(1.5) }
+        );
         assert.lengthOf(entities, 0, "no entities intersects with the ranges");
         svg.remove();
       });
@@ -239,7 +243,8 @@ describe("Plots", () => {
                                     x1: number, x2: number, y1: number, y2: number) {
         let entities = plot.entitiesIn(
           { min: xScale.scale(x1), max: xScale.scale(x2) },
-          { min: yScale.scale(y1), max: yScale.scale(y2) });
+          { min: yScale.scale(y1), max: yScale.scale(y2) }
+        );
         assert.lengthOf(entities, 1, "retrieved 1 entity that intersects with the box");
         assert.strictEqual(entities[0].index, index, `the entity of index ${index} is retrieved`);
       }

--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -20,6 +20,10 @@ describe("Plots", () => {
         yScale = new Plottable.Scales.Linear();
       });
 
+      afterEach(() => {
+        svg.remove();
+      });
+
       it("renders a line properly", () => {
         let plot = new Plottable.Plots.Segment();
         plot.x((d) => d.x, xScale);
@@ -34,7 +38,6 @@ describe("Plots", () => {
         assert.strictEqual(+lineSelection.attr("x2"), 437.5, "x2 is correct");
         assert.strictEqual(+lineSelection.attr("y1"), 437.5, "y1 is correct");
         assert.strictEqual(+lineSelection.attr("y2"), 62.5, "y2 is correct");
-        svg.remove();
       });
 
       it("renders vertical lines when x2 is not set", () => {
@@ -46,10 +49,9 @@ describe("Plots", () => {
         plot.renderTo(svg);
         renderArea = (<any> plot)._renderArea;
         renderArea.selectAll("line")[0].forEach((line) => {
-        let lineSelection = d3.select(line);
-        assert.strictEqual(lineSelection.attr("x1"), lineSelection.attr("x2"), "line is vertical");
+          let lineSelection = d3.select(line);
+          assert.strictEqual(lineSelection.attr("x1"), lineSelection.attr("x2"), "line is vertical");
         });
-        svg.remove();
       });
 
       it("renders horizontal lines when y2 is not set", () => {
@@ -61,10 +63,9 @@ describe("Plots", () => {
         plot.renderTo(svg);
         renderArea = (<any> plot)._renderArea;
         renderArea.selectAll("line")[0].forEach((line) => {
-        let lineSelection = d3.select(line);
-        assert.strictEqual(lineSelection.attr("y1"), lineSelection.attr("y2"), "line is horizontal");
+          let lineSelection = d3.select(line);
+          assert.strictEqual(lineSelection.attr("y1"), lineSelection.attr("y2"), "line is horizontal");
         });
-        svg.remove();
       });
 
       it("autorangeMode(\"x\")", () => {
@@ -90,8 +91,6 @@ describe("Plots", () => {
 
         yScale.domain([0.5, 1.5]);
         assert.deepEqual(xScale.domain(), [1, 2], "y domain includes only the visible segment (second)");
-
-        svg.remove();
       });
 
       it("autorangeMode(\"y\")", () => {
@@ -117,12 +116,10 @@ describe("Plots", () => {
 
         xScale.domain([0.5, 1.5]);
         assert.deepEqual(yScale.domain(), [1, 2], "y domain includes only the visible segment (second)");
-
-        svg.remove();
       });
     });
 
-    describe("entitiesIn() returns segments that intersect with the given constraints", () => {
+    describe("SegmentPlot - entitiesIn()", () => {
       let data = [
         { x: 1, x2: 1, y: 1, y2: 4 },
         { x: 2, x2: 3, y: 4, y2: 3 },
@@ -139,6 +136,10 @@ describe("Plots", () => {
         yScale = new Plottable.Scales.Linear();
       });
 
+      afterEach(() => {
+        svg.remove();
+      });
+
       it("retrieves the entities that intersect with the bounding box", () => {
         let plot = new Plottable.Plots.Segment()
           .x((d) => d.x, xScale).x2((d) => d.x2)
@@ -150,7 +151,6 @@ describe("Plots", () => {
         assert.lengthOf(entities, 2, "retrieved 2 entities intersect with the box");
         assert.strictEqual(entities[0].index, 0, "the entity of index 0 is retrieved");
         assert.strictEqual(entities[1].index, 1, "the entity of index 1 is retrieved");
-        svg.remove();
       });
 
       it("retrieves the entities that intersect with given ranges", () => {
@@ -164,7 +164,6 @@ describe("Plots", () => {
         assert.lengthOf(entities, 2, "retrieved 2 entities intersect with the ranges");
         assert.strictEqual(entities[0].index, 1, "the entity of index 1 is retrieved");
         assert.strictEqual(entities[1].index, 2, "the entity of index 2 is retrieved");
-        svg.remove();
       });
 
       it("retrieves the entity if exactly one of its endpoints is in the ranges", () => {
@@ -188,8 +187,6 @@ describe("Plots", () => {
         // horizontal segment
         checkEntitiesInRange(plot, 3, 1.5, 2.5, 1.5, 0.5);
         checkEntitiesInRange(plot, 3, 3.5, 4.5, 1.5, 0.5);
-
-        svg.remove();
       });
 
       it("retrieves the entity if both of its endpoints are in the ranges", () => {
@@ -209,8 +206,6 @@ describe("Plots", () => {
 
         // horizontal segment
         checkEntitiesInRange(plot, 3, 1.5, 4.5, 1.5, 0.5);
-
-        svg.remove();
       });
 
       it("retrieves the entity if it intersects with the ranges with no endpoints inside", () => {
@@ -230,8 +225,6 @@ describe("Plots", () => {
 
         // horizontal segment
         checkEntitiesInRange(plot, 3, 2.5, 3.5, 1.5, 0.5);
-
-        svg.remove();
       });
 
       it("returns empty array when no entities intersect with the ranges", () => {
@@ -244,8 +237,6 @@ describe("Plots", () => {
           { min: xScale.scale(1.5), max: xScale.scale(2.5) },
           { min: yScale.scale(2.5), max: yScale.scale(1.5) });
         assert.lengthOf(entities, 0, "no entities intersects with the ranges");
-
-        svg.remove();
       });
 
       function checkEntitiesInRange(plot: Plottable.Plots.Segment<any, any>, index: number,

--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -45,7 +45,9 @@ describe("Plots", () => {
         plot.addDataset(new Plottable.Dataset(data));
         plot.renderTo(svg);
 
-        plot.content().selectAll("line").each(function() {
+        let lines = plot.content().selectAll("line");
+        assert.strictEqual(lines.size(), data.length, "correct number of lines has been drawn");
+        lines.each(function() {
           let lineSelection = d3.select(this);
           assert.strictEqual(lineSelection.attr("x1"), lineSelection.attr("x2"), "line is vertical");
         });
@@ -60,11 +62,27 @@ describe("Plots", () => {
         plot.addDataset(new Plottable.Dataset(data));
         plot.renderTo(svg);
 
-        plot.content().selectAll("line").each(function() {
+        let lines = plot.content().selectAll("line");
+        assert.strictEqual(lines.size(), data.length, "correct number of lines has been drawn");
+        lines.each(function() {
           let lineSelection = d3.select(this);
           assert.strictEqual(lineSelection.attr("y1"), lineSelection.attr("y2"), "line is horizontal");
         });
         svg.remove();
+      });
+    });
+
+    describe("autorangeMode", () => {
+      let svg: d3.Selection<void>;
+      let xScale: Plottable.Scales.Linear;
+      let yScale: Plottable.Scales.Linear;
+
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(500, 500);
+        xScale = new Plottable.Scales.Linear();
+        yScale = new Plottable.Scales.Linear();
+        xScale.padProportion(0);
+        yScale.padProportion(0);
       });
 
       it("adjusts the xScale domain with respect to the yScale domain when autorangeMode is set to x", () => {
@@ -72,7 +90,6 @@ describe("Plots", () => {
           { y: 0, x: 0, x2: 1 },
           { y: 1, x: 1, x2: 2 }
         ];
-        xScale.padProportion(0);
 
         let plot = new Plottable.Plots.Segment();
         plot.x((d) => d.x, xScale);
@@ -98,7 +115,6 @@ describe("Plots", () => {
           { x: 0, y: 0, y2: 1 },
           { x: 1, y: 1, y2: 2 }
         ];
-        yScale.padProportion(0);
 
         let plot = new Plottable.Plots.Segment();
         plot.x((d) => d.x, xScale);

--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -3,7 +3,7 @@
 describe("Plots", () => {
   describe("SegmentPlot", () => {
 
-    describe("SegmentPlot - basics", () => {
+    describe("Basics", () => {
       let svg: d3.Selection<void>;
       let xScale: Plottable.Scales.Linear;
       let yScale: Plottable.Scales.Linear;
@@ -32,12 +32,13 @@ describe("Plots", () => {
         plot.y2((d) => d.y2);
         plot.addDataset(new Plottable.Dataset([data[0]]));
         plot.renderTo(svg);
-        renderArea = (<any> plot)._renderArea;
-        let lineSelection = d3.select(renderArea.selectAll("line")[0][0]);
-        assert.strictEqual(+lineSelection.attr("x1"), 62.5, "x1 is correct");
-        assert.strictEqual(+lineSelection.attr("x2"), 437.5, "x2 is correct");
-        assert.strictEqual(+lineSelection.attr("y1"), 437.5, "y1 is correct");
-        assert.strictEqual(+lineSelection.attr("y2"), 62.5, "y2 is correct");
+
+        let line = plot.content().selectAll("line");
+        assert.strictEqual(line.size(), 1, "exactly one line has been rendered");
+        assert.strictEqual(+line.attr("x1"), 62.5, "x1 is correct");
+        assert.strictEqual(+line.attr("x2"), 437.5, "x2 is correct");
+        assert.strictEqual(+line.attr("y1"), 437.5, "y1 is correct");
+        assert.strictEqual(+line.attr("y2"), 62.5, "y2 is correct");
       });
 
       it("renders vertical lines when x2 is not set", () => {
@@ -47,8 +48,8 @@ describe("Plots", () => {
         plot.y2((d) => d.y2);
         plot.addDataset(new Plottable.Dataset(data));
         plot.renderTo(svg);
-        renderArea = (<any> plot)._renderArea;
-        renderArea.selectAll("line")[0].forEach((line) => {
+
+        plot.content().selectAll("line")[0].forEach((line) => {
           let lineSelection = d3.select(line);
           assert.strictEqual(lineSelection.attr("x1"), lineSelection.attr("x2"), "line is vertical");
         });
@@ -61,8 +62,8 @@ describe("Plots", () => {
         plot.y((d) => d.y, yScale);
         plot.addDataset(new Plottable.Dataset(data));
         plot.renderTo(svg);
-        renderArea = (<any> plot)._renderArea;
-        renderArea.selectAll("line")[0].forEach((line) => {
+
+        plot.content().selectAll("line")[0].forEach((line) => {
           let lineSelection = d3.select(line);
           assert.strictEqual(lineSelection.attr("y1"), lineSelection.attr("y2"), "line is horizontal");
         });
@@ -84,13 +85,13 @@ describe("Plots", () => {
 
         plot.renderTo(svg);
 
-        assert.deepEqual(xScale.domain(), [0, 2], "y domain includes both visible segments");
+        assert.deepEqual(xScale.domain(), [0, 2], "x domain includes both visible segments");
 
         yScale.domain([-0.5, 0.5]);
-        assert.deepEqual(xScale.domain(), [0, 1], "y domain includes only the visible segment (first)");
+        assert.deepEqual(xScale.domain(), [0, 1], "x domain includes only the visible segment (first)");
 
         yScale.domain([0.5, 1.5]);
-        assert.deepEqual(xScale.domain(), [1, 2], "y domain includes only the visible segment (second)");
+        assert.deepEqual(xScale.domain(), [1, 2], "x domain includes only the visible segment (second)");
       });
 
       it("autorangeMode(\"y\")", () => {
@@ -119,7 +120,7 @@ describe("Plots", () => {
       });
     });
 
-    describe("SegmentPlot - entitiesIn()", () => {
+    describe("entitiesIn()", () => {
       let data = [
         { x: 1, x2: 1, y: 1, y2: 4 },
         { x: 2, x2: 3, y: 4, y2: 3 },

--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -7,7 +7,6 @@ describe("Plots", () => {
       let svg: d3.Selection<void>;
       let xScale: Plottable.Scales.Linear;
       let yScale: Plottable.Scales.Linear;
-      let renderArea: d3.Selection<void>;
       let data = [
         { x: 1, y: 1, x2: 4, y2: 4 },
         { x: 2, y: 2, x2: 3, y2: 5 },

--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -30,7 +30,7 @@ describe("Plots", () => {
         plot.x2((d) => d.x2);
         plot.y((d) => d.y, yScale);
         plot.y2((d) => d.y2);
-        plot.addDataset(new Plottable.Dataset([data[0]]))
+        plot.addDataset(new Plottable.Dataset([data[0]]));
         plot.renderTo(svg);
         renderArea = (<any> plot)._renderArea;
         let lineSelection = d3.select(renderArea.selectAll("line")[0][0]);
@@ -45,7 +45,7 @@ describe("Plots", () => {
         plot.x((d) => d.x, xScale);
         plot.y((d) => d.y, yScale);
         plot.y2((d) => d.y2);
-        plot.addDataset(new Plottable.Dataset(data))
+        plot.addDataset(new Plottable.Dataset(data));
         plot.renderTo(svg);
         renderArea = (<any> plot)._renderArea;
         renderArea.selectAll("line")[0].forEach((line) => {
@@ -59,7 +59,7 @@ describe("Plots", () => {
         plot.x((d) => d.x, xScale);
         plot.x2((d) => d.x2);
         plot.y((d) => d.y, yScale);
-        plot.addDataset(new Plottable.Dataset(data))
+        plot.addDataset(new Plottable.Dataset(data));
         plot.renderTo(svg);
         renderArea = (<any> plot)._renderArea;
         renderArea.selectAll("line")[0].forEach((line) => {

--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -3,7 +3,7 @@
 describe("Plots", () => {
   describe("SegmentPlot", () => {
 
-    describe("Basics", () => {
+    describe("Basic Usage", () => {
       let svg: d3.Selection<void>;
       let xScale: Plottable.Scales.Linear;
       let yScale: Plottable.Scales.Linear;
@@ -67,7 +67,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("autorangeMode(\"x\")", () => {
+      it("adjusts the xScale domain with respect to the yScale domain when autorangeMode is set to x", () => {
         let staggeredData = [
           { y: 0, x: 0, x2: 1 },
           { y: 1, x: 1, x2: 2 }
@@ -93,7 +93,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("autorangeMode(\"y\")", () => {
+      it("adjusts the yScale domain with respect to the xScale domain when autorangeMode is set to y", () => {
         let staggeredData = [
           { x: 0, y: 0, y2: 1 },
           { x: 1, y: 1, y2: 2 }


### PR DESCRIPTION
Part of #2636

I will be doing multiple passes because I will get more context (and better sense of best practices) by refactoring other files. However, please flag anything that seems unusual.

As part of this: 
- Applied best practices from the wiki page
- Factored out common code into `beforeEach()` clauses
- No nested `beforeEach()`es
- Added `afterEach()` to save some LOCs
- Remade hierarchy as shown bellow
![screen shot 2015-08-20 at 4 20 48 pm](https://cloud.githubusercontent.com/assets/3248682/9398020/72e6dea6-4757-11e5-8b90-d43c34668b47.png)


