### PR TITLE
Refactor x/y drag box layer tests - Pass 1

### DIFF
--- a/test/components/xDragBoxLayerTests.ts
+++ b/test/components/xDragBoxLayerTests.ts
@@ -4,7 +4,7 @@ describe("Layer Components", () => {
   describe("XDragBoxLayer", () => {
     describe("Basic Usage", () => {
       let SVG_WIDTH = 400;
-      let SVG_HEIGHT = 400;
+      let SVG_HEIGHT = 300;
 
       let quarterTopLeftPoint = {
         x: SVG_WIDTH / 4,
@@ -27,7 +27,7 @@ describe("Layer Components", () => {
         dbl = new Plottable.Components.XDragBoxLayer();
       });
 
-      it("has the correct bounds()", () => {
+      it("has bounds() that extend across full SVG height", () => {
         dbl.boxVisible(true);
         dbl.renderTo(svg);
 
@@ -39,7 +39,7 @@ describe("Layer Components", () => {
         let actualBounds = dbl.bounds();
         assert.strictEqual(actualBounds.topLeft.y, 0, "box starts at top");
         assert.strictEqual(actualBounds.topLeft.x, quarterTopLeftPoint.x, "left edge set correctly");
-        assert.strictEqual(actualBounds.bottomRight.y, dbl.height(), "box ends at bottom");
+        assert.strictEqual(actualBounds.bottomRight.y, SVG_HEIGHT, "box ends at bottom");
         assert.strictEqual(actualBounds.bottomRight.x, middlePoint.x, "right edge set correctly");
 
         svg.remove();
@@ -56,19 +56,15 @@ describe("Layer Components", () => {
         });
 
         let actualBounds = dbl.bounds();
-        let dragTo = {
-          x: SVG_WIDTH * 3 / 4,
-          y: SVG_HEIGHT / 2
-        };
-        TestMethods.triggerFakeDragSequence(dbl.background(), actualBounds.bottomRight, dragTo);
+        TestMethods.triggerFakeDragSequence(dbl.background(), actualBounds.bottomRight, quarterBottomRightPoint);
         actualBounds = dbl.bounds();
-        assert.strictEqual(actualBounds.bottomRight.x, dragTo.x, "resized in x");
+        assert.strictEqual(actualBounds.bottomRight.x, quarterBottomRightPoint.x, "resized in x");
         assert.strictEqual(actualBounds.topLeft.y, 0, "box still starts at top");
-        assert.strictEqual(actualBounds.bottomRight.y, dbl.height(), "box still ends at bottom");
+        assert.strictEqual(actualBounds.bottomRight.y, SVG_HEIGHT, "box still ends at bottom");
         svg.remove();
       });
 
-      it("stays full height after resizing", () => {
+      it("adapts to new SVG heights upon redraws", () => {
         dbl.boxVisible(true);
         dbl.resizable(true);
         dbl.renderTo(svg);
@@ -88,7 +84,7 @@ describe("Layer Components", () => {
         assert.strictEqual(boundsAfter.topLeft.x, boundsBefore.topLeft.x, "box keeps same left edge");
         assert.strictEqual(boundsAfter.topLeft.y, 0, "box still starts at top");
         assert.strictEqual(boundsAfter.bottomRight.x, boundsBefore.bottomRight.x, "box keeps same right edge");
-        assert.strictEqual(boundsAfter.bottomRight.y, dbl.height(), "box still ends at bottom");
+        assert.strictEqual(boundsAfter.bottomRight.y, SVG_HEIGHT * 2, "box still ends at bottom");
         svg.remove();
       });
 
@@ -128,7 +124,7 @@ describe("Layer Components", () => {
         assert.strictEqual(boundsAfter.topLeft.x, boundsBefore.topLeft.x + dragDistance, "left edge moved");
         assert.strictEqual(boundsAfter.topLeft.y, 0, "box still starts at top");
         assert.strictEqual(boundsAfter.bottomRight.x, boundsBefore.bottomRight.x + dragDistance, "right edge moved");
-        assert.strictEqual(boundsAfter.bottomRight.y, dbl.height(), "box still ends at bottom");
+        assert.strictEqual(boundsAfter.bottomRight.y, SVG_HEIGHT, "box still ends at bottom");
 
         svg.remove();
       });

--- a/test/components/xDragBoxLayerTests.ts
+++ b/test/components/xDragBoxLayerTests.ts
@@ -29,7 +29,7 @@ describe("Interactive Components", () => {
         dbl = new Plottable.Components.XDragBoxLayer();
       });
 
-      it("bounds()", () => {
+      it("has the correct bounds", () => {
         dbl.boxVisible(true);
         dbl.renderTo(svg);
 
@@ -147,7 +147,7 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
-      it("destroy() does not error if scales are not inputted", () => {
+      it("does not error on destroy() when scales are not inputted", () => {
         dbl.renderTo(svg);
         assert.doesNotThrow(() => dbl.destroy(), Error, "can destroy");
         svg.remove();

--- a/test/components/xDragBoxLayerTests.ts
+++ b/test/components/xDragBoxLayerTests.ts
@@ -2,9 +2,7 @@
 
 describe("Interactive Components", () => {
   describe("XDragBoxLayer", () => {
-
     describe("Basic Usage", () => {
-
       let SVG_WIDTH = 400;
       let SVG_HEIGHT = 400;
 
@@ -29,7 +27,7 @@ describe("Interactive Components", () => {
         dbl = new Plottable.Components.XDragBoxLayer();
       });
 
-      it("has the correct bounds", () => {
+      it("has the correct bounds()", () => {
         dbl.boxVisible(true);
         dbl.renderTo(svg);
 

--- a/test/components/xDragBoxLayerTests.ts
+++ b/test/components/xDragBoxLayerTests.ts
@@ -21,9 +21,15 @@ describe("Interactive Components", () => {
           y: SVG_HEIGHT * 3 / 4
       };
 
+      let svg: d3.Selection<void>;
+      let dbl: Plottable.Components.XDragBoxLayer;
+
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        dbl = new Plottable.Components.XDragBoxLayer();
+      });
+
       it("bounds()", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        let dbl = new Plottable.Components.XDragBoxLayer();
         dbl.boxVisible(true);
         dbl.renderTo(svg);
 
@@ -42,8 +48,6 @@ describe("Interactive Components", () => {
       });
 
       it("resizes only in x", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        let dbl = new Plottable.Components.XDragBoxLayer();
         dbl.boxVisible(true);
         dbl.resizable(true);
         dbl.renderTo(svg);
@@ -67,8 +71,6 @@ describe("Interactive Components", () => {
       });
 
       it("stays full height after resizing", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        let dbl = new Plottable.Components.XDragBoxLayer();
         dbl.boxVisible(true);
         dbl.resizable(true);
         dbl.renderTo(svg);
@@ -93,23 +95,21 @@ describe("Interactive Components", () => {
       });
 
       it("throws error on getting y scale", () => {
-        let dbl = new Plottable.Components.XDragBoxLayer();
         assert.throws(() => dbl.yScale(), "no yScale");
+        svg.remove();
       });
 
       it("throws error on setting y scale", () => {
-        let dbl = new Plottable.Components.XDragBoxLayer();
         assert.throws(() => dbl.yScale(new Plottable.Scales.Linear()), "yScales cannot be set");
+        svg.remove();
       });
 
       it("throws error on getting y extent", () => {
-        let dbl = new Plottable.Components.XDragBoxLayer();
         assert.throws(() => dbl.yExtent(), "no yExtent");
+        svg.remove();
       });
 
       it("moves only in x", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        let dbl = new Plottable.Components.XDragBoxLayer();
         dbl.boxVisible(true);
         dbl.movable(true);
         dbl.renderTo(svg);
@@ -136,22 +136,20 @@ describe("Interactive Components", () => {
       });
 
       it("does not have resizable CSS class when enabled(false)", () => {
-        let xdbl = new Plottable.Components.XDragBoxLayer();
-        xdbl.resizable(true);
-        assert.isTrue(xdbl.hasClass("x-resizable"), "carries \"x-resizable\" class if resizable");
-        xdbl.enabled(false);
-        assert.isFalse(xdbl.hasClass("x-resizable"), "does not carry \"x-resizable\" class if resizable, but not enabled");
-        xdbl.resizable(false);
-        xdbl.enabled(true);
-        assert.isFalse(xdbl.hasClass("x-resizable"), "does not carry \"x-resizable\" class if enabled, but not resizable");
+        dbl.resizable(true);
+        assert.isTrue(dbl.hasClass("x-resizable"), "carries \"x-resizable\" class if resizable");
+        dbl.enabled(false);
+        assert.isFalse(dbl.hasClass("x-resizable"), "does not carry \"x-resizable\" class if resizable, but not enabled");
+        dbl.resizable(false);
+        dbl.enabled(true);
+        assert.isFalse(dbl.hasClass("x-resizable"), "does not carry \"x-resizable\" class if enabled, but not resizable");
+
+        svg.remove();
       });
 
       it("destroy() does not error if scales are not inputted", () => {
-        let svg = TestMethods.generateSVG();
-        let sbl = new Plottable.Components.XDragBoxLayer();
-        sbl.renderTo(svg);
-        assert.doesNotThrow(() => sbl.destroy(), Error, "can destroy");
-
+        dbl.renderTo(svg);
+        assert.doesNotThrow(() => dbl.destroy(), Error, "can destroy");
         svg.remove();
       });
     });

--- a/test/components/xDragBoxLayerTests.ts
+++ b/test/components/xDragBoxLayerTests.ts
@@ -2,177 +2,158 @@
 
 describe("Interactive Components", () => {
   describe("XDragBoxLayer", () => {
-    let SVG_WIDTH = 400;
-    let SVG_HEIGHT = 400;
 
-    it("bounds()", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.XDragBoxLayer();
-      dbl.boxVisible(true);
-      dbl.renderTo(svg);
+    describe("Basic Usage", () => {
 
-      let topLeft = {
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 400;
+
+      let quarterTopLeftPoint = {
         x: SVG_WIDTH / 4,
         y: SVG_HEIGHT / 4
       };
-      let bottomRight = {
+      let middlePoint = {
         x: SVG_WIDTH / 2,
         y: SVG_HEIGHT / 2
       };
+      let quarterBottomRightPoint = {
+          x: SVG_WIDTH * 3 / 4,
+          y: SVG_HEIGHT * 3 / 4
+      };
 
-      dbl.bounds({
-        topLeft: topLeft,
-        bottomRight: bottomRight
+      it("bounds()", () => {
+        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        let dbl = new Plottable.Components.XDragBoxLayer();
+        dbl.boxVisible(true);
+        dbl.renderTo(svg);
+
+        dbl.bounds({
+          topLeft: quarterTopLeftPoint,
+          bottomRight: middlePoint
+        });
+
+        let actualBounds = dbl.bounds();
+        assert.strictEqual(actualBounds.topLeft.y, 0, "box starts at top");
+        assert.strictEqual(actualBounds.topLeft.x, quarterTopLeftPoint.x, "left edge set correctly");
+        assert.strictEqual(actualBounds.bottomRight.y, dbl.height(), "box ends at bottom");
+        assert.strictEqual(actualBounds.bottomRight.x, middlePoint.x, "right edge set correctly");
+
+        svg.remove();
       });
 
-      let actualBounds = dbl.bounds();
-      assert.strictEqual(actualBounds.topLeft.y, 0, "box starts at top");
-      assert.strictEqual(actualBounds.topLeft.x, topLeft.x, "left edge set correctly");
-      assert.strictEqual(actualBounds.bottomRight.y, dbl.height(), "box ends at bottom");
-      assert.strictEqual(actualBounds.bottomRight.x, bottomRight.x, "right edge set correctly");
+      it("resizes only in x", () => {
+        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        let dbl = new Plottable.Components.XDragBoxLayer();
+        dbl.boxVisible(true);
+        dbl.resizable(true);
+        dbl.renderTo(svg);
 
-      svg.remove();
-    });
+        dbl.bounds({
+          topLeft: quarterTopLeftPoint,
+          bottomRight: middlePoint
+        });
 
-    it("resizes only in x", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.XDragBoxLayer();
-      dbl.boxVisible(true);
-      dbl.resizable(true);
-      dbl.renderTo(svg);
-
-      let topLeft = {
-        x: SVG_WIDTH / 4,
-        y: SVG_HEIGHT / 4
-      };
-      let bottomRight = {
-        x: SVG_WIDTH / 2,
-        y: SVG_HEIGHT / 2
-      };
-
-      dbl.bounds({
-        topLeft: topLeft,
-        bottomRight: bottomRight
+        let actualBounds = dbl.bounds();
+        let dragTo = {
+          x: SVG_WIDTH * 3 / 4,
+          y: SVG_HEIGHT / 2
+        };
+        TestMethods.triggerFakeDragSequence(dbl.background(), actualBounds.bottomRight, dragTo);
+        actualBounds = dbl.bounds();
+        assert.strictEqual(actualBounds.bottomRight.x, dragTo.x, "resized in x");
+        assert.strictEqual(actualBounds.topLeft.y, 0, "box still starts at top");
+        assert.strictEqual(actualBounds.bottomRight.y, dbl.height(), "box still ends at bottom");
+        svg.remove();
       });
 
-      let actualBounds = dbl.bounds();
-      let dragTo = {
-        x: SVG_WIDTH * 3 / 4,
-        y: SVG_HEIGHT / 2
-      };
-      TestMethods.triggerFakeDragSequence(dbl.background(), actualBounds.bottomRight, dragTo);
-      actualBounds = dbl.bounds();
-      assert.strictEqual(actualBounds.bottomRight.x, dragTo.x, "resized in x");
-      assert.strictEqual(actualBounds.topLeft.y, 0, "box still starts at top");
-      assert.strictEqual(actualBounds.bottomRight.y, dbl.height(), "box still ends at bottom");
-      svg.remove();
-    });
+      it("stays full height after resizing", () => {
+        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        let dbl = new Plottable.Components.XDragBoxLayer();
+        dbl.boxVisible(true);
+        dbl.resizable(true);
+        dbl.renderTo(svg);
 
-    it("stays full height after resizing", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.XDragBoxLayer();
-      dbl.boxVisible(true);
-      dbl.resizable(true);
-      dbl.renderTo(svg);
+        dbl.bounds({
+          topLeft: quarterTopLeftPoint,
+          bottomRight: middlePoint
+        });
 
-      let topLeft = {
-        x: SVG_WIDTH / 4,
-        y: SVG_HEIGHT / 4
-      };
-      let bottomRight = {
-        x: SVG_WIDTH / 2,
-        y: SVG_HEIGHT / 2
-      };
+        let heightBefore = dbl.height();
+        let boundsBefore = dbl.bounds();
+        svg.attr("height", 2 * SVG_HEIGHT);
+        dbl.redraw();
+        assert.notStrictEqual(dbl.height(), heightBefore, "component changed size");
 
-      dbl.bounds({
-        topLeft: topLeft,
-        bottomRight: bottomRight
+        let boundsAfter = dbl.bounds();
+        assert.strictEqual(boundsAfter.topLeft.x, boundsBefore.topLeft.x, "box keeps same left edge");
+        assert.strictEqual(boundsAfter.topLeft.y, 0, "box still starts at top");
+        assert.strictEqual(boundsAfter.bottomRight.x, boundsBefore.bottomRight.x, "box keeps same right edge");
+        assert.strictEqual(boundsAfter.bottomRight.y, dbl.height(), "box still ends at bottom");
+        svg.remove();
       });
 
-      let heightBefore = dbl.height();
-      let boundsBefore = dbl.bounds();
-      svg.attr("height", 2 * SVG_HEIGHT);
-      dbl.redraw();
-      assert.notStrictEqual(dbl.height(), heightBefore, "component changed size");
-
-      let boundsAfter = dbl.bounds();
-      assert.strictEqual(boundsAfter.topLeft.x, boundsBefore.topLeft.x, "box keeps same left edge");
-      assert.strictEqual(boundsAfter.topLeft.y, 0, "box still starts at top");
-      assert.strictEqual(boundsAfter.bottomRight.x, boundsBefore.bottomRight.x, "box keeps same right edge");
-      assert.strictEqual(boundsAfter.bottomRight.y, dbl.height(), "box still ends at bottom");
-      svg.remove();
-    });
-
-    it("throws error on getting y scale", () => {
-      let dbl = new Plottable.Components.XDragBoxLayer();
-      assert.throws(() => dbl.yScale(), "no yScale");
-    });
-
-    it("throws error on setting y scale", () => {
-      let dbl = new Plottable.Components.XDragBoxLayer();
-      assert.throws(() => dbl.yScale(new Plottable.Scales.Linear()), "yScales cannot be set");
-    });
-
-    it("throws error on getting y extent", () => {
-      let dbl = new Plottable.Components.XDragBoxLayer();
-      assert.throws(() => dbl.yExtent(), "no yExtent");
-    });
-
-    it("moves only in x", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.XDragBoxLayer();
-      dbl.boxVisible(true);
-      dbl.movable(true);
-      dbl.renderTo(svg);
-
-      let topLeft = {
-        x: SVG_WIDTH / 4,
-        y: SVG_HEIGHT / 4
-      };
-      let bottomRight = {
-        x: SVG_WIDTH * 3 / 4,
-        y: SVG_HEIGHT * 3 / 4
-      };
-
-      dbl.bounds({
-        topLeft: topLeft,
-        bottomRight: bottomRight
+      it("throws error on getting y scale", () => {
+        let dbl = new Plottable.Components.XDragBoxLayer();
+        assert.throws(() => dbl.yScale(), "no yScale");
       });
 
-      let boundsBefore = dbl.bounds();
-      let dragDistance = 10;
-      TestMethods.triggerFakeDragSequence(dbl.background(),
-        { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 },
-        { x: SVG_WIDTH / 2 + dragDistance, y: SVG_HEIGHT / 2 + dragDistance }
-      );
+      it("throws error on setting y scale", () => {
+        let dbl = new Plottable.Components.XDragBoxLayer();
+        assert.throws(() => dbl.yScale(new Plottable.Scales.Linear()), "yScales cannot be set");
+      });
 
-      let boundsAfter = dbl.bounds();
-      assert.strictEqual(boundsAfter.topLeft.x, boundsBefore.topLeft.x + dragDistance, "left edge moved");
-      assert.strictEqual(boundsAfter.topLeft.y, 0, "box still starts at top");
-      assert.strictEqual(boundsAfter.bottomRight.x, boundsBefore.bottomRight.x + dragDistance, "right edge moved");
-      assert.strictEqual(boundsAfter.bottomRight.y, dbl.height(), "box still ends at bottom");
+      it("throws error on getting y extent", () => {
+        let dbl = new Plottable.Components.XDragBoxLayer();
+        assert.throws(() => dbl.yExtent(), "no yExtent");
+      });
 
-      svg.remove();
-    });
+      it("moves only in x", () => {
+        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        let dbl = new Plottable.Components.XDragBoxLayer();
+        dbl.boxVisible(true);
+        dbl.movable(true);
+        dbl.renderTo(svg);
 
-    it("does not have resizable CSS class when enabled(false)", () => {
-      let xdbl = new Plottable.Components.XDragBoxLayer();
-      xdbl.resizable(true);
-      assert.isTrue(xdbl.hasClass("x-resizable"), "carries \"x-resizable\" class if resizable");
-      xdbl.enabled(false);
-      assert.isFalse(xdbl.hasClass("x-resizable"), "does not carry \"x-resizable\" class if resizable, but not enabled");
-      xdbl.resizable(false);
-      xdbl.enabled(true);
-      assert.isFalse(xdbl.hasClass("x-resizable"), "does not carry \"x-resizable\" class if enabled, but not resizable");
-    });
+        dbl.bounds({
+          topLeft: quarterTopLeftPoint,
+          bottomRight: quarterBottomRightPoint
+        });
 
-    it("destroy() does not error if scales are not inputted", () => {
-      let svg = TestMethods.generateSVG();
-      let sbl = new Plottable.Components.XDragBoxLayer();
-      sbl.renderTo(svg);
-      assert.doesNotThrow(() => sbl.destroy(), Error, "can destroy");
+        let boundsBefore = dbl.bounds();
+        let dragDistance = 10;
+        TestMethods.triggerFakeDragSequence(dbl.background(),
+          { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 },
+          { x: SVG_WIDTH / 2 + dragDistance, y: SVG_HEIGHT / 2 + dragDistance }
+        );
 
-      svg.remove();
+        let boundsAfter = dbl.bounds();
+        assert.strictEqual(boundsAfter.topLeft.x, boundsBefore.topLeft.x + dragDistance, "left edge moved");
+        assert.strictEqual(boundsAfter.topLeft.y, 0, "box still starts at top");
+        assert.strictEqual(boundsAfter.bottomRight.x, boundsBefore.bottomRight.x + dragDistance, "right edge moved");
+        assert.strictEqual(boundsAfter.bottomRight.y, dbl.height(), "box still ends at bottom");
+
+        svg.remove();
+      });
+
+      it("does not have resizable CSS class when enabled(false)", () => {
+        let xdbl = new Plottable.Components.XDragBoxLayer();
+        xdbl.resizable(true);
+        assert.isTrue(xdbl.hasClass("x-resizable"), "carries \"x-resizable\" class if resizable");
+        xdbl.enabled(false);
+        assert.isFalse(xdbl.hasClass("x-resizable"), "does not carry \"x-resizable\" class if resizable, but not enabled");
+        xdbl.resizable(false);
+        xdbl.enabled(true);
+        assert.isFalse(xdbl.hasClass("x-resizable"), "does not carry \"x-resizable\" class if enabled, but not resizable");
+      });
+
+      it("destroy() does not error if scales are not inputted", () => {
+        let svg = TestMethods.generateSVG();
+        let sbl = new Plottable.Components.XDragBoxLayer();
+        sbl.renderTo(svg);
+        assert.doesNotThrow(() => sbl.destroy(), Error, "can destroy");
+
+        svg.remove();
+      });
     });
   });
 });

--- a/test/components/xDragBoxLayerTests.ts
+++ b/test/components/xDragBoxLayerTests.ts
@@ -17,8 +17,8 @@ describe("Interactive Components", () => {
         y: SVG_HEIGHT / 2
       };
       let quarterBottomRightPoint = {
-          x: SVG_WIDTH * 3 / 4,
-          y: SVG_HEIGHT * 3 / 4
+        x: SVG_WIDTH * 3 / 4,
+        y: SVG_HEIGHT * 3 / 4
       };
 
       let svg: d3.Selection<void>;

--- a/test/components/xDragBoxLayerTests.ts
+++ b/test/components/xDragBoxLayerTests.ts
@@ -1,6 +1,6 @@
 ///<reference path="../testReference.ts" />
 
-describe("Interactive Components", () => {
+describe("Layer Components", () => {
   describe("XDragBoxLayer", () => {
     describe("Basic Usage", () => {
       let SVG_WIDTH = 400;

--- a/test/components/yDragBoxLayerTests.ts
+++ b/test/components/yDragBoxLayerTests.ts
@@ -4,7 +4,7 @@ describe("Layer Components", () => {
   describe("YDragBoxLayer", () => {
     describe("Basic usage", () => {
       let SVG_WIDTH = 400;
-      let SVG_HEIGHT = 400;
+      let SVG_HEIGHT = 300;
 
       let quarterTopLeftPoint = {
         x: SVG_WIDTH / 4,
@@ -27,7 +27,7 @@ describe("Layer Components", () => {
         dbl = new Plottable.Components.YDragBoxLayer();
       });
 
-      it("has the correct bounds()", () => {
+      it("has bounds() that extend across full SVG width", () => {
         dbl.boxVisible(true);
         dbl.renderTo(svg);
 
@@ -37,9 +37,9 @@ describe("Layer Components", () => {
         });
 
         let actualBounds = dbl.bounds();
-        assert.strictEqual(actualBounds.topLeft.x, 0, "box starts at left");
+        assert.strictEqual(actualBounds.topLeft.x, 0, "box starts at SVG left edge");
         assert.strictEqual(actualBounds.topLeft.y, quarterTopLeftPoint.y, "top edge set correctly");
-        assert.strictEqual(actualBounds.bottomRight.x, dbl.width(), "box ends at right");
+        assert.strictEqual(actualBounds.bottomRight.x, SVG_WIDTH, "box ends at SVG right edge");
         assert.strictEqual(actualBounds.bottomRight.y, middlePoint.y, "bottom edge set correctly");
 
         svg.remove();
@@ -56,19 +56,15 @@ describe("Layer Components", () => {
         });
 
         let actualBounds = dbl.bounds();
-        let dragTo = {
-          x: SVG_WIDTH / 2,
-          y: SVG_HEIGHT * 3 / 4
-        };
-        TestMethods.triggerFakeDragSequence(dbl.background(), actualBounds.bottomRight, dragTo);
+        TestMethods.triggerFakeDragSequence(dbl.background(), actualBounds.bottomRight, quarterBottomRightPoint);
         actualBounds = dbl.bounds();
         assert.strictEqual(actualBounds.topLeft.x, 0, "box still starts at left");
-        assert.strictEqual(actualBounds.bottomRight.x, dbl.width(), "box still ends at right");
-        assert.strictEqual(actualBounds.bottomRight.y, dragTo.y, "resized in y");
+        assert.strictEqual(actualBounds.bottomRight.x, SVG_WIDTH, "box still ends at right");
+        assert.strictEqual(actualBounds.bottomRight.y, quarterBottomRightPoint.y, "resized in y");
         svg.remove();
       });
 
-      it("stays full width after resizing", () => {
+      it("adapts to new SVG widths upon redraws", () => {
         dbl.boxVisible(true);
         dbl.resizable(true);
         dbl.renderTo(svg);
@@ -87,7 +83,7 @@ describe("Layer Components", () => {
         let boundsAfter = dbl.bounds();
         assert.strictEqual(boundsAfter.topLeft.x, 0, "box still starts at left");
         assert.strictEqual(boundsAfter.topLeft.y, boundsBefore.topLeft.y, "box keeps same top edge");
-        assert.strictEqual(boundsAfter.bottomRight.x, dbl.width(), "box still ends at right");
+        assert.strictEqual(boundsAfter.bottomRight.x, SVG_WIDTH * 2, "box still ends at right");
         assert.strictEqual(boundsAfter.bottomRight.y, boundsBefore.bottomRight.y, "box keeps same bottom edge");
         svg.remove();
       });
@@ -127,7 +123,7 @@ describe("Layer Components", () => {
         let boundsAfter = dbl.bounds();
         assert.strictEqual(boundsAfter.topLeft.x, 0, "box still starts at left");
         assert.strictEqual(boundsAfter.topLeft.y, boundsBefore.topLeft.y + dragDistance, "top edge moved");
-        assert.strictEqual(boundsAfter.bottomRight.x, dbl.width(), "box still ends at right");
+        assert.strictEqual(boundsAfter.bottomRight.x, SVG_WIDTH, "box still ends at right");
         assert.strictEqual(boundsAfter.bottomRight.y, boundsBefore.bottomRight.y + dragDistance, "bottom edge moved");
 
         svg.remove();

--- a/test/components/yDragBoxLayerTests.ts
+++ b/test/components/yDragBoxLayerTests.ts
@@ -2,57 +2,56 @@
 
 describe("Interactive Components", () => {
   describe("YDragBoxLayer", () => {
-    let SVG_WIDTH = 400;
-    let SVG_HEIGHT = 400;
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 400;
 
-    it("bounds()", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.YDragBoxLayer();
-      dbl.boxVisible(true);
-      dbl.renderTo(svg);
-
-      let topLeft = {
+      let quarterTopLeftPoint = {
         x: SVG_WIDTH / 4,
         y: SVG_HEIGHT / 4
       };
-      let bottomRight = {
+      let middlePoint = {
         x: SVG_WIDTH / 2,
         y: SVG_HEIGHT / 2
       };
+      let quarterBottomRightPoint = {
+          x: SVG_WIDTH * 3 / 4,
+          y: SVG_HEIGHT * 3 / 4
+      };
+
+      let svg: d3.Selection<void>;
+      let dbl: Plottable.Components.YDragBoxLayer;
+
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        dbl = new Plottable.Components.YDragBoxLayer();
+      });
+
+    it("bounds()", () => {
+      dbl.boxVisible(true);
+      dbl.renderTo(svg);
 
       dbl.bounds({
-        topLeft: topLeft,
-        bottomRight: bottomRight
+        topLeft: quarterTopLeftPoint,
+        bottomRight: middlePoint
       });
 
       let actualBounds = dbl.bounds();
       assert.strictEqual(actualBounds.topLeft.x, 0, "box starts at left");
-      assert.strictEqual(actualBounds.topLeft.y, topLeft.y, "top edge set correctly");
+      assert.strictEqual(actualBounds.topLeft.y, quarterTopLeftPoint.y, "top edge set correctly");
       assert.strictEqual(actualBounds.bottomRight.x, dbl.width(), "box ends at right");
-      assert.strictEqual(actualBounds.bottomRight.y, bottomRight.y, "bottom edge set correctly");
+      assert.strictEqual(actualBounds.bottomRight.y, middlePoint.y, "bottom edge set correctly");
 
       svg.remove();
     });
 
     it("resizes only in y", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.YDragBoxLayer();
       dbl.boxVisible(true);
       dbl.resizable(true);
       dbl.renderTo(svg);
 
-      let topLeft = {
-        x: SVG_WIDTH / 4,
-        y: SVG_HEIGHT / 4
-      };
-      let bottomRight = {
-        x: SVG_WIDTH / 2,
-        y: SVG_HEIGHT / 2
-      };
-
       dbl.bounds({
-        topLeft: topLeft,
-        bottomRight: bottomRight
+        topLeft: quarterTopLeftPoint,
+        bottomRight: middlePoint
       });
 
       let actualBounds = dbl.bounds();
@@ -69,24 +68,13 @@ describe("Interactive Components", () => {
     });
 
     it("stays full width after resizing", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.YDragBoxLayer();
       dbl.boxVisible(true);
       dbl.resizable(true);
       dbl.renderTo(svg);
 
-      let topLeft = {
-        x: SVG_WIDTH / 4,
-        y: SVG_HEIGHT / 4
-      };
-      let bottomRight = {
-        x: SVG_WIDTH / 2,
-        y: SVG_HEIGHT / 2
-      };
-
       dbl.bounds({
-        topLeft: topLeft,
-        bottomRight: bottomRight
+        topLeft: quarterTopLeftPoint,
+        bottomRight: middlePoint
       });
 
       let widthBefore = dbl.width();
@@ -104,39 +92,28 @@ describe("Interactive Components", () => {
     });
 
     it("throws error on getting x scale", () => {
-      let dbl = new Plottable.Components.YDragBoxLayer();
       assert.throws(() => dbl.xScale(), "no xScale");
+      svg.remove();
     });
 
     it("throws error on setting x scale", () => {
-      let dbl = new Plottable.Components.YDragBoxLayer();
       assert.throws(() => dbl.xScale(new Plottable.Scales.Linear()), "xScales cannot be set");
+      svg.remove();
     });
 
     it("throws error on getting x extent", () => {
-      let dbl = new Plottable.Components.YDragBoxLayer();
       assert.throws(() => dbl.xExtent(), "no xExtent");
+      svg.remove();
     });
 
     it("moves only in y", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let dbl = new Plottable.Components.YDragBoxLayer();
       dbl.boxVisible(true);
       dbl.movable(true);
       dbl.renderTo(svg);
 
-      let topLeft = {
-        x: SVG_WIDTH / 4,
-        y: SVG_HEIGHT / 4
-      };
-      let bottomRight = {
-        x: SVG_WIDTH * 3 / 4,
-        y: SVG_HEIGHT * 3 / 4
-      };
-
       dbl.bounds({
-        topLeft: topLeft,
-        bottomRight: bottomRight
+        topLeft: quarterTopLeftPoint,
+        bottomRight: quarterBottomRightPoint
       });
 
       let boundsBefore = dbl.bounds();
@@ -164,13 +141,12 @@ describe("Interactive Components", () => {
       ydbl.resizable(false);
       ydbl.enabled(true);
       assert.isFalse(ydbl.hasClass("y-resizable"), "does not carry \"y-resizable\" class if enabled, but not resizable");
+      svg.remove();
     });
 
     it("destroy() does not error if scales are not inputted", () => {
-      let svg = TestMethods.generateSVG();
-      let sbl = new Plottable.Components.YDragBoxLayer();
-      sbl.renderTo(svg);
-      assert.doesNotThrow(() => sbl.destroy(), Error, "can destroy");
+      dbl.renderTo(svg);
+      assert.doesNotThrow(() => dbl.destroy(), Error, "can destroy");
 
       svg.remove();
     });

--- a/test/components/yDragBoxLayerTests.ts
+++ b/test/components/yDragBoxLayerTests.ts
@@ -2,6 +2,7 @@
 
 describe("Interactive Components", () => {
   describe("YDragBoxLayer", () => {
+    describe("Basic usage", () => {
       let SVG_WIDTH = 400;
       let SVG_HEIGHT = 400;
 
@@ -14,8 +15,8 @@ describe("Interactive Components", () => {
         y: SVG_HEIGHT / 2
       };
       let quarterBottomRightPoint = {
-          x: SVG_WIDTH * 3 / 4,
-          y: SVG_HEIGHT * 3 / 4
+        x: SVG_WIDTH * 3 / 4,
+        y: SVG_HEIGHT * 3 / 4
       };
 
       let svg: d3.Selection<void>;
@@ -26,129 +27,130 @@ describe("Interactive Components", () => {
         dbl = new Plottable.Components.YDragBoxLayer();
       });
 
-    it("bounds()", () => {
-      dbl.boxVisible(true);
-      dbl.renderTo(svg);
+      it("bounds()", () => {
+        dbl.boxVisible(true);
+        dbl.renderTo(svg);
 
-      dbl.bounds({
-        topLeft: quarterTopLeftPoint,
-        bottomRight: middlePoint
+        dbl.bounds({
+          topLeft: quarterTopLeftPoint,
+          bottomRight: middlePoint
+        });
+
+        let actualBounds = dbl.bounds();
+        assert.strictEqual(actualBounds.topLeft.x, 0, "box starts at left");
+        assert.strictEqual(actualBounds.topLeft.y, quarterTopLeftPoint.y, "top edge set correctly");
+        assert.strictEqual(actualBounds.bottomRight.x, dbl.width(), "box ends at right");
+        assert.strictEqual(actualBounds.bottomRight.y, middlePoint.y, "bottom edge set correctly");
+
+        svg.remove();
       });
 
-      let actualBounds = dbl.bounds();
-      assert.strictEqual(actualBounds.topLeft.x, 0, "box starts at left");
-      assert.strictEqual(actualBounds.topLeft.y, quarterTopLeftPoint.y, "top edge set correctly");
-      assert.strictEqual(actualBounds.bottomRight.x, dbl.width(), "box ends at right");
-      assert.strictEqual(actualBounds.bottomRight.y, middlePoint.y, "bottom edge set correctly");
+      it("resizes only in y", () => {
+        dbl.boxVisible(true);
+        dbl.resizable(true);
+        dbl.renderTo(svg);
 
-      svg.remove();
-    });
+        dbl.bounds({
+          topLeft: quarterTopLeftPoint,
+          bottomRight: middlePoint
+        });
 
-    it("resizes only in y", () => {
-      dbl.boxVisible(true);
-      dbl.resizable(true);
-      dbl.renderTo(svg);
-
-      dbl.bounds({
-        topLeft: quarterTopLeftPoint,
-        bottomRight: middlePoint
+        let actualBounds = dbl.bounds();
+        let dragTo = {
+          x: SVG_WIDTH / 2,
+          y: SVG_HEIGHT * 3 / 4
+        };
+        TestMethods.triggerFakeDragSequence(dbl.background(), actualBounds.bottomRight, dragTo);
+        actualBounds = dbl.bounds();
+        assert.strictEqual(actualBounds.topLeft.x, 0, "box still starts at left");
+        assert.strictEqual(actualBounds.bottomRight.x, dbl.width(), "box still ends at right");
+        assert.strictEqual(actualBounds.bottomRight.y, dragTo.y, "resized in y");
+        svg.remove();
       });
 
-      let actualBounds = dbl.bounds();
-      let dragTo = {
-        x: SVG_WIDTH / 2,
-        y: SVG_HEIGHT * 3 / 4
-      };
-      TestMethods.triggerFakeDragSequence(dbl.background(), actualBounds.bottomRight, dragTo);
-      actualBounds = dbl.bounds();
-      assert.strictEqual(actualBounds.topLeft.x, 0, "box still starts at left");
-      assert.strictEqual(actualBounds.bottomRight.x, dbl.width(), "box still ends at right");
-      assert.strictEqual(actualBounds.bottomRight.y, dragTo.y, "resized in y");
-      svg.remove();
-    });
+      it("stays full width after resizing", () => {
+        dbl.boxVisible(true);
+        dbl.resizable(true);
+        dbl.renderTo(svg);
 
-    it("stays full width after resizing", () => {
-      dbl.boxVisible(true);
-      dbl.resizable(true);
-      dbl.renderTo(svg);
+        dbl.bounds({
+          topLeft: quarterTopLeftPoint,
+          bottomRight: middlePoint
+        });
 
-      dbl.bounds({
-        topLeft: quarterTopLeftPoint,
-        bottomRight: middlePoint
+        let widthBefore = dbl.width();
+        let boundsBefore = dbl.bounds();
+        svg.attr("width", 2 * SVG_WIDTH);
+        dbl.redraw();
+        assert.notStrictEqual(dbl.width(), widthBefore, "component changed size");
+
+        let boundsAfter = dbl.bounds();
+        assert.strictEqual(boundsAfter.topLeft.x, 0, "box still starts at left");
+        assert.strictEqual(boundsAfter.topLeft.y, boundsBefore.topLeft.y, "box keeps same top edge");
+        assert.strictEqual(boundsAfter.bottomRight.x, dbl.width(), "box still ends at right");
+        assert.strictEqual(boundsAfter.bottomRight.y, boundsBefore.bottomRight.y, "box keeps same bottom edge");
+        svg.remove();
       });
 
-      let widthBefore = dbl.width();
-      let boundsBefore = dbl.bounds();
-      svg.attr("width", 2 * SVG_WIDTH);
-      dbl.redraw();
-      assert.notStrictEqual(dbl.width(), widthBefore, "component changed size");
-
-      let boundsAfter = dbl.bounds();
-      assert.strictEqual(boundsAfter.topLeft.x, 0, "box still starts at left");
-      assert.strictEqual(boundsAfter.topLeft.y, boundsBefore.topLeft.y, "box keeps same top edge");
-      assert.strictEqual(boundsAfter.bottomRight.x, dbl.width(), "box still ends at right");
-      assert.strictEqual(boundsAfter.bottomRight.y, boundsBefore.bottomRight.y, "box keeps same bottom edge");
-      svg.remove();
-    });
-
-    it("throws error on getting x scale", () => {
-      assert.throws(() => dbl.xScale(), "no xScale");
-      svg.remove();
-    });
-
-    it("throws error on setting x scale", () => {
-      assert.throws(() => dbl.xScale(new Plottable.Scales.Linear()), "xScales cannot be set");
-      svg.remove();
-    });
-
-    it("throws error on getting x extent", () => {
-      assert.throws(() => dbl.xExtent(), "no xExtent");
-      svg.remove();
-    });
-
-    it("moves only in y", () => {
-      dbl.boxVisible(true);
-      dbl.movable(true);
-      dbl.renderTo(svg);
-
-      dbl.bounds({
-        topLeft: quarterTopLeftPoint,
-        bottomRight: quarterBottomRightPoint
+      it("throws error on getting x scale", () => {
+        assert.throws(() => dbl.xScale(), "no xScale");
+        svg.remove();
       });
 
-      let boundsBefore = dbl.bounds();
-      let dragDistance = 10;
-      TestMethods.triggerFakeDragSequence(dbl.background(),
-        { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 },
-        { x: SVG_WIDTH / 2 + dragDistance, y: SVG_HEIGHT / 2 + dragDistance }
-      );
+      it("throws error on setting x scale", () => {
+        assert.throws(() => dbl.xScale(new Plottable.Scales.Linear()), "xScales cannot be set");
+        svg.remove();
+      });
 
-      let boundsAfter = dbl.bounds();
-      assert.strictEqual(boundsAfter.topLeft.x, 0, "box still starts at left");
-      assert.strictEqual(boundsAfter.topLeft.y, boundsBefore.topLeft.y + dragDistance, "top edge moved");
-      assert.strictEqual(boundsAfter.bottomRight.x, dbl.width(), "box still ends at right");
-      assert.strictEqual(boundsAfter.bottomRight.y, boundsBefore.bottomRight.y + dragDistance, "bottom edge moved");
+      it("throws error on getting x extent", () => {
+        assert.throws(() => dbl.xExtent(), "no xExtent");
+        svg.remove();
+      });
 
-      svg.remove();
-    });
+      it("moves only in y", () => {
+        dbl.boxVisible(true);
+        dbl.movable(true);
+        dbl.renderTo(svg);
 
-    it("does not have resizable CSS class when enabled(false)", () => {
-      let ydbl = new Plottable.Components.YDragBoxLayer();
-      ydbl.resizable(true);
-      assert.isTrue(ydbl.hasClass("y-resizable"), "carries \"y-resizable\" class if resizable");
-      ydbl.enabled(false);
-      assert.isFalse(ydbl.hasClass("y-resizable"), "does not carry \"y-resizable\" class if resizable, but not enabled");
-      ydbl.resizable(false);
-      ydbl.enabled(true);
-      assert.isFalse(ydbl.hasClass("y-resizable"), "does not carry \"y-resizable\" class if enabled, but not resizable");
-      svg.remove();
-    });
+        dbl.bounds({
+          topLeft: quarterTopLeftPoint,
+          bottomRight: quarterBottomRightPoint
+        });
 
-    it("destroy() does not error if scales are not inputted", () => {
-      dbl.renderTo(svg);
-      assert.doesNotThrow(() => dbl.destroy(), Error, "can destroy");
+        let boundsBefore = dbl.bounds();
+        let dragDistance = 10;
+        TestMethods.triggerFakeDragSequence(dbl.background(),
+          { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 },
+          { x: SVG_WIDTH / 2 + dragDistance, y: SVG_HEIGHT / 2 + dragDistance }
+        );
 
-      svg.remove();
+        let boundsAfter = dbl.bounds();
+        assert.strictEqual(boundsAfter.topLeft.x, 0, "box still starts at left");
+        assert.strictEqual(boundsAfter.topLeft.y, boundsBefore.topLeft.y + dragDistance, "top edge moved");
+        assert.strictEqual(boundsAfter.bottomRight.x, dbl.width(), "box still ends at right");
+        assert.strictEqual(boundsAfter.bottomRight.y, boundsBefore.bottomRight.y + dragDistance, "bottom edge moved");
+
+        svg.remove();
+      });
+
+      it("does not have resizable CSS class when enabled(false)", () => {
+        let ydbl = new Plottable.Components.YDragBoxLayer();
+        ydbl.resizable(true);
+        assert.isTrue(ydbl.hasClass("y-resizable"), "carries \"y-resizable\" class if resizable");
+        ydbl.enabled(false);
+        assert.isFalse(ydbl.hasClass("y-resizable"), "does not carry \"y-resizable\" class if resizable, but not enabled");
+        ydbl.resizable(false);
+        ydbl.enabled(true);
+        assert.isFalse(ydbl.hasClass("y-resizable"), "does not carry \"y-resizable\" class if enabled, but not resizable");
+        svg.remove();
+      });
+
+      it("destroy() does not error if scales are not inputted", () => {
+        dbl.renderTo(svg);
+        assert.doesNotThrow(() => dbl.destroy(), Error, "can destroy");
+
+        svg.remove();
+      });
     });
   });
 });

--- a/test/components/yDragBoxLayerTests.ts
+++ b/test/components/yDragBoxLayerTests.ts
@@ -27,7 +27,7 @@ describe("Interactive Components", () => {
         dbl = new Plottable.Components.YDragBoxLayer();
       });
 
-      it("bounds()", () => {
+      it("has the correct bounds()", () => {
         dbl.boxVisible(true);
         dbl.renderTo(svg);
 
@@ -134,18 +134,18 @@ describe("Interactive Components", () => {
       });
 
       it("does not have resizable CSS class when enabled(false)", () => {
-        let ydbl = new Plottable.Components.YDragBoxLayer();
-        ydbl.resizable(true);
-        assert.isTrue(ydbl.hasClass("y-resizable"), "carries \"y-resizable\" class if resizable");
-        ydbl.enabled(false);
-        assert.isFalse(ydbl.hasClass("y-resizable"), "does not carry \"y-resizable\" class if resizable, but not enabled");
-        ydbl.resizable(false);
-        ydbl.enabled(true);
-        assert.isFalse(ydbl.hasClass("y-resizable"), "does not carry \"y-resizable\" class if enabled, but not resizable");
+        dbl.resizable(true);
+        assert.isTrue(dbl.hasClass("y-resizable"), "carries \"y-resizable\" class if resizable");
+        dbl.enabled(false);
+        assert.isFalse(dbl.hasClass("y-resizable"), "does not carry \"y-resizable\" class if resizable, but not enabled");
+        dbl.resizable(false);
+        dbl.enabled(true);
+        assert.isFalse(dbl.hasClass("y-resizable"), "does not carry \"y-resizable\" class if enabled, but not resizable");
+
         svg.remove();
       });
 
-      it("destroy() does not error if scales are not inputted", () => {
+      it("does not error on destroy() when scales are not inputted", () => {
         dbl.renderTo(svg);
         assert.doesNotThrow(() => dbl.destroy(), Error, "can destroy");
 

--- a/test/components/yDragBoxLayerTests.ts
+++ b/test/components/yDragBoxLayerTests.ts
@@ -1,6 +1,6 @@
 ///<reference path="../testReference.ts" />
 
-describe("Interactive Components", () => {
+describe("Layer Components", () => {
   describe("YDragBoxLayer", () => {
     describe("Basic usage", () => {
       let SVG_WIDTH = 400;


### PR DESCRIPTION
Part of #2623 

I will be doing 2 passes because I will get more context (and better sense of best practices) by refactoring other files. However, please flag anything that seems unusual.

As part of this: 
- **Test semantics: hierarchy, naming, testing, but no coverage check**
- Applied best practices from the wiki page
- Factored out common code into `beforeEach()` clauses
- No nested `beforeEach()`es
- Remade hierarchy as shown bellow
![Uploading Screen Shot 2015-08-24 at 5.14.43 PM.png…]()
