### PR TITLE
Refactor drag box layer tests - Part 1

### DIFF
--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -132,6 +132,34 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
+      it("can register two onDragStart callbacks on the same component", () => {
+        dbl.renderTo(svg);
+
+        let callbackDragStart1Called = false;
+        let callbackDragStart2Called = false;
+
+        let callbackDragStart1 = () => callbackDragStart1Called = true;
+        let callbackDragStart2 = () => callbackDragStart2Called = true;
+
+        dbl.onDragStart(callbackDragStart1);
+        dbl.onDragStart(callbackDragStart2);
+
+        let target = dbl.background();
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+
+        assert.isTrue(callbackDragStart1Called, "the callback 1 for drag start was called");
+        assert.isTrue(callbackDragStart2Called, "the callback 2 for drag start was called");
+
+        dbl.offDragStart(callbackDragStart1);
+        callbackDragStart1Called = false;
+        callbackDragStart2Called = false;
+
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+        assert.isFalse(callbackDragStart1Called, "the callback 1 for drag start was disconnected");
+        assert.isTrue(callbackDragStart2Called, "the callback 2 for drag start is still connected");
+        svg.remove();
+      });
+
       it("calls the onDrag callback", () => {
         dbl.renderTo(svg);
 
@@ -155,6 +183,34 @@ describe("Interactive Components", () => {
 
         TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
         assert.isFalse(callbackCalled, "the callback was detached from the dragoBoxLayer and not called");
+        svg.remove();
+      });
+
+      it("can register two onDrag callbacks on the same component", () => {
+        dbl.renderTo(svg);
+
+        let callbackDrag1Called = false;
+        let callbackDrag2Called = false;
+
+        let callbackDrag1 = () => callbackDrag1Called = true;
+        let callbackDrag2 = () => callbackDrag2Called = true;
+
+        dbl.onDrag(callbackDrag1);
+        dbl.onDrag(callbackDrag2);
+
+        let target = dbl.background();
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+
+        assert.isTrue(callbackDrag1Called, "the callback 1 for drag was called");
+        assert.isTrue(callbackDrag2Called, "the callback 2 for drag was called");
+
+        dbl.offDrag(callbackDrag1);
+        callbackDrag1Called = false;
+        callbackDrag2Called = false;
+
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+        assert.isFalse(callbackDrag1Called, "the callback 1 for drag was disconnected");
+        assert.isTrue(callbackDrag2Called, "the callback 2 for drag is still connected");
         svg.remove();
       });
 
@@ -183,31 +239,31 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
-      it("can register two callbacks for the same event", () => {
+      it("can register two onDragEnd callbacks on the same component", () => {
         dbl.renderTo(svg);
 
-        let callbackDragStart1Called = false;
-        let callbackDragStart2Called = false;
+        let callbackDragEnd1Called = false;
+        let callbackDragEnd2Called = false;
 
-        let callbackDragStart1 = () => callbackDragStart1Called = true;
-        let callbackDragStart2 = () => callbackDragStart2Called = true;
+        let callbackDragEnd1 = () => callbackDragEnd1Called = true;
+        let callbackDragEnd2 = () => callbackDragEnd2Called = true;
 
-        dbl.onDragStart(callbackDragStart1);
-        dbl.onDragStart(callbackDragStart2);
+        dbl.onDragEnd(callbackDragEnd1);
+        dbl.onDragEnd(callbackDragEnd2);
 
         let target = dbl.background();
         TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
 
-        assert.isTrue(callbackDragStart1Called, "the callback 1 for drag start was called");
-        assert.isTrue(callbackDragStart2Called, "the callback 2 for drag start was called");
+        assert.isTrue(callbackDragEnd1Called, "the callback 1 for drag end was called");
+        assert.isTrue(callbackDragEnd2Called, "the callback 2 for drag end was called");
 
-        dbl.offDragStart(callbackDragStart1);
-        callbackDragStart1Called = false;
-        callbackDragStart2Called = false;
+        dbl.offDragEnd(callbackDragEnd1);
+        callbackDragEnd1Called = false;
+        callbackDragEnd2Called = false;
 
         TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
-        assert.isFalse(callbackDragStart1Called, "the callback 1 for drag start was disconnected");
-        assert.isTrue(callbackDragStart2Called, "the callback 2 for drag start is still connected");
+        assert.isFalse(callbackDragEnd1Called, "the callback 1 for drag end was disconnected");
+        assert.isTrue(callbackDragEnd2Called, "the callback 2 for drag end is still connected");
         svg.remove();
       });
 

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -7,12 +7,24 @@ describe("Interactive Components", () => {
       let SVG_WIDTH = 400;
       let SVG_HEIGHT = 400;
 
-      var svg: d3.Selection<void>;
+      let svg: d3.Selection<void>;
       let dbl: Plottable.Components.DragBoxLayer;
+      let quarterPoint: Plottable.Point;
+      let halfPoint: Plottable.Point;
 
       beforeEach(() => {
         svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         dbl = new Plottable.Components.DragBoxLayer();
+
+        quarterPoint = {
+          x: SVG_WIDTH / 4,
+          y: SVG_HEIGHT / 4
+        };
+        halfPoint = {
+          x: SVG_WIDTH / 2,
+          y: SVG_HEIGHT / 2
+        };
+
       });
 
       afterEach(() => {
@@ -23,33 +35,19 @@ describe("Interactive Components", () => {
         dbl.renderTo(svg);
         assert.isFalse(dbl.boxVisible(), "box is hidden initially");
 
-        let startPoint = {
-          x: SVG_WIDTH / 4,
-          y: SVG_HEIGHT / 4
-        };
-        let endPoint = {
-          x: SVG_WIDTH / 2,
-          y: SVG_HEIGHT / 2
-        };
-
         let target = dbl.background();
-        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
         assert.isTrue(dbl.boxVisible(), "box is drawn on drag");
         let bounds = dbl.bounds();
-        assert.deepEqual(bounds.topLeft, startPoint, "top-left point was set correctly");
-        assert.deepEqual(bounds.bottomRight, endPoint, "bottom-right point was set correctly");
+        assert.deepEqual(bounds.topLeft, quarterPoint, "top-left point was set correctly");
+        assert.deepEqual(bounds.bottomRight, halfPoint, "bottom-right point was set correctly");
       });
 
       it("dismisses on click", () => {
         dbl.renderTo(svg);
 
-        let targetPoint = {
-          x: SVG_WIDTH / 2,
-          y: SVG_HEIGHT / 2
-        };
-
         let target = dbl.background();
-        TestMethods.triggerFakeDragSequence(target, targetPoint, targetPoint);
+        TestMethods.triggerFakeDragSequence(target, halfPoint, halfPoint);
 
         assert.isFalse(dbl.boxVisible(), "box is hidden on click");
       });
@@ -88,15 +86,6 @@ describe("Interactive Components", () => {
       it("onDragStart()", () => {
         dbl.renderTo(svg);
 
-        let startPoint = {
-          x: SVG_WIDTH / 4,
-          y: SVG_HEIGHT / 4
-        };
-        let endPoint = {
-          x: SVG_WIDTH / 2,
-          y: SVG_HEIGHT / 2
-        };
-
         let receivedBounds: Plottable.Bounds;
         let callbackCalled = false;
         let callback = (b: Plottable.Bounds) => {
@@ -106,30 +95,21 @@ describe("Interactive Components", () => {
         dbl.onDragStart(callback);
 
         let target = dbl.background();
-        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
 
         assert.isTrue(callbackCalled, "the callback was called");
-        assert.deepEqual(receivedBounds.topLeft, startPoint, "top-left point was set correctly");
-        assert.deepEqual(receivedBounds.bottomRight, startPoint, "bottom-right point was set correctly");
+        assert.deepEqual(receivedBounds.topLeft, quarterPoint, "top-left point was set correctly");
+        assert.deepEqual(receivedBounds.bottomRight, quarterPoint, "bottom-right point was set correctly");
 
         dbl.offDragStart(callback);
 
         callbackCalled = false;
-        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
         assert.isFalse(callbackCalled, "the callback was detached from the dragBoxLayer and not called");
       });
 
       it("onDrag()", () => {
         dbl.renderTo(svg);
-
-        let startPoint = {
-          x: SVG_WIDTH / 4,
-          y: SVG_HEIGHT / 4
-        };
-        let endPoint = {
-          x: SVG_WIDTH / 2,
-          y: SVG_HEIGHT / 2
-        };
 
         let receivedBounds: Plottable.Bounds;
         let callbackCalled = false;
@@ -140,30 +120,21 @@ describe("Interactive Components", () => {
         dbl.onDrag(callback);
 
         let target = dbl.background();
-        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
 
         assert.isTrue(callbackCalled, "the callback was called");
-        assert.deepEqual(receivedBounds.topLeft, startPoint, "top-left point was set correctly");
-        assert.deepEqual(receivedBounds.bottomRight, endPoint, "bottom-right point was set correctly");
+        assert.deepEqual(receivedBounds.topLeft, quarterPoint, "top-left point was set correctly");
+        assert.deepEqual(receivedBounds.bottomRight, halfPoint, "bottom-right point was set correctly");
 
         callbackCalled = false;
         dbl.offDrag(callback);
 
-        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
         assert.isFalse(callbackCalled, "the callback was detached from the dragoBoxLayer and not called");
       });
 
       it("onDragEnd()", () => {
         dbl.renderTo(svg);
-
-        let startPoint = {
-          x: SVG_WIDTH / 4,
-          y: SVG_HEIGHT / 4
-        };
-        let endPoint = {
-          x: SVG_WIDTH / 2,
-          y: SVG_HEIGHT / 2
-        };
 
         let receivedBounds: Plottable.Bounds;
         let callbackCalled = false;
@@ -174,29 +145,20 @@ describe("Interactive Components", () => {
         dbl.onDragEnd(callback);
 
         let target = dbl.background();
-        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
 
         assert.isTrue(callbackCalled, "the callback was called");
-        assert.deepEqual(receivedBounds.topLeft, startPoint, "top-left point was set correctly");
-        assert.deepEqual(receivedBounds.bottomRight, endPoint, "bottom-right point was set correctly");
+        assert.deepEqual(receivedBounds.topLeft, quarterPoint, "top-left point was set correctly");
+        assert.deepEqual(receivedBounds.bottomRight, halfPoint, "bottom-right point was set correctly");
         dbl.offDragEnd(callback);
         callbackCalled = false;
 
-        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
         assert.isFalse(callbackCalled, "the callback was detached from the dragoBoxLayer and not called");
       });
 
       it("multiple drag interaction callbacks", () => {
         dbl.renderTo(svg);
-
-        let startPoint = {
-          x: SVG_WIDTH / 4,
-          y: SVG_HEIGHT / 4
-        };
-        let endPoint = {
-          x: SVG_WIDTH / 2,
-          y: SVG_HEIGHT / 2
-        };
 
         let callbackDragStart1Called = false;
         let callbackDragStart2Called = false;
@@ -220,7 +182,7 @@ describe("Interactive Components", () => {
         dbl.onDragEnd(callbackDragEnd2);
 
         let target = dbl.background();
-        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
 
         assert.isTrue(callbackDragStart1Called, "the callback 1 for drag start was called");
         assert.isTrue(callbackDragStart2Called, "the callback 2 for drag start was called");
@@ -240,7 +202,7 @@ describe("Interactive Components", () => {
         callbackDragEnd1Called = false;
         callbackDragEnd2Called = false;
 
-        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
         assert.isFalse(callbackDragStart1Called, "the callback 1 for drag start was disconnected");
         assert.isTrue(callbackDragStart2Called, "the callback 2 for drag start is still connected");
         assert.isFalse(callbackDrag1Called, "the callback 1 for drag was called disconnected");

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -25,7 +25,7 @@ describe("Interactive Components", () => {
         };
       });
 
-      it("correctly draws box on drag", () => {
+      it("draws box on drag", () => {
         dbl.renderTo(svg);
         assert.isFalse(dbl.boxVisible(), "box is hidden initially");
 
@@ -75,7 +75,7 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
-      it("applies the given detection radius", () => {
+      it("applies the given detection radius property", () => {
         dbl.renderTo("svg");
 
         let radius = 5;

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -81,6 +81,10 @@ describe("Interactive Components", () => {
         (<any> assert.throws)(() => dbl.detectionRadius(-1), Error, "", "rejects negative values");
       });
 
+      it("destroy() does not error if scales are not inputted", () => {
+        assert.doesNotThrow(() => dbl.destroy(), Error, "can destroy");
+      });
+
       it("onDragStart()", () => {
         dbl.renderTo(svg);
 
@@ -279,7 +283,6 @@ describe("Interactive Components", () => {
     });
 
     describe("DragBoxLayer - resizing", () => {
-
       let SVG_WIDTH = 400;
       let SVG_HEIGHT = 400;
 
@@ -295,7 +298,7 @@ describe("Interactive Components", () => {
       function resetBox() {
         dbl.bounds({
           topLeft: { x: 0, y: 0 },
-          bottomRight: { x: 0, y: 0}
+          bottomRight: { x: 0, y: 0 }
         });
         TestMethods.triggerFakeDragSequence(target,
                                 { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4},
@@ -467,7 +470,6 @@ describe("Interactive Components", () => {
     });
 
     describe("DragBoxLayer - moving", () => {
-
       let SVG_WIDTH = 400;
       let SVG_HEIGHT = 400;
 
@@ -601,12 +603,6 @@ describe("Interactive Components", () => {
         let bounds = dbl.bounds();
         assert.strictEqual(bounds.topLeft.x, midPoint.x, "new box was started at the drag start position (x)");
         assert.strictEqual(bounds.topLeft.y, midPoint.y, "new box was started at the drag start position (y)");
-      });
-
-      it("destroy() does not error if scales are not inputted", () => {
-        let sbl = new Plottable.Components.DragBoxLayer();
-        sbl.renderTo(svg);
-        assert.doesNotThrow(() => sbl.destroy(), Error, "can destroy");
       });
     });
   });

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -218,7 +218,7 @@ describe("Interactive Components", () => {
       let SVG_WIDTH = 400;
       let SVG_HEIGHT = 400;
 
-      var svg: d3.Selection<void>;
+      let svg: d3.Selection<void>;
       let dbl: Plottable.Components.DragBoxLayer;
 
       beforeEach(() => {

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -235,10 +235,10 @@ describe("Interactive Components", () => {
 
         dbl.offDragStart(callbackDragStart);
         dbl.offDrag(callbackDrag);
-        dbl.offDragEnd(callbackDragEnd);
 
         callbackDragStartCalled = false;
         callbackDragCalled = false;
+        callbackDragEndCalled = false;
 
         TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
         assert.isFalse(callbackDragStartCalled, "the callback for drag start was disconnected");

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -101,7 +101,7 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
-      it("does not error on destroy() if scales are not inputted", () => {
+      it("does not error on destroy() if scales are not added", () => {
         assert.doesNotThrow(() => dbl.destroy(), Error, "can destroy");
         svg.remove();
       });

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -2,272 +2,280 @@
 
 describe("Interactive Components", () => {
   describe("DragBoxLayer", () => {
-    let SVG_WIDTH = 400;
-    let SVG_HEIGHT = 400;
 
-    it("correctly draws box on drag", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.DragBoxLayer();
-      dbl.renderTo(svg);
-      assert.isFalse(dbl.boxVisible(), "box is hidden initially");
+    describe("DragBoxLayer - basics", () => {
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 400;
 
-      let startPoint = {
-        x: SVG_WIDTH / 4,
-        y: SVG_HEIGHT / 4
-      };
-      let endPoint = {
-        x: SVG_WIDTH / 2,
-        y: SVG_HEIGHT / 2
-      };
+      it("correctly draws box on drag", () => {
+        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        let dbl = new Plottable.Components.DragBoxLayer();
+        dbl.renderTo(svg);
+        assert.isFalse(dbl.boxVisible(), "box is hidden initially");
 
-      let target = dbl.background();
-      TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
-      assert.isTrue(dbl.boxVisible(), "box is drawn on drag");
-      let bounds = dbl.bounds();
-      assert.deepEqual(bounds.topLeft, startPoint, "top-left point was set correctly");
-      assert.deepEqual(bounds.bottomRight, endPoint, "bottom-right point was set correctly");
+        let startPoint = {
+          x: SVG_WIDTH / 4,
+          y: SVG_HEIGHT / 4
+        };
+        let endPoint = {
+          x: SVG_WIDTH / 2,
+          y: SVG_HEIGHT / 2
+        };
 
-      svg.remove();
-    });
+        let target = dbl.background();
+        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+        assert.isTrue(dbl.boxVisible(), "box is drawn on drag");
+        let bounds = dbl.bounds();
+        assert.deepEqual(bounds.topLeft, startPoint, "top-left point was set correctly");
+        assert.deepEqual(bounds.bottomRight, endPoint, "bottom-right point was set correctly");
 
-    it("dismisses on click", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.DragBoxLayer();
-      dbl.renderTo(svg);
-
-      let targetPoint = {
-        x: SVG_WIDTH / 2,
-        y: SVG_HEIGHT / 2
-      };
-
-      let target = dbl.background();
-      TestMethods.triggerFakeDragSequence(target, targetPoint, targetPoint);
-
-      assert.isFalse(dbl.boxVisible(), "box is hidden on click");
-
-      svg.remove();
-    });
-
-    it("clipPath enabled", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.DragBoxLayer();
-      dbl.renderTo(svg);
-      TestMethods.verifyClipPath(dbl);
-      let clipRect = (<any> dbl)._boxContainer.select(".clip-rect");
-      assert.strictEqual(TestMethods.numAttr(clipRect, "width"), SVG_WIDTH, "the clipRect has an appropriate width");
-      assert.strictEqual(TestMethods.numAttr(clipRect, "height"), SVG_HEIGHT, "the clipRect has an appropriate height");
-      svg.remove();
-    });
-
-    it("detectionRadius()", () => {
-      let dbl = new Plottable.Components.DragBoxLayer();
-
-      assert.doesNotThrow(() => dbl.detectionRadius(3), Error, "can set detection radius before anchoring");
-
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      dbl.renderTo("svg");
-
-      let radius = 5;
-      dbl.detectionRadius(radius);
-      assert.strictEqual(dbl.detectionRadius(), radius, "can retrieve the detection radius");
-      let edges = dbl.content().selectAll("line");
-      edges.each(function() {
-        let edge = d3.select(this);
-        assert.strictEqual(edge.style("stroke-width"), 2 * radius, "edge width was set correctly");
-      });
-      let corners = dbl.content().selectAll("circle");
-      corners.each(function() {
-        let corner = d3.select(this);
-        assert.strictEqual(corner.attr("r"), radius, "corner radius was set correctly");
+        svg.remove();
       });
 
-      // HACKHACK: chai-assert.d.ts has the wrong signature
-      (<any> assert.throws)(() => dbl.detectionRadius(-1), Error, "", "rejects negative values");
+      it("dismisses on click", () => {
+        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        let dbl = new Plottable.Components.DragBoxLayer();
+        dbl.renderTo(svg);
 
-      svg.remove();
+        let targetPoint = {
+          x: SVG_WIDTH / 2,
+          y: SVG_HEIGHT / 2
+        };
+
+        let target = dbl.background();
+        TestMethods.triggerFakeDragSequence(target, targetPoint, targetPoint);
+
+        assert.isFalse(dbl.boxVisible(), "box is hidden on click");
+
+        svg.remove();
+      });
+
+      it("clipPath enabled", () => {
+        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        let dbl = new Plottable.Components.DragBoxLayer();
+        dbl.renderTo(svg);
+        TestMethods.verifyClipPath(dbl);
+        let clipRect = (<any> dbl)._boxContainer.select(".clip-rect");
+        assert.strictEqual(TestMethods.numAttr(clipRect, "width"), SVG_WIDTH, "the clipRect has an appropriate width");
+        assert.strictEqual(TestMethods.numAttr(clipRect, "height"), SVG_HEIGHT, "the clipRect has an appropriate height");
+        svg.remove();
+      });
+
+      it("detectionRadius()", () => {
+        let dbl = new Plottable.Components.DragBoxLayer();
+
+        assert.doesNotThrow(() => dbl.detectionRadius(3), Error, "can set detection radius before anchoring");
+
+        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        dbl.renderTo("svg");
+
+        let radius = 5;
+        dbl.detectionRadius(radius);
+        assert.strictEqual(dbl.detectionRadius(), radius, "can retrieve the detection radius");
+        let edges = dbl.content().selectAll("line");
+        edges.each(function() {
+          let edge = d3.select(this);
+          assert.strictEqual(edge.style("stroke-width"), 2 * radius, "edge width was set correctly");
+        });
+        let corners = dbl.content().selectAll("circle");
+        corners.each(function() {
+          let corner = d3.select(this);
+          assert.strictEqual(corner.attr("r"), radius, "corner radius was set correctly");
+        });
+
+        // HACKHACK: chai-assert.d.ts has the wrong signature
+        (<any> assert.throws)(() => dbl.detectionRadius(-1), Error, "", "rejects negative values");
+
+        svg.remove();
+      });
+
+      it("onDragStart()", () => {
+        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        let dbl = new Plottable.Components.DragBoxLayer();
+        dbl.renderTo(svg);
+
+        let startPoint = {
+          x: SVG_WIDTH / 4,
+          y: SVG_HEIGHT / 4
+        };
+        let endPoint = {
+          x: SVG_WIDTH / 2,
+          y: SVG_HEIGHT / 2
+        };
+
+        let receivedBounds: Plottable.Bounds;
+        let callbackCalled = false;
+        let callback = (b: Plottable.Bounds) => {
+          receivedBounds = b;
+          callbackCalled = true;
+        };
+        dbl.onDragStart(callback);
+
+        let target = dbl.background();
+        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+
+        assert.isTrue(callbackCalled, "the callback was called");
+        assert.deepEqual(receivedBounds.topLeft, startPoint, "top-left point was set correctly");
+        assert.deepEqual(receivedBounds.bottomRight, startPoint, "bottom-right point was set correctly");
+
+        dbl.offDragStart(callback);
+
+        callbackCalled = false;
+        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+        assert.isFalse(callbackCalled, "the callback was detached from the dragBoxLayer and not called");
+
+        svg.remove();
+      });
+
+      it("onDrag()", () => {
+        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        let dbl = new Plottable.Components.DragBoxLayer();
+        dbl.renderTo(svg);
+
+        let startPoint = {
+          x: SVG_WIDTH / 4,
+          y: SVG_HEIGHT / 4
+        };
+        let endPoint = {
+          x: SVG_WIDTH / 2,
+          y: SVG_HEIGHT / 2
+        };
+
+        let receivedBounds: Plottable.Bounds;
+        let callbackCalled = false;
+        let callback = (b: Plottable.Bounds) => {
+          receivedBounds = b;
+          callbackCalled = true;
+        };
+        dbl.onDrag(callback);
+
+        let target = dbl.background();
+        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+
+        assert.isTrue(callbackCalled, "the callback was called");
+        assert.deepEqual(receivedBounds.topLeft, startPoint, "top-left point was set correctly");
+        assert.deepEqual(receivedBounds.bottomRight, endPoint, "bottom-right point was set correctly");
+
+        callbackCalled = false;
+        dbl.offDrag(callback);
+
+        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+        assert.isFalse(callbackCalled, "the callback was detached from the dragoBoxLayer and not called");
+
+        svg.remove();
+      });
+
+      it("onDragEnd()", () => {
+        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        let dbl = new Plottable.Components.DragBoxLayer();
+        dbl.renderTo(svg);
+
+        let startPoint = {
+          x: SVG_WIDTH / 4,
+          y: SVG_HEIGHT / 4
+        };
+        let endPoint = {
+          x: SVG_WIDTH / 2,
+          y: SVG_HEIGHT / 2
+        };
+
+        let receivedBounds: Plottable.Bounds;
+        let callbackCalled = false;
+        let callback = (b: Plottable.Bounds) => {
+          receivedBounds = b;
+          callbackCalled = true;
+        };
+        dbl.onDragEnd(callback);
+
+        let target = dbl.background();
+        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+
+        assert.isTrue(callbackCalled, "the callback was called");
+        assert.deepEqual(receivedBounds.topLeft, startPoint, "top-left point was set correctly");
+        assert.deepEqual(receivedBounds.bottomRight, endPoint, "bottom-right point was set correctly");
+        dbl.offDragEnd(callback);
+        callbackCalled = false;
+
+        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+        assert.isFalse(callbackCalled, "the callback was detached from the dragoBoxLayer and not called");
+
+        svg.remove();
+      });
+
+      it("multiple drag interaction callbacks", () => {
+        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        let dbl = new Plottable.Components.DragBoxLayer();
+        dbl.renderTo(svg);
+
+        let startPoint = {
+          x: SVG_WIDTH / 4,
+          y: SVG_HEIGHT / 4
+        };
+        let endPoint = {
+          x: SVG_WIDTH / 2,
+          y: SVG_HEIGHT / 2
+        };
+
+        let callbackDragStart1Called = false;
+        let callbackDragStart2Called = false;
+        let callbackDrag1Called = false;
+        let callbackDrag2Called = false;
+        let callbackDragEnd1Called = false;
+        let callbackDragEnd2Called = false;
+
+        let callbackDragStart1 = () => callbackDragStart1Called = true;
+        let callbackDragStart2 = () => callbackDragStart2Called = true;
+        let callbackDrag1 = () => callbackDrag1Called = true;
+        let callbackDrag2 = () => callbackDrag2Called = true;
+        let callbackDragEnd1 = () => callbackDragEnd1Called = true;
+        let callbackDragEnd2 = () => callbackDragEnd2Called = true;
+
+        dbl.onDragStart(callbackDragStart1);
+        dbl.onDragStart(callbackDragStart2);
+        dbl.onDrag(callbackDrag1);
+        dbl.onDrag(callbackDrag2);
+        dbl.onDragEnd(callbackDragEnd1);
+        dbl.onDragEnd(callbackDragEnd2);
+
+        let target = dbl.background();
+        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+
+        assert.isTrue(callbackDragStart1Called, "the callback 1 for drag start was called");
+        assert.isTrue(callbackDragStart2Called, "the callback 2 for drag start was called");
+        assert.isTrue(callbackDrag1Called, "the callback 1 for drag was called");
+        assert.isTrue(callbackDrag2Called, "the callback 2 for drag was called");
+        assert.isTrue(callbackDragEnd1Called, "the callback 1 for drag end was called");
+        assert.isTrue(callbackDragEnd2Called, "the callback 2 for drag end was called");
+
+        dbl.offDragStart(callbackDragStart1);
+        dbl.offDrag(callbackDrag1);
+        dbl.offDragEnd(callbackDragEnd1);
+
+        callbackDragStart1Called = false;
+        callbackDragStart2Called = false;
+        callbackDrag1Called = false;
+        callbackDrag2Called = false;
+        callbackDragEnd1Called = false;
+        callbackDragEnd2Called = false;
+
+        TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
+        assert.isFalse(callbackDragStart1Called, "the callback 1 for drag start was disconnected");
+        assert.isTrue(callbackDragStart2Called, "the callback 2 for drag start is still connected");
+        assert.isFalse(callbackDrag1Called, "the callback 1 for drag was called disconnected");
+        assert.isTrue(callbackDrag2Called, "the callback 2 for drag is still connected");
+        assert.isFalse(callbackDragEnd1Called, "the callback 1 for drag end was disconnected");
+        assert.isTrue(callbackDragEnd2Called, "the callback 2 for drag end is still connected");
+
+        svg.remove();
+      });
     });
 
-    it("onDragStart()", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.DragBoxLayer();
-      dbl.renderTo(svg);
-
-      let startPoint = {
-        x: SVG_WIDTH / 4,
-        y: SVG_HEIGHT / 4
-      };
-      let endPoint = {
-        x: SVG_WIDTH / 2,
-        y: SVG_HEIGHT / 2
-      };
-
-      let receivedBounds: Plottable.Bounds;
-      let callbackCalled = false;
-      let callback = (b: Plottable.Bounds) => {
-        receivedBounds = b;
-        callbackCalled = true;
-      };
-      dbl.onDragStart(callback);
-
-      let target = dbl.background();
-      TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
-
-      assert.isTrue(callbackCalled, "the callback was called");
-      assert.deepEqual(receivedBounds.topLeft, startPoint, "top-left point was set correctly");
-      assert.deepEqual(receivedBounds.bottomRight, startPoint, "bottom-right point was set correctly");
-
-      dbl.offDragStart(callback);
-
-      callbackCalled = false;
-      TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
-      assert.isFalse(callbackCalled, "the callback was detached from the dragBoxLayer and not called");
-
-      svg.remove();
-    });
-
-    it("onDrag()", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.DragBoxLayer();
-      dbl.renderTo(svg);
-
-      let startPoint = {
-        x: SVG_WIDTH / 4,
-        y: SVG_HEIGHT / 4
-      };
-      let endPoint = {
-        x: SVG_WIDTH / 2,
-        y: SVG_HEIGHT / 2
-      };
-
-      let receivedBounds: Plottable.Bounds;
-      let callbackCalled = false;
-      let callback = (b: Plottable.Bounds) => {
-        receivedBounds = b;
-        callbackCalled = true;
-      };
-      dbl.onDrag(callback);
-
-      let target = dbl.background();
-      TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
-
-      assert.isTrue(callbackCalled, "the callback was called");
-      assert.deepEqual(receivedBounds.topLeft, startPoint, "top-left point was set correctly");
-      assert.deepEqual(receivedBounds.bottomRight, endPoint, "bottom-right point was set correctly");
-
-      callbackCalled = false;
-      dbl.offDrag(callback);
-
-      TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
-      assert.isFalse(callbackCalled, "the callback was detached from the dragoBoxLayer and not called");
-
-      svg.remove();
-    });
-
-    it("onDragEnd()", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.DragBoxLayer();
-      dbl.renderTo(svg);
-
-      let startPoint = {
-        x: SVG_WIDTH / 4,
-        y: SVG_HEIGHT / 4
-      };
-      let endPoint = {
-        x: SVG_WIDTH / 2,
-        y: SVG_HEIGHT / 2
-      };
-
-      let receivedBounds: Plottable.Bounds;
-      let callbackCalled = false;
-      let callback = (b: Plottable.Bounds) => {
-        receivedBounds = b;
-        callbackCalled = true;
-      };
-      dbl.onDragEnd(callback);
-
-      let target = dbl.background();
-      TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
-
-      assert.isTrue(callbackCalled, "the callback was called");
-      assert.deepEqual(receivedBounds.topLeft, startPoint, "top-left point was set correctly");
-      assert.deepEqual(receivedBounds.bottomRight, endPoint, "bottom-right point was set correctly");
-      dbl.offDragEnd(callback);
-      callbackCalled = false;
-
-      TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
-      assert.isFalse(callbackCalled, "the callback was detached from the dragoBoxLayer and not called");
-
-      svg.remove();
-    });
-
-    it("multiple drag interaction callbacks", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.DragBoxLayer();
-      dbl.renderTo(svg);
-
-      let startPoint = {
-        x: SVG_WIDTH / 4,
-        y: SVG_HEIGHT / 4
-      };
-      let endPoint = {
-        x: SVG_WIDTH / 2,
-        y: SVG_HEIGHT / 2
-      };
-
-      let callbackDragStart1Called = false;
-      let callbackDragStart2Called = false;
-      let callbackDrag1Called = false;
-      let callbackDrag2Called = false;
-      let callbackDragEnd1Called = false;
-      let callbackDragEnd2Called = false;
-
-      let callbackDragStart1 = () => callbackDragStart1Called = true;
-      let callbackDragStart2 = () => callbackDragStart2Called = true;
-      let callbackDrag1 = () => callbackDrag1Called = true;
-      let callbackDrag2 = () => callbackDrag2Called = true;
-      let callbackDragEnd1 = () => callbackDragEnd1Called = true;
-      let callbackDragEnd2 = () => callbackDragEnd2Called = true;
-
-      dbl.onDragStart(callbackDragStart1);
-      dbl.onDragStart(callbackDragStart2);
-      dbl.onDrag(callbackDrag1);
-      dbl.onDrag(callbackDrag2);
-      dbl.onDragEnd(callbackDragEnd1);
-      dbl.onDragEnd(callbackDragEnd2);
-
-      let target = dbl.background();
-      TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
-
-      assert.isTrue(callbackDragStart1Called, "the callback 1 for drag start was called");
-      assert.isTrue(callbackDragStart2Called, "the callback 2 for drag start was called");
-      assert.isTrue(callbackDrag1Called, "the callback 1 for drag was called");
-      assert.isTrue(callbackDrag2Called, "the callback 2 for drag was called");
-      assert.isTrue(callbackDragEnd1Called, "the callback 1 for drag end was called");
-      assert.isTrue(callbackDragEnd2Called, "the callback 2 for drag end was called");
-
-      dbl.offDragStart(callbackDragStart1);
-      dbl.offDrag(callbackDrag1);
-      dbl.offDragEnd(callbackDragEnd1);
-
-      callbackDragStart1Called = false;
-      callbackDragStart2Called = false;
-      callbackDrag1Called = false;
-      callbackDrag2Called = false;
-      callbackDragEnd1Called = false;
-      callbackDragEnd2Called = false;
-
-      TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
-      assert.isFalse(callbackDragStart1Called, "the callback 1 for drag start was disconnected");
-      assert.isTrue(callbackDragStart2Called, "the callback 2 for drag start is still connected");
-      assert.isFalse(callbackDrag1Called, "the callback 1 for drag was called disconnected");
-      assert.isTrue(callbackDrag2Called, "the callback 2 for drag is still connected");
-      assert.isFalse(callbackDragEnd1Called, "the callback 1 for drag end was disconnected");
-      assert.isTrue(callbackDragEnd2Called, "the callback 2 for drag end is still connected");
-
-      svg.remove();
-    });
 
     describe("enabling/disabling", () => {
+
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 400;
+
       it("enabled(boolean) properly modifies the state", () => {
         let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         let dbl = new Plottable.Components.DragBoxLayer();
@@ -329,6 +337,10 @@ describe("Interactive Components", () => {
     });
 
     describe("resizing", () => {
+
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 400;
+
       let svg: d3.Selection<void>;
       let dbl: Plottable.Components.DragBoxLayer;
       let target: d3.Selection<void>;
@@ -519,6 +531,10 @@ describe("Interactive Components", () => {
     });
 
     describe("moving", () => {
+
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 400;
+
       let svg: d3.Selection<void>;
       let dbl: Plottable.Components.DragBoxLayer;
       let target: d3.Selection<void>;

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -15,7 +15,6 @@ describe("Interactive Components", () => {
       beforeEach(() => {
         svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         dbl = new Plottable.Components.DragBoxLayer();
-
         quarterPoint = {
           x: SVG_WIDTH / 4,
           y: SVG_HEIGHT / 4
@@ -24,7 +23,6 @@ describe("Interactive Components", () => {
           x: SVG_WIDTH / 2,
           y: SVG_HEIGHT / 2
         };
-
       });
 
       afterEach(() => {

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -7,8 +7,17 @@ describe("Interactive Components", () => {
       let SVG_WIDTH = 400;
       let SVG_HEIGHT = 400;
 
+      var svg: d3.Selection<void>;
+
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      });
+
+      afterEach(() => {
+        svg.remove();
+      });
+
       it("correctly draws box on drag", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         let dbl = new Plottable.Components.DragBoxLayer();
         dbl.renderTo(svg);
         assert.isFalse(dbl.boxVisible(), "box is hidden initially");
@@ -28,12 +37,9 @@ describe("Interactive Components", () => {
         let bounds = dbl.bounds();
         assert.deepEqual(bounds.topLeft, startPoint, "top-left point was set correctly");
         assert.deepEqual(bounds.bottomRight, endPoint, "bottom-right point was set correctly");
-
-        svg.remove();
       });
 
       it("dismisses on click", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         let dbl = new Plottable.Components.DragBoxLayer();
         dbl.renderTo(svg);
 
@@ -46,19 +52,15 @@ describe("Interactive Components", () => {
         TestMethods.triggerFakeDragSequence(target, targetPoint, targetPoint);
 
         assert.isFalse(dbl.boxVisible(), "box is hidden on click");
-
-        svg.remove();
       });
 
       it("clipPath enabled", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         let dbl = new Plottable.Components.DragBoxLayer();
         dbl.renderTo(svg);
         TestMethods.verifyClipPath(dbl);
         let clipRect = (<any> dbl)._boxContainer.select(".clip-rect");
         assert.strictEqual(TestMethods.numAttr(clipRect, "width"), SVG_WIDTH, "the clipRect has an appropriate width");
         assert.strictEqual(TestMethods.numAttr(clipRect, "height"), SVG_HEIGHT, "the clipRect has an appropriate height");
-        svg.remove();
       });
 
       it("detectionRadius()", () => {
@@ -66,7 +68,6 @@ describe("Interactive Components", () => {
 
         assert.doesNotThrow(() => dbl.detectionRadius(3), Error, "can set detection radius before anchoring");
 
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         dbl.renderTo("svg");
 
         let radius = 5;
@@ -85,12 +86,9 @@ describe("Interactive Components", () => {
 
         // HACKHACK: chai-assert.d.ts has the wrong signature
         (<any> assert.throws)(() => dbl.detectionRadius(-1), Error, "", "rejects negative values");
-
-        svg.remove();
       });
 
       it("onDragStart()", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         let dbl = new Plottable.Components.DragBoxLayer();
         dbl.renderTo(svg);
 
@@ -123,12 +121,9 @@ describe("Interactive Components", () => {
         callbackCalled = false;
         TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
         assert.isFalse(callbackCalled, "the callback was detached from the dragBoxLayer and not called");
-
-        svg.remove();
       });
 
       it("onDrag()", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         let dbl = new Plottable.Components.DragBoxLayer();
         dbl.renderTo(svg);
 
@@ -161,12 +156,9 @@ describe("Interactive Components", () => {
 
         TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
         assert.isFalse(callbackCalled, "the callback was detached from the dragoBoxLayer and not called");
-
-        svg.remove();
       });
 
       it("onDragEnd()", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         let dbl = new Plottable.Components.DragBoxLayer();
         dbl.renderTo(svg);
 
@@ -198,12 +190,9 @@ describe("Interactive Components", () => {
 
         TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
         assert.isFalse(callbackCalled, "the callback was detached from the dragoBoxLayer and not called");
-
-        svg.remove();
       });
 
       it("multiple drag interaction callbacks", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         let dbl = new Plottable.Components.DragBoxLayer();
         dbl.renderTo(svg);
 
@@ -265,28 +254,32 @@ describe("Interactive Components", () => {
         assert.isTrue(callbackDrag2Called, "the callback 2 for drag is still connected");
         assert.isFalse(callbackDragEnd1Called, "the callback 1 for drag end was disconnected");
         assert.isTrue(callbackDragEnd2Called, "the callback 2 for drag end is still connected");
-
-        svg.remove();
       });
     });
 
 
-    describe("enabling/disabling", () => {
-
+    describe("DragBoxLayer - enabling/disabling", () => {
       let SVG_WIDTH = 400;
       let SVG_HEIGHT = 400;
 
+      var svg: d3.Selection<void>;
+
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      });
+
+      afterEach(() => {
+        svg.remove();
+      });
+
       it("enabled(boolean) properly modifies the state", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         let dbl = new Plottable.Components.DragBoxLayer();
         assert.isTrue(dbl.enabled(), "drag box layer is enabled by default");
         assert.strictEqual(dbl.enabled(false), dbl, "enabled(boolean) returns itself");
         assert.isFalse(dbl.enabled(), "drag box layer reports when it is disabled");
-        svg.remove();
       });
 
       it("disables box when enabled(false)", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         let dbl = new Plottable.Components.DragBoxLayer();
         dbl.enabled(false);
         dbl.renderTo(svg);
@@ -307,7 +300,6 @@ describe("Interactive Components", () => {
         dbl.enabled(true);
         TestMethods.triggerFakeDragSequence(target, startPoint, endPoint);
         assert.isTrue(dbl.boxVisible(), "box is shown when enabled");
-        svg.remove();
       });
 
       it("does not have resizable CSS classes when enabled(false)", () => {
@@ -336,7 +328,7 @@ describe("Interactive Components", () => {
       });
     });
 
-    describe("resizing", () => {
+    describe("DragBoxLayer - resizing", () => {
 
       let SVG_WIDTH = 400;
       let SVG_HEIGHT = 400;
@@ -371,11 +363,14 @@ describe("Interactive Components", () => {
         resetBox();
       });
 
+      afterEach(() => {
+        svg.remove();
+      });
+
       it("resizable() getter/setter", () => {
         assert.isFalse(dbl.resizable(), "defaults to false");
         assert.strictEqual(dbl.resizable(true), dbl, "returns DragBoxLayer when invoked as setter");
         assert.isTrue(dbl.resizable(), "successfully set to true");
-        svg.remove();
       });
 
       it("resizable() correctly sets pointer-events", () => {
@@ -390,7 +385,6 @@ describe("Interactive Components", () => {
           let computedStyle = window.getComputedStyle(<Element> corner);
           assert.strictEqual(computedStyle.pointerEvents.toLowerCase(), "visiblefill", "pointer-events set correctly on corners");
         });
-        svg.remove();
       });
 
       it("resize from top edge", () => {
@@ -412,7 +406,6 @@ describe("Interactive Components", () => {
                                );
         bounds = dbl.bounds();
         assert.strictEqual(bounds.bottomRight.y, SVG_HEIGHT, "can drag through to other side");
-        svg.remove();
       });
 
       it("resize from bottom edge", () => {
@@ -434,7 +427,6 @@ describe("Interactive Components", () => {
                                );
         bounds = dbl.bounds();
         assert.strictEqual(bounds.topLeft.y, 0, "can drag through to other side");
-        svg.remove();
       });
 
       it("resize from left edge", () => {
@@ -456,7 +448,6 @@ describe("Interactive Components", () => {
                                );
         bounds = dbl.bounds();
         assert.strictEqual(bounds.bottomRight.x, SVG_WIDTH, "can drag through to other side");
-        svg.remove();
       });
 
       it("resize from right edge", () => {
@@ -478,7 +469,6 @@ describe("Interactive Components", () => {
                                );
         bounds = dbl.bounds();
         assert.strictEqual(bounds.topLeft.x, 0, "can drag through to other side");
-        svg.remove();
       });
 
       it("resizes if grabbed within detectionRadius()", () => {
@@ -502,8 +492,6 @@ describe("Interactive Components", () => {
                                );
         bounds = dbl.bounds();
         assert.strictEqual(bounds.topLeft.y, startYOutside, "new box was started at the drag start position");
-
-        svg.remove();
       });
 
       it("doesn't dismiss on no-op resize", () => {
@@ -525,12 +513,10 @@ describe("Interactive Components", () => {
                                );
         let bounds = dbl.bounds();
         assert.strictEqual(bounds.topLeft.y, initialBounds.bottomRight.y, "new box was started at the drag start position");
-
-        svg.remove();
       });
     });
 
-    describe("moving", () => {
+    describe("DragBoxLayer - moving", () => {
 
       let SVG_WIDTH = 400;
       let SVG_HEIGHT = 400;
@@ -559,13 +545,16 @@ describe("Interactive Components", () => {
         initialBounds = dbl.bounds();
       });
 
+      afterEach(() => {
+        svg.remove();
+      });
+
       it("get and set movable()", () => {
         assert.isFalse(dbl.movable(), "defaults to false");
         assert.isFalse(dbl.hasClass("movable"), "initially does not have \"movable\" CSS class");
         assert.strictEqual(dbl.movable(true), dbl, "setter mode returns DragBoxLayer");
         assert.isTrue(dbl.movable(), "set to true");
         assert.isTrue(dbl.hasClass("movable"), "\"movable\" CSS class is applied");
-        svg.remove();
       });
 
       it("move left", () => {
@@ -579,7 +568,6 @@ describe("Interactive Components", () => {
         assert.strictEqual(bounds.bottomRight.x, initialBounds.bottomRight.x - dragDistance, "right edge moved");
         assert.strictEqual(bounds.topLeft.y, initialBounds.topLeft.y, "top edge did not move");
         assert.strictEqual(bounds.bottomRight.y, initialBounds.bottomRight.y, "bottom edge did not move");
-        svg.remove();
       });
 
       it("move right", () => {
@@ -593,7 +581,6 @@ describe("Interactive Components", () => {
         assert.strictEqual(bounds.bottomRight.x, initialBounds.bottomRight.x + dragDistance, "right edge moved");
         assert.strictEqual(bounds.topLeft.y, initialBounds.topLeft.y, "top edge did not move");
         assert.strictEqual(bounds.bottomRight.y, initialBounds.bottomRight.y, "bottom edge did not move");
-        svg.remove();
       });
 
       it("move up", () => {
@@ -607,7 +594,6 @@ describe("Interactive Components", () => {
         assert.strictEqual(bounds.bottomRight.x, initialBounds.bottomRight.x, "right edge did not move");
         assert.strictEqual(bounds.topLeft.y, initialBounds.topLeft.y - dragDistance, "top edge moved");
         assert.strictEqual(bounds.bottomRight.y, initialBounds.bottomRight.y - dragDistance, "bottom edge moved");
-        svg.remove();
       });
 
       it("move down", () => {
@@ -621,7 +607,6 @@ describe("Interactive Components", () => {
         assert.strictEqual(bounds.bottomRight.x, initialBounds.bottomRight.x, "right edge did not move");
         assert.strictEqual(bounds.topLeft.y, initialBounds.topLeft.y + dragDistance, "top edge moved");
         assert.strictEqual(bounds.bottomRight.y, initialBounds.bottomRight.y + dragDistance, "bottom edge moved");
-        svg.remove();
       });
 
       it("does not move if grabbed within detectionRadius() while resizable()", () => {
@@ -636,7 +621,6 @@ describe("Interactive Components", () => {
         assert.strictEqual(bounds.bottomRight.y, initialBounds.bottomRight.y, "bottom edge was not moved");
         assert.strictEqual(bounds.topLeft.x, initialBounds.topLeft.x, "left edge was not moved");
         assert.strictEqual(bounds.bottomRight.x, SVG_WIDTH, "right edge was repositioned");
-        svg.remove();
       });
 
       it("doesn't dismiss on no-op move", () => {
@@ -648,7 +632,6 @@ describe("Interactive Components", () => {
         assert.isTrue(dbl.boxVisible(), "box remains visible");
         let bounds = dbl.bounds();
         assert.deepEqual(bounds, initialBounds, "bounds did not change");
-        svg.remove();
       });
 
       it("dismisses on click outside of box", () => {
@@ -656,7 +639,6 @@ describe("Interactive Components", () => {
         let origin = { x: 0, y: 0 };
         TestMethods.triggerFakeDragSequence(target, origin, origin);
         assert.isFalse(dbl.boxVisible(), "box is no longer visible");
-        svg.remove();
       });
 
       it("starts new box if hidden instead of moving", () => {
@@ -669,16 +651,12 @@ describe("Interactive Components", () => {
         let bounds = dbl.bounds();
         assert.strictEqual(bounds.topLeft.x, midPoint.x, "new box was started at the drag start position (x)");
         assert.strictEqual(bounds.topLeft.y, midPoint.y, "new box was started at the drag start position (y)");
-
-        svg.remove();
       });
 
       it("destroy() does not error if scales are not inputted", () => {
         let sbl = new Plottable.Components.DragBoxLayer();
         sbl.renderTo(svg);
         assert.doesNotThrow(() => sbl.destroy(), Error, "can destroy");
-
-        svg.remove();
       });
     });
   });

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -215,9 +215,11 @@ describe("Interactive Components", () => {
       let SVG_HEIGHT = 400;
 
       var svg: d3.Selection<void>;
+      let dbl: Plottable.Components.DragBoxLayer;
 
       beforeEach(() => {
         svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        dbl = new Plottable.Components.DragBoxLayer();
       });
 
       afterEach(() => {
@@ -225,14 +227,12 @@ describe("Interactive Components", () => {
       });
 
       it("enabled(boolean) properly modifies the state", () => {
-        let dbl = new Plottable.Components.DragBoxLayer();
         assert.isTrue(dbl.enabled(), "drag box layer is enabled by default");
         assert.strictEqual(dbl.enabled(false), dbl, "enabled(boolean) returns itself");
         assert.isFalse(dbl.enabled(), "drag box layer reports when it is disabled");
       });
 
       it("disables box when enabled(false)", () => {
-        let dbl = new Plottable.Components.DragBoxLayer();
         dbl.enabled(false);
         dbl.renderTo(svg);
         assert.isFalse(dbl.boxVisible(), "box is hidden initially");
@@ -255,7 +255,6 @@ describe("Interactive Components", () => {
       });
 
       it("does not have resizable CSS classes when enabled(false)", () => {
-        let dbl = new Plottable.Components.DragBoxLayer();
         dbl.resizable(true);
         assert.isTrue(dbl.hasClass("x-resizable"), "carries \"x-resizable\" class if resizable");
         assert.isTrue(dbl.hasClass("y-resizable"), "carries \"y-resizable\" class if resizable");
@@ -269,7 +268,6 @@ describe("Interactive Components", () => {
       });
 
       it("does not have movable CSS classe when enabled(false)", () => {
-        let dbl = new Plottable.Components.DragBoxLayer();
         dbl.movable(true);
         assert.isTrue(dbl.hasClass("movable"), "carries \"movable\" class if movable");
         dbl.enabled(false);

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -87,13 +87,15 @@ describe("Interactive Components", () => {
         assert.strictEqual(edges.size(), 4, "the edges of a rectangle are drawn");
         edges.each(function() {
           let edge = d3.select(this);
-          assert.strictEqual(edge.style("stroke-width"), 2 * radius + "px", "edge width was set correctly");
+          let strokeWidth = parseFloat(edge.style("stroke-width"));
+          assert.strictEqual(strokeWidth, 2 * radius, "edge width was set correctly");
         });
         let corners = dbl.content().selectAll("circle");
         assert.strictEqual(corners.size(), 4, "the corners of a rectangle are drawn");
         corners.each(function() {
           let corner = d3.select(this);
-          assert.strictEqual(corner.attr("r"), "" + radius, "corner radius was set correctly");
+          let cornerRadius = parseFloat(corner.attr("r"));
+          assert.strictEqual(cornerRadius, radius, "corner radius was set correctly");
         });
 
         svg.remove();

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -8,9 +8,11 @@ describe("Interactive Components", () => {
       let SVG_HEIGHT = 400;
 
       var svg: d3.Selection<void>;
+      let dbl: Plottable.Components.DragBoxLayer;
 
       beforeEach(() => {
         svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        dbl = new Plottable.Components.DragBoxLayer();
       });
 
       afterEach(() => {
@@ -18,7 +20,6 @@ describe("Interactive Components", () => {
       });
 
       it("correctly draws box on drag", () => {
-        let dbl = new Plottable.Components.DragBoxLayer();
         dbl.renderTo(svg);
         assert.isFalse(dbl.boxVisible(), "box is hidden initially");
 
@@ -40,7 +41,6 @@ describe("Interactive Components", () => {
       });
 
       it("dismisses on click", () => {
-        let dbl = new Plottable.Components.DragBoxLayer();
         dbl.renderTo(svg);
 
         let targetPoint = {
@@ -55,8 +55,8 @@ describe("Interactive Components", () => {
       });
 
       it("clipPath enabled", () => {
-        let dbl = new Plottable.Components.DragBoxLayer();
         dbl.renderTo(svg);
+
         TestMethods.verifyClipPath(dbl);
         let clipRect = (<any> dbl)._boxContainer.select(".clip-rect");
         assert.strictEqual(TestMethods.numAttr(clipRect, "width"), SVG_WIDTH, "the clipRect has an appropriate width");
@@ -64,10 +64,7 @@ describe("Interactive Components", () => {
       });
 
       it("detectionRadius()", () => {
-        let dbl = new Plottable.Components.DragBoxLayer();
-
         assert.doesNotThrow(() => dbl.detectionRadius(3), Error, "can set detection radius before anchoring");
-
         dbl.renderTo("svg");
 
         let radius = 5;
@@ -89,7 +86,6 @@ describe("Interactive Components", () => {
       });
 
       it("onDragStart()", () => {
-        let dbl = new Plottable.Components.DragBoxLayer();
         dbl.renderTo(svg);
 
         let startPoint = {
@@ -124,7 +120,6 @@ describe("Interactive Components", () => {
       });
 
       it("onDrag()", () => {
-        let dbl = new Plottable.Components.DragBoxLayer();
         dbl.renderTo(svg);
 
         let startPoint = {
@@ -159,7 +154,6 @@ describe("Interactive Components", () => {
       });
 
       it("onDragEnd()", () => {
-        let dbl = new Plottable.Components.DragBoxLayer();
         dbl.renderTo(svg);
 
         let startPoint = {
@@ -193,7 +187,6 @@ describe("Interactive Components", () => {
       });
 
       it("multiple drag interaction callbacks", () => {
-        let dbl = new Plottable.Components.DragBoxLayer();
         dbl.renderTo(svg);
 
         let startPoint = {
@@ -256,7 +249,6 @@ describe("Interactive Components", () => {
         assert.isTrue(callbackDragEnd2Called, "the callback 2 for drag end is still connected");
       });
     });
-
 
     describe("DragBoxLayer - enabling/disabling", () => {
       let SVG_WIDTH = 400;

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -181,58 +181,67 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
-      it("calls all the drag interaction callbacks when needed", () => {
+      it("can register two callbacks for the same event", () => {
         dbl.renderTo(svg);
 
         let callbackDragStart1Called = false;
         let callbackDragStart2Called = false;
-        let callbackDrag1Called = false;
-        let callbackDrag2Called = false;
-        let callbackDragEnd1Called = false;
-        let callbackDragEnd2Called = false;
 
         let callbackDragStart1 = () => callbackDragStart1Called = true;
         let callbackDragStart2 = () => callbackDragStart2Called = true;
-        let callbackDrag1 = () => callbackDrag1Called = true;
-        let callbackDrag2 = () => callbackDrag2Called = true;
-        let callbackDragEnd1 = () => callbackDragEnd1Called = true;
-        let callbackDragEnd2 = () => callbackDragEnd2Called = true;
 
         dbl.onDragStart(callbackDragStart1);
         dbl.onDragStart(callbackDragStart2);
-        dbl.onDrag(callbackDrag1);
-        dbl.onDrag(callbackDrag2);
-        dbl.onDragEnd(callbackDragEnd1);
-        dbl.onDragEnd(callbackDragEnd2);
 
         let target = dbl.background();
         TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
 
         assert.isTrue(callbackDragStart1Called, "the callback 1 for drag start was called");
         assert.isTrue(callbackDragStart2Called, "the callback 2 for drag start was called");
-        assert.isTrue(callbackDrag1Called, "the callback 1 for drag was called");
-        assert.isTrue(callbackDrag2Called, "the callback 2 for drag was called");
-        assert.isTrue(callbackDragEnd1Called, "the callback 1 for drag end was called");
-        assert.isTrue(callbackDragEnd2Called, "the callback 2 for drag end was called");
 
         dbl.offDragStart(callbackDragStart1);
-        dbl.offDrag(callbackDrag1);
-        dbl.offDragEnd(callbackDragEnd1);
-
         callbackDragStart1Called = false;
         callbackDragStart2Called = false;
-        callbackDrag1Called = false;
-        callbackDrag2Called = false;
-        callbackDragEnd1Called = false;
-        callbackDragEnd2Called = false;
 
         TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
         assert.isFalse(callbackDragStart1Called, "the callback 1 for drag start was disconnected");
         assert.isTrue(callbackDragStart2Called, "the callback 2 for drag start is still connected");
-        assert.isFalse(callbackDrag1Called, "the callback 1 for drag was called disconnected");
-        assert.isTrue(callbackDrag2Called, "the callback 2 for drag is still connected");
-        assert.isFalse(callbackDragEnd1Called, "the callback 1 for drag end was disconnected");
-        assert.isTrue(callbackDragEnd2Called, "the callback 2 for drag end is still connected");
+        svg.remove();
+      });
+
+      it("calls all the drag interaction callbacks when needed", () => {
+        dbl.renderTo(svg);
+
+        let callbackDragStartCalled = false;
+        let callbackDragCalled = false;
+        let callbackDragEndCalled = false;
+
+        let callbackDragStart = () => callbackDragStartCalled = true;
+        let callbackDrag = () => callbackDragCalled = true;
+        let callbackDragEnd = () => callbackDragEndCalled = true;
+
+        dbl.onDragStart(callbackDragStart);
+        dbl.onDrag(callbackDrag);
+        dbl.onDragEnd(callbackDragEnd);
+
+        let target = dbl.background();
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+
+        assert.isTrue(callbackDragStartCalled, "the callback for drag start was called");
+        assert.isTrue(callbackDragCalled, "the callback for drag was called");
+        assert.isTrue(callbackDragEndCalled, "the callback for drag end was called");
+
+        dbl.offDragStart(callbackDragStart);
+        dbl.offDrag(callbackDrag);
+        dbl.offDragEnd(callbackDragEnd);
+
+        callbackDragStartCalled = false;
+        callbackDragCalled = false;
+
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+        assert.isFalse(callbackDragStartCalled, "the callback for drag start was disconnected");
+        assert.isFalse(callbackDragCalled, "the callback for drag was disconnected");
+        assert.isTrue(callbackDragEndCalled, "the callback for drag end is still connected");
         svg.remove();
       });
     });


### PR DESCRIPTION
Part of #2623 

I will be doing multiple passes because I will get more context (and better sense of best practices) by refactoring other files. However, please flag anything that seems unusual.

As part of this: 
- Applied best practices from the wiki page
- Factored out common code into `beforeEach()` clauses
- No nested `beforeEach()`es
- Added `afterEach()` to save some LOCs
- Remade hierarchy as shown bellow
![screen shot 2015-08-20 at 4 28 31 pm](https://cloud.githubusercontent.com/assets/3248682/9398122/8fd761f6-4758-11e5-9a02-c972b1d0ebc6.png)



[NOQE] as no JS changes