### PR TITLE
add label() and labelsEnable() for Plots.Wheel

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -54,10 +54,7 @@ declare module Plottable {
              * @return {number} dist(p1, p2)^2
              */
             function distanceSquared(p1: Point, p2: Point): number;
-            /**
-             * Converts degree to radian
-             */
-            function degreeToRadian(degree: number): number;
+            function degreesToRadians(degree: number): number;
         }
     }
 }
@@ -3593,18 +3590,18 @@ declare module Plottable {
             protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
             protected _propertyProjectors(): AttributeToProjector;
             /**
-             * Gets the AccessorScaleBinding for the start angle in degree.
+             * Gets the AccessorScaleBinding for the start angle in degrees.
              */
             startAngle<T>(): AccessorScaleBinding<T, number>;
             /**
-             * Sets the start angle to a constant number or the result of an Accessor<number> in degree.
+             * Sets the start angle to a constant number or the result of an Accessor<number> in degrees.
              *
              * @param {number|Accessor<number>} startAngle
              * @returns {Wheel} The calling Wheel Plot.
              */
             startAngle(startAngle: number | Accessor<number>): Plots.Wheel<R, T>;
             /**
-             * Sets the start angle to a scaled constant value or scaled result of an Accessor in degree.
+             * Sets the start angle to a scaled constant value or scaled result of an Accessor in degrees.
              * The supplied Scale will also be used for endAngle().
              * The provided Scale will account for the values when autoDomain()-ing.
              *
@@ -3614,11 +3611,11 @@ declare module Plottable {
              */
             startAngle<T>(startAngle: T | Accessor<T>, scale: Scale<T, number>): Plots.Wheel<R, T>;
             /**
-             * Gets the AccessorScaleBinding for the end angle in degree.
+             * Gets the AccessorScaleBinding for the end angle in degrees.
              */
             endAngle<T>(): AccessorScaleBinding<T, number>;
             /**
-             * Sets the end angle to a constant number or the result of an Accessor<number> in degree.
+             * Sets the end angle to a constant number or the result of an Accessor<number> in degrees.
              * If a Scale has been set for startAngle, it will also be used to scale endAngle.
              *
              * @param {number|Accessor<number>} endAngle

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3603,8 +3603,8 @@ declare module Plottable {
              * Sets the start angle to a scaled constant value or scaled result of an Accessor.
              * The provided Scale will account for the values when autoDomain()-ing.
              *
-             * @param {S|Accessor<S>} startAngle
-             * @param {Scale<S, number>} scale
+             * @param {S|Accessor<number>} startAngle
+             * @param {Scale<T, number>} scale
              * @returns {Wheel} The calling Wheel Plot.
              */
             startAngle<T>(startAngle: T | Accessor<T>, scale: Scale<T, number>): Plots.Wheel<R, T>;
@@ -3619,15 +3619,6 @@ declare module Plottable {
              * @returns {Wheel} The calling Wheel Plot.
              */
             endAngle(endAngle: number | Accessor<number>): Plots.Wheel<R, T>;
-            /**
-             * Sets the end angle to a scaled constant value or scaled result of an Accessor.
-             * The provided Scale will account for the values when autoDomain()-ing.
-             *
-             * @param {S|Accessor<S>} endAngle
-             * @param {Scale<S, number>} scale
-             * @returns {Wheel} The calling Wheel Plot.
-             */
-            endAngle<T>(endAngle: T | Accessor<T>, scale: Scale<T, number>): Plots.Wheel<R, T>;
             /**
              * Gets the AccessorScaleBinding for the inner radius.
              */
@@ -3659,15 +3650,6 @@ declare module Plottable {
              * @returns {Wheel} The calling Wheel Plot.
              */
             outerRadius(outerRadius: number | Accessor<number>): Plots.Wheel<R, T>;
-            /**
-             * Sets the outer radius to a scaled constant value or scaled result of an Accessor.
-             * The provided Scale will account for the values when autoDomain()-ing.
-             *
-             * @param {R|Accessor<R>} outerRadius
-             * @param {Scale<R, number>} scale
-             * @returns {Wheel} The calling Wheel Plot.
-             */
-            outerRadius<R>(outerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Wheel<R, T>;
             protected _pixelPoint(datum: any, index: number, dataset: Dataset): {
                 x: number;
                 y: number;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3577,6 +3577,107 @@ declare module Plottable {
 
 
 declare module Plottable {
+    module Plots {
+        class Wheel<R, T> extends Plot {
+            /**
+             * @constructor
+             */
+            constructor();
+            computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Wheel<R, T>;
+            protected _createDrawer(dataset: Dataset): Drawers.Arc;
+            entities(datasets?: Dataset[]): PlotEntity[];
+            protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
+            protected _propertyProjectors(): AttributeToProjector;
+            /**
+             * Gets the AccessorScaleBinding for the start angle.
+             */
+            startAngle<T>(): AccessorScaleBinding<T, number>;
+            /**
+             * Sets the start angle to a constant number or the result of an Accessor<number>.
+             *
+             * @param {number|Accessor<number>} startAngle
+             * @returns {Wheel} The calling Wheel Plot.
+             */
+            startAngle(startAngle: number | Accessor<number>): Plots.Wheel<R, T>;
+            /**
+             * Sets the start angle to a scaled constant value or scaled result of an Accessor.
+             * The provided Scale will account for the values when autoDomain()-ing.
+             *
+             * @param {S|Accessor<S>} startAngle
+             * @param {Scale<S, number>} scale
+             * @returns {Wheel} The calling Wheel Plot.
+             */
+            startAngle<T>(startAngle: T | Accessor<T>, scale: Scale<T, number>): Plots.Wheel<R, T>;
+            /**
+             * Gets the AccessorScaleBinding for the end angle.
+             */
+            endAngle<T>(): AccessorScaleBinding<T, number>;
+            /**
+             * Sets the end angle to a constant number or the result of an Accessor<number>.
+             *
+             * @param {number|Accessor<number>} endAngle
+             * @returns {Wheel} The calling Wheel Plot.
+             */
+            endAngle(endAngle: number | Accessor<number>): Plots.Wheel<R, T>;
+            /**
+             * Sets the end angle to a scaled constant value or scaled result of an Accessor.
+             * The provided Scale will account for the values when autoDomain()-ing.
+             *
+             * @param {S|Accessor<S>} endAngle
+             * @param {Scale<S, number>} scale
+             * @returns {Wheel} The calling Wheel Plot.
+             */
+            endAngle<T>(endAngle: T | Accessor<T>, scale: Scale<T, number>): Plots.Wheel<R, T>;
+            /**
+             * Gets the AccessorScaleBinding for the inner radius.
+             */
+            innerRadius<R>(): AccessorScaleBinding<R, number>;
+            /**
+             * Sets the inner radius to a constant number or the result of an Accessor<number>.
+             *
+             * @param {number|Accessor<number>} innerRadius
+             * @returns {Wheel} The calling Wheel Plot.
+             */
+            innerRadius(innerRadius: number | Accessor<number>): Plots.Wheel<R, T>;
+            /**
+             * Sets the inner radius to a scaled constant value or scaled result of an Accessor.
+             * The provided Scale will account for the values when autoDomain()-ing.
+             *
+             * @param {R|Accessor<R>} innerRadius
+             * @param {Scale<R, number>} scale
+             * @returns {Wheel} The calling Wheel Plot.
+             */
+            innerRadius<R>(innerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Wheel<R, T>;
+            /**
+             * Gets the AccessorScaleBinding for the outer radius.
+             */
+            outerRadius<R>(): AccessorScaleBinding<R, number>;
+            /**
+             * Sets the outer radius to a constant number or the result of an Accessor<number>.
+             *
+             * @param {number|Accessor<number>} outerRadius
+             * @returns {Wheel} The calling Wheel Plot.
+             */
+            outerRadius(outerRadius: number | Accessor<number>): Plots.Wheel<R, T>;
+            /**
+             * Sets the outer radius to a scaled constant value or scaled result of an Accessor.
+             * The provided Scale will account for the values when autoDomain()-ing.
+             *
+             * @param {R|Accessor<R>} outerRadius
+             * @param {Scale<R, number>} scale
+             * @returns {Wheel} The calling Wheel Plot.
+             */
+            outerRadius<R>(outerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Wheel<R, T>;
+            protected _pixelPoint(datum: any, index: number, dataset: Dataset): {
+                x: number;
+                y: number;
+            };
+        }
+    }
+}
+
+
+declare module Plottable {
     interface Animator {
         /**
          * Applies the supplied attributes to a d3.Selection with some animation.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -54,6 +54,10 @@ declare module Plottable {
              * @return {number} dist(p1, p2)^2
              */
             function distanceSquared(p1: Point, p2: Point): number;
+            /**
+             * Converts degree to radian
+             */
+            function degreeToRadian(degree: number): number;
         }
     }
 }
@@ -3589,19 +3593,19 @@ declare module Plottable {
             protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
             protected _propertyProjectors(): AttributeToProjector;
             /**
-             * Gets the AccessorScaleBinding for the start angle.
+             * Gets the AccessorScaleBinding for the start angle in degree.
              */
             startAngle<T>(): AccessorScaleBinding<T, number>;
             /**
-             * Sets the start angle to a constant number or the result of an Accessor<number>.
+             * Sets the start angle to a constant number or the result of an Accessor<number> in degree.
              *
              * @param {number|Accessor<number>} startAngle
              * @returns {Wheel} The calling Wheel Plot.
              */
             startAngle(startAngle: number | Accessor<number>): Plots.Wheel<R, T>;
             /**
-             * Sets the start angle to a scaled constant value or scaled result of an Accessor.
-             * This also sets the scale for end angle.
+             * Sets the start angle to a scaled constant value or scaled result of an Accessor in degree.
+             * The supplied Scale will also be used for endAngle().
              * The provided Scale will account for the values when autoDomain()-ing.
              *
              * @param {T|Accessor<T>} startAngle
@@ -3610,12 +3614,12 @@ declare module Plottable {
              */
             startAngle<T>(startAngle: T | Accessor<T>, scale: Scale<T, number>): Plots.Wheel<R, T>;
             /**
-             * Gets the AccessorScaleBinding for the end angle.
+             * Gets the AccessorScaleBinding for the end angle in degree.
              */
             endAngle<T>(): AccessorScaleBinding<T, number>;
             /**
-             * Sets the end angle to a constant number or the result of an Accessor<number>.
-             * The scale of end angle is set to be the scale of start angle.
+             * Sets the end angle to a constant number or the result of an Accessor<number> in degree.
+             * If a Scale has been set for startAngle, it will also be used to scale endAngle.
              *
              * @param {number|Accessor<number>} endAngle
              * @returns {Wheel} The calling Wheel Plot.
@@ -3634,7 +3638,7 @@ declare module Plottable {
             innerRadius(innerRadius: number | Accessor<number>): Plots.Wheel<R, T>;
             /**
              * Sets the inner radius to a scaled constant value or scaled result of an Accessor.
-             * This also sets the scale for outer radius.
+             * The supplied Scale will also be used for outerRadius().
              * The provided Scale will account for the values when autoDomain()-ing.
              *
              * @param {R|Accessor<R>} innerRadius
@@ -3648,7 +3652,7 @@ declare module Plottable {
             outerRadius<R>(): AccessorScaleBinding<R, number>;
             /**
              * Sets the outer radius to a constant number or the result of an Accessor<number>.
-             * The scale of outer radius is set to be the scale of inner radius.
+             * If a Scale has been set for innerRadius, it will also be used to scale outerRadius.
              *
              * @param {number|Accessor<number>} outerRadius
              * @returns {Wheel} The calling Wheel Plot.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3601,9 +3601,10 @@ declare module Plottable {
             startAngle(startAngle: number | Accessor<number>): Plots.Wheel<R, T>;
             /**
              * Sets the start angle to a scaled constant value or scaled result of an Accessor.
+             * This also sets the scale for end angle.
              * The provided Scale will account for the values when autoDomain()-ing.
              *
-             * @param {S|Accessor<number>} startAngle
+             * @param {T|Accessor<T>} startAngle
              * @param {Scale<T, number>} scale
              * @returns {Wheel} The calling Wheel Plot.
              */
@@ -3614,6 +3615,7 @@ declare module Plottable {
             endAngle<T>(): AccessorScaleBinding<T, number>;
             /**
              * Sets the end angle to a constant number or the result of an Accessor<number>.
+             * The scale of end angle is set to be the scale of start angle.
              *
              * @param {number|Accessor<number>} endAngle
              * @returns {Wheel} The calling Wheel Plot.
@@ -3632,6 +3634,7 @@ declare module Plottable {
             innerRadius(innerRadius: number | Accessor<number>): Plots.Wheel<R, T>;
             /**
              * Sets the inner radius to a scaled constant value or scaled result of an Accessor.
+             * This also sets the scale for outer radius.
              * The provided Scale will account for the values when autoDomain()-ing.
              *
              * @param {R|Accessor<R>} innerRadius
@@ -3645,6 +3648,7 @@ declare module Plottable {
             outerRadius<R>(): AccessorScaleBinding<R, number>;
             /**
              * Sets the outer radius to a constant number or the result of an Accessor<number>.
+             * The scale of outer radius is set to be the scale of inner radius.
              *
              * @param {number|Accessor<number>} outerRadius
              * @returns {Wheel} The calling Wheel Plot.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3655,10 +3655,38 @@ declare module Plottable {
              * @returns {Wheel} The calling Wheel Plot.
              */
             outerRadius(outerRadius: number | Accessor<number>): Plots.Wheel<R, T>;
+            /**
+             * Gets the Accessor for labels.
+             *
+             * @returns {Accessor<string>}
+             */
+            label(): Accessor<string>;
+            /**
+             * Sets the text of labels to the result of an Accessor.
+             *
+             * @param {Accessor<string>} label
+             * @returns {Plots.Wheel} The calling Wheel Plot.
+             */
+            label(label: Accessor<string>): Plots.Wheel<R, T>;
+            /**
+             * Gets whether labels are enabled.
+             *
+             * @returns {boolean}
+             */
+            labelsEnabled(): boolean;
+            /**
+             * Sets whether labels are enabled.
+             * Labels too big to be contained in the sector or cut off by edges will not be shown.
+             *
+             * @param {boolean} labelsEnabled
+             * @returns {Wheel} The calling Wheel Plot.
+             */
+            labelsEnabled(enabled: boolean): Plots.Wheel<R, T>;
             protected _pixelPoint(datum: any, index: number, dataset: Dataset): {
                 x: number;
                 y: number;
             };
+            protected _additionalPaint(time: number): void;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -111,6 +111,13 @@ var Plottable;
                 return nativeMath.pow(p2.y - p1.y, 2) + nativeMath.pow(p2.x - p1.x, 2);
             }
             Math.distanceSquared = distanceSquared;
+            /**
+             * Converts degree to radian
+             */
+            function degreeToRadian(degree) {
+                return degree / 360 * nativeMath.PI * 2;
+            }
+            Math.degreeToRadian = degreeToRadian;
         })(Math = Utils.Math || (Utils.Math = {}));
     })(Utils = Plottable.Utils || (Plottable.Utils = {}));
 })(Plottable || (Plottable = {}));
@@ -9844,12 +9851,12 @@ var Plottable;
                     var startAngle = startAngleAccessor(datum, index, ds);
                     var endAngle = endAngleAccessor(datum, index, ds);
                     if (endAngle < startAngle) {
-                        endAngle += (Math.floor((startAngle - endAngle) / (Math.PI * 2)) + 1) * Math.PI * 2;
+                        endAngle += (Math.floor((startAngle - endAngle) / 360) + 1) * 360;
                     }
                     return d3.svg.arc().innerRadius(innerRadiusAccessor(datum, index, ds))
                         .outerRadius(outerRadiusAccessor(datum, index, ds))
-                        .startAngle(startAngle)
-                        .endAngle(endAngle)(datum, index);
+                        .startAngle(Plottable.Utils.Math.degreeToRadian(startAngle))
+                        .endAngle(Plottable.Utils.Math.degreeToRadian(endAngle))(datum, index);
                 };
                 return attrToProjector;
             };
@@ -9858,7 +9865,7 @@ var Plottable;
                     return this._propertyBindings.get(Wheel._START_ANGLE_KEY);
                 }
                 if (scale != null) {
-                    scale.range([0, Math.PI * 2]);
+                    scale.range([0, 360]);
                 }
                 var endAngleBinding = this.endAngle();
                 var endAngleAccessor = endAngleBinding && endAngleBinding.accessor;
@@ -9884,7 +9891,7 @@ var Plottable;
                     return this._propertyBindings.get(Wheel._INNER_RADIUS_KEY);
                 }
                 if (scale != null) {
-                    scale.range([0, Math.PI * 2]);
+                    scale.range([0, 360]);
                 }
                 var outerRadiusBinding = this.outerRadius();
                 var outerRadiusAccessor = outerRadiusBinding && outerRadiusBinding.accessor;
@@ -9911,7 +9918,7 @@ var Plottable;
                 var avgRadius = (innerRadius + outerRadius) / 2;
                 var startAngle = Plottable.Plot._scaledAccessor(this.startAngle())(datum, index, dataset);
                 var endAngle = Plottable.Plot._scaledAccessor(this.endAngle())(datum, index, dataset);
-                var avgAngle = (startAngle + endAngle) / 2;
+                var avgAngle = Plottable.Utils.Math.degreeToRadian((startAngle + endAngle) / 2);
                 return { x: avgRadius * Math.sin(avgAngle), y: -avgRadius * Math.cos(avgAngle) };
             };
             Wheel._INNER_RADIUS_KEY = "inner-radius";

--- a/plottable.js
+++ b/plottable.js
@@ -111,13 +111,10 @@ var Plottable;
                 return nativeMath.pow(p2.y - p1.y, 2) + nativeMath.pow(p2.x - p1.x, 2);
             }
             Math.distanceSquared = distanceSquared;
-            /**
-             * Converts degree to radian
-             */
-            function degreeToRadian(degree) {
+            function degreesToRadians(degree) {
                 return degree / 360 * nativeMath.PI * 2;
             }
-            Math.degreeToRadian = degreeToRadian;
+            Math.degreesToRadians = degreesToRadians;
         })(Math = Utils.Math || (Utils.Math = {}));
     })(Utils = Plottable.Utils || (Plottable.Utils = {}));
 })(Plottable || (Plottable = {}));
@@ -9855,8 +9852,8 @@ var Plottable;
                     }
                     return d3.svg.arc().innerRadius(innerRadiusAccessor(datum, index, ds))
                         .outerRadius(outerRadiusAccessor(datum, index, ds))
-                        .startAngle(Plottable.Utils.Math.degreeToRadian(startAngle))
-                        .endAngle(Plottable.Utils.Math.degreeToRadian(endAngle))(datum, index);
+                        .startAngle(Plottable.Utils.Math.degreesToRadians(startAngle))
+                        .endAngle(Plottable.Utils.Math.degreesToRadians(endAngle))(datum, index);
                 };
                 return attrToProjector;
             };
@@ -9918,7 +9915,7 @@ var Plottable;
                 var avgRadius = (innerRadius + outerRadius) / 2;
                 var startAngle = Plottable.Plot._scaledAccessor(this.startAngle())(datum, index, dataset);
                 var endAngle = Plottable.Plot._scaledAccessor(this.endAngle())(datum, index, dataset);
-                var avgAngle = Plottable.Utils.Math.degreeToRadian((startAngle + endAngle) / 2);
+                var avgAngle = Plottable.Utils.Math.degreesToRadians((startAngle + endAngle) / 2);
                 return { x: avgRadius * Math.sin(avgAngle), y: -avgRadius * Math.cos(avgAngle) };
             };
             Wheel._INNER_RADIUS_KEY = "inner-radius";

--- a/plottable.js
+++ b/plottable.js
@@ -9841,10 +9841,10 @@ var Plottable;
                 var startAngleAccessor = Plottable.Plot._scaledAccessor(this.startAngle());
                 var endAngleAccessor = Plottable.Plot._scaledAccessor(this.endAngle());
                 attrToProjector["d"] = function (datum, index, ds) {
-                    var startAngle = startAngleAccessor(datum, index, ds) % (Math.PI * 2);
-                    var endAngle = endAngleAccessor(datum, index, ds) % (Math.PI * 2);
-                    while (endAngle < startAngle) {
-                        endAngle += Math.PI * 2;
+                    var startAngle = startAngleAccessor(datum, index, ds);
+                    var endAngle = endAngleAccessor(datum, index, ds);
+                    if (endAngle < startAngle) {
+                        endAngle += (Math.floor((startAngle - endAngle) / (Math.PI * 2)) + 1) * Math.PI * 2;
                     }
                     return d3.svg.arc().innerRadius(innerRadiusAccessor(datum, index, ds))
                         .outerRadius(outerRadiusAccessor(datum, index, ds))

--- a/plottable.js
+++ b/plottable.js
@@ -9770,6 +9770,143 @@ var Plottable;
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    __.prototype = b.prototype;
+    d.prototype = new __();
+};
+var Plottable;
+(function (Plottable) {
+    var Plots;
+    (function (Plots) {
+        var Wheel = (function (_super) {
+            __extends(Wheel, _super);
+            /**
+             * @constructor
+             */
+            function Wheel() {
+                _super.call(this);
+                this.addClass("wheel-plot");
+                this.attr("fill", function (d, i) { return String(i); }, new Plottable.Scales.Color());
+            }
+            Wheel.prototype.computeLayout = function (origin, availableWidth, availableHeight) {
+                _super.prototype.computeLayout.call(this, origin, availableWidth, availableHeight);
+                this._renderArea.attr("transform", "translate(" + this.width() / 2 + "," + this.height() / 2 + ")");
+                var radiusLimit = Math.min(this.width(), this.height()) / 2;
+                if (this.innerRadius() != null && this.innerRadius().scale != null) {
+                    this.innerRadius().scale.range([0, radiusLimit]);
+                }
+                if (this.outerRadius() != null && this.outerRadius().scale != null) {
+                    this.outerRadius().scale.range([0, radiusLimit]);
+                }
+                return this;
+            };
+            Wheel.prototype._createDrawer = function (dataset) {
+                return new Plottable.Drawers.Arc(dataset);
+            };
+            Wheel.prototype.entities = function (datasets) {
+                var _this = this;
+                if (datasets === void 0) { datasets = this.datasets(); }
+                var entities = _super.prototype.entities.call(this, datasets);
+                entities.forEach(function (entity) {
+                    entity.position.x += _this.width() / 2;
+                    entity.position.y += _this.height() / 2;
+                });
+                return entities;
+            };
+            Wheel.prototype._getDataToDraw = function () {
+                var dataToDraw = _super.prototype._getDataToDraw.call(this);
+                if (this.datasets().length === 0) {
+                    return dataToDraw;
+                }
+                var startAngleAccessor = Plottable.Plot._scaledAccessor(this.startAngle());
+                var endAngleAccessor = Plottable.Plot._scaledAccessor(this.endAngle());
+                var innerRadiusAccessor = Plottable.Plot._scaledAccessor(this.innerRadius());
+                var outerRadiusAccessor = Plottable.Plot._scaledAccessor(this.outerRadius());
+                var ds = this.datasets()[0];
+                var data = dataToDraw.get(ds);
+                var filteredData = data.filter(function (d, i) {
+                    return Plottable.Utils.Math.isValidNumber(startAngleAccessor(d, i, ds)) &&
+                        Plottable.Utils.Math.isValidNumber(endAngleAccessor(d, i, ds)) &&
+                        Plottable.Utils.Math.isValidNumber(innerRadiusAccessor(d, i, ds)) &&
+                        Plottable.Utils.Math.isValidNumber(outerRadiusAccessor(d, i, ds));
+                });
+                dataToDraw.set(ds, filteredData);
+                return dataToDraw;
+            };
+            Wheel.prototype._propertyProjectors = function () {
+                var attrToProjector = _super.prototype._propertyProjectors.call(this);
+                var innerRadiusAccessor = Plottable.Plot._scaledAccessor(this.innerRadius());
+                var outerRadiusAccessor = Plottable.Plot._scaledAccessor(this.outerRadius());
+                var startAngleAccessor = Plottable.Plot._scaledAccessor(this.startAngle());
+                var endAngleAccessor = Plottable.Plot._scaledAccessor(this.endAngle());
+                attrToProjector["d"] = function (datum, index, ds) {
+                    return d3.svg.arc().innerRadius(innerRadiusAccessor(datum, index, ds))
+                        .outerRadius(outerRadiusAccessor(datum, index, ds))
+                        .startAngle(startAngleAccessor(datum, index, ds))
+                        .endAngle(endAngleAccessor(datum, index, ds))(datum, index);
+                };
+                return attrToProjector;
+            };
+            Wheel.prototype.startAngle = function (startAngle, scale) {
+                if (startAngle == null) {
+                    return this._propertyBindings.get(Wheel._START_ANGLE_KEY);
+                }
+                if (scale != null) {
+                    scale.range([0, Math.PI * 2]);
+                }
+                this._bindProperty(Wheel._START_ANGLE_KEY, startAngle, scale);
+                this.render();
+                return this;
+            };
+            Wheel.prototype.endAngle = function (endAngle, scale) {
+                if (endAngle == null) {
+                    return this._propertyBindings.get(Wheel._END_ANGLE_KEY);
+                }
+                if (scale != null) {
+                    scale.range([0, Math.PI * 2]);
+                }
+                this._bindProperty(Wheel._END_ANGLE_KEY, endAngle, scale);
+                this.render();
+                return this;
+            };
+            Wheel.prototype.innerRadius = function (innerRadius, scale) {
+                if (innerRadius == null) {
+                    return this._propertyBindings.get(Wheel._INNER_RADIUS_KEY);
+                }
+                this._bindProperty(Wheel._INNER_RADIUS_KEY, innerRadius, scale);
+                this.render();
+                return this;
+            };
+            Wheel.prototype.outerRadius = function (outerRadius, scale) {
+                if (outerRadius == null) {
+                    return this._propertyBindings.get(Wheel._OUTER_RADIUS_KEY);
+                }
+                this._bindProperty(Wheel._OUTER_RADIUS_KEY, outerRadius, scale);
+                this.render();
+                return this;
+            };
+            Wheel.prototype._pixelPoint = function (datum, index, dataset) {
+                var innerRadius = Plottable.Plot._scaledAccessor(this.innerRadius())(datum, index, dataset);
+                var outerRadius = Plottable.Plot._scaledAccessor(this.outerRadius())(datum, index, dataset);
+                var avgRadius = (innerRadius + outerRadius) / 2;
+                var startAngle = Plottable.Plot._scaledAccessor(this.startAngle())(datum, index, dataset);
+                var endAngle = Plottable.Plot._scaledAccessor(this.endAngle())(datum, index, dataset);
+                var avgAngle = (startAngle + endAngle) / 2;
+                return { x: avgRadius * Math.sin(avgAngle), y: -avgRadius * Math.cos(avgAngle) };
+            };
+            Wheel._INNER_RADIUS_KEY = "inner-radius";
+            Wheel._OUTER_RADIUS_KEY = "outer-radius";
+            Wheel._START_ANGLE_KEY = "start-angle";
+            Wheel._END_ANGLE_KEY = "end-angle";
+            return Wheel;
+        })(Plottable.Plot);
+        Plots.Wheel = Wheel;
+    })(Plots = Plottable.Plots || (Plottable.Plots = {}));
+})(Plottable || (Plottable = {}));
+
+///<reference path="../reference.ts" />
 
 ///<reference path="../reference.ts" />
 var Plottable;

--- a/src/plots/wheelPlot.ts
+++ b/src/plots/wheelPlot.ts
@@ -1,0 +1,219 @@
+///<reference path="../reference.ts" />
+
+module Plottable {
+export module Plots {
+  export class Wheel<R, T> extends Plot {
+
+    private static _INNER_RADIUS_KEY = "inner-radius";
+    private static _OUTER_RADIUS_KEY = "outer-radius";
+    private static _START_ANGLE_KEY = "start-angle";
+    private static _END_ANGLE_KEY = "end-angle";
+
+    /**
+     * @constructor
+     */
+    constructor() {
+      super();
+      this.addClass("wheel-plot");
+      this.attr("fill", (d, i) => String(i), new Scales.Color());
+    }
+
+    public computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number) {
+      super.computeLayout(origin, availableWidth, availableHeight);
+      this._renderArea.attr("transform", "translate(" + this.width() / 2 + "," + this.height() / 2 + ")");
+      let radiusLimit = Math.min(this.width(), this.height()) / 2;
+      if (this.innerRadius() != null && this.innerRadius().scale != null) {
+        this.innerRadius().scale.range([0, radiusLimit]);
+      }
+      if (this.outerRadius() != null && this.outerRadius().scale != null) {
+        this.outerRadius().scale.range([0, radiusLimit]);
+      }
+      return this;
+    }
+
+    protected _createDrawer(dataset: Dataset) {
+      return new Plottable.Drawers.Arc(dataset);
+    }
+
+    public entities(datasets = this.datasets()): PlotEntity[] {
+      let entities = super.entities(datasets);
+      entities.forEach((entity) => {
+        entity.position.x += this.width() / 2;
+        entity.position.y += this.height() / 2;
+      });
+      return entities;
+    }
+
+    protected _getDataToDraw() {
+      let dataToDraw = super._getDataToDraw();
+      if (this.datasets().length === 0) { return dataToDraw; }
+      let startAngleAccessor = Plot._scaledAccessor(this.startAngle());
+      let endAngleAccessor = Plot._scaledAccessor(this.endAngle());
+      let innerRadiusAccessor = Plot._scaledAccessor(this.innerRadius());
+      let outerRadiusAccessor = Plot._scaledAccessor(this.outerRadius());
+      let ds = this.datasets()[0];
+      let data = dataToDraw.get(ds);
+      let filteredData = data.filter((d, i) =>
+        Plottable.Utils.Math.isValidNumber(startAngleAccessor(d, i, ds)) &&
+        Plottable.Utils.Math.isValidNumber(endAngleAccessor(d, i, ds)) &&
+        Plottable.Utils.Math.isValidNumber(innerRadiusAccessor(d, i, ds)) &&
+        Plottable.Utils.Math.isValidNumber(outerRadiusAccessor(d, i, ds)));
+      dataToDraw.set(ds, filteredData);
+      return dataToDraw;
+    }
+
+    protected _propertyProjectors(): AttributeToProjector {
+      let attrToProjector = super._propertyProjectors();
+      let innerRadiusAccessor = Plot._scaledAccessor(this.innerRadius());
+      let outerRadiusAccessor = Plot._scaledAccessor(this.outerRadius());
+      let startAngleAccessor = Plot._scaledAccessor(this.startAngle());
+      let endAngleAccessor = Plot._scaledAccessor(this.endAngle());
+      attrToProjector["d"] = (datum: any, index: number, ds: Dataset) => {
+        return d3.svg.arc().innerRadius(innerRadiusAccessor(datum, index, ds))
+                           .outerRadius(outerRadiusAccessor(datum, index, ds))
+                           .startAngle(startAngleAccessor(datum, index, ds))
+                           .endAngle(endAngleAccessor(datum, index, ds))(datum, index);
+      };
+      return attrToProjector;
+    }
+
+    /**
+     * Gets the AccessorScaleBinding for the start angle.
+     */
+    public startAngle<T>(): AccessorScaleBinding<T, number>;
+    /**
+     * Sets the start angle to a constant number or the result of an Accessor<number>.
+     *
+     * @param {number|Accessor<number>} startAngle
+     * @returns {Wheel} The calling Wheel Plot.
+     */
+    public startAngle(startAngle: number | Accessor<number>): Plots.Wheel<R, T>;
+    /**
+     * Sets the start angle to a scaled constant value or scaled result of an Accessor.
+     * The provided Scale will account for the values when autoDomain()-ing.
+     *
+     * @param {S|Accessor<S>} startAngle
+     * @param {Scale<S, number>} scale
+     * @returns {Wheel} The calling Wheel Plot.
+     */
+    public startAngle<T>(startAngle: T | Accessor<T>, scale: Scale<T, number>): Plots.Wheel<R, T>;
+    public startAngle<T>(startAngle?: number | Accessor<number> | T | Accessor<T>, scale?: Scale<T, number>): any {
+      if (startAngle == null) {
+        return this._propertyBindings.get(Wheel._START_ANGLE_KEY);
+      }
+
+      if (scale != null) {
+        scale.range([0, Math.PI * 2]);
+      }
+
+      this._bindProperty(Wheel._START_ANGLE_KEY, startAngle, scale);
+      this.render();
+      return this;
+    }
+
+    /**
+     * Gets the AccessorScaleBinding for the end angle.
+     */
+    public endAngle<T>(): AccessorScaleBinding<T, number>;
+    /**
+     * Sets the end angle to a constant number or the result of an Accessor<number>.
+     *
+     * @param {number|Accessor<number>} endAngle
+     * @returns {Wheel} The calling Wheel Plot.
+     */
+    public endAngle(endAngle: number | Accessor<number>): Plots.Wheel<R, T>;
+    /**
+     * Sets the end angle to a scaled constant value or scaled result of an Accessor.
+     * The provided Scale will account for the values when autoDomain()-ing.
+     *
+     * @param {S|Accessor<S>} endAngle
+     * @param {Scale<S, number>} scale
+     * @returns {Wheel} The calling Wheel Plot.
+     */
+    public endAngle<T>(endAngle: T | Accessor<T>, scale: Scale<T, number>): Plots.Wheel<R, T>;
+    public endAngle<T>(endAngle?: number | Accessor<number> | T | Accessor<T>, scale?: Scale<T, number>): any {
+      if (endAngle == null) {
+        return this._propertyBindings.get(Wheel._END_ANGLE_KEY);
+      }
+
+      if (scale != null) {
+        scale.range([0, Math.PI * 2]);
+      }
+
+      this._bindProperty(Wheel._END_ANGLE_KEY, endAngle, scale);
+      this.render();
+      return this;
+    }
+
+    /**
+     * Gets the AccessorScaleBinding for the inner radius.
+     */
+    public innerRadius<R>(): AccessorScaleBinding<R, number>;
+    /**
+     * Sets the inner radius to a constant number or the result of an Accessor<number>.
+     *
+     * @param {number|Accessor<number>} innerRadius
+     * @returns {Wheel} The calling Wheel Plot.
+     */
+    public innerRadius(innerRadius: number | Accessor<number>): Plots.Wheel<R, T>;
+    /**
+     * Sets the inner radius to a scaled constant value or scaled result of an Accessor.
+     * The provided Scale will account for the values when autoDomain()-ing.
+     *
+     * @param {R|Accessor<R>} innerRadius
+     * @param {Scale<R, number>} scale
+     * @returns {Wheel} The calling Wheel Plot.
+     */
+    public innerRadius<R>(innerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Wheel<R, T>;
+    public innerRadius<R>(innerRadius?: number | Accessor<number> | R | Accessor<R>, scale?: Scale<R, number>): any {
+      if (innerRadius == null) {
+        return this._propertyBindings.get(Wheel._INNER_RADIUS_KEY);
+      }
+      this._bindProperty(Wheel._INNER_RADIUS_KEY, innerRadius, scale);
+      this.render();
+      return this;
+    }
+
+    /**
+     * Gets the AccessorScaleBinding for the outer radius.
+     */
+    public outerRadius<R>(): AccessorScaleBinding<R, number>;
+    /**
+     * Sets the outer radius to a constant number or the result of an Accessor<number>.
+     *
+     * @param {number|Accessor<number>} outerRadius
+     * @returns {Wheel} The calling Wheel Plot.
+     */
+    public outerRadius(outerRadius: number | Accessor<number>): Plots.Wheel<R, T>;
+    /**
+     * Sets the outer radius to a scaled constant value or scaled result of an Accessor.
+     * The provided Scale will account for the values when autoDomain()-ing.
+     *
+     * @param {R|Accessor<R>} outerRadius
+     * @param {Scale<R, number>} scale
+     * @returns {Wheel} The calling Wheel Plot.
+     */
+    public outerRadius<R>(outerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Wheel<R, T>;
+    public outerRadius<R>(outerRadius?: number | Accessor<number> | R | Accessor<R>, scale?: Scale<R, number>): any {
+      if (outerRadius == null) {
+        return this._propertyBindings.get(Wheel._OUTER_RADIUS_KEY);
+      }
+      this._bindProperty(Wheel._OUTER_RADIUS_KEY, outerRadius, scale);
+      this.render();
+      return this;
+    }
+
+    protected _pixelPoint(datum: any, index: number, dataset: Dataset) {
+      let innerRadius = Plot._scaledAccessor(this.innerRadius())(datum, index, dataset);
+      let outerRadius = Plot._scaledAccessor(this.outerRadius())(datum, index, dataset);
+      let avgRadius = (innerRadius + outerRadius) / 2;
+
+      let startAngle = Plot._scaledAccessor(this.startAngle())(datum, index, dataset);
+      let endAngle = Plot._scaledAccessor(this.endAngle())(datum, index, dataset);
+      let avgAngle = (startAngle + endAngle) / 2;
+      return { x: avgRadius * Math.sin(avgAngle), y: -avgRadius * Math.cos(avgAngle) };
+    }
+
+  }
+}
+}

--- a/src/plots/wheelPlot.ts
+++ b/src/plots/wheelPlot.ts
@@ -68,9 +68,11 @@ export module Plots {
       let startAngleAccessor = Plot._scaledAccessor(this.startAngle());
       let endAngleAccessor = Plot._scaledAccessor(this.endAngle());
       attrToProjector["d"] = (datum: any, index: number, ds: Dataset) => {
-        let startAngle = startAngleAccessor(datum, index, ds) % (Math.PI * 2);
-        let endAngle = endAngleAccessor(datum, index, ds) % (Math.PI * 2);
-        while (endAngle < startAngle) { endAngle += Math.PI * 2; }
+        let startAngle = startAngleAccessor(datum, index, ds);
+        let endAngle = endAngleAccessor(datum, index, ds);
+        if (endAngle < startAngle) {
+          endAngle += (Math.floor((startAngle - endAngle) / (Math.PI * 2)) + 1) * Math.PI * 2;
+        }
         return d3.svg.arc().innerRadius(innerRadiusAccessor(datum, index, ds))
                            .outerRadius(outerRadiusAccessor(datum, index, ds))
                            .startAngle(startAngle)
@@ -92,9 +94,10 @@ export module Plots {
     public startAngle(startAngle: number | Accessor<number>): Plots.Wheel<R, T>;
     /**
      * Sets the start angle to a scaled constant value or scaled result of an Accessor.
+     * This also sets the scale for end angle.
      * The provided Scale will account for the values when autoDomain()-ing.
      *
-     * @param {S|Accessor<number>} startAngle
+     * @param {T|Accessor<T>} startAngle
      * @param {Scale<T, number>} scale
      * @returns {Wheel} The calling Wheel Plot.
      */
@@ -125,6 +128,7 @@ export module Plots {
     public endAngle<T>(): AccessorScaleBinding<T, number>;
     /**
      * Sets the end angle to a constant number or the result of an Accessor<number>.
+     * The scale of end angle is set to be the scale of start angle.
      *
      * @param {number|Accessor<number>} endAngle
      * @returns {Wheel} The calling Wheel Plot.
@@ -156,6 +160,7 @@ export module Plots {
     public innerRadius(innerRadius: number | Accessor<number>): Plots.Wheel<R, T>;
     /**
      * Sets the inner radius to a scaled constant value or scaled result of an Accessor.
+     * This also sets the scale for outer radius.
      * The provided Scale will account for the values when autoDomain()-ing.
      *
      * @param {R|Accessor<R>} innerRadius
@@ -189,6 +194,7 @@ export module Plots {
     public outerRadius<R>(): AccessorScaleBinding<R, number>;
     /**
      * Sets the outer radius to a constant number or the result of an Accessor<number>.
+     * The scale of outer radius is set to be the scale of inner radius.
      *
      * @param {number|Accessor<number>} outerRadius
      * @returns {Wheel} The calling Wheel Plot.

--- a/src/plots/wheelPlot.ts
+++ b/src/plots/wheelPlot.ts
@@ -75,25 +75,25 @@ export module Plots {
         }
         return d3.svg.arc().innerRadius(innerRadiusAccessor(datum, index, ds))
                            .outerRadius(outerRadiusAccessor(datum, index, ds))
-                           .startAngle(Utils.Math.degreeToRadian(startAngle))
-                           .endAngle(Utils.Math.degreeToRadian(endAngle))(datum, index);
+                           .startAngle(Utils.Math.degreesToRadians(startAngle))
+                           .endAngle(Utils.Math.degreesToRadians(endAngle))(datum, index);
       };
       return attrToProjector;
     }
 
     /**
-     * Gets the AccessorScaleBinding for the start angle in degree.
+     * Gets the AccessorScaleBinding for the start angle in degrees.
      */
     public startAngle<T>(): AccessorScaleBinding<T, number>;
     /**
-     * Sets the start angle to a constant number or the result of an Accessor<number> in degree.
+     * Sets the start angle to a constant number or the result of an Accessor<number> in degrees.
      *
      * @param {number|Accessor<number>} startAngle
      * @returns {Wheel} The calling Wheel Plot.
      */
     public startAngle(startAngle: number | Accessor<number>): Plots.Wheel<R, T>;
     /**
-     * Sets the start angle to a scaled constant value or scaled result of an Accessor in degree.
+     * Sets the start angle to a scaled constant value or scaled result of an Accessor in degrees.
      * The supplied Scale will also be used for endAngle().
      * The provided Scale will account for the values when autoDomain()-ing.
      *
@@ -123,11 +123,11 @@ export module Plots {
     }
 
     /**
-     * Gets the AccessorScaleBinding for the end angle in degree.
+     * Gets the AccessorScaleBinding for the end angle in degrees.
      */
     public endAngle<T>(): AccessorScaleBinding<T, number>;
     /**
-     * Sets the end angle to a constant number or the result of an Accessor<number> in degree.
+     * Sets the end angle to a constant number or the result of an Accessor<number> in degrees.
      * If a Scale has been set for startAngle, it will also be used to scale endAngle.
      *
      * @param {number|Accessor<number>} endAngle
@@ -219,7 +219,7 @@ export module Plots {
 
       let startAngle = Plot._scaledAccessor(this.startAngle())(datum, index, dataset);
       let endAngle = Plot._scaledAccessor(this.endAngle())(datum, index, dataset);
-      let avgAngle = Utils.Math.degreeToRadian((startAngle + endAngle) / 2);
+      let avgAngle = Utils.Math.degreesToRadians((startAngle + endAngle) / 2);
       return { x: avgRadius * Math.sin(avgAngle), y: -avgRadius * Math.cos(avgAngle) };
     }
 

--- a/src/plots/wheelPlot.ts
+++ b/src/plots/wheelPlot.ts
@@ -71,30 +71,30 @@ export module Plots {
         let startAngle = startAngleAccessor(datum, index, ds);
         let endAngle = endAngleAccessor(datum, index, ds);
         if (endAngle < startAngle) {
-          endAngle += (Math.floor((startAngle - endAngle) / (Math.PI * 2)) + 1) * Math.PI * 2;
+          endAngle += (Math.floor((startAngle - endAngle) / 360) + 1) * 360;
         }
         return d3.svg.arc().innerRadius(innerRadiusAccessor(datum, index, ds))
                            .outerRadius(outerRadiusAccessor(datum, index, ds))
-                           .startAngle(startAngle)
-                           .endAngle(endAngle)(datum, index);
+                           .startAngle(Utils.Math.degreeToRadian(startAngle))
+                           .endAngle(Utils.Math.degreeToRadian(endAngle))(datum, index);
       };
       return attrToProjector;
     }
 
     /**
-     * Gets the AccessorScaleBinding for the start angle.
+     * Gets the AccessorScaleBinding for the start angle in degree.
      */
     public startAngle<T>(): AccessorScaleBinding<T, number>;
     /**
-     * Sets the start angle to a constant number or the result of an Accessor<number>.
+     * Sets the start angle to a constant number or the result of an Accessor<number> in degree.
      *
      * @param {number|Accessor<number>} startAngle
      * @returns {Wheel} The calling Wheel Plot.
      */
     public startAngle(startAngle: number | Accessor<number>): Plots.Wheel<R, T>;
     /**
-     * Sets the start angle to a scaled constant value or scaled result of an Accessor.
-     * This also sets the scale for end angle.
+     * Sets the start angle to a scaled constant value or scaled result of an Accessor in degree.
+     * The supplied Scale will also be used for endAngle().
      * The provided Scale will account for the values when autoDomain()-ing.
      *
      * @param {T|Accessor<T>} startAngle
@@ -108,7 +108,7 @@ export module Plots {
       }
 
       if (scale != null) {
-        scale.range([0, Math.PI * 2]);
+        scale.range([0, 360]);
       }
 
       let endAngleBinding = this.endAngle();
@@ -123,12 +123,12 @@ export module Plots {
     }
 
     /**
-     * Gets the AccessorScaleBinding for the end angle.
+     * Gets the AccessorScaleBinding for the end angle in degree.
      */
     public endAngle<T>(): AccessorScaleBinding<T, number>;
     /**
-     * Sets the end angle to a constant number or the result of an Accessor<number>.
-     * The scale of end angle is set to be the scale of start angle.
+     * Sets the end angle to a constant number or the result of an Accessor<number> in degree.
+     * If a Scale has been set for startAngle, it will also be used to scale endAngle.
      *
      * @param {number|Accessor<number>} endAngle
      * @returns {Wheel} The calling Wheel Plot.
@@ -160,7 +160,7 @@ export module Plots {
     public innerRadius(innerRadius: number | Accessor<number>): Plots.Wheel<R, T>;
     /**
      * Sets the inner radius to a scaled constant value or scaled result of an Accessor.
-     * This also sets the scale for outer radius.
+     * The supplied Scale will also be used for outerRadius().
      * The provided Scale will account for the values when autoDomain()-ing.
      *
      * @param {R|Accessor<R>} innerRadius
@@ -174,7 +174,7 @@ export module Plots {
       }
 
       if (scale != null) {
-        scale.range([0, Math.PI * 2]);
+        scale.range([0, 360]);
       }
 
       let outerRadiusBinding = this.outerRadius();
@@ -194,7 +194,7 @@ export module Plots {
     public outerRadius<R>(): AccessorScaleBinding<R, number>;
     /**
      * Sets the outer radius to a constant number or the result of an Accessor<number>.
-     * The scale of outer radius is set to be the scale of inner radius.
+     * If a Scale has been set for innerRadius, it will also be used to scale outerRadius.
      *
      * @param {number|Accessor<number>} outerRadius
      * @returns {Wheel} The calling Wheel Plot.
@@ -219,7 +219,7 @@ export module Plots {
 
       let startAngle = Plot._scaledAccessor(this.startAngle())(datum, index, dataset);
       let endAngle = Plot._scaledAccessor(this.endAngle())(datum, index, dataset);
-      let avgAngle = (startAngle + endAngle) / 2;
+      let avgAngle = Utils.Math.degreeToRadian((startAngle + endAngle) / 2);
       return { x: avgRadius * Math.sin(avgAngle), y: -avgRadius * Math.cos(avgAngle) };
     }
 

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -72,6 +72,7 @@
 /// <reference path="plots/stackedBarPlot.ts" />
 /// <reference path="plots/segmentPlot.ts" />
 /// <reference path="plots/waterfallPlot.ts" />
+/// <reference path="plots/wheelPlot.ts" />
 
 /// <reference path="animators/animator.ts" />
 /// <reference path="animators/nullAnimator.ts" />

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -103,6 +103,13 @@ export module Utils {
     export function distanceSquared(p1: Point, p2: Point) {
       return nativeMath.pow(p2.y - p1.y, 2) + nativeMath.pow(p2.x - p1.x, 2);
     }
+
+    /**
+     * Converts degree to radian
+     */
+     export function degreeToRadian(degree: number) {
+      return degree / 360 * nativeMath.PI * 2;
+    }
   }
 }
 }

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -104,10 +104,7 @@ export module Utils {
       return nativeMath.pow(p2.y - p1.y, 2) + nativeMath.pow(p2.x - p1.x, 2);
     }
 
-    /**
-     * Converts degree to radian
-     */
-     export function degreeToRadian(degree: number) {
+    export function degreesToRadians(degree: number) {
       return degree / 360 * nativeMath.PI * 2;
     }
   }

--- a/test/plots/wheelPlotTests.ts
+++ b/test/plots/wheelPlotTests.ts
@@ -49,8 +49,8 @@ describe("Plots", () => {
         let arc2 = d3.svg.arc().innerRadius(rScale.scale(1)).outerRadius(rScale.scale(2))
                                .startAngle(tScale.scale(180)).endAngle(tScale.scale(360));
         let arc2Path = (<any> arc2)();
-        assert.strictEqual(path1, arc1Path);
-        assert.strictEqual(path2, arc2Path);
+        TestMethods.assertAreaPathCloseTo(path1, arc1Path, 0.1, "arc is drawn as represented by data");
+        TestMethods.assertAreaPathCloseTo(path2, arc2Path, 0.1, "arc is drawn as represented by data");
 
         svg.remove();
       });

--- a/test/plots/wheelPlotTests.ts
+++ b/test/plots/wheelPlotTests.ts
@@ -1,0 +1,304 @@
+///<reference path="../testReference.ts" />
+
+describe("Plots", () => {
+  describe("WheelPlot", () => {
+    describe("basic usage", () => {
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 500;
+      let svg: d3.Selection<void>;
+      let wheelPlot: Plottable.Plots.Wheel<number, number>;
+      let rScale: Plottable.Scales.Linear;
+      let tScale: Plottable.Scales.Linear;
+
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        rScale = new Plottable.Scales.Linear();
+        tScale = new Plottable.Scales.Linear();
+        tScale.domain([0, 360]);
+        wheelPlot = new Plottable.Plots.Wheel();
+        wheelPlot.innerRadius((d) => d.r1, rScale);
+        wheelPlot.outerRadius((d) => d.r2, rScale);
+        wheelPlot.startAngle((d) => d.t1, tScale);
+        wheelPlot.endAngle((d) => d.t2, tScale);
+      });
+
+      it("renders correctly with no data", () => {
+        assert.doesNotThrow(() => wheelPlot.renderTo(svg), Error);
+        assert.strictEqual(wheelPlot.width(), SVG_WIDTH, "plot has been allocated width");
+        assert.strictEqual(wheelPlot.height(), SVG_HEIGHT, "plot has been allocated height");
+
+        svg.remove();
+      });
+
+      it("the accessors properly access data, index and Dataset", () => {
+        let data = [
+          {r1: 0, r2: 1, t1: 0, t2: 180 },
+          {r1: 1, r2: 2, t1: 180, t2: 360 }];
+        let dataset = new Plottable.Dataset(data);
+        wheelPlot.addDataset(dataset);
+        wheelPlot.renderTo(svg);
+
+        let slices = wheelPlot.selections();
+        let path1 = d3.select(slices[0][0]).attr("d");
+        let path2 = d3.select(slices[0][1]).attr("d");
+
+        let arc1 = d3.svg.arc().innerRadius(rScale.scale(0)).outerRadius(rScale.scale(1))
+                               .startAngle(tScale.scale(0)).endAngle(tScale.scale(180));
+        let arc1Path = (<any> arc1)();
+
+        let arc2 = d3.svg.arc().innerRadius(rScale.scale(1)).outerRadius(rScale.scale(2))
+                               .startAngle(tScale.scale(180)).endAngle(tScale.scale(360));
+        let arc2Path = (<any> arc2)();
+        assert.strictEqual(path1, arc1Path);
+        assert.strictEqual(path2, arc2Path);
+
+        svg.remove();
+      });
+
+      it("updates slices when data changes", () => {
+        let data = [
+          {r1: 0, r2: 1, t1: 0, t2: 180 },
+          {r1: 1, r2: 2, t1: 180, t2: 360 }];
+        let dataset = new Plottable.Dataset(data);
+        wheelPlot.addDataset(dataset);
+        wheelPlot.renderTo(svg);
+
+        assert.strictEqual(wheelPlot.content().selectAll("path").size(), 2, "there are 2 sectors for 2 data entries");
+
+        data = [{r1: 2, r2: 3, t1: 0, t2: 120 }];
+        dataset.data(data);
+        assert.strictEqual(wheelPlot.content().selectAll("path").size(), 1, "there are 2 sectors for 1 data entry");
+
+        svg.remove();
+      });
+
+      it("computes correct layout", () => {
+        wheelPlot.renderTo(svg);
+
+        let renderArea = (<any> wheelPlot)._renderArea;
+        let transform = d3.transform(renderArea.attr("transform")).translate;
+        assert.closeTo(transform[0], SVG_WIDTH / 2, 0.01, "origin is set to the middle of the svg");
+        assert.closeTo(transform[1], SVG_HEIGHT / 2, 0.01, "origin is set to the middle of the svg");
+        let radiusLimit = Math.min(SVG_WIDTH, SVG_HEIGHT) / 2;
+        assert.deepEqual(rScale.range(), [0, radiusLimit] , "the radius scale range is set properly");
+
+        svg.remove();
+      });
+
+      it("undefined, NaN and non-numeric strings not be represented in a Pie Chart", () => {
+        let data = [
+          { r1: 0, r2: 1, t1: 0, t2: 180 },
+          { r1: undefined, r2: 2, t1: 180, t2: 360 },
+          { r1: NaN, r2: 2, t1: 180, t2: 360 },
+          { r1: "Bad String", r2: 2, t1: 180, t2: 360 },
+          { r1: 1, r2: undefined, t1: 180, t2: 360 },
+          { r1: 1, r2: NaN, t1: 180, t2: 360 },
+          { r1: 1, r2: "Bad String", t1: 180, t2: 360 },
+          { r1: 1, r2: 2, t1: 180, t2: 360 },
+          { r1: 1, r2: 2, t1: undefined, t2: 360 },
+          { r1: 1, r2: 2, t1: NaN, t2: 360 },
+          { r1: 1, r2: 2, t1: "Bad String", t2: 360 },
+          { r1: 1, r2: 2, t1: 180, t2: undefined },
+          { r1: 1, r2: 2, t1: 180, t2: NaN },
+          { r1: 1, r2: 2, t1: 180, t2: "Bad String" },
+          { r1: 2, r2: 3, t1: 90, t2: 180 }
+        ];
+
+        let dataset = new Plottable.Dataset(data);
+        wheelPlot.addDataset(dataset);
+        wheelPlot.renderTo(svg);
+
+        let elementsDrawn = (<any> wheelPlot)._element.selectAll(".arc");
+
+        assert.strictEqual(elementsDrawn.size(), 3,
+          "There should be exactly 3 sectors in the wheel chart, representing the valid values");
+
+        assert.lengthOf(wheelPlot.entities(), 3,
+          "There should be exactly 3 entities in the wheel chart, representing the valid values");
+
+        svg.remove();
+      });
+    });
+
+    describe("innerRadius and outerRadius", () => {
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 500;
+      let svg: d3.Selection<void>;
+      let wheelPlot: Plottable.Plots.Wheel<number, number>;
+      let rScale: Plottable.Scales.Linear;
+      let tScale: Plottable.Scales.Linear;
+      let data: [any];
+      let dataset: Plottable.Dataset;
+
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        rScale = new Plottable.Scales.Linear();
+        tScale = new Plottable.Scales.Linear();
+        tScale.domain([0, 360]);
+        wheelPlot = new Plottable.Plots.Wheel();
+        wheelPlot.startAngle((d) => d.t1, tScale);
+        wheelPlot.endAngle((d) => d.t2, tScale);
+        data = [
+          {r1: 0, r2: 1, t1: 0, t2: 180 },
+          {r1: 1, r2: 2, t1: 180, t2: 360 }];
+        dataset = new Plottable.Dataset(data);
+        wheelPlot.addDataset(dataset);
+      });
+
+      it("can set and get innerRadius", () => {
+        wheelPlot.outerRadius((d) => d.r2, rScale);
+        assert.isUndefined(wheelPlot.innerRadius(), "innerRadius is initiized to undefined");
+
+        wheelPlot.innerRadius(0);
+        wheelPlot.renderTo(svg);
+        let constInnerRadiusAccessor = (<any> Plottable.Plot)._scaledAccessor(wheelPlot.innerRadius());
+        assert.strictEqual(constInnerRadiusAccessor(data[0], 0, dataset), 0, "access innerRadius that is set to a constant");
+        assert.strictEqual(constInnerRadiusAccessor(data[1], 1, dataset), 0, "access innerRadius that is set to a constant");
+
+        wheelPlot.innerRadius((d: any) => d.r1);
+        let innerRadiusAccessor = (<any> Plottable.Plot)._scaledAccessor(wheelPlot.innerRadius());
+        assert.strictEqual(innerRadiusAccessor(data[0], 0, dataset), 0, "access innerRadius correctly without a scale");
+        assert.strictEqual(innerRadiusAccessor(data[1], 1, dataset), 1, "access innerRadius correctly without a scale");
+
+        wheelPlot.innerRadius((d: any) => d.r1, rScale);
+        let scaledInnerRadiusAccessor = (<any> Plottable.Plot)._scaledAccessor(wheelPlot.innerRadius());
+        assert.strictEqual(scaledInnerRadiusAccessor(data[0], 0, dataset), rScale.scale(0), "access innerRadius correctly with a scale");
+        assert.strictEqual(scaledInnerRadiusAccessor(data[1], 1, dataset), rScale.scale(1), "access innerRadius correctly with a scale");
+
+        svg.remove();
+      });
+
+      it("can set and get outerRadius", () => {
+        wheelPlot.innerRadius((d) => d.r1, rScale);
+        assert.isUndefined(wheelPlot.outerRadius(), "outerRadius is initiized to undefined");
+
+        wheelPlot.outerRadius(0);
+        wheelPlot.renderTo(svg);
+        let constEndAngleAccessor = (<any> Plottable.Plot)._scaledAccessor(wheelPlot.outerRadius());
+        assert.strictEqual(constEndAngleAccessor(data[0], 0, dataset), 0, "access outerRadius that is set to a constant");
+        assert.strictEqual(constEndAngleAccessor(data[1], 1, dataset), 0, "access outerRadius that is set to a constant");
+
+        wheelPlot.outerRadius((d: any) => d.r2);
+        let outerRadiusAccessor = (<any> Plottable.Plot)._scaledAccessor(wheelPlot.outerRadius());
+        assert.strictEqual(outerRadiusAccessor(data[0], 0, dataset), 1, "access outerRadius correctly without a scale");
+        assert.strictEqual(outerRadiusAccessor(data[1], 1, dataset), 2, "access outerRadius correctly without a scale");
+
+        wheelPlot.outerRadius((d: any) => d.r2, rScale);
+        let scaledEndAngleAccessor = (<any> Plottable.Plot)._scaledAccessor(wheelPlot.outerRadius());
+        assert.strictEqual(scaledEndAngleAccessor(data[0], 0, dataset), rScale.scale(1), "access outerRadius correctly with a scale");
+        assert.strictEqual(scaledEndAngleAccessor(data[1], 1, dataset), rScale.scale(2), "access outerRadius correctly with a scale");
+
+        svg.remove();
+      });
+
+      it("can set innerRadius and outerRadius to different scale", () => {
+        let rScale2 = new Plottable.Scales.ModifiedLog;
+        wheelPlot.innerRadius((d) => d.r1, rScale);
+        wheelPlot.outerRadius((d) => d.r2, rScale2);
+        wheelPlot.renderTo(svg);
+
+        let innerRadiusAccessor = (<any> Plottable.Plot)._scaledAccessor(wheelPlot.innerRadius());
+        let outerRadiusAccessor = (<any> Plottable.Plot)._scaledAccessor(wheelPlot.outerRadius());
+        assert.strictEqual(innerRadiusAccessor(data[0], 0, dataset), rScale.scale(0), "access innerRadius correctly");
+        assert.strictEqual(innerRadiusAccessor(data[1], 1, dataset), rScale.scale(1), "access innerRadius correctly");
+        assert.strictEqual(outerRadiusAccessor(data[0], 0, dataset), rScale2.scale(1), "access outerRadius correctly");
+        assert.strictEqual(outerRadiusAccessor(data[1], 1, dataset), rScale2.scale(2), "access outerRadius correctly");
+
+        svg.remove();
+      });
+    });
+
+    describe("startAngle and endAngle", () => {
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 500;
+      let svg: d3.Selection<void>;
+      let wheelPlot: Plottable.Plots.Wheel<number, number>;
+      let rScale: Plottable.Scales.Linear;
+      let tScale: Plottable.Scales.Linear;
+      let data: [any];
+      let dataset: Plottable.Dataset;
+
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        rScale = new Plottable.Scales.Linear();
+        tScale = new Plottable.Scales.Linear();
+        tScale.domain([0, 360]);
+        wheelPlot = new Plottable.Plots.Wheel();
+        wheelPlot.innerRadius((d) => d.r1, rScale);
+        wheelPlot.outerRadius((d) => d.r2, rScale);
+        data = [
+          {r1: 0, r2: 1, t1: 0, t2: 180 },
+          {r1: 1, r2: 2, t1: 180, t2: 360 }];
+        dataset = new Plottable.Dataset(data);
+        wheelPlot.addDataset(dataset);
+      });
+
+      it("can set and get startAngle", () => {
+        wheelPlot.endAngle((d) => d.t2, tScale);
+        assert.isUndefined(wheelPlot.startAngle(), "startAngle is initiized to undefined");
+
+        wheelPlot.startAngle(0);
+        wheelPlot.renderTo(svg);
+        let constStartAngleAccessor = (<any> Plottable.Plot)._scaledAccessor(wheelPlot.startAngle());
+        assert.strictEqual(constStartAngleAccessor(data[0], 0, dataset), 0, "access startAngle that is set to a constant");
+        assert.strictEqual(constStartAngleAccessor(data[1], 1, dataset), 0, "access startAngle that is set to a constant");
+
+        wheelPlot.startAngle((d) => d.t1);
+        let startAngleAccessor = (<any> Plottable.Plot)._scaledAccessor(wheelPlot.startAngle());
+        assert.strictEqual(startAngleAccessor(data[0], 0, dataset), 0, "access startAngle correctly without a scale");
+        assert.strictEqual(startAngleAccessor(data[1], 1, dataset), 180, "access startAngle correctly without a scale");
+
+        wheelPlot.startAngle((d) => d.t1, tScale);
+        let scaledStartAngleAccessor = (<any> Plottable.Plot)._scaledAccessor(wheelPlot.startAngle());
+        assert.deepEqual(wheelPlot.startAngle().scale.range(), [0, Math.PI * 2], "range of startAngle should be 0 to 2PI");
+        assert.strictEqual(scaledStartAngleAccessor(data[0], 0, dataset), tScale.scale(0), "access startAngle correctly with a scale");
+        assert.strictEqual(scaledStartAngleAccessor(data[1], 1, dataset), tScale.scale(180), "access startAngle correctly with a scale");
+
+        svg.remove();
+      });
+
+      it("can set and get endAngle", () => {
+        wheelPlot.startAngle((d) => d.t1, tScale);
+        assert.isUndefined(wheelPlot.endAngle(), "endAngle is initiized to undefined");
+
+        wheelPlot.endAngle(0);
+        wheelPlot.renderTo(svg);
+        let constOuterRadiusAccessor = (<any> Plottable.Plot)._scaledAccessor(wheelPlot.endAngle());
+        assert.strictEqual(constOuterRadiusAccessor(data[0], 0, dataset), 0, "access endAngle that is set to a constant");
+        assert.strictEqual(constOuterRadiusAccessor(data[1], 1, dataset), 0, "access endAngle that is set to a constant");
+
+        wheelPlot.endAngle((d) => d.t2);
+        let endAngleAccessor = (<any> Plottable.Plot)._scaledAccessor(wheelPlot.endAngle());
+        assert.strictEqual(endAngleAccessor(data[0], 0, dataset), 180, "access endAngle correctly without a scale");
+        assert.strictEqual(endAngleAccessor(data[1], 1, dataset), 360, "access endAngle correctly without a scale");
+
+        wheelPlot.endAngle((d) => d.t2, tScale);
+        let scaledOuterRadiusAccessor = (<any> Plottable.Plot)._scaledAccessor(wheelPlot.endAngle());
+        assert.deepEqual(wheelPlot.endAngle().scale.range(), [0, Math.PI * 2], "range of endAngle should be 0 to 2PI");
+        assert.strictEqual(scaledOuterRadiusAccessor(data[0], 0, dataset), tScale.scale(180), "access endAngle correctly with a scale");
+        assert.strictEqual(scaledOuterRadiusAccessor(data[1], 1, dataset), tScale.scale(360), "access endAngle correctly with a scale");
+        svg.remove();
+      });
+
+      it("can set startAngle and endAngle to different scale", () => {
+        let tScale2 = new Plottable.Scales.ModifiedLog;
+        tScale2.domain([0, 360]);
+        wheelPlot.startAngle((d) => d.t1, tScale);
+        wheelPlot.endAngle((d) => d.t2, tScale2);
+        wheelPlot.renderTo(svg);
+        let startAngleAccessor = (<any> Plottable.Plot)._scaledAccessor(wheelPlot.startAngle());
+        let endAngleAccessor = (<any> Plottable.Plot)._scaledAccessor(wheelPlot.endAngle());
+        assert.deepEqual(wheelPlot.endAngle().scale.range(), [0, Math.PI * 2], "range of startAngle should be 0 to 2PI");
+
+        assert.deepEqual(wheelPlot.endAngle().scale.range(), [0, Math.PI * 2], "range of endAngle should be 0 to 2PI");
+        assert.strictEqual(startAngleAccessor(data[0], 0, dataset), tScale.scale(0), "access startAngle correctly");
+        assert.strictEqual(startAngleAccessor(data[1], 1, dataset), tScale.scale(180), "access startAngle correctly");
+        assert.strictEqual(endAngleAccessor(data[0], 0, dataset), tScale2.scale(180), "access endAngle correctly");
+        assert.strictEqual(endAngleAccessor(data[1], 1, dataset), tScale2.scale(360), "access endAngle correctly");
+
+        svg.remove();
+      });
+    });
+  });
+
+});

--- a/test/plots/wheelPlotTests.ts
+++ b/test/plots/wheelPlotTests.ts
@@ -86,8 +86,8 @@ describe("Plots", () => {
         wheelPlot.renderTo(svg);
         let slices = wheelPlot.selections();
         data.forEach((datum, i) => {
-          let startAngle = Plottable.Utils.Math.degreeToRadian(datum.t1);
-          let expectedEndAngle = Plottable.Utils.Math.degreeToRadian(datum.expectedEndAngle);
+          let startAngle = Plottable.Utils.Math.degreesToRadians(datum.t1);
+          let expectedEndAngle = Plottable.Utils.Math.degreesToRadians(datum.expectedEndAngle);
           let path = d3.select(slices[0][i]).attr("d");
           let arc = d3.svg.arc().innerRadius(rScale.scale(datum.r1)).outerRadius(rScale.scale(datum.r2))
                                 .startAngle(startAngle).endAngle(expectedEndAngle);

--- a/test/plots/wheelPlotTests.ts
+++ b/test/plots/wheelPlotTests.ts
@@ -69,17 +69,28 @@ describe("Plots", () => {
       });
 
       it("draws arc clockwise from startAngle toendAngle", () => {
-        let data = [{r1: 0, r2: 1, t1: 60, t2: -60 }];
+        let data = [
+            { r1: 0, r2: 1, t1: 60, t2: -60, expected: 300 },
+            { r1: 1, r2: 2, t1: 60, t2: 60, expected: 60 },
+            { r1: 2, r2: 3, t1: 60, t2: -300, expected: 420 },
+            { r1: 3, r2: 4, t1: 0, t2: 360, expected: 360 },
+            { r1: 3, r2: 4, t1: 90, t2: 70, expected: 430 },
+            { r1: 3, r2: 4, t1: -60, t2: -180, expected: 180 }
+        ];
         let dataset = new Plottable.Dataset(data);
         wheelPlot.addDataset(dataset);
         wheelPlot.renderTo(svg);
-
         let slices = wheelPlot.selections();
-        let path = d3.select(slices[0][0]).attr("d");
-        let arc = d3.svg.arc().innerRadius(rScale.scale(0)).outerRadius(rScale.scale(1))
-                               .startAngle(tScale.scale(60)).endAngle(tScale.scale(300));
-        let expectedPath = arc(null);
-        TestMethods.assertAreaPathCloseTo(path, expectedPath, 0.1, "arc is drawn from 60 to -60");
+        data.forEach((datum, i) => {
+          let startAngle = datum.t1;
+          let endAngle = datum.t2;
+          let expectedEndAngle = datum.expected;
+          let path = d3.select(slices[0][i]).attr("d");
+          let arc = d3.svg.arc().innerRadius(rScale.scale(datum.r1)).outerRadius(rScale.scale(datum.r2))
+                                .startAngle(tScale.scale(startAngle)).endAngle(tScale.scale(expectedEndAngle));
+          let expectedPath = arc(null);
+          TestMethods.assertAreaPathCloseTo(path, expectedPath, 0.1, `arc is drawn from ${startAngle} to ${endAngle}`);
+        });
 
         svg.remove();
       });

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -253,21 +253,27 @@ module TestMethods {
     actualAreaPathStrings.pop();
     expectedAreaPathStrings.pop();
 
-    let actualAreaPathPoints = actualAreaPathStrings.map((path) => path.split(/[A-Z]/).map((point) => point.split(",")));
-    actualAreaPathPoints.forEach((areaPathPoint) => areaPathPoint.shift());
-    let expectedAreaPathPoints = expectedAreaPathStrings.map((path) => path.split(/[A-Z]/).map((point) => point.split(",")));
-    expectedAreaPathPoints.forEach((areaPathPoint) => areaPathPoint.shift());
+    let actualAreaPathNumbers = tokenizePathString(actualAreaPathStrings);
+    let expectedAreaPathNumbers = tokenizePathString(expectedAreaPathStrings);
 
-    assert.lengthOf(actualAreaPathPoints, expectedAreaPathPoints.length, "number of broken area paths should be equal");
-    actualAreaPathPoints.forEach((actualAreaPoints, i) => {
-      let expectedAreaPoints = expectedAreaPathPoints[i];
-      assert.lengthOf(actualAreaPoints, expectedAreaPoints.length, "number of points in path should be equal");
-      actualAreaPoints.forEach((actualAreaPoint, j) => {
-        let expectedAreaPoint = expectedAreaPoints[j];
-        assert.closeTo(+actualAreaPoint[0], +expectedAreaPoint[0], 0.1, msg);
-        assert.closeTo(+actualAreaPoint[1], +expectedAreaPoint[1], 0.1, msg);
-      });
+    assert.lengthOf(actualAreaPathNumbers, expectedAreaPathNumbers.length, "number of numbers in each path should be equal");
+    actualAreaPathNumbers.forEach((actualAreaNumber, i) => {
+      let expectedAreaNumber = expectedAreaPathNumbers[i];
+        assert.closeTo(+actualAreaNumber, +expectedAreaNumber, 0.1, msg);
     });
+  }
+
+  function tokenizePathString(pathStrings: string[]) {
+    let numbers: string[] = [];
+    pathStrings.forEach((path) =>
+      path.split(/[A-Z]/).forEach((token) =>
+        token.split(",").forEach((numberString) =>
+          numberString.split(" ").forEach((num) => {
+            if (num !== "") {
+              numbers.push(num);
+            }
+          }))));
+    return numbers;
   }
 
   export function verifyClipPath(c: Plottable.Component) {

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -247,14 +247,8 @@ module TestMethods {
   }
 
   export function assertAreaPathCloseTo(actualPath: string, expectedPath: string, precision: number, msg: string) {
-    let actualAreaPathStrings = actualPath.split("Z");
-    let expectedAreaPathStrings = expectedPath.split("Z");
-
-    actualAreaPathStrings.pop();
-    expectedAreaPathStrings.pop();
-
-    let actualAreaPathNumbers = tokenizePathString(actualAreaPathStrings);
-    let expectedAreaPathNumbers = tokenizePathString(expectedAreaPathStrings);
+    let actualAreaPathNumbers = tokenizePathString(actualPath);
+    let expectedAreaPathNumbers = tokenizePathString(expectedPath);
 
     assert.lengthOf(actualAreaPathNumbers, expectedAreaPathNumbers.length, "number of numbers in each path should be equal");
     actualAreaPathNumbers.forEach((actualAreaNumber, i) => {
@@ -263,9 +257,9 @@ module TestMethods {
     });
   }
 
-  function tokenizePathString(pathStrings: string[]) {
+  function tokenizePathString(pathString: string) {
     let numbers: string[] = [];
-    pathStrings.forEach((path) =>
+    pathString.split("Z").forEach((path) =>
       path.split(/[A-Z]/).forEach((token) =>
         token.split(",").forEach((numberString) =>
           numberString.split(" ").forEach((num) => {

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -250,7 +250,7 @@ module TestMethods {
     let actualAreaPathNumbers = tokenizePathString(actualPath);
     let expectedAreaPathNumbers = tokenizePathString(expectedPath);
 
-    assert.lengthOf(actualAreaPathNumbers, expectedAreaPathNumbers.length, "number of numbers in each path should be equal");
+    assert.lengthOf(actualAreaPathNumbers, expectedAreaPathNumbers.length, `${msg}: number of numbers in each path should be equal`);
     actualAreaPathNumbers.forEach((actualAreaNumber, i) => {
       let expectedAreaNumber = expectedAreaPathNumbers[i];
         assert.closeTo(+actualAreaNumber, +expectedAreaNumber, 0.1, msg);

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -44,6 +44,7 @@
 ///<reference path="plots/clusteredBarPlotTests.ts" />
 ///<reference path="plots/segmentPlotTests.ts" />
 ///<reference path="plots/waterfallPlotTests.ts" />
+///<reference path="plots/wheelPlotTests.ts" />
 
 ///<reference path="core/metadataTests.ts" />
 ///<reference path="core/renderControllerTests.ts" />


### PR DESCRIPTION
closes #2683
demo: http://jsfiddle.net/ztsai/use8b6ek/

`labelsEnabled(enabled?: boolean)`: gets/sets whether labels are enabled.
`label(label?: Accessor<string>)`: gets/sets the text of labels to the result of an Accessor.

It does not show labels that are too big to be contained in the sector or cut off by edges
However, it will show labels that overlap with other sectors (since the computation is too complicated and it seems like a lower priority, I decided to leave this as a future enhancement. Will open an issue for it after this is closed)
