### PR TITLE
Refactor interpolated color scale tests - Pass 1

### DIFF
--- a/test/scales/interpolatedColorScaleTests.ts
+++ b/test/scales/interpolatedColorScaleTests.ts
@@ -19,12 +19,10 @@ describe("Scales", () => {
 
         assert.deepEqual(scale.range(), Plottable.Scales.InterpolatedColor.REDS,
           "the range of the default scale is made of shades of red");
-      });
 
-      it("linearly interpolates colors in L*a*b color space", () => {
         scale.domain([0, 1]);
-        assert.strictEqual(scale.scale(1), "#b10026", "domain maximum maps to red");
-        assert.strictEqual(scale.scale(0.5), "#feb24c", "domain median maps in between red and white");
+        assert.strictEqual(scale.scale(1), "#b10026", "new domain maximum maps to red");
+        assert.strictEqual(scale.scale(0.5), "#feb24c", "new domain median maps in between red and white");
         assert.strictEqual(scale.scale(0.9), "#d9151f", "different shades of red are obtained for different values");
       });
 
@@ -53,14 +51,6 @@ describe("Scales", () => {
         assert.strictEqual(scale.scale(100), "#ffffff", "values larger than the domain maximum clamp to white");
       });
 
-      it("can be converted to a different range", () => {
-        scale.range(["black", "white"]);
-        scale.domain([0, 16]);
-        assert.strictEqual(scale.scale(16), "#ffffff", "domain maximum maps to white");
-        scale.range(Plottable.Scales.InterpolatedColor.REDS);
-        assert.strictEqual(scale.scale(16), "#b10026", "scale changing took effect");
-      });
     });
-
   });
 });

--- a/test/scales/interpolatedColorScaleTests.ts
+++ b/test/scales/interpolatedColorScaleTests.ts
@@ -57,6 +57,38 @@ describe("Scales", () => {
         scale.range(Plottable.Scales.InterpolatedColor.REDS);
         assert.strictEqual(scale.scale(16), "#b10026", "");
       });
+
+      function linearlyInterpolateColors(color1: string, color2: string, ratio: number) {
+
+        let red1 = parseInt(color1.substr(1, 2), 16);
+        let green1 = parseInt(color1.substr(3, 2), 16);
+        let blue1 = parseInt(color1.substr(5, 2), 16);
+
+        let red2 = parseInt(color2.substr(1, 2), 16);
+        let green2 = parseInt(color2.substr(3, 2), 16);
+        let blue2 = parseInt(color2.substr(5, 2), 16);
+
+        let redOutput = Math.floor(red1 * ratio + red2 * (1 - ratio));
+        let greenOutput = Math.floor(green1 * ratio + green2 * (1 - ratio));
+        let blueOutput = Math.floor(blue1 * ratio + blue2 * (1 - ratio));
+
+        let redHex = redOutput.toString(16);
+        if (redHex.length === 1) {
+          redHex = "0" + redHex;
+        }
+
+        let greenHex = greenOutput.toString(16);
+        if (greenHex.length === 1) {
+          greenHex = "0" + greenHex;
+        }
+
+        let blueHex = blueOutput.toString(16);
+        if (blueHex.length === 1) {
+          blueHex = "0" + blueHex;
+        }
+
+        return "#" + redHex + greenHex + blueHex;
+      }
     });
 
   });

--- a/test/scales/interpolatedColorScaleTests.ts
+++ b/test/scales/interpolatedColorScaleTests.ts
@@ -11,63 +11,55 @@ describe("Scales", () => {
         scale = new Plottable.Scales.InterpolatedColor();
       })
 
-      it("default scale uses reds and a linear scale type", () => {
+      it("defaults to a linear scale and a red color palette", () => {
         scale.domain([0, 16]);
-        assert.strictEqual(scale.scale(0), "#ffffff", "");
-        assert.strictEqual(scale.scale(8), "#feb24c", "");
-        assert.strictEqual(scale.scale(16), "#b10026", "");
+        assert.strictEqual(scale.scale(0), "#ffffff", "domain minimum maps to white");
+        assert.strictEqual(scale.scale(8), "#feb24c", "domain median maps in between red and white");
+        assert.strictEqual(scale.scale(16), "#b10026", "domain maximum maps to red");
+
+        assert.deepEqual(scale.range(), Plottable.Scales.InterpolatedColor.REDS,
+          "the range of the default scale is made of shades of red");
       });
 
       it("linearly interpolates colors in L*a*b color space", () => {
         scale.domain([0, 1]);
-        assert.strictEqual(scale.scale(1), "#b10026", "");
-        assert.strictEqual(scale.scale(0.9), "#d9151f", "");
+        assert.strictEqual(scale.scale(1), "#b10026", "domain maximum maps to red");
+        assert.strictEqual(scale.scale(0.5), "#feb24c", "domain median maps in between red and white");
+        assert.strictEqual(scale.scale(0.9), "#d9151f", "different shades of red are obtained for different values");
       });
 
       it("accepts array types with color hex values", () => {
         scale.range(["#000", "#FFF"]);
         scale.domain([0, 16]);
-        assert.strictEqual(scale.scale(0), "#000000", "");
-        assert.strictEqual(scale.scale(8), "#777777", "");
-        assert.strictEqual(scale.scale(16), "#ffffff", "");
+        assert.strictEqual(scale.scale(0), "#000000", "domain minimum maps to black");
+        assert.strictEqual(scale.scale(8), "#777777", "domain median maps to gray");
+        assert.strictEqual(scale.scale(16), "#ffffff", "domain maximum maps to white");
       });
 
       it("accepts array types with color names", () => {
-        scale.range(["black", "white"]);
+        scale.range(["white", "black"]);
         scale.domain([0, 16]);
-        assert.strictEqual(scale.scale(0), "#000000", "");
-        assert.strictEqual(scale.scale(8), "#777777", "");
-        assert.strictEqual(scale.scale(16), "#ffffff", "");
+        assert.strictEqual(scale.scale(0), "#ffffff", "domain minimum maps to white");
+        assert.strictEqual(scale.scale(8), "#777777", "domain median maps to gray");
+        assert.strictEqual(scale.scale(16), "#000000", "domain maximum maps to black");
       });
 
-      it("overflow scale values clamp to range", () => {
+      it("clamps overflow and underflow values to range", () => {
         scale.range(["black", "white"]);
         scale.domain([0, 16]);
-        assert.strictEqual(scale.scale(0), "#000000", "");
-        assert.strictEqual(scale.scale(16), "#ffffff", "");
-        assert.strictEqual(scale.scale(-100), "#000000", "");
-        assert.strictEqual(scale.scale(100), "#ffffff", "");
+        assert.strictEqual(scale.scale(0), "#000000", "domain minimum maps to black");
+        assert.strictEqual(scale.scale(16), "#ffffff", "domain maximum maps to white");
+        assert.strictEqual(scale.scale(-100), "#000000", "values smaller than the domain minimum clamp to black");
+        assert.strictEqual(scale.scale(100), "#ffffff", "values larger than the domain maximum clamp to white");
       });
 
       it("can be converted to a different range", () => {
         scale.range(["black", "white"]);
         scale.domain([0, 16]);
-        assert.strictEqual(scale.scale(0), "#000000", "");
-        assert.strictEqual(scale.scale(16), "#ffffff", "");
+        assert.strictEqual(scale.scale(16), "#ffffff", "domain maximum maps to white");
         scale.range(Plottable.Scales.InterpolatedColor.REDS);
-        assert.strictEqual(scale.scale(16), "#b10026", "");
+        assert.strictEqual(scale.scale(16), "#b10026", "scale changing took effect");
       });
-
-      function linearlyInterpolateColors(color1Hex: string, color2Hex: string, ratio: number) {
-        let color1 = TestMethods.colorHexToRGB(color1Hex);
-        let color2 = TestMethods.colorHexToRGB(color2Hex);
-
-        return TestMethods.colorRGBToHex({
-          red: Math.floor(color1.red * ratio + color2.red * (1 - ratio)),
-          green: Math.floor(color1.green * ratio + color2.green * (1 - ratio)),
-          blue: Math.floor(color1.blue * ratio + color2.blue * (1 - ratio))
-        });
-      }
     });
 
   });

--- a/test/scales/interpolatedColorScaleTests.ts
+++ b/test/scales/interpolatedColorScaleTests.ts
@@ -1,0 +1,63 @@
+///<reference path="../testReference.ts" />
+
+describe("Scales", () => {
+  describe("Interploated Color Scale", () => {
+
+    describe("Basic usage", () => {
+
+      let scale: Plottable.Scales.InterpolatedColor;
+
+      beforeEach(() => {
+        scale = new Plottable.Scales.InterpolatedColor();
+      })
+
+      it("default scale uses reds and a linear scale type", () => {
+        scale.domain([0, 16]);
+        assert.strictEqual(scale.scale(0), "#ffffff", "");
+        assert.strictEqual(scale.scale(8), "#feb24c", "");
+        assert.strictEqual(scale.scale(16), "#b10026", "");
+      });
+
+      it("linearly interpolates colors in L*a*b color space", () => {
+        scale.domain([0, 1]);
+        assert.strictEqual(scale.scale(1), "#b10026", "");
+        assert.strictEqual(scale.scale(0.9), "#d9151f", "");
+      });
+
+      it("accepts array types with color hex values", () => {
+        scale.range(["#000", "#FFF"]);
+        scale.domain([0, 16]);
+        assert.strictEqual(scale.scale(0), "#000000", "");
+        assert.strictEqual(scale.scale(8), "#777777", "");
+        assert.strictEqual(scale.scale(16), "#ffffff", "");
+      });
+
+      it("accepts array types with color names", () => {
+        scale.range(["black", "white"]);
+        scale.domain([0, 16]);
+        assert.strictEqual(scale.scale(0), "#000000", "");
+        assert.strictEqual(scale.scale(8), "#777777", "");
+        assert.strictEqual(scale.scale(16), "#ffffff", "");
+      });
+
+      it("overflow scale values clamp to range", () => {
+        scale.range(["black", "white"]);
+        scale.domain([0, 16]);
+        assert.strictEqual(scale.scale(0), "#000000", "");
+        assert.strictEqual(scale.scale(16), "#ffffff", "");
+        assert.strictEqual(scale.scale(-100), "#000000", "");
+        assert.strictEqual(scale.scale(100), "#ffffff", "");
+      });
+
+      it("can be converted to a different range", () => {
+        scale.range(["black", "white"]);
+        scale.domain([0, 16]);
+        assert.strictEqual(scale.scale(0), "#000000", "");
+        assert.strictEqual(scale.scale(16), "#ffffff", "");
+        scale.range(Plottable.Scales.InterpolatedColor.REDS);
+        assert.strictEqual(scale.scale(16), "#b10026", "");
+      });
+    });
+
+  });
+});

--- a/test/scales/interpolatedColorScaleTests.ts
+++ b/test/scales/interpolatedColorScaleTests.ts
@@ -58,36 +58,15 @@ describe("Scales", () => {
         assert.strictEqual(scale.scale(16), "#b10026", "");
       });
 
-      function linearlyInterpolateColors(color1: string, color2: string, ratio: number) {
+      function linearlyInterpolateColors(color1Hex: string, color2Hex: string, ratio: number) {
+        let color1 = TestMethods.colorHexToRGB(color1Hex);
+        let color2 = TestMethods.colorHexToRGB(color2Hex);
 
-        let red1 = parseInt(color1.substr(1, 2), 16);
-        let green1 = parseInt(color1.substr(3, 2), 16);
-        let blue1 = parseInt(color1.substr(5, 2), 16);
-
-        let red2 = parseInt(color2.substr(1, 2), 16);
-        let green2 = parseInt(color2.substr(3, 2), 16);
-        let blue2 = parseInt(color2.substr(5, 2), 16);
-
-        let redOutput = Math.floor(red1 * ratio + red2 * (1 - ratio));
-        let greenOutput = Math.floor(green1 * ratio + green2 * (1 - ratio));
-        let blueOutput = Math.floor(blue1 * ratio + blue2 * (1 - ratio));
-
-        let redHex = redOutput.toString(16);
-        if (redHex.length === 1) {
-          redHex = "0" + redHex;
-        }
-
-        let greenHex = greenOutput.toString(16);
-        if (greenHex.length === 1) {
-          greenHex = "0" + greenHex;
-        }
-
-        let blueHex = blueOutput.toString(16);
-        if (blueHex.length === 1) {
-          blueHex = "0" + blueHex;
-        }
-
-        return "#" + redHex + greenHex + blueHex;
+        return TestMethods.colorRGBToHex({
+          red: Math.floor(color1.red * ratio + color2.red * (1 - ratio)),
+          green: Math.floor(color1.green * ratio + color2.green * (1 - ratio)),
+          blue: Math.floor(color1.blue * ratio + color2.blue * (1 - ratio))
+        });
       }
     });
 

--- a/test/scales/interpolatedColorScaleTests.ts
+++ b/test/scales/interpolatedColorScaleTests.ts
@@ -9,7 +9,7 @@ describe("Scales", () => {
 
       beforeEach(() => {
         scale = new Plottable.Scales.InterpolatedColor();
-      })
+      });
 
       it("defaults to a linear scale and a red color palette", () => {
         scale.domain([0, 16]);

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -144,61 +144,6 @@ describe("Scales", () => {
 
   });
 
-  describe("Interpolated Color Scales", () => {
-    it("default scale uses reds and a linear scale type", () => {
-      let scale = new Plottable.Scales.InterpolatedColor();
-      scale.domain([0, 16]);
-      assert.strictEqual("#ffffff", scale.scale(0));
-      assert.strictEqual("#feb24c", scale.scale(8));
-      assert.strictEqual("#b10026", scale.scale(16));
-    });
-
-    it("linearly interpolates colors in L*a*b color space", () => {
-      let scale = new Plottable.Scales.InterpolatedColor();
-      scale.domain([0, 1]);
-      assert.strictEqual("#b10026", scale.scale(1));
-      assert.strictEqual("#d9151f", scale.scale(0.9));
-    });
-
-    it("accepts array types with color hex values", () => {
-      let scale = new Plottable.Scales.InterpolatedColor();
-      scale.range(["#000", "#FFF"]);
-      scale.domain([0, 16]);
-      assert.strictEqual("#000000", scale.scale(0));
-      assert.strictEqual("#ffffff", scale.scale(16));
-      assert.strictEqual("#777777", scale.scale(8));
-    });
-
-    it("accepts array types with color names", () => {
-      let scale = new Plottable.Scales.InterpolatedColor();
-      scale.range(["black", "white"]);
-      scale.domain([0, 16]);
-      assert.strictEqual("#000000", scale.scale(0));
-      assert.strictEqual("#ffffff", scale.scale(16));
-      assert.strictEqual("#777777", scale.scale(8));
-    });
-
-    it("overflow scale values clamp to range", () => {
-      let scale = new Plottable.Scales.InterpolatedColor();
-      scale.range(["black", "white"]);
-      scale.domain([0, 16]);
-      assert.strictEqual("#000000", scale.scale(0));
-      assert.strictEqual("#ffffff", scale.scale(16));
-      assert.strictEqual("#000000", scale.scale(-100));
-      assert.strictEqual("#ffffff", scale.scale(100));
-    });
-
-    it("can be converted to a different range", () => {
-      let scale = new Plottable.Scales.InterpolatedColor();
-      scale.range(["black", "white"]);
-      scale.domain([0, 16]);
-      assert.strictEqual("#000000", scale.scale(0));
-      assert.strictEqual("#ffffff", scale.scale(16));
-      scale.range(Plottable.Scales.InterpolatedColor.REDS);
-      assert.strictEqual("#b10026", scale.scale(16));
-    });
-  });
-
   describe("extent calculation", () => {
 
     it("quantitaveScale gives the minimum and maxiumum when the domain is stringy", () => {

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -280,38 +280,4 @@ module TestMethods {
     assert.isTrue(normalizeClipPath((<any> c)._element.attr("clip-path")) === expectedClipPathURL,
                   "the element has clip-path url attached");
   }
-
-  export type RGB = {
-    red: number,
-    green: number,
-    blue: number
-  };
-
-  export function colorHexToRGB(hex: string): RGB {
-    return {
-      red: parseInt(hex.substr(1, 2), 16),
-      green: parseInt(hex.substr(3, 2), 16),
-      blue: parseInt(hex.substr(5, 2), 16)
-    }
-  }
-
-  export function colorRGBToHex(rgb: RGB) {
-      let redHex = rgb.red.toString(16);
-      if (redHex.length === 1) {
-        redHex = "0" + redHex;
-      }
-
-      let greenHex = rgb.blue.toString(16);
-      if (greenHex.length === 1) {
-        greenHex = "0" + greenHex;
-      }
-
-      let blueHex = rgb.green.toString(16);
-      if (blueHex.length === 1) {
-        blueHex = "0" + blueHex;
-      }
-
-      return "#" + redHex + greenHex + blueHex;
-  }
-
 }

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -280,4 +280,38 @@ module TestMethods {
     assert.isTrue(normalizeClipPath((<any> c)._element.attr("clip-path")) === expectedClipPathURL,
                   "the element has clip-path url attached");
   }
+
+  export type RGB = {
+    red: number,
+    green: number,
+    blue: number
+  };
+
+  export function colorHexToRGB(hex: string): RGB {
+    return {
+      red: parseInt(hex.substr(1, 2), 16),
+      green: parseInt(hex.substr(3, 2), 16),
+      blue: parseInt(hex.substr(5, 2), 16)
+    }
+  }
+
+  export function colorRGBToHex(rgb: RGB) {
+      let redHex = rgb.red.toString(16);
+      if (redHex.length === 1) {
+        redHex = "0" + redHex;
+      }
+
+      let greenHex = rgb.blue.toString(16);
+      if (greenHex.length === 1) {
+        greenHex = "0" + greenHex;
+      }
+
+      let blueHex = rgb.green.toString(16);
+      if (blueHex.length === 1) {
+        blueHex = "0" + blueHex;
+      }
+
+      return "#" + redHex + greenHex + blueHex;
+  }
+
 }

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -55,6 +55,7 @@
 ///<reference path="scales/linearScaleTests.ts" />
 ///<reference path="scales/modifiedLogScaleTests.ts" />
 ///<reference path="scales/timeScaleTests.ts" />
+///<reference path="scales/interpolatedColorScaleTests.ts" />
 ///<reference path="scales/tickGeneratorsTests.ts" />
 
 ///<reference path="utils/domUtilsTests.ts" />


### PR DESCRIPTION
Part of #2640 

I will be doing 2 passes because I will get more context (and better sense of best practices) by refactoring other files. However, please flag anything that seems unusual.

As part of this: 
- **Test semantics: hierarchy, naming, testing, but no coverage check**
- Applied best practices from the wiki page
- Factored out common code into `beforeEach()` clauses
- No nested `beforeEach()`es
- Remade hierarchy as shown bellow
![screen shot 2015-08-25 at 3 31 56 pm](https://cloud.githubusercontent.com/assets/3248682/9481358/730d7724-4b3e-11e5-81a3-994c35ddf7c6.png)
