### PR TITLE
Refactor Category Scale Tests - Pass 1

### DIFF
--- a/test/scales/categoryScaleTests.ts
+++ b/test/scales/categoryScaleTests.ts
@@ -61,27 +61,27 @@ describe("Scales", () => {
           });
         }
       });
+    });
 
-      describe("extent calculation", () => {
-        let scale: Plottable.Scales.Category;
+    describe("Extent calculation", () => {
+      let scale: Plottable.Scales.Category;
 
-        beforeEach(() => {
-          scale = new Plottable.Scales.Category();
-        });
+      beforeEach(() => {
+        scale = new Plottable.Scales.Category();
+      });
 
-        it("categoryScale gives the unique values when domain is stringy", () => {
-          let values = ["1", "3", "2", "1"];
-          let computedExtent = scale.extentOfValues(values);
+      it("categoryScale gives the unique values when domain is stringy", () => {
+        let values = ["1", "3", "2", "1"];
+        let computedExtent = scale.extentOfValues(values);
 
-          assert.deepEqual(computedExtent, ["1", "3", "2"], "the extent is made of all the unique values in the domain");
-        });
+        assert.deepEqual(computedExtent, ["1", "3", "2"], "the extent is made of all the unique values in the domain");
+      });
 
-        it("categoryScale gives the unique values when domain is numeric", () => {
-          let values = [1, 3, 2, 1];
-          let computedExtent = scale.extentOfValues(<any>values);
+      it("categoryScale gives the unique values when domain is numeric", () => {
+        let values = [1, 3, 2, 1];
+        let computedExtent = scale.extentOfValues(<any>values);
 
-          assert.deepEqual(computedExtent, [1, 3, 2], "the extent is made of all the unique values in the domain");
-        });
+        assert.deepEqual(computedExtent, [1, 3, 2], "the extent is made of all the unique values in the domain");
       });
     });
 

--- a/test/scales/categoryScaleTests.ts
+++ b/test/scales/categoryScaleTests.ts
@@ -10,7 +10,7 @@ describe("Scales", () => {
         scale = new Plottable.Scales.Category();
       });
 
-      it("rangeBand is updated when domain changes", () => {
+      it("updates rangeBand when domain changes", () => {
         scale.range([0, 2679]);
 
         scale.domain(["1", "2", "3", "4"]);
@@ -20,7 +20,7 @@ describe("Scales", () => {
         assert.closeTo(scale.rangeBand(), 329, 1);
       });
 
-      it("stepWidth operates normally", () => {
+      it("computes the correct stepWidth", () => {
         scale.range([0, 3000]);
 
         scale.domain(["1", "2", "3", "4"]);
@@ -28,7 +28,7 @@ describe("Scales", () => {
         assert.strictEqual(scale.stepWidth(), widthSum, "step width is the sum of innerPadding width and band width");
       });
 
-      it("CategoryScale + BarPlot combo works as expected when the data is swapped", () => {
+      it("interacts well with BarPlot and data swapping", () => {
         // This unit test taken from SLATE, see SLATE-163 a fix for SLATE-102
         let xScale = new Plottable.Scales.Category();
         let yScale = new Plottable.Scales.Linear();
@@ -70,14 +70,14 @@ describe("Scales", () => {
         scale = new Plottable.Scales.Category();
       });
 
-      it("categoryScale gives the unique values when domain is stringy", () => {
+      it("gives the unique values when domain is stringy", () => {
         let values = ["1", "3", "2", "1"];
         let computedExtent = scale.extentOfValues(values);
 
         assert.deepEqual(computedExtent, ["1", "3", "2"], "the extent is made of all the unique values in the domain");
       });
 
-      it("categoryScale gives the unique values when domain is numeric", () => {
+      it("gives the unique values even when domain is numeric", () => {
         let values = [1, 3, 2, 1];
         let computedExtent = scale.extentOfValues(<any>values);
 

--- a/test/scales/categoryScaleTests.ts
+++ b/test/scales/categoryScaleTests.ts
@@ -1,0 +1,89 @@
+///<reference path="../testReference.ts" />
+
+describe("Scales", () => {
+  describe("Category Scale", () => {
+    describe("Basic usage", () => {
+
+      let scale: Plottable.Scales.Category;
+
+      beforeEach(() => {
+        scale = new Plottable.Scales.Category();
+      });
+
+      it("rangeBand is updated when domain changes", () => {
+        scale.range([0, 2679]);
+
+        scale.domain(["1", "2", "3", "4"]);
+        assert.closeTo(scale.rangeBand(), 399, 1);
+
+        scale.domain(["1", "2", "3", "4", "5"]);
+        assert.closeTo(scale.rangeBand(), 329, 1);
+      });
+
+      it("stepWidth operates normally", () => {
+        scale.range([0, 3000]);
+
+        scale.domain(["1", "2", "3", "4"]);
+        let widthSum = scale.rangeBand() * (1 + scale.innerPadding());
+        assert.strictEqual(scale.stepWidth(), widthSum, "step width is the sum of innerPadding width and band width");
+      });
+
+      it("CategoryScale + BarPlot combo works as expected when the data is swapped", () => {
+        // This unit test taken from SLATE, see SLATE-163 a fix for SLATE-102
+        let xScale = new Plottable.Scales.Category();
+        let yScale = new Plottable.Scales.Linear();
+        let dA = {x: "A", y: 2};
+        let dB = {x: "B", y: 2};
+        let dC = {x: "C", y: 2};
+        let dataset = new Plottable.Dataset([dA, dB]);
+        let barPlot = new Plottable.Plots.Bar();
+        barPlot.addDataset(dataset);
+        barPlot.x((d: any) => d.x, xScale);
+        barPlot.y((d: any) => d.y, yScale);
+        let svg = TestMethods.generateSVG();
+        assert.deepEqual(xScale.domain(), [], "before anchoring, the bar plot doesn't proxy data to the scale");
+        barPlot.renderTo(svg);
+        assert.deepEqual(xScale.domain(), ["A", "B"], "after anchoring, the bar plot's data is on the scale");
+
+        iterateDataChanges([], [dA, dB, dC], []);
+        assert.lengthOf(xScale.domain(), 0);
+
+        iterateDataChanges([dA], [dB]);
+        assert.lengthOf(xScale.domain(), 1);
+        iterateDataChanges([], [dA, dB, dC]);
+        assert.lengthOf(xScale.domain(), 3);
+
+        svg.remove();
+
+        function iterateDataChanges(...dataChanges: any[]) {
+          dataChanges.forEach((dataChange) => {
+            dataset.data(dataChange);
+          });
+        }
+      });
+
+      describe("extent calculation", () => {
+        let scale: Plottable.Scales.Category;
+
+        beforeEach(() => {
+          scale = new Plottable.Scales.Category();
+        });
+
+        it("categoryScale gives the unique values when domain is stringy", () => {
+          let values = ["1", "3", "2", "1"];
+          let computedExtent = scale.extentOfValues(values);
+
+          assert.deepEqual(computedExtent, ["1", "3", "2"], "the extent is made of all the unique values in the domain");
+        });
+
+        it("categoryScale gives the unique values when domain is numeric", () => {
+          let values = [1, 3, 2, 1];
+          let computedExtent = scale.extentOfValues(<any>values);
+
+          assert.deepEqual(computedExtent, [1, 3, 2], "the extent is made of all the unique values in the domain");
+        });
+      });
+    });
+
+  });
+});

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -36,61 +36,6 @@ describe("Scales", () => {
     assert.isFalse(callbackWasCalled, "The registered callback was not called because the callback was removed");
   });
 
-  describe("Category Scales", () => {
-    it("rangeBand is updated when domain changes", () => {
-      let scale = new Plottable.Scales.Category();
-      scale.range([0, 2679]);
-
-      scale.domain(["1", "2", "3", "4"]);
-      assert.closeTo(scale.rangeBand(), 399, 1);
-
-      scale.domain(["1", "2", "3", "4", "5"]);
-      assert.closeTo(scale.rangeBand(), 329, 1);
-    });
-
-    it("stepWidth operates normally", () => {
-      let scale = new Plottable.Scales.Category();
-      scale.range([0, 3000]);
-
-      scale.domain(["1", "2", "3", "4"]);
-      let widthSum = scale.rangeBand() * (1 + scale.innerPadding());
-      assert.strictEqual(scale.stepWidth(), widthSum, "step width is the sum of innerPadding width and band width");
-    });
-  });
-
-  it("CategoryScale + BarPlot combo works as expected when the data is swapped", () => {
-    // This unit test taken from SLATE, see SLATE-163 a fix for SLATE-102
-    let xScale = new Plottable.Scales.Category();
-    let yScale = new Plottable.Scales.Linear();
-    let dA = {x: "A", y: 2};
-    let dB = {x: "B", y: 2};
-    let dC = {x: "C", y: 2};
-    let dataset = new Plottable.Dataset([dA, dB]);
-    let barPlot = new Plottable.Plots.Bar();
-    barPlot.addDataset(dataset);
-    barPlot.x((d: any) => d.x, xScale);
-    barPlot.y((d: any) => d.y, yScale);
-    let svg = TestMethods.generateSVG();
-    assert.deepEqual(xScale.domain(), [], "before anchoring, the bar plot doesn't proxy data to the scale");
-    barPlot.renderTo(svg);
-    assert.deepEqual(xScale.domain(), ["A", "B"], "after anchoring, the bar plot's data is on the scale");
-
-    function iterateDataChanges(...dataChanges: any[]) {
-      dataChanges.forEach((dataChange) => {
-        dataset.data(dataChange);
-      });
-    }
-
-    iterateDataChanges([], [dA, dB, dC], []);
-    assert.lengthOf(xScale.domain(), 0);
-
-    iterateDataChanges([dA], [dB]);
-    assert.lengthOf(xScale.domain(), 1);
-    iterateDataChanges([], [dA, dB, dC]);
-    assert.lengthOf(xScale.domain(), 3);
-    svg.remove();
-  });
-
   describe("Color Scales", () => {
     it("accepts categorical string types and Category domain", () => {
       let scale = new Plottable.Scales.Color("10");
@@ -255,21 +200,6 @@ describe("Scales", () => {
   });
 
   describe("extent calculation", () => {
-    it("categoryScale gives the unique values when domain is stringy", () => {
-      let values = ["1", "3", "2", "1"];
-      let scale = new Plottable.Scales.Category();
-      let computedExtent = scale.extentOfValues(values);
-
-      assert.deepEqual(computedExtent, ["1", "3", "2"], "the extent is made of all the unique values in the domain");
-    });
-
-    it("categoryScale gives the unique values when domain is numeric", () => {
-      let values = [1, 3, 2, 1];
-      let scale = new Plottable.Scales.Category();
-      let computedExtent = scale.extentOfValues(<any>values);
-
-      assert.deepEqual(computedExtent, [1, 3, 2], "the extent is made of all the unique values in the domain");
-    });
 
     it("quantitaveScale gives the minimum and maxiumum when the domain is stringy", () => {
       let values = ["1", "3", "2", "1"];

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -51,6 +51,7 @@
 ///<reference path="core/formattersTests.ts" />
 
 ///<reference path="scales/scaleTests.ts" />
+///<reference path="scales/categoryScaleTests.ts" />
 ///<reference path="scales/linearScaleTests.ts" />
 ///<reference path="scales/modifiedLogScaleTests.ts" />
 ///<reference path="scales/timeScaleTests.ts" />


### PR DESCRIPTION
Part of #2640 

I will be doing 2 passes because I will get more context (and better sense of best practices) by refactoring other files. However, please flag anything that seems unusual.

As part of this: 
- **Test semantics: hierarchy, naming, testing, but no coverage check**
- Applied best practices from the wiki page
- Factored out common code into `beforeEach()` clauses
- No nested `beforeEach()`es
- Remade hierarchy as shown bellow
![screen shot 2015-08-24 at 3 33 13 pm](https://cloud.githubusercontent.com/assets/3248682/9454263/7f134fea-4a75-11e5-9f04-599defb93327.png)
