### PR TITLE
Refactor selection box layer - Pass 1

### DIFF
--- a/test/components/selectionBoxLayerTests.ts
+++ b/test/components/selectionBoxLayerTests.ts
@@ -15,7 +15,7 @@ describe("Interactive Components", () => {
         sbl = new Plottable.Components.SelectionBoxLayer();
       });
 
-      it("can get and set the boxVisible() property", () => {
+      it("can set the boxVisible() property", () => {
         assert.strictEqual(sbl.boxVisible(), false, "The box is not visible by default");
 
         sbl.renderTo(svg);
@@ -48,7 +48,7 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
-      it("can get and set the bounds() property", () => {
+      it("can set the bounds() property", () => {
         let defaultBounds = sbl.bounds();
         assert.strictEqual(defaultBounds.topLeft.x, 0, "top-left bound is correct (x)");
         assert.strictEqual(defaultBounds.topLeft.y, 0, "top-left bound is correct (y)");
@@ -108,7 +108,7 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
-      it("can get and set the xScale() property", () => {
+      it("can set the xScale() property", () => {
         let xScale = new Plottable.Scales.Linear();
         xScale.domain([0, 2000]);
         xScale.range([0, svgWidth]);
@@ -173,7 +173,7 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
-      it("can get and set the yScale() property", () => {
+      it("can set the yScale() property", () => {
         let yScale = new Plottable.Scales.Linear();
         yScale.domain([0, 2000]);
         yScale.range([0, svgHeight]);

--- a/test/components/selectionBoxLayerTests.ts
+++ b/test/components/selectionBoxLayerTests.ts
@@ -26,6 +26,7 @@ describe("Interactive Components", () => {
         sbl.boxVisible(false);
         assert.strictEqual(sbl.boxVisible(), false, "Setting the boxVisible attribute to false works");
 
+        sbl.destroy();
         svg.remove();
       });
 
@@ -43,13 +44,7 @@ describe("Interactive Components", () => {
         selectionBox = svg.select(".selection-box");
         assert.isTrue(selectionBox.empty(), "box is removed from DOM when not showing");
 
-        svg.remove();
-      });
-
-      it("does not error on destroy() when scales are not inputted", () => {
-        sbl.renderTo(svg);
-        assert.doesNotThrow(() => sbl.destroy(), Error, "can destroy even with no scales");
-
+        sbl.destroy();
         svg.remove();
       });
 
@@ -90,6 +85,7 @@ describe("Interactive Components", () => {
         assert.deepEqual(queriedBounds.topLeft, topLeft, "returns correct top-left position");
         assert.deepEqual(queriedBounds.bottomRight, bottomRight, "returns correct bottom-right position");
 
+        sbl.destroy();
         svg.remove();
 
         function assertCorrectRendering(expectedTL: Plottable.Point, expectedBR: Plottable.Point, msg: string) {
@@ -108,6 +104,7 @@ describe("Interactive Components", () => {
         assert.isTrue(sbl.fixedWidth(), "fixed width");
         assert.isTrue(sbl.fixedHeight(), "fixed height");
 
+        sbl.destroy();
         svg.remove();
       });
 
@@ -143,6 +140,7 @@ describe("Interactive Components", () => {
         selectionBox = svg.select(".selection-area");
         assert.strictEqual(selectionBox.attr("x"), "250", "domain change moves box");
 
+        sbl.destroy();
         svg.remove();
       });
 
@@ -171,6 +169,7 @@ describe("Interactive Components", () => {
         assert.strictEqual(sbl.xExtent()[0], xScale.invert(100), "left data value maps correctly");
         assert.strictEqual(sbl.xExtent()[1], xScale.invert(250), "right data value maps correctly");
 
+        sbl.destroy();
         svg.remove();
       });
 
@@ -207,6 +206,7 @@ describe("Interactive Components", () => {
         selectionBox = svg.select(".selection-area");
         assert.strictEqual(selectionBox.attr("y"), "250", "domain change moves box");
 
+        sbl.destroy();
         svg.remove();
       });
 
@@ -236,9 +236,9 @@ describe("Interactive Components", () => {
         assert.strictEqual(sbl.yExtent()[0], yScale.invert(0), "bottom data value maps correctly");
         assert.strictEqual(sbl.yExtent()[1], yScale.invert(300), "top data value maps correctly");
 
+        sbl.destroy();
         svg.remove();
       });
-
     });
   });
 });

--- a/test/components/selectionBoxLayerTests.ts
+++ b/test/components/selectionBoxLayerTests.ts
@@ -8,13 +8,28 @@ describe("Interactive Components", () => {
       let svgHeight = 500;
 
       let svg: d3.Selection<void>;
+      let sbl: Plottable.Components.SelectionBoxLayer;
 
       beforeEach(() => {
         svg = TestMethods.generateSVG(svgWidth, svgHeight);
+        sbl = new Plottable.Components.SelectionBoxLayer();
       });
 
-      it("boxVisible()", () => {
-        let sbl = new Plottable.Components.SelectionBoxLayer();
+      it("can get and set the boxVisible() property", () => {
+        assert.strictEqual(sbl.boxVisible(), false, "The box is not visible by default");
+
+        sbl.renderTo(svg);
+        assert.strictEqual(sbl.boxVisible(), false, "The box is not visible by default after rendering to svg");
+
+        assert.strictEqual(sbl.boxVisible(true), sbl, "Setting the boxVisible attribute returns the selection box layer");
+        assert.strictEqual(sbl.boxVisible(), true, "Setting the boxVisible to true attribute works");
+        sbl.boxVisible(false);
+        assert.strictEqual(sbl.boxVisible(), false, "Setting the boxVisible attribute to false works");
+
+        svg.remove();
+      });
+
+      it("renders the box in accordance to boxVisible() property", () => {
         sbl.renderTo(svg);
 
         let selectionBox = svg.select(".selection-box");
@@ -31,8 +46,7 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
-      it("destroy() does not error if scales are not inputted", () => {
-        let sbl = new Plottable.Components.SelectionBoxLayer();
+      it("does not error on destroy() when scales are not inputted", () => {
         sbl.renderTo(svg);
         assert.doesNotThrow(() => sbl.destroy(), Error, "can destroy even with no scales");
 
@@ -40,8 +54,6 @@ describe("Interactive Components", () => {
       });
 
       it("bounds()", () => {
-        let sbl = new Plottable.Components.SelectionBoxLayer();
-
         let topLeft: Plottable.Point = {
           x: 100,
           y: 100
@@ -85,7 +97,6 @@ describe("Interactive Components", () => {
       });
 
       it("has an effective size of 0, but will occupy all offered space", () => {
-        let sbl = new Plottable.Components.SelectionBoxLayer();
         let request = sbl.requestedSpace(400, 400);
         TestMethods.verifySpaceRequest(request, 0, 0, "does not request any space");
         assert.isTrue(sbl.fixedWidth(), "fixed width");
@@ -99,7 +110,6 @@ describe("Interactive Components", () => {
         xScale.domain([0, 2000]);
         xScale.range([0, svgWidth]);
 
-        let sbl = new Plottable.Components.SelectionBoxLayer();
         sbl.xScale(xScale);
         sbl.renderTo(svg);
 
@@ -133,7 +143,6 @@ describe("Interactive Components", () => {
         yScale.domain([0, 2000]);
         yScale.range([0, svgHeight]);
 
-        let sbl = new Plottable.Components.SelectionBoxLayer();
         sbl.yScale(yScale);
         sbl.renderTo(svg);
 
@@ -167,7 +176,6 @@ describe("Interactive Components", () => {
         xScale.domain([0, 2000]);
         xScale.range([0, svgHeight]);
 
-        let sbl = new Plottable.Components.SelectionBoxLayer();
         sbl.xScale(xScale);
         sbl.renderTo(svg);
 

--- a/test/components/selectionBoxLayerTests.ts
+++ b/test/components/selectionBoxLayerTests.ts
@@ -53,7 +53,13 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
-      it("bounds()", () => {
+      it("can get and set the bounds() property", () => {
+        let defaultBounds = sbl.bounds();
+        assert.strictEqual(defaultBounds.topLeft.x, 0, "top-left bound is correct (x)");
+        assert.strictEqual(defaultBounds.topLeft.y, 0, "top-left bound is correct (y)");
+        assert.strictEqual(defaultBounds.bottomRight.x, 0, "bottom-right bound is correct (x)");
+        assert.strictEqual(defaultBounds.bottomRight.y, 0, "bottom-right bound is correct (y)");
+
         let topLeft: Plottable.Point = {
           x: 100,
           y: 100
@@ -70,6 +76,22 @@ describe("Interactive Components", () => {
         sbl.boxVisible(true);
         sbl.renderTo(svg);
 
+        assertCorrectRendering(topLeft, bottomRight, "rendered correctly");
+        let queriedBounds = sbl.bounds();
+        assert.deepEqual(queriedBounds.topLeft, topLeft, "returns correct top-left position");
+        assert.deepEqual(queriedBounds.bottomRight, bottomRight, "returns correct bottom-right position");
+
+        assert.strictEqual(sbl.bounds({
+          topLeft: bottomRight,
+          bottomRight: topLeft
+        }), sbl, "Setting the bounds property returns the selection box layer");
+        assertCorrectRendering(topLeft, bottomRight, "rendered correctly with reversed bounds");
+        queriedBounds = sbl.bounds();
+        assert.deepEqual(queriedBounds.topLeft, topLeft, "returns correct top-left position");
+        assert.deepEqual(queriedBounds.bottomRight, bottomRight, "returns correct bottom-right position");
+
+        svg.remove();
+
         function assertCorrectRendering(expectedTL: Plottable.Point, expectedBR: Plottable.Point, msg: string) {
           let selectionBox = svg.select(".selection-box");
           let bbox = Plottable.Utils.DOM.elementBBox(selectionBox);
@@ -78,22 +100,6 @@ describe("Interactive Components", () => {
           assert.strictEqual(bbox.width, expectedBR.x - expectedTL.x, msg + " (width)");
           assert.strictEqual(bbox.height, expectedBR.y - expectedTL.y, msg + " (height)");
         }
-
-        assertCorrectRendering(topLeft, bottomRight, "rendered correctly");
-        let queriedBounds = sbl.bounds();
-        assert.deepEqual(queriedBounds.topLeft, topLeft, "returns correct top-left position");
-        assert.deepEqual(queriedBounds.bottomRight, bottomRight, "returns correct bottom-right position");
-
-        sbl.bounds({
-          topLeft: bottomRight,
-          bottomRight: topLeft
-        });
-        assertCorrectRendering(topLeft, bottomRight, "rendered correctly with reversed bounds");
-        queriedBounds = sbl.bounds();
-        assert.deepEqual(queriedBounds.topLeft, topLeft, "returns correct top-left position");
-        assert.deepEqual(queriedBounds.bottomRight, bottomRight, "returns correct bottom-right position");
-
-        svg.remove();
       });
 
       it("has an effective size of 0, but will occupy all offered space", () => {
@@ -105,12 +111,14 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
-      it("xScale()", () => {
+      it("can get and set the xScale() property", () => {
         let xScale = new Plottable.Scales.Linear();
         xScale.domain([0, 2000]);
         xScale.range([0, svgWidth]);
 
-        sbl.xScale(xScale);
+        assert.isUndefined(sbl.xScale(), "no xScale is specified by default");
+        assert.strictEqual(sbl.xScale(xScale), sbl, "setting the xScale returns the selection box layer");
+        assert.strictEqual(sbl.xScale(), xScale, "The getter returns the correct scale");
         sbl.renderTo(svg);
 
         let topLeft: Plottable.Point = {
@@ -138,12 +146,15 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
-      it("yScale()", () => {
+      it("can get and set the yScale() property", () => {
         let yScale = new Plottable.Scales.Linear();
         yScale.domain([0, 2000]);
         yScale.range([0, svgHeight]);
 
-        sbl.yScale(yScale);
+        assert.isUndefined(sbl.yScale(), "no yScale is specified by default");
+        assert.strictEqual(sbl.yScale(yScale), sbl, "setting the yScale returns the selection box layer");
+        assert.strictEqual(sbl.yScale(), yScale, "The getter returns the correct scale");
+
         sbl.renderTo(svg);
 
         let topLeft: Plottable.Point = {

--- a/test/components/selectionBoxLayerTests.ts
+++ b/test/components/selectionBoxLayerTests.ts
@@ -1,193 +1,194 @@
 ///<reference path="../testReference.ts" />
 
-describe("SelectionBoxLayer", () => {
-  it("boxVisible()", () => {
-    let svg = TestMethods.generateSVG();
-    let sbl = new Plottable.Components.SelectionBoxLayer();
-    sbl.renderTo(svg);
+describe("Interactive Components", () => {
+  describe("SelectionBoxLayer", () => {
 
-    let selectionBox = svg.select(".selection-box");
-    assert.isTrue(selectionBox.empty(), "initilizes without box in DOM");
+    describe("Basic Usage", () => {
+      let svgWidth = 500;
+      let svgHeight = 500;
 
-    sbl.boxVisible(true);
-    selectionBox = svg.select(".selection-box");
-    assert.isFalse(selectionBox.empty(), "box is inserted in DOM when showing");
+      let svg: d3.Selection<void>;
 
-    sbl.boxVisible(false);
-    selectionBox = svg.select(".selection-box");
-    assert.isTrue(selectionBox.empty(), "box is removed from DOM when not showing");
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(svgWidth, svgHeight);
+      });
 
-    svg.remove();
-  });
+      it("boxVisible()", () => {
+        let sbl = new Plottable.Components.SelectionBoxLayer();
+        sbl.renderTo(svg);
 
-  it("destroy() does not error if scales are not inputted", () => {
-    let svg = TestMethods.generateSVG();
-    let sbl = new Plottable.Components.SelectionBoxLayer();
-    sbl.renderTo(svg);
-    assert.doesNotThrow(() => sbl.destroy(), Error, "can destroy even with no scales");
+        let selectionBox = svg.select(".selection-box");
+        assert.isTrue(selectionBox.empty(), "initilizes without box in DOM");
 
-    svg.remove();
-  });
+        sbl.boxVisible(true);
+        selectionBox = svg.select(".selection-box");
+        assert.isFalse(selectionBox.empty(), "box is inserted in DOM when showing");
 
-  it("bounds()", () => {
-    let svg = TestMethods.generateSVG();
-    let sbl = new Plottable.Components.SelectionBoxLayer();
+        sbl.boxVisible(false);
+        selectionBox = svg.select(".selection-box");
+        assert.isTrue(selectionBox.empty(), "box is removed from DOM when not showing");
 
-    let topLeft: Plottable.Point = {
-      x: 100,
-      y: 100
-    };
-    let bottomRight: Plottable.Point = {
-      x: 300,
-      y: 300
-    };
-    assert.doesNotThrow(() => sbl.bounds({
-      topLeft: topLeft,
-      bottomRight: bottomRight
-    }), Error, "can set bounds before anchoring");
+        svg.remove();
+      });
 
-    sbl.boxVisible(true);
-    sbl.renderTo(svg);
+      it("destroy() does not error if scales are not inputted", () => {
+        let sbl = new Plottable.Components.SelectionBoxLayer();
+        sbl.renderTo(svg);
+        assert.doesNotThrow(() => sbl.destroy(), Error, "can destroy even with no scales");
 
-    function assertCorrectRendering(expectedTL: Plottable.Point, expectedBR: Plottable.Point, msg: string) {
-      let selectionBox = svg.select(".selection-box");
-      let bbox = Plottable.Utils.DOM.elementBBox(selectionBox);
-      assert.strictEqual(bbox.x, expectedTL.x, msg + " (x-origin)");
-      assert.strictEqual(bbox.x, expectedTL.y, msg + " (y-origin)");
-      assert.strictEqual(bbox.width, expectedBR.x - expectedTL.x, msg + " (width)");
-      assert.strictEqual(bbox.height, expectedBR.y - expectedTL.y, msg + " (height)");
-    }
+        svg.remove();
+      });
 
-    assertCorrectRendering(topLeft, bottomRight, "rendered correctly");
-    let queriedBounds = sbl.bounds();
-    assert.deepEqual(queriedBounds.topLeft, topLeft, "returns correct top-left position");
-    assert.deepEqual(queriedBounds.bottomRight, bottomRight, "returns correct bottom-right position");
+      it("bounds()", () => {
+        let sbl = new Plottable.Components.SelectionBoxLayer();
 
-    sbl.bounds({
-      topLeft: bottomRight,
-      bottomRight: topLeft
+        let topLeft: Plottable.Point = {
+          x: 100,
+          y: 100
+        };
+        let bottomRight: Plottable.Point = {
+          x: 300,
+          y: 300
+        };
+        assert.doesNotThrow(() => sbl.bounds({
+          topLeft: topLeft,
+          bottomRight: bottomRight
+        }), Error, "can set bounds before anchoring");
+
+        sbl.boxVisible(true);
+        sbl.renderTo(svg);
+
+        function assertCorrectRendering(expectedTL: Plottable.Point, expectedBR: Plottable.Point, msg: string) {
+          let selectionBox = svg.select(".selection-box");
+          let bbox = Plottable.Utils.DOM.elementBBox(selectionBox);
+          assert.strictEqual(bbox.x, expectedTL.x, msg + " (x-origin)");
+          assert.strictEqual(bbox.x, expectedTL.y, msg + " (y-origin)");
+          assert.strictEqual(bbox.width, expectedBR.x - expectedTL.x, msg + " (width)");
+          assert.strictEqual(bbox.height, expectedBR.y - expectedTL.y, msg + " (height)");
+        }
+
+        assertCorrectRendering(topLeft, bottomRight, "rendered correctly");
+        let queriedBounds = sbl.bounds();
+        assert.deepEqual(queriedBounds.topLeft, topLeft, "returns correct top-left position");
+        assert.deepEqual(queriedBounds.bottomRight, bottomRight, "returns correct bottom-right position");
+
+        sbl.bounds({
+          topLeft: bottomRight,
+          bottomRight: topLeft
+        });
+        assertCorrectRendering(topLeft, bottomRight, "rendered correctly with reversed bounds");
+        queriedBounds = sbl.bounds();
+        assert.deepEqual(queriedBounds.topLeft, topLeft, "returns correct top-left position");
+        assert.deepEqual(queriedBounds.bottomRight, bottomRight, "returns correct bottom-right position");
+
+        svg.remove();
+      });
+
+      it("has an effective size of 0, but will occupy all offered space", () => {
+        let sbl = new Plottable.Components.SelectionBoxLayer();
+        let request = sbl.requestedSpace(400, 400);
+        TestMethods.verifySpaceRequest(request, 0, 0, "does not request any space");
+        assert.isTrue(sbl.fixedWidth(), "fixed width");
+        assert.isTrue(sbl.fixedHeight(), "fixed height");
+
+        svg.remove();
+      });
+
+      it("xScale()", () => {
+        let xScale = new Plottable.Scales.Linear();
+        xScale.domain([0, 2000]);
+        xScale.range([0, svgWidth]);
+
+        let sbl = new Plottable.Components.SelectionBoxLayer();
+        sbl.xScale(xScale);
+        sbl.renderTo(svg);
+
+        let topLeft: Plottable.Point = {
+          x: 0,
+          y: 0
+        };
+        let bottomRight: Plottable.Point = {
+          x: 250,
+          y: 300
+        };
+        sbl.bounds({
+          topLeft: topLeft,
+          bottomRight: bottomRight
+        });
+
+        sbl.boxVisible(true);
+        let selectionBox = svg.select(".selection-area");
+        assert.strictEqual(selectionBox.attr("x"), "0", "box starts at left edge");
+
+        xScale.domain([-1000, 1000]);
+
+        selectionBox = svg.select(".selection-area");
+        assert.strictEqual(selectionBox.attr("x"), "250", "domain change moves box");
+
+        svg.remove();
+      });
+
+      it("yScale()", () => {
+        let yScale = new Plottable.Scales.Linear();
+        yScale.domain([0, 2000]);
+        yScale.range([0, svgHeight]);
+
+        let sbl = new Plottable.Components.SelectionBoxLayer();
+        sbl.yScale(yScale);
+        sbl.renderTo(svg);
+
+        let topLeft: Plottable.Point = {
+          x: 0,
+          y: 0
+        };
+        let bottomRight: Plottable.Point = {
+          x: 250,
+          y: 300
+        };
+        sbl.bounds({
+          topLeft: topLeft,
+          bottomRight: bottomRight
+        });
+
+        sbl.boxVisible(true);
+        let selectionBox = svg.select(".selection-area");
+        assert.strictEqual(selectionBox.attr("y"), "0", "box starts at top edge");
+
+        yScale.domain([-1000, 1000]);
+
+        selectionBox = svg.select(".selection-area");
+        assert.strictEqual(selectionBox.attr("y"), "250", "domain change moves box");
+
+        svg.remove();
+      });
+
+      it("boxDataValue endpoints", () => {
+        let xScale = new Plottable.Scales.Linear();
+        xScale.domain([0, 2000]);
+        xScale.range([0, svgHeight]);
+
+        let sbl = new Plottable.Components.SelectionBoxLayer();
+        sbl.xScale(xScale);
+        sbl.renderTo(svg);
+
+        let topLeft: Plottable.Point = {
+          x: 100,
+          y: 0
+        };
+        let bottomRight: Plottable.Point = {
+          x: 250,
+          y: 300
+        };
+        sbl.bounds({
+          topLeft: topLeft,
+          bottomRight: bottomRight
+        });
+
+        assert.strictEqual(sbl.xExtent()[0], 400, "data value maps correctly");
+        assert.strictEqual(sbl.xExtent()[1], 1000, "data value maps correctly");
+
+        svg.remove();
+      });
     });
-    assertCorrectRendering(topLeft, bottomRight, "rendered correctly with reversed bounds");
-    queriedBounds = sbl.bounds();
-    assert.deepEqual(queriedBounds.topLeft, topLeft, "returns correct top-left position");
-    assert.deepEqual(queriedBounds.bottomRight, bottomRight, "returns correct bottom-right position");
-
-    svg.remove();
-  });
-
-  it("has an effective size of 0, but will occupy all offered space", () => {
-    let sbl = new Plottable.Components.SelectionBoxLayer();
-    let request = sbl.requestedSpace(400, 400);
-    TestMethods.verifySpaceRequest(request, 0, 0, "does not request any space");
-    assert.isTrue(sbl.fixedWidth(), "fixed width");
-    assert.isTrue(sbl.fixedHeight(), "fixed height");
-  });
-
-  it("xScale()", () => {
-    let svgWidth = 500;
-    let svgHeight = 500;
-    let svg = TestMethods.generateSVG(svgWidth, svgHeight);
-
-    let xScale = new Plottable.Scales.Linear();
-    xScale.domain([0, 2000]);
-    xScale.range([0, svgWidth]);
-
-    let sbl = new Plottable.Components.SelectionBoxLayer();
-    sbl.xScale(xScale);
-    sbl.renderTo(svg);
-
-    let topLeft: Plottable.Point = {
-      x: 0,
-      y: 0
-    };
-    let bottomRight: Plottable.Point = {
-      x: 250,
-      y: 300
-    };
-    sbl.bounds({
-      topLeft: topLeft,
-      bottomRight: bottomRight
-    });
-
-    sbl.boxVisible(true);
-    let selectionBox = svg.select(".selection-area");
-    assert.strictEqual(selectionBox.attr("x"), "0", "box starts at left edge");
-
-    xScale.domain([-1000, 1000]);
-
-    selectionBox = svg.select(".selection-area");
-    assert.strictEqual(selectionBox.attr("x"), "250", "domain change moves box");
-
-    svg.remove();
-  });
-
-  it("yScale()", () => {
-    let svgWidth = 500;
-    let svgHeight = 500;
-    let svg = TestMethods.generateSVG(svgWidth, svgHeight);
-
-    let yScale = new Plottable.Scales.Linear();
-    yScale.domain([0, 2000]);
-    yScale.range([0, svgHeight]);
-
-    let sbl = new Plottable.Components.SelectionBoxLayer();
-    sbl.yScale(yScale);
-    sbl.renderTo(svg);
-
-    let topLeft: Plottable.Point = {
-      x: 0,
-      y: 0
-    };
-    let bottomRight: Plottable.Point = {
-      x: 250,
-      y: 300
-    };
-    sbl.bounds({
-      topLeft: topLeft,
-      bottomRight: bottomRight
-    });
-
-    sbl.boxVisible(true);
-    let selectionBox = svg.select(".selection-area");
-    assert.strictEqual(selectionBox.attr("y"), "0", "box starts at top edge");
-
-    yScale.domain([-1000, 1000]);
-
-    selectionBox = svg.select(".selection-area");
-    assert.strictEqual(selectionBox.attr("y"), "250", "domain change moves box");
-
-    svg.remove();
-  });
-
-  it("boxDataValue endpoints", () => {
-    let svgWidth = 500;
-    let svgHeight = 500;
-    let svg = TestMethods.generateSVG(svgWidth, svgHeight);
-
-    let xScale = new Plottable.Scales.Linear();
-    xScale.domain([0, 2000]);
-    xScale.range([0, svgHeight]);
-
-    let sbl = new Plottable.Components.SelectionBoxLayer();
-    sbl.xScale(xScale);
-    sbl.renderTo(svg);
-
-    let topLeft: Plottable.Point = {
-      x: 100,
-      y: 0
-    };
-    let bottomRight: Plottable.Point = {
-      x: 250,
-      y: 300
-    };
-    sbl.bounds({
-      topLeft: topLeft,
-      bottomRight: bottomRight
-    });
-
-    assert.strictEqual(sbl.xExtent()[0], 400, "data value maps correctly");
-    assert.strictEqual(sbl.xExtent()[1], 1000, "data value maps correctly");
-
-    svg.remove();
   });
 });

--- a/test/components/selectionBoxLayerTests.ts
+++ b/test/components/selectionBoxLayerTests.ts
@@ -146,6 +146,34 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
+      it("gets the correct xExtent", () => {
+        let xScale = new Plottable.Scales.Linear();
+        xScale.domain([0, 2000]);
+        xScale.range([0, svgWidth]);
+
+        assert.deepEqual(sbl.xExtent(), [undefined, undefined], "xExtent is not set unless an yScale is set");
+        sbl.xScale(xScale);
+        sbl.renderTo(svg);
+
+        let topLeft: Plottable.Point = {
+          x: 100,
+          y: 0
+        };
+        let bottomRight: Plottable.Point = {
+          x: 250,
+          y: 300
+        };
+        sbl.bounds({
+          topLeft: topLeft,
+          bottomRight: bottomRight
+        });
+
+        assert.strictEqual(sbl.xExtent()[0], xScale.invert(100), "left data value maps correctly");
+        assert.strictEqual(sbl.xExtent()[1], xScale.invert(250), "right data value maps correctly");
+
+        svg.remove();
+      });
+
       it("can get and set the yScale() property", () => {
         let yScale = new Plottable.Scales.Linear();
         yScale.domain([0, 2000]);
@@ -182,12 +210,14 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
-      it("boxDataValue endpoints", () => {
-        let xScale = new Plottable.Scales.Linear();
-        xScale.domain([0, 2000]);
-        xScale.range([0, svgHeight]);
+      it("gets the correct yExtent", () => {
+        let yScale = new Plottable.Scales.Linear();
+        yScale.domain([0, 2000]);
+        yScale.range([0, svgHeight]);
 
-        sbl.xScale(xScale);
+        assert.deepEqual(sbl.yExtent(), [undefined, undefined], "yExtent is not set unless an yScale is set");
+
+        sbl.yScale(yScale);
         sbl.renderTo(svg);
 
         let topLeft: Plottable.Point = {
@@ -203,11 +233,12 @@ describe("Interactive Components", () => {
           bottomRight: bottomRight
         });
 
-        assert.strictEqual(sbl.xExtent()[0], 400, "data value maps correctly");
-        assert.strictEqual(sbl.xExtent()[1], 1000, "data value maps correctly");
+        assert.strictEqual(sbl.yExtent()[0], yScale.invert(0), "bottom data value maps correctly");
+        assert.strictEqual(sbl.yExtent()[1], yScale.invert(300), "top data value maps correctly");
 
         svg.remove();
       });
+
     });
   });
 });


### PR DESCRIPTION
Part of #2623 

I will be doing 2 passes because I will get more context (and better sense of best practices) by refactoring other files. However, please flag anything that seems unusual.

As part of this: 
- **Test semantics: hierarchy, naming, testing, but no coverage check**
- Applied best practices from the wiki page
- Factored out common code into `beforeEach()` clauses
- No nested `beforeEach()`es
- Remade hierarchy as shown bellow
![screen shot 2015-08-24 at 12 59 14 pm](https://cloud.githubusercontent.com/assets/3248682/9450855/f2431ab0-4a5f-11e5-8bba-c94779d8545b.png)
