### PR TITLE
allow InterpolatedColorLegend to span entire space

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2192,16 +2192,16 @@ declare module Plottable {
              */
             formatter(formatter: Formatter): InterpolatedColorLegend;
             /**
-             * Gets whether InterpolatedColorLegend will expand in the long direction
+             * Gets whether the InterpolatedColorLegend expands to occupy all offered space in the long direction
              */
-            expand(): boolean;
+            expands(): boolean;
             /**
-             * Sets whether InterpolatedColorLegend will expand in the long direction
+             * Sets whether the InterpolatedColorLegend expands to occupy all offered space in the long direction
              *
-             * @param {expand} boolean
+             * @param {expands} boolean
              * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
              */
-            expand(expand: boolean): InterpolatedColorLegend;
+            expands(expands: boolean): InterpolatedColorLegend;
             /**
              * Gets the orientation.
              */

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2192,16 +2192,16 @@ declare module Plottable {
              */
             formatter(formatter: Formatter): InterpolatedColorLegend;
             /**
-             * Gets whether InterpolatedColorLegend is fixed size.
+             * Gets whether InterpolatedColorLegend will expand in the long direction
              */
-            fixedSize(): boolean;
+            expand(): boolean;
             /**
-             * Sets whether InterpolatedColorLegend is fixed size.
+             * Sets whether InterpolatedColorLegend will expand in the long direction
              *
-             * @param {fixed} boolean
+             * @param {expand} boolean
              * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
              */
-            fixedSize(fixed: boolean): InterpolatedColorLegend;
+            expand(expand: boolean): InterpolatedColorLegend;
             /**
              * Gets the orientation.
              */

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2192,6 +2192,17 @@ declare module Plottable {
              */
             formatter(formatter: Formatter): InterpolatedColorLegend;
             /**
+             * Gets whether InterpolatedColorLegend is fixed size.
+             */
+            fixedSize(): boolean;
+            /**
+             * Sets whether InterpolatedColorLegend is fixed size.
+             *
+             * @param {fixed} boolean
+             * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
+             */
+            fixedSize(fixed: boolean): InterpolatedColorLegend;
+            /**
              * Gets the orientation.
              */
             orientation(): string;

--- a/plottable.js
+++ b/plottable.js
@@ -5393,7 +5393,6 @@ var Plottable;
                 var _this = this;
                 _super.call(this);
                 this._padding = 5;
-                this._numSwatches = 10;
                 if (interpolatedColorScale == null) {
                     throw new Error("InterpolatedColorLegend requires a interpolatedColorScale");
                 }
@@ -5402,7 +5401,7 @@ var Plottable;
                 this._scale.onUpdate(this._redrawCallback);
                 this._formatter = Plottable.Formatters.general();
                 this._orientation = "horizontal";
-                this._expand = false;
+                this._expands = false;
                 this.addClass("legend");
                 this.addClass("interpolated-color-legend");
             }
@@ -5418,11 +5417,11 @@ var Plottable;
                 this.redraw();
                 return this;
             };
-            InterpolatedColorLegend.prototype.expand = function (expand) {
-                if (expand == null) {
-                    return this._expand;
+            InterpolatedColorLegend.prototype.expands = function (expands) {
+                if (expands == null) {
+                    return this._expands;
                 }
-                this._expand = expand;
+                this._expands = expands;
                 this.redraw();
                 return this;
             };
@@ -5446,13 +5445,13 @@ var Plottable;
                 }
             };
             InterpolatedColorLegend.prototype.fixedWidth = function () {
-                return !this.expand() || this._isVertical();
+                return !this.expands() || this._isVertical();
             };
             InterpolatedColorLegend.prototype.fixedHeight = function () {
-                return !this.expand() || !this._isVertical();
+                return !this.expands() || !this._isVertical();
             };
             InterpolatedColorLegend.prototype._generateTicks = function (numSwatches) {
-                if (numSwatches === void 0) { numSwatches = this._numSwatches; }
+                if (numSwatches === void 0) { numSwatches = InterpolatedColorLegend._DEFAULT_NUM_SWATCHES; }
                 var domain = this._scale.domain();
                 var slope = (domain[1] - domain[0]) / (numSwatches - 1);
                 var ticks = [];
@@ -5478,15 +5477,16 @@ var Plottable;
                 var labelWidths = domain.map(function (d) { return _this._measurer.measure(_this._formatter(d)).width; });
                 var desiredHeight;
                 var desiredWidth;
+                var numSwatches = InterpolatedColorLegend._DEFAULT_NUM_SWATCHES;
                 if (this._isVertical()) {
                     var longestWidth = Plottable.Utils.Math.max(labelWidths, 0);
                     desiredWidth = this._padding + textHeight + this._padding + longestWidth + this._padding;
-                    desiredHeight = this._padding + this._numSwatches * textHeight + this._padding;
+                    desiredHeight = this._padding + numSwatches * textHeight + this._padding;
                 }
                 else {
                     desiredHeight = this._padding + textHeight + this._padding;
                     desiredWidth = this._padding + labelWidths[0] + this._padding
-                        + this._numSwatches * textHeight
+                        + numSwatches * textHeight
                         + this._padding + labelWidths[1] + this._padding;
                 }
                 return {
@@ -5530,12 +5530,12 @@ var Plottable;
                     width: 0,
                     height: 0
                 };
-                var numSwatches = this._numSwatches;
-                if (this.expand()) {
+                var numSwatches = InterpolatedColorLegend._DEFAULT_NUM_SWATCHES;
+                if (this.expands()) {
                     var textHeight = this._measurer.measure().height;
                     var offset = this._isVertical() ? 2 * padding : 4 * padding - text0Width - text1Width;
                     var fullLength = this._isVertical() ? this.height() : this.width();
-                    numSwatches = Math.max(Math.floor((fullLength - offset) / textHeight), this._numSwatches);
+                    numSwatches = Math.max(Math.floor((fullLength - offset) / textHeight), numSwatches);
                 }
                 if (this._isVertical()) {
                     var longestTextWidth = Math.max(text0Width, text1Width);
@@ -5598,6 +5598,7 @@ var Plottable;
                 });
                 return this;
             };
+            InterpolatedColorLegend._DEFAULT_NUM_SWATCHES = 10;
             /**
              * The css class applied to the legend labels.
              */

--- a/plottable.js
+++ b/plottable.js
@@ -5531,11 +5531,8 @@ var Plottable;
                     height: 0
                 };
                 var numSwatches = InterpolatedColorLegend._DEFAULT_NUM_SWATCHES;
-                if (this.expands()) {
-                    var textHeight = this._measurer.measure().height;
-                    if (textHeight === 0) {
-                        return this;
-                    }
+                var textHeight = this._measurer.measure().height;
+                if (this.expands() && textHeight > 0) {
                     var offset = this._isVertical() ? 2 * padding : 4 * padding - text0Width - text1Width;
                     var fullLength = this._isVertical() ? this.height() : this.width();
                     numSwatches = Math.max(Math.floor((fullLength - offset) / textHeight), numSwatches);

--- a/plottable.js
+++ b/plottable.js
@@ -5533,6 +5533,9 @@ var Plottable;
                 var numSwatches = InterpolatedColorLegend._DEFAULT_NUM_SWATCHES;
                 if (this.expands()) {
                     var textHeight = this._measurer.measure().height;
+                    if (textHeight === 0) {
+                        return this;
+                    }
                     var offset = this._isVertical() ? 2 * padding : 4 * padding - text0Width - text1Width;
                     var fullLength = this._isVertical() ? this.height() : this.width();
                     numSwatches = Math.max(Math.floor((fullLength - offset) / textHeight), numSwatches);
@@ -5598,7 +5601,7 @@ var Plottable;
                 });
                 return this;
             };
-            InterpolatedColorLegend._DEFAULT_NUM_SWATCHES = 10;
+            InterpolatedColorLegend._DEFAULT_NUM_SWATCHES = 11;
             /**
              * The css class applied to the legend labels.
              */

--- a/plottable.js
+++ b/plottable.js
@@ -5402,6 +5402,7 @@ var Plottable;
                 this._scale.onUpdate(this._redrawCallback);
                 this._formatter = Plottable.Formatters.general();
                 this._orientation = "horizontal";
+                this._fixedSize = true;
                 this.addClass("legend");
                 this.addClass("interpolated-color-legend");
             }
@@ -5414,6 +5415,14 @@ var Plottable;
                     return this._formatter;
                 }
                 this._formatter = formatter;
+                this.redraw();
+                return this;
+            };
+            InterpolatedColorLegend.prototype.fixedSize = function (fixed) {
+                if (fixed == null) {
+                    return this._fixedSize;
+                }
+                this._fixedSize = fixed;
                 this.redraw();
                 return this;
             };
@@ -5437,10 +5446,10 @@ var Plottable;
                 }
             };
             InterpolatedColorLegend.prototype.fixedWidth = function () {
-                return true;
+                return this._fixedSize || this._isVertical();
             };
             InterpolatedColorLegend.prototype.fixedHeight = function () {
-                return true;
+                return this._fixedSize || !this._isVertical();
             };
             InterpolatedColorLegend.prototype._generateTicks = function () {
                 var domain = this._scale.domain();

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -3,7 +3,7 @@
 module Plottable {
 export module Components {
   export class InterpolatedColorLegend extends Component {
-    private static _DEFAULT_NUM_SWATCHES = 10;
+    private static _DEFAULT_NUM_SWATCHES = 11;
 
     private _measurer: SVGTypewriter.Measurers.Measurer;
     private _wrapper: SVGTypewriter.Wrappers.Wrapper;
@@ -230,6 +230,9 @@ export module Components {
 
       if (this.expands()) {
         let textHeight = this._measurer.measure().height;
+        if (textHeight === 0) {
+          return this;
+        }
         let offset = this._isVertical() ? 2 * padding :  4 * padding - text0Width - text1Width;
         let fullLength = this._isVertical() ? this.height() : this.width();
         numSwatches = Math.max(Math.floor((fullLength - offset) / textHeight), numSwatches);

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -3,15 +3,16 @@
 module Plottable {
 export module Components {
   export class InterpolatedColorLegend extends Component {
+    private static _DEFAULT_NUM_SWATCHES = 10;
+
     private _measurer: SVGTypewriter.Measurers.Measurer;
     private _wrapper: SVGTypewriter.Wrappers.Wrapper;
     private _writer: SVGTypewriter.Writers.Writer;
     private _scale: Scales.InterpolatedColor;
     private _orientation: String ;
     private _padding = 5;
-    private _numSwatches = 10;
     private _formatter: Formatter;
-    private _expand: boolean;
+    private _expands: boolean;
 
     private _swatchContainer: d3.Selection<void>;
     private _swatchBoundingBox: d3.Selection<void>;
@@ -44,7 +45,7 @@ export module Components {
       this._scale.onUpdate(this._redrawCallback);
       this._formatter = Formatters.general();
       this._orientation = "horizontal";
-      this._expand = false;
+      this._expands = false;
 
       this.addClass("legend");
       this.addClass("interpolated-color-legend");
@@ -76,21 +77,21 @@ export module Components {
     }
 
     /**
-     * Gets whether InterpolatedColorLegend will expand in the long direction
+     * Gets whether the InterpolatedColorLegend expands to occupy all offered space in the long direction
      */
-    public expand(): boolean;
+    public expands(): boolean;
     /**
-     * Sets whether InterpolatedColorLegend will expand in the long direction
+     * Sets whether the InterpolatedColorLegend expands to occupy all offered space in the long direction
      *
-     * @param {expand} boolean
+     * @param {expands} boolean
      * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
      */
-    public expand(expand: boolean): InterpolatedColorLegend;
-    public expand(expand?: boolean): any {
-      if (expand == null) {
-        return this._expand;
+    public expands(expands: boolean): InterpolatedColorLegend;
+    public expands(expands?: boolean): any {
+      if (expands == null) {
+        return this._expands;
       }
-      this._expand = expand;
+      this._expands = expands;
       this.redraw();
       return this;
     }
@@ -126,14 +127,14 @@ export module Components {
     }
 
     public fixedWidth() {
-      return !this.expand() || this._isVertical();
+      return !this.expands() || this._isVertical();
     }
 
     public fixedHeight() {
-      return !this.expand() || !this._isVertical();
+      return !this.expands() || !this._isVertical();
     }
 
-    private _generateTicks(numSwatches = this._numSwatches) {
+    private _generateTicks(numSwatches = InterpolatedColorLegend._DEFAULT_NUM_SWATCHES) {
       let domain = this._scale.domain();
       let slope = (domain[1] - domain[0]) / (numSwatches - 1);
       let ticks: number[] = [];
@@ -164,14 +165,15 @@ export module Components {
 
       let desiredHeight: number;
       let desiredWidth: number;
+      let numSwatches = InterpolatedColorLegend._DEFAULT_NUM_SWATCHES;
       if (this._isVertical()) {
         let longestWidth = Utils.Math.max(labelWidths, 0);
         desiredWidth = this._padding + textHeight + this._padding + longestWidth + this._padding;
-        desiredHeight = this._padding + this._numSwatches * textHeight + this._padding;
+        desiredHeight = this._padding + numSwatches * textHeight + this._padding;
       } else {
         desiredHeight = this._padding + textHeight + this._padding;
         desiredWidth = this._padding + labelWidths[0] + this._padding
-                        + this._numSwatches * textHeight
+                        + numSwatches * textHeight
                         + this._padding + labelWidths[1] + this._padding;
       }
 
@@ -224,13 +226,13 @@ export module Components {
         height: 0
       };
 
-      let numSwatches = this._numSwatches;
+      let numSwatches = InterpolatedColorLegend._DEFAULT_NUM_SWATCHES;
 
-      if (this.expand()) {
+      if (this.expands()) {
         let textHeight = this._measurer.measure().height;
         let offset = this._isVertical() ? 2 * padding :  4 * padding - text0Width - text1Width;
         let fullLength = this._isVertical() ? this.height() : this.width();
-        numSwatches = Math.max(Math.floor((fullLength - offset) / textHeight), this._numSwatches);
+        numSwatches = Math.max(Math.floor((fullLength - offset) / textHeight), numSwatches);
       }
 
       if (this._isVertical()) {

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -227,12 +227,8 @@ export module Components {
       };
 
       let numSwatches = InterpolatedColorLegend._DEFAULT_NUM_SWATCHES;
-
-      if (this.expands()) {
-        let textHeight = this._measurer.measure().height;
-        if (textHeight === 0) {
-          return this;
-        }
+      let textHeight = this._measurer.measure().height;
+      if (this.expands() && textHeight > 0) {
         let offset = this._isVertical() ? 2 * padding :  4 * padding - text0Width - text1Width;
         let fullLength = this._isVertical() ? this.height() : this.width();
         numSwatches = Math.max(Math.floor((fullLength - offset) / textHeight), numSwatches);

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -11,6 +11,7 @@ export module Components {
     private _padding = 5;
     private _numSwatches = 10;
     private _formatter: Formatter;
+    private _fixedSize: boolean;
 
     private _swatchContainer: d3.Selection<void>;
     private _swatchBoundingBox: d3.Selection<void>;
@@ -43,6 +44,7 @@ export module Components {
       this._scale.onUpdate(this._redrawCallback);
       this._formatter = Formatters.general();
       this._orientation = "horizontal";
+      this._fixedSize = true;
 
       this.addClass("legend");
       this.addClass("interpolated-color-legend");
@@ -69,6 +71,26 @@ export module Components {
         return this._formatter;
       }
       this._formatter = formatter;
+      this.redraw();
+      return this;
+    }
+
+    /**
+     * Gets whether InterpolatedColorLegend is fixed size.
+     */
+    public fixedSize(): boolean;
+    /**
+     * Sets whether InterpolatedColorLegend is fixed size.
+     *
+     * @param {fixed} boolean
+     * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
+     */
+    public fixedSize(fixed: boolean): InterpolatedColorLegend;
+    public fixedSize(fixed?: boolean): any {
+      if (fixed == null) {
+        return this._fixedSize;
+      }
+      this._fixedSize = fixed;
       this.redraw();
       return this;
     }
@@ -104,11 +126,11 @@ export module Components {
     }
 
     public fixedWidth() {
-      return true;
+      return this._fixedSize || this._isVertical();
     }
 
     public fixedHeight() {
-      return true;
+      return this._fixedSize || !this._isVertical();
     }
 
     private _generateTicks() {

--- a/test/components/interpolatedColorLegendTests.ts
+++ b/test/components/interpolatedColorLegendTests.ts
@@ -105,9 +105,9 @@ describe("InterpolatedColorLegend", () => {
   it("does not crash when font-size is 0px", () => {
     let legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
     legend.renderTo(svg);
-    let style = (<any> legend)._element.append("style");
+    let style = legend.content().append("style");
     style.attr("type", "text/css");
-    style.text(".plottable .legend { font-size: 0px; }");
+    style.text(".plottable .interpolated-color-legend text { font-size: 0px; }");
     assert.doesNotThrow(() => legend.expands(true), Error, "it does not throw error when font-size is 0px");
 
     style.remove();

--- a/test/components/interpolatedColorLegendTests.ts
+++ b/test/components/interpolatedColorLegendTests.ts
@@ -189,11 +189,13 @@ describe("InterpolatedColorLegend", () => {
     svg.remove();
   });
 
-  it("fixed height if fixedSize is set to true or orientation is horizontal", () => {
+  it("fixed height if expand is set to false or orientation is horizontal", () => {
     let legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    legend.renderTo(svg);
+
     assert.isTrue(legend.fixedHeight(), "height is fixed on default");
 
-    legend.fixedSize(false);
+    legend.expand(true);
     assert.isTrue(legend.fixedHeight(), "height is fixed oriented horizontally");
 
     legend.orientation("left");
@@ -202,17 +204,19 @@ describe("InterpolatedColorLegend", () => {
     legend.orientation("right");
     assert.isFalse(legend.fixedHeight(), "height is not fixed oriented vertically");
 
-    legend.fixedSize(true);
-    assert.isTrue(legend.fixedHeight(), "height is fixed when fixedSize is set to true");
+    legend.expand(false);
+    assert.isTrue(legend.fixedHeight(), "height is fixed when expand is set to false");
 
     svg.remove();
   });
 
-  it("fixed width if fixedSize is set to true or orientation is vertically", () => {
+  it("fixed width if expand is set to false or orientation is vertically", () => {
     let legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    legend.renderTo(svg);
+
     assert.isTrue(legend.fixedWidth(), "width is fixed on default");
 
-    legend.fixedSize(false);
+    legend.expand(true);
     assert.isFalse(legend.fixedWidth(), "width is not fixed oriented horizontally");
 
     legend.orientation("left");
@@ -221,27 +225,65 @@ describe("InterpolatedColorLegend", () => {
     legend.orientation("right");
     assert.isTrue(legend.fixedWidth(), "width is fixed oriented vertically");
 
-    legend.fixedSize(true);
+    legend.expand(false);
     legend.orientation("horizontal");
-    assert.isTrue(legend.fixedWidth(), "width is fixed when fixedSize is set to true");
+    assert.isTrue(legend.fixedWidth(), "width is fixed when expand is set to false");
 
     svg.remove();
   });
 
-  it("spams the entire height if oriented vertically and fixedSize is set to false", () => {
+  it("spams the entire height if oriented vertically and expand is set to true", () => {
     let legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
     legend.orientation("left");
-    legend.fixedSize(false);
+    legend.expand(true);
     legend.renderTo(svg);
     assert.closeTo(legend.height(), SVG_HEIGNT, 0.01, "legend height is the same as svg height");
     svg.remove();
   });
 
-  it("spams the entire width if oriented horizontally and fixedSize is set to false", () => {
+  it("spams the entire width if oriented horizontally and expand is set to true", () => {
     let legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
-    legend.fixedSize(false);
+    legend.expand(true);
     legend.renderTo(svg);
     assert.closeTo(legend.width(), SVG_WIDTH, 0.01, "legend width is the same as svg width");
+    svg.remove();
+  });
+
+  it("has default number of swatches by default", () => {
+    let legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    legend.renderTo(svg);
+
+    let numSwatches = (<any> legend)._numSwatches;
+    let horzontalSwatches = legend.content().selectAll(".swatch");
+    assert.strictEqual(horzontalSwatches.size(), numSwatches, "there are 10 swatches by default");
+
+    legend.orientation("left");
+    let leftSwatches = legend.content().selectAll(".swatch");
+    assert.strictEqual(leftSwatches.size(), numSwatches, "there are 10 swatches by default");
+
+    legend.orientation("right");
+    let rightSwatches = legend.content().selectAll(".swatch");
+    assert.strictEqual(rightSwatches.size(), numSwatches, "there are 10 swatches by default");
+
+    svg.remove();
+  });
+
+  it("has more swatches than default when expand is true", () => {
+    let legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    legend.expand(true).renderTo(svg);
+
+    let numSwatches = (<any> legend)._numSwatches;
+    let horzontalSwatches = legend.content().selectAll(".swatch");
+    assert.isTrue(horzontalSwatches.size() > numSwatches, "there are more than 10 swatches when expanded");
+
+    legend.orientation("left");
+    let leftSwatches = legend.content().selectAll(".swatch");
+    assert.isTrue(leftSwatches.size() > numSwatches, "there are more than 10 swatches when expanded");
+
+    legend.orientation("right");
+    let rightSwatches = legend.content().selectAll(".swatch");
+    assert.isTrue(rightSwatches.size() > numSwatches, "there are more than 10 swatches when expanded");
+
     svg.remove();
   });
 });

--- a/test/components/interpolatedColorLegendTests.ts
+++ b/test/components/interpolatedColorLegendTests.ts
@@ -21,6 +21,8 @@ describe("InterpolatedColorLegend", () => {
     assert.strictEqual(d3.select(swatches[0][swatches[0].length - 1]).attr("fill"),
                        colorScale.scale(scaleDomain[1]),
                        "last swatch's color corresponds with second domain value");
+    let defaultNumSwatches = (<any> Plottable.Components.InterpolatedColorLegend)._DEFAULT_NUM_SWATCHES;
+    assert.isTrue(swatches.size() >= defaultNumSwatches, "there are at least 10 swatches");
 
     let swatchContainer = legendElement.select(".swatch-container");
     let swatchContainerBCR = (<Element> swatchContainer.node()).getBoundingClientRect();
@@ -195,7 +197,7 @@ describe("InterpolatedColorLegend", () => {
 
     assert.isTrue(legend.fixedHeight(), "height is fixed on default");
 
-    legend.expand(true);
+    legend.expands(true);
     assert.isTrue(legend.fixedHeight(), "height is fixed oriented horizontally");
 
     legend.orientation("left");
@@ -204,7 +206,7 @@ describe("InterpolatedColorLegend", () => {
     legend.orientation("right");
     assert.isFalse(legend.fixedHeight(), "height is not fixed oriented vertically");
 
-    legend.expand(false);
+    legend.expands(false);
     assert.isTrue(legend.fixedHeight(), "height is fixed when expand is set to false");
 
     svg.remove();
@@ -216,7 +218,7 @@ describe("InterpolatedColorLegend", () => {
 
     assert.isTrue(legend.fixedWidth(), "width is fixed on default");
 
-    legend.expand(true);
+    legend.expands(true);
     assert.isFalse(legend.fixedWidth(), "width is not fixed oriented horizontally");
 
     legend.orientation("left");
@@ -225,7 +227,7 @@ describe("InterpolatedColorLegend", () => {
     legend.orientation("right");
     assert.isTrue(legend.fixedWidth(), "width is fixed oriented vertically");
 
-    legend.expand(false);
+    legend.expands(false);
     legend.orientation("horizontal");
     assert.isTrue(legend.fixedWidth(), "width is fixed when expand is set to false");
 
@@ -235,55 +237,31 @@ describe("InterpolatedColorLegend", () => {
   it("spams the entire height if oriented vertically and expand is set to true", () => {
     let legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
     legend.orientation("left");
-    legend.expand(true);
+    legend.expands(true);
     legend.renderTo(svg);
-    assert.closeTo(legend.height(), SVG_HEIGNT, 0.01, "legend height is the same as svg height");
+    assert.strictEqual(legend.height(), SVG_HEIGNT, "legend height is the same as svg height");
     svg.remove();
   });
 
   it("spams the entire width if oriented horizontally and expand is set to true", () => {
     let legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
-    legend.expand(true);
+    legend.expands(true);
     legend.renderTo(svg);
-    assert.closeTo(legend.width(), SVG_WIDTH, 0.01, "legend width is the same as svg width");
-    svg.remove();
-  });
-
-  it("has default number of swatches by default", () => {
-    let legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
-    legend.renderTo(svg);
-
-    let numSwatches = (<any> legend)._numSwatches;
-    let horzontalSwatches = legend.content().selectAll(".swatch");
-    assert.strictEqual(horzontalSwatches.size(), numSwatches, "there are 10 swatches by default");
-
-    legend.orientation("left");
-    let leftSwatches = legend.content().selectAll(".swatch");
-    assert.strictEqual(leftSwatches.size(), numSwatches, "there are 10 swatches by default");
-
-    legend.orientation("right");
-    let rightSwatches = legend.content().selectAll(".swatch");
-    assert.strictEqual(rightSwatches.size(), numSwatches, "there are 10 swatches by default");
-
+    assert.strictEqual(legend.width(), SVG_WIDTH, "legend width is the same as svg width");
     svg.remove();
   });
 
   it("has more swatches than default when expand is true", () => {
     let legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
-    legend.expand(true).renderTo(svg);
-
-    let numSwatches = (<any> legend)._numSwatches;
-    let horzontalSwatches = legend.content().selectAll(".swatch");
-    assert.isTrue(horzontalSwatches.size() > numSwatches, "there are more than 10 swatches when expanded");
-
-    legend.orientation("left");
-    let leftSwatches = legend.content().selectAll(".swatch");
-    assert.isTrue(leftSwatches.size() > numSwatches, "there are more than 10 swatches when expanded");
-
-    legend.orientation("right");
-    let rightSwatches = legend.content().selectAll(".swatch");
-    assert.isTrue(rightSwatches.size() > numSwatches, "there are more than 10 swatches when expanded");
-
+    legend.renderTo(svg);
+    let orientations = ["horizontal", "left", "right"];
+    orientations.forEach((orientation) => {
+      legend.orientation(orientation).expands(false);
+      let numSwatches = legend.content().selectAll(".swatch").size();
+      legend.expands(true);
+      let newNumSwatches = legend.content().selectAll(".swatch").size();
+      assert.isTrue(newNumSwatches > numSwatches, `there are more swatches when expanded (orientation: ${orientation})`);
+    });
     svg.remove();
   });
 });

--- a/test/components/interpolatedColorLegendTests.ts
+++ b/test/components/interpolatedColorLegendTests.ts
@@ -107,9 +107,12 @@ describe("InterpolatedColorLegend", () => {
     legend.renderTo(svg);
     let style = legend.content().append("style");
     style.attr("type", "text/css");
-    style.text(".plottable .interpolated-color-legend text { font-size: 0px; }");
-    assert.doesNotThrow(() => legend.expands(true), Error, "it does not throw error when font-size is 0px");
+    style.text(".plottable .interpolated-color-legend text { font-size: 0px; }" +
+               ".plottable .interpolated-color-legend { display: none; }");
+    let textHeight = (<any> legend)._measurer.measure().height;
 
+    assert.doesNotThrow(() => legend.expands(true), Error, "it does not throw error when text height is 0");
+    assert.strictEqual(textHeight, 0, "text height is set to 0");
     style.remove();
     svg.remove();
   });

--- a/test/components/interpolatedColorLegendTests.ts
+++ b/test/components/interpolatedColorLegendTests.ts
@@ -3,10 +3,10 @@
 describe("InterpolatedColorLegend", () => {
   let svg: d3.Selection<void>;
   let colorScale: Plottable.Scales.InterpolatedColor;
-  let SVG_HEIGNT = 400;
+  let SVG_HEIGHT = 400;
   let SVG_WIDTH = 400;
   beforeEach(() => {
-    svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGNT);
+    svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
     colorScale = new Plottable.Scales.InterpolatedColor();
   });
 
@@ -22,7 +22,7 @@ describe("InterpolatedColorLegend", () => {
                        colorScale.scale(scaleDomain[1]),
                        "last swatch's color corresponds with second domain value");
     let defaultNumSwatches = (<any> Plottable.Components.InterpolatedColorLegend)._DEFAULT_NUM_SWATCHES;
-    assert.isTrue(swatches.size() >= defaultNumSwatches, "there are at least 10 swatches");
+    assert.operator(swatches.size(), ">=", defaultNumSwatches, "there are at least 11 swatches");
 
     let swatchContainer = legendElement.select(".swatch-container");
     let swatchContainerBCR = (<Element> swatchContainer.node()).getBoundingClientRect();
@@ -99,6 +99,18 @@ describe("InterpolatedColorLegend", () => {
     assert.operator(upperLabelBCR.left, "<=", swatchContainerBCR.left, "second label to left of swatches");
     assert.operator(upperLabelBCR.bottom, "<=", lowerLabelBCR.top, "lower label is drawn below upper label");
 
+    svg.remove();
+  });
+
+  it("does not crash when font-size is 0px", () => {
+    let legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    legend.renderTo(svg);
+    let style = (<any> legend)._element.append("style");
+    style.attr("type", "text/css");
+    style.text(".plottable .legend { font-size: 0px; }");
+    assert.doesNotThrow(() => legend.expands(true), Error, "it does not throw error when font-size is 0px");
+
+    style.remove();
     svg.remove();
   });
 
@@ -239,7 +251,7 @@ describe("InterpolatedColorLegend", () => {
     legend.orientation("left");
     legend.expands(true);
     legend.renderTo(svg);
-    assert.strictEqual(legend.height(), SVG_HEIGNT, "legend height is the same as svg height");
+    assert.strictEqual(legend.height(), SVG_HEIGHT, "legend height is the same as svg height");
     svg.remove();
   });
 
@@ -260,7 +272,7 @@ describe("InterpolatedColorLegend", () => {
       let numSwatches = legend.content().selectAll(".swatch").size();
       legend.expands(true);
       let newNumSwatches = legend.content().selectAll(".swatch").size();
-      assert.isTrue(newNumSwatches > numSwatches, `there are more swatches when expanded (orientation: ${orientation})`);
+      assert.operator(newNumSwatches, ">", numSwatches, `there are more swatches when expanded (orientation: ${orientation})`);
     });
     svg.remove();
   });

--- a/test/components/interpolatedColorLegendTests.ts
+++ b/test/components/interpolatedColorLegendTests.ts
@@ -3,9 +3,10 @@
 describe("InterpolatedColorLegend", () => {
   let svg: d3.Selection<void>;
   let colorScale: Plottable.Scales.InterpolatedColor;
-
+  let SVG_HEIGNT = 400;
+  let SVG_WIDTH = 400;
   beforeEach(() => {
-    svg = TestMethods.generateSVG(400, 400);
+    svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGNT);
     colorScale = new Plottable.Scales.InterpolatedColor();
   });
 
@@ -185,6 +186,62 @@ describe("InterpolatedColorLegend", () => {
     legend.orientation("left");
     legend.renderTo(svg);
     assertBasicRendering(legend);
+    svg.remove();
+  });
+
+  it("fixed height if fixedSize is set to true or orientation is horizontal", () => {
+    let legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    assert.isTrue(legend.fixedHeight(), "height is fixed on default");
+
+    legend.fixedSize(false);
+    assert.isTrue(legend.fixedHeight(), "height is fixed oriented horizontally");
+
+    legend.orientation("left");
+    assert.isFalse(legend.fixedHeight(), "height is not fixed oriented vertically");
+
+    legend.orientation("right");
+    assert.isFalse(legend.fixedHeight(), "height is not fixed oriented vertically");
+
+    legend.fixedSize(true);
+    assert.isTrue(legend.fixedHeight(), "height is fixed when fixedSize is set to true");
+
+    svg.remove();
+  });
+
+  it("fixed width if fixedSize is set to true or orientation is vertically", () => {
+    let legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    assert.isTrue(legend.fixedWidth(), "width is fixed on default");
+
+    legend.fixedSize(false);
+    assert.isFalse(legend.fixedWidth(), "width is not fixed oriented horizontally");
+
+    legend.orientation("left");
+    assert.isTrue(legend.fixedWidth(), "width is fixed oriented vertically");
+
+    legend.orientation("right");
+    assert.isTrue(legend.fixedWidth(), "width is fixed oriented vertically");
+
+    legend.fixedSize(true);
+    legend.orientation("horizontal");
+    assert.isTrue(legend.fixedWidth(), "width is fixed when fixedSize is set to true");
+
+    svg.remove();
+  });
+
+  it("spams the entire height if oriented vertically and fixedSize is set to false", () => {
+    let legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    legend.orientation("left");
+    legend.fixedSize(false);
+    legend.renderTo(svg);
+    assert.closeTo(legend.height(), SVG_HEIGNT, 0.01, "legend height is the same as svg height");
+    svg.remove();
+  });
+
+  it("spams the entire width if oriented horizontally and fixedSize is set to false", () => {
+    let legend = new Plottable.Components.InterpolatedColorLegend(colorScale);
+    legend.fixedSize(false);
+    legend.renderTo(svg);
+    assert.closeTo(legend.width(), SVG_WIDTH, 0.01, "legend width is the same as svg width");
     svg.remove();
   });
 });


### PR DESCRIPTION
closes #1568
demo: http://jsfiddle.net/ztsai/mwowegms/11

```expands(expands?: boolean)``` gets/sets whether the legend will expand in the long direction
if `expands` is set to `true` then the legend would span either the width or height depending on the orientation
