### PR TITLE
Link to definitions in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,9 @@
   "description": "A modular charting library built on D3",
   "version": "1.8.0",
   "main": ["plottable.js", "plottable.css"],
+  "typescript": {
+    "definition": "plottable.d.ts"
+  },
   "license": "MIT",
   "ignore": [
     "**/*",


### PR DESCRIPTION
As per "Link to bundled definitions" explained at https://github.com/DefinitelyTyped/tsd#link-to-bundled-definitions