### PR TITLE
Refactor linear scale tests - Pass 1

### DIFF
--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -147,7 +147,7 @@ describe("Scales", () => {
       it("modififes the autodomain flag accordingly", () => {
         scale.addIncludedValuesProvider((scale) => [0, 5]);
         assert.isTrue((<any> scale)._autoDomainAutomatically,
-          "the autoDomain flag is still set after autoranginging and padding and nice-ing");
+          "the autoDomain flag is still set after autodomaining, padding and nice-ing");
         scale.domain([0, 5]);
         assert.isFalse((<any> scale)._autoDomainAutomatically, "the autoDomain flag is false after domain explicitly set");
       });
@@ -378,7 +378,7 @@ describe("Scales", () => {
         plot.attr("x", (d) => d.x, scale);
         plot.renderTo(svg);
 
-        assert.deepEqual(scale.domain(), [0, 5], "scale domain was autoranged properly");
+        assert.deepEqual(scale.domain(), [0, 5], "scale domain was autodomained correctly");
 
         dataset.data([{x: 100}]);
         assert.deepEqual(scale.domain(), [99, 101], "scale domain was updated properly");

--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -19,6 +19,11 @@ describe("Scales", () => {
 
         assert.deepEqual(scale.domain(), [5, 6], "the domain has been set");
         assert.deepEqual(scale.range(), [6, 7], "the range has been set");
+
+        scale.domain([6, 5]);
+        scale.range([7, 6]);
+        assert.deepEqual(scale.domain(), [6, 5], "the domain can be unordered");
+        assert.deepEqual(scale.range(), [7, 6], "the range can be unordered");
       });
 
       it("maps domain to range in a linear fashion", () => {
@@ -49,18 +54,25 @@ describe("Scales", () => {
         assert.deepEqual(extent, expectedExtent, "invalid values were filtered out");
       });
 
-      it("domain can't include NaN or Infinity", () => {
+      it("does not accept NaN or Infinity as domain", () => {
         scale.domain([1, 2]);
         scale.domain([5, Infinity]);
         assert.deepEqual(scale.domain(), [1, 2], "Infinity containing domain was ignored");
-        scale.domain([5, -Infinity]);
+        scale.domain([-Infinity, 5]);
         assert.deepEqual(scale.domain(), [1, 2], "-Infinity containing domain was ignored");
         scale.domain([NaN, 7]);
         assert.deepEqual(scale.domain(), [1, 2], "NaN containing domain was ignored");
         scale.domain([-1, 5]);
         assert.deepEqual(scale.domain(), [-1, 5], "Regular domains still accepted");
-        scale.domain([5, -1]);
-        assert.deepEqual(scale.domain(), [5, -1], "Values that flip the domain are accepted");
+      });
+
+      it("accepts NaN or Infinity as range", () => {
+        scale.range([5, Infinity]);
+        assert.deepEqual(scale.range(), [5, Infinity], "Infinity accepted as part of range");
+        scale.range([-Infinity, 5]);
+        assert.deepEqual(scale.range(), [-Infinity, 5], "-Infinity accepted as part of range");
+        scale.range([NaN, 7]);
+        assert.deepEqual(scale.range(), [NaN, 7], "NaN accepted as part of range");
       });
     });
 

--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -220,7 +220,6 @@ describe("Scales", () => {
       });
 
       it("can stop padding on one end using addPaddingExceptionsProvider()", () => {
-        let scale = new Plottable.Scales.Linear();
         scale.addIncludedValuesProvider(() => [10, 13]);
         assert.strictEqual(scale.domain()[0], 9.5, "The left side of the domain is padded");
 
@@ -232,7 +231,6 @@ describe("Scales", () => {
       });
 
       it("can stop padding on both ends using addPaddingExceptionsProvider()", () => {
-        let scale = new Plottable.Scales.Linear();
         scale.addIncludedValuesProvider(() => [10, 13]);
         assert.deepEqual(scale.domain(), [9.5, 13.5], "The domain is padded");
 
@@ -247,7 +245,6 @@ describe("Scales", () => {
       });
 
       it("can remove the PaddingExceptionProvider", () => {
-        let scale = new Plottable.Scales.Linear();
         scale.addIncludedValuesProvider(() => [10, 13]);
 
         let paddingExceptionProviderLeft = () => [10];
@@ -277,11 +274,15 @@ describe("Scales", () => {
     });
 
     describe("Autoranging behavior", () => {
-      let data: any[];
+      let data = [
+        {foo: 2, bar: 1},
+        {foo: 5, bar: -20},
+        {foo: 0, bar: 0}
+      ];
       let dataset: Plottable.Dataset;
       let scale: Plottable.Scales.Linear;
+
       beforeEach(() => {
-        data = [{foo: 2, bar: 1}, {foo: 5, bar: -20}, {foo: 0, bar: 0}];
         dataset = new Plottable.Dataset(data);
         scale = new Plottable.Scales.Linear();
         scale.padProportion(0);

--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -48,7 +48,7 @@ describe("Scales", () => {
         assert.strictEqual(scale.invert(400), 20, "first value in range maps to first value in flipped domain");
         assert.strictEqual(scale.invert(500), 10, "last value in range maps to last value in flipped domain");
         assert.strictEqual(scale.invert(450), 15, "middle value in range maps to middle value in flipped domain");
-      })
+      });
 
       it("filters out invalid numbers when using extentOfValues()", () => {
         let arrayWithBadValues: any[] = [null, NaN, undefined, Infinity, -Infinity, "a string", 1, 1.2];

--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -83,7 +83,6 @@ describe("Scales", () => {
         let customTicks = scale.ticks();
         assert.deepEqual(customTicks, [0, 3, 6, 9], "ticks were generated correctly with custom generator");
       });
-
     });
 
     describe("Auto Domaining", () => {
@@ -98,6 +97,14 @@ describe("Scales", () => {
 
         scale.autoDomain();
         assert.deepEqual(scale.domain(), [0, 1], "the domain is still [0, 1]");
+      });
+
+      it("modififes the autodomain flag accordingly", () => {
+        scale.addIncludedValuesProvider((scale) => [0, 5]);
+        assert.isTrue((<any> scale)._autoDomainAutomatically,
+          "the autoDomain flag is still set after autoranginging and padding and nice-ing");
+        scale.domain([0, 5]);
+        assert.isFalse((<any> scale)._autoDomainAutomatically, "the autoDomain flag is false after domain explicitly set");
       });
 
       it("expands single value domains to [value - 1, value + 1] when auto domaining", () => {
@@ -286,14 +293,6 @@ describe("Scales", () => {
         dataset = new Plottable.Dataset(data);
         scale = new Plottable.Scales.Linear();
         scale.padProportion(0);
-      });
-
-      it("scale autoDomain flag is not overwritten without explicitly setting the domain", () => {
-        scale.addIncludedValuesProvider((scale: Plottable.Scale<number, number>) => d3.extent(data, (e) => e.foo));
-        assert.isTrue((<any> scale)._autoDomainAutomatically,
-                            "the autoDomain flag is still set after autoranginging and padding and nice-ing");
-        scale.domain([0, 5]);
-        assert.isFalse((<any> scale)._autoDomainAutomatically, "the autoDomain flag is false after domain explicitly set");
       });
 
       it("scale autorange works as expected with single dataset", () => {

--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -55,15 +55,38 @@ describe("Scales", () => {
       });
 
       it("does not accept NaN or Infinity as domain", () => {
+        let warningCalled = false;
+        let oldWarn = Plottable.Utils.Window.warn;
+        Plottable.Utils.Window.warn = (msg: string) => {
+          if (msg.indexOf("NaN or Infinity") > -1) {
+            warningCalled = true;
+          }
+        };
+
         scale.domain([1, 2]);
+        assert.deepEqual(scale.domain(), [1, 2], "initial domain is set");
+
+        warningCalled = false;
         scale.domain([5, Infinity]);
         assert.deepEqual(scale.domain(), [1, 2], "Infinity containing domain was ignored");
+        assert.isTrue(warningCalled, "a warning was thrown for setting domain to Infinity");
+
+        warningCalled = false;
         scale.domain([-Infinity, 5]);
         assert.deepEqual(scale.domain(), [1, 2], "-Infinity containing domain was ignored");
+        assert.isTrue(warningCalled, "a warning was thrown for setting domain to -Infinity");
+
+        warningCalled = false;
         scale.domain([NaN, 7]);
         assert.deepEqual(scale.domain(), [1, 2], "NaN containing domain was ignored");
+        assert.isTrue(warningCalled, "a warning was thrown for setting domain to NaN");
+
+        warningCalled = false;
         scale.domain([-1, 5]);
         assert.deepEqual(scale.domain(), [-1, 5], "Regular domains still accepted");
+        assert.isFalse(warningCalled, "a warning is not thrown when correct domains are given");
+
+        Plottable.Utils.Window.warn = oldWarn;
       });
 
       it("accepts NaN or Infinity as range", () => {

--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -107,6 +107,38 @@ describe("Scales", () => {
         assert.isFalse((<any> scale)._autoDomainAutomatically, "the autoDomain flag is false after domain explicitly set");
       });
 
+      it("accounts for included values providers", () => {
+        scale.padProportion(0);
+
+        assert.deepEqual(scale.domain(), [0, 1], "the default domain is [0, 1]");
+
+        scale.addIncludedValuesProvider((scale) => [0, 10]);
+        assert.deepEqual(scale.domain(), [0, 10], "scale domain accounts for first provider");
+
+        scale.addIncludedValuesProvider((scale) => [-10, 0]);
+        assert.deepEqual(scale.domain(), [-10, 10], "scale domain accounts for second provider");
+      });
+
+      it("can remove included values providers", () => {
+        scale.padProportion(0);
+
+        assert.deepEqual(scale.domain(), [0, 1], "the default domain is [0, 1]");
+
+        let posProvider = () => [0, 10];
+        assert.strictEqual(scale.addIncludedValuesProvider(posProvider), scale,
+          "Adding an included values provider returns the scale");
+        let negProvider = () => [-10, 0];
+        scale.addIncludedValuesProvider(negProvider);
+        assert.deepEqual(scale.domain(), [-10, 10], "scale domain accounts for both providers");
+
+        assert.strictEqual(scale.removeIncludedValuesProvider(negProvider), scale,
+          "Removing an included values provider returns the scale");
+        assert.deepEqual(scale.domain(), [0, 10], "scale domain only accounts for remaining provider");
+
+        scale.removeIncludedValuesProvider(posProvider);
+        assert.deepEqual(scale.domain(), [0, 1], "scale defaults back to the [0, 1] domain when all value providers are removed");
+      });
+
       it("expands single value domains to [value - 1, value + 1] when auto domaining", () => {
         let singleValue = 15;
         scale.addIncludedValuesProvider((scale: Plottable.Scales.Linear) => [singleValue]);
@@ -280,7 +312,7 @@ describe("Scales", () => {
       });
     });
 
-    describe("Autoranging behavior", () => {
+    describe("Plot interaction", () => {
       let data = [
         {foo: 2, bar: 1},
         {foo: 5, bar: -20},
@@ -330,25 +362,6 @@ describe("Scales", () => {
         assert.deepEqual(scale.domain(), [0, 1], "scale shows default values when all perspectives removed");
         svg1.remove();
         svg2.remove();
-      });
-
-      it("addIncludedValuesProvider()", () => {
-        scale.addIncludedValuesProvider((scale: Plottable.Scale<number, number>) => [0, 10]);
-        assert.deepEqual(scale.domain(), [0, 10], "scale domain accounts for first provider");
-
-        scale.addIncludedValuesProvider((scale: Plottable.Scale<number, number>) => [-10, 0]);
-        assert.deepEqual(scale.domain(), [-10, 10], "scale domain accounts for second provider");
-      });
-
-      it("removeIncludedValuesProvider()", () => {
-        let posProvider = (scale: Plottable.Scale<number, number>) => [0, 10];
-        scale.addIncludedValuesProvider(posProvider);
-        let negProvider = (scale: Plottable.Scale<number, number>) => [-10, 0];
-        scale.addIncludedValuesProvider(negProvider);
-        assert.deepEqual(scale.domain(), [-10, 10], "scale domain accounts for both providers");
-
-        scale.removeIncludedValuesProvider(negProvider);
-        assert.deepEqual(scale.domain(), [0, 10], "scale domain only accounts for remaining provider");
       });
 
       it("should resize when a plot is removed", () => {

--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -324,13 +324,15 @@ describe("Scales", () => {
         scale.padProportion(0);
       });
 
-      it("scale autorange works as expected with single dataset", () => {
+      it("receives updates from the plot and autodomains in accordange", () => {
         let svg = TestMethods.generateSVG();
         let plot = new Plottable.Plot();
+
         (<any> plot)._createDrawer = (dataset: Plottable.Dataset) => createMockDrawer(dataset);
         plot.addDataset(dataset);
         plot.attr("x", (d) => d.x, scale);
         plot.renderTo(svg);
+
         assert.deepEqual(scale.domain(), [0, 5], "scale domain was autoranged properly");
 
         dataset.data([{x: 100}]);
@@ -339,7 +341,7 @@ describe("Scales", () => {
         svg.remove();
       });
 
-      it("scale reference counting works as expected", () => {
+      it("uses reference counting to keep track of the plots it coordinates", () => {
         let svg1 = TestMethods.generateSVG();
         let svg2 = TestMethods.generateSVG();
 
@@ -371,13 +373,13 @@ describe("Scales", () => {
         svg2.remove();
       });
 
-      it("scale domain updates when plots are added or removed", () => {
+      it("adjusts to plot detaching, reattaching or destruction", () => {
         let svg = TestMethods.generateSVG();
-        let ds1 = new Plottable.Dataset([
+        let dataset1 = new Plottable.Dataset([
           {x: 0, y: 0},
           {x: 1, y: 1}
         ]);
-        let ds2 = new Plottable.Dataset([
+        let dataset2 = new Plottable.Dataset([
           {x: 1, y: 1},
           {x: 2, y: 2}
         ]);
@@ -388,12 +390,12 @@ describe("Scales", () => {
         yScale.padProportion(0);
 
         let plot1 = new Plottable.Plots.Line();
-        plot1.addDataset(ds1);
+        plot1.addDataset(dataset1);
         plot1.x((d) => d.x, xScale);
         plot1.y((d) => d.y, yScale);
 
         let plot2 = new Plottable.Plots.Line();
-        plot2.addDataset(ds2);
+        plot2.addDataset(dataset2);
         plot2.x((d) => d.x, xScale);
         plot2.y((d) => d.y, yScale);
 

--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -74,6 +74,16 @@ describe("Scales", () => {
         scale.range([NaN, 7]);
         assert.deepEqual(scale.range(), [NaN, 7], "NaN accepted as part of range");
       });
+
+      it("can receive custom tick generator", () => {
+        scale.domain([0, 10]);
+        let defaultTicks = scale.ticks();
+        assert.strictEqual(defaultTicks.length, 11, "ticks were generated correctly with default generator");
+        scale.tickGenerator((scale) => scale.defaultTicks().filter(tick => tick % 3 === 0));
+        let customTicks = scale.ticks();
+        assert.deepEqual(customTicks, [0, 3, 6, 9], "ticks were generated correctly with custom generator");
+      });
+
     });
 
     describe("Auto Domaining", () => {
@@ -177,16 +187,19 @@ describe("Scales", () => {
     });
 
     describe("Domain snapping", () => {
-      it("domain snapping setter and getter", () => {
-        let scale = new Plottable.Scales.Linear();
+      let scale: Plottable.Scales.Linear;
 
+      beforeEach(() => {
+        scale = new Plottable.Scales.Linear();
+      });
+
+      it("can set domain snapping", () => {
         assert.strictEqual(scale.snappingDomainEnabled(), true, "scales make their domain snap by default");
         assert.strictEqual(scale.snappingDomainEnabled(false), scale, "setting disabling domain snapping returns the scale");
         assert.strictEqual(scale.snappingDomainEnabled(), false, "the domain is no longer snaps");
       });
 
-      it("domain snapping works", () => {
-        let scale = new Plottable.Scales.Linear();
+      it("stops snapping the domain when option is disabled", () => {
         scale.addIncludedValuesProvider(function() {
           return [1.123123123, 3.123123123];
         });
@@ -197,20 +210,16 @@ describe("Scales", () => {
         scale.snappingDomainEnabled(true);
         assert.deepEqual(scale.domain(), [1, 3.2], "domain snapping can be activated back");
       });
-
-      it("custom tick generator", () => {
-        let scale = new Plottable.Scales.Linear();
-        scale.domain([0, 10]);
-        let defaultTicks = scale.ticks();
-        assert.closeTo(defaultTicks.length, 10, 1, "ticks were generated correctly with default generator");
-        scale.tickGenerator((scale) => scale.defaultTicks().filter(tick => tick % 3 === 0));
-        let customTicks = scale.ticks();
-        assert.deepEqual(customTicks, [0, 3, 6, 9], "ticks were generated correctly with custom generator");
-      });
     });
 
     describe("Padding exceptions", () => {
-      it("addPaddingExceptionsProvider() works as expected on one end", () => {
+      let scale: Plottable.Scales.Linear;
+
+      beforeEach(() => {
+        scale = new Plottable.Scales.Linear();
+      });
+
+      it("can stop padding on one end using addPaddingExceptionsProvider()", () => {
         let scale = new Plottable.Scales.Linear();
         scale.addIncludedValuesProvider(() => [10, 13]);
         assert.strictEqual(scale.domain()[0], 9.5, "The left side of the domain is padded");
@@ -222,7 +231,7 @@ describe("Scales", () => {
         assert.strictEqual(scale.domain()[0], 10, "The left side of the domain is no longer padded");
       });
 
-      it("addPaddingExceptionsProvider() works as expected on both ends", () => {
+      it("can stop padding on both ends using addPaddingExceptionsProvider()", () => {
         let scale = new Plottable.Scales.Linear();
         scale.addIncludedValuesProvider(() => [10, 13]);
         assert.deepEqual(scale.domain(), [9.5, 13.5], "The domain is padded");
@@ -237,7 +246,7 @@ describe("Scales", () => {
         assert.deepEqual(scale.domain(), [10, 13], "The domain is no longer padded");
       });
 
-      it("removePaddingExceptionsProvider() works as expected", () => {
+      it("can remove the PaddingExceptionProvider", () => {
         let scale = new Plottable.Scales.Linear();
         scale.addIncludedValuesProvider(() => [10, 13]);
 
@@ -262,8 +271,8 @@ describe("Scales", () => {
         scale.addPaddingExceptionsProvider(paddingExceptionProviderBoth);
         assert.deepEqual(scale.domain(), [10, 13], "The domain is no longer padded");
 
-        scale.addPaddingExceptionsProvider(paddingExceptionProviderLeft);
-        assert.deepEqual(scale.domain(), [10, 13], "The domain is still no longer padded");
+        scale.removePaddingExceptionsProvider(paddingExceptionProviderLeft);
+        assert.deepEqual(scale.domain(), [10, 13], "The domain is still not padded");
       });
     });
 

--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -36,8 +36,11 @@ describe("Scales", () => {
         assert.strictEqual(scale.invert(400), 10, "first value in range maps to first value in domain");
         assert.strictEqual(scale.invert(500), 20, "last value in range maps to last value in domain");
         assert.strictEqual(scale.invert(450), 15, "middle value in range maps to middle value in domain");
+      });
 
+      it("can have a reversed domain", () => {
         scale.domain([20, 10]);
+        scale.range([400, 500]);
         assert.strictEqual(scale.scale(10), 500, "first value in flipped domain maps to first value in range");
         assert.strictEqual(scale.scale(20), 400, "last value in flipped domain maps to last value in range");
         assert.strictEqual(scale.scale(15), 450, "middle value in flipped domain maps to middle value in range");
@@ -45,7 +48,7 @@ describe("Scales", () => {
         assert.strictEqual(scale.invert(400), 20, "first value in range maps to first value in flipped domain");
         assert.strictEqual(scale.invert(500), 10, "last value in range maps to last value in flipped domain");
         assert.strictEqual(scale.invert(450), 15, "middle value in range maps to middle value in flipped domain");
-      });
+      })
 
       it("filters out invalid numbers when using extentOfValues()", () => {
         let arrayWithBadValues: any[] = [null, NaN, undefined, Infinity, -Infinity, "a string", 1, 1.2];
@@ -102,6 +105,8 @@ describe("Scales", () => {
         scale.domain([0, 10]);
         let defaultTicks = scale.ticks();
         assert.strictEqual(defaultTicks.length, 11, "ticks were generated correctly with default generator");
+        assert.deepEqual(defaultTicks, Array.apply(null, Array(11)).map((d: any, i: number) => i),
+          "all numbers from 0 to 10 were generated");
         scale.tickGenerator((scale) => scale.defaultTicks().filter(tick => tick % 3 === 0));
         let customTicks = scale.ticks();
         assert.deepEqual(customTicks, [0, 3, 6, 9], "ticks were generated correctly with custom generator");
@@ -115,11 +120,28 @@ describe("Scales", () => {
         scale = new Plottable.Scales.Linear();
       });
 
-      it("auto domains by default", () => {
+      it("has a default domain of [0, 1]", () => {
         assert.deepEqual(scale.domain(), [0, 1], "the default domain is [0, 1]");
 
         scale.autoDomain();
         assert.deepEqual(scale.domain(), [0, 1], "the domain is still [0, 1]");
+      });
+
+      it("auto domains upon request", () => {
+        scale.padProportion(0);
+
+        assert.deepEqual(scale.domain(), [0, 1], "Default domain is [0, 1]");
+        scale.addIncludedValuesProvider(() => [4, 6]);
+        assert.deepEqual(scale.domain(), [4, 6], "auto domains by default");
+
+        assert.strictEqual(scale.domain([7, 8]), scale, "Setting the domain explicitly returns the scale");
+        assert.deepEqual(scale.domain(), [7, 8], "setting the domain explicitly stops autoDomaining");
+
+        scale.addIncludedValuesProvider(() => [4, 6]);
+        assert.deepEqual(scale.domain(), [7, 8], "adding new values providers does not trigger autoDomain");
+
+        assert.strictEqual(scale.autoDomain(), scale, "setting the autoDomain returns the scale");
+        assert.deepEqual(scale.domain(), [4, 6], "triggering the autoDomain overrides the manually inputted domain");
       });
 
       it("modififes the autodomain flag accordingly", () => {

--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -369,7 +369,7 @@ describe("Scales", () => {
         scale.padProportion(0);
       });
 
-      it("receives updates from the plot and autodomains in accordange", () => {
+      it("receives updates from the plot and autodomains accordingly", () => {
         let svg = TestMethods.generateSVG();
         let plot = new Plottable.Plot();
 
@@ -410,7 +410,7 @@ describe("Scales", () => {
         assert.deepEqual(scale.domain(), [10, 11], "scale was still listening to dataset after one perspective deregistered");
 
         plot2.attr("x", (d) => d.x, otherScale);
-        assert.deepEqual(scale.domain(), [0, 1], "scale resetted to the default domain as it is no longer attached to plots");
+        assert.deepEqual(scale.domain(), [0, 1], "scale resets to the default domain as it is no longer attached to plots");
         dataset.data([{x: 99}, {x: 100}]);
         assert.deepEqual(scale.domain(), [0, 1], "scale shows default values when all perspectives removed");
 

--- a/test/scales/linearScaleTests.ts
+++ b/test/scales/linearScaleTests.ts
@@ -105,8 +105,7 @@ describe("Scales", () => {
         scale.domain([0, 10]);
         let defaultTicks = scale.ticks();
         assert.strictEqual(defaultTicks.length, 11, "ticks were generated correctly with default generator");
-        assert.deepEqual(defaultTicks, Array.apply(null, Array(11)).map((d: any, i: number) => i),
-          "all numbers from 0 to 10 were generated");
+        assert.deepEqual(defaultTicks, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], "all numbers from 0 to 10 were generated");
         scale.tickGenerator((scale) => scale.defaultTicks().filter(tick => tick % 3 === 0));
         let customTicks = scale.ticks();
         assert.deepEqual(customTicks, [0, 3, 6, 9], "ticks were generated correctly with custom generator");
@@ -142,14 +141,6 @@ describe("Scales", () => {
 
         assert.strictEqual(scale.autoDomain(), scale, "setting the autoDomain returns the scale");
         assert.deepEqual(scale.domain(), [4, 6], "triggering the autoDomain overrides the manually inputted domain");
-      });
-
-      it("modififes the autodomain flag accordingly", () => {
-        scale.addIncludedValuesProvider((scale) => [0, 5]);
-        assert.isTrue((<any> scale)._autoDomainAutomatically,
-          "the autoDomain flag is still set after autodomaining, padding and nice-ing");
-        scale.domain([0, 5]);
-        assert.isFalse((<any> scale)._autoDomainAutomatically, "the autoDomain flag is false after domain explicitly set");
       });
 
       it("accounts for included values providers", () => {


### PR DESCRIPTION
Part of #2640 

I will be doing 2 passes because I will get more context (and better sense of best practices) by refactoring other files. However, please flag anything that seems unusual.

As part of this: 
- **Test semantics: hierarchy, naming, testing, but no coverage check**
- Applied best practices from the wiki page
- Factored out common code into `beforeEach()` clauses
- No nested `beforeEach()`es
- Removed annoying console warnings
- Remade hierarchy as shown bellow
![screen shot 2015-08-26 at 11 56 41 am](https://cloud.githubusercontent.com/assets/3248682/9503041/8cd3f20e-4be9-11e5-9332-2e1e1a35d476.png)
