### PR TITLE
Refactor click interaction tests - Pass 1

### DIFF
--- a/test/interactions/clickInteractionTests.ts
+++ b/test/interactions/clickInteractionTests.ts
@@ -114,7 +114,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can register multiple callbacks listeners for the same Component", () => {
+      it("can register multiple callbacks", () => {
         clickInteraction.attachTo(component);
 
         let callback1WasCalled = false;

--- a/test/interactions/clickInteractionTests.ts
+++ b/test/interactions/clickInteractionTests.ts
@@ -19,12 +19,12 @@ describe("Interactions", () => {
         clickInteraction.attachTo(component);
       });
 
-      it("onClick", () => {
+      it("can register interaction using onClick()", () => {
         let callbackCalled = false;
         let lastPoint: Plottable.Point;
-        let callback = function(p: Plottable.Point) {
+        let callback = function(point: Plottable.Point) {
           callbackCalled = true;
-          lastPoint = p;
+          lastPoint = point;
         };
         clickInteraction.onClick(callback);
 
@@ -86,7 +86,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("offClick()", () => {
+      it("can deregister interaction using offClick()", () => {
         let callbackWasCalled = false;
         let callback = () => callbackWasCalled = true;
 
@@ -104,7 +104,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("multiple click listeners", () => {
+      it("can register multiple interaction listeners for the same component", () => {
         clickInteraction.attachTo(component);
 
         let callback1WasCalled = false;
@@ -129,10 +129,9 @@ describe("Interactions", () => {
         assert.isTrue(callback2WasCalled, "Callback2 should still exist on the click interaction");
 
         svg.remove();
-
       });
 
-      it("cancelling touches cancels any ongoing clicks", () => {
+      it("cancels ongoing clicks by cancelling touches", () => {
         let callbackCalled = false;
         let callback = () => callbackCalled = true;
         clickInteraction.onClick(callback);

--- a/test/interactions/clickInteractionTests.ts
+++ b/test/interactions/clickInteractionTests.ts
@@ -30,58 +30,68 @@ describe("Interactions", () => {
 
         TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
         TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
-        assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
-        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (mouse)");
+        assert.isTrue(callbackCalled, "callback called on clicking Component without moving mouse");
+        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point");
 
         callbackCalled = false;
         lastPoint = null;
         TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
         TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH / 4, SVG_HEIGHT / 4);
-        assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
-        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed mouseup point (mouse)");
+        assert.isTrue(callbackCalled, "callback called on clicking and releasing inside the component");
+        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed mouseup point");
 
         callbackCalled = false;
         TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
         TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
-        assert.isFalse(callbackCalled, "callback not called if released outside component (mouse)");
+        assert.isFalse(callbackCalled, "callback not called if released outside component");
 
         TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
         TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
-        assert.isFalse(callbackCalled, "callback not called if started outside component (mouse)");
+        assert.isFalse(callbackCalled, "callback not called if started outside component");
 
         TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
         TestMethods.triggerFakeMouseEvent("mousemove", component.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
         TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
-        assert.isTrue(callbackCalled, "callback called even if moved outside component (mouse)");
+        assert.isTrue(callbackCalled, "callback called even if moved outside component");
 
-        callbackCalled = false;
-        lastPoint = null;
+        svg.remove();
+      });
+
+      it("treats touch events same as click events for interactions registered with onClick()", () => {
+        let callbackCalled = false;
+        let lastPoint: Plottable.Point;
+        let callback = function(point: Plottable.Point) {
+          callbackCalled = true;
+          lastPoint = point;
+        };
+        clickInteraction.onClick(callback);
+
         TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
         TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-        assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
-        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (touch)");
+        assert.isTrue(callbackCalled, "callback called on clicking Component without moving mouse");
+        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point");
 
         callbackCalled = false;
         lastPoint = null;
         TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
         TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4}]);
-        assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
-        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed mouseup point (touch)");
+        assert.isTrue(callbackCalled, "callback called on clicking and releasing inside the component");
+        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed mouseup point");
 
         callbackCalled = false;
         TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
         TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: SVG_WIDTH * 2, y: SVG_HEIGHT * 2}]);
-        assert.isFalse(callbackCalled, "callback not called if released outside component (touch)");
+        assert.isFalse(callbackCalled, "callback not called if released outside component");
 
         callbackCalled = false;
         TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: SVG_WIDTH * 2, y: SVG_HEIGHT * 2}]);
         TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-        assert.isFalse(callbackCalled, "callback not called if started outside component (touch)");
+        assert.isFalse(callbackCalled, "callback not called if started outside component");
 
         TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
         TestMethods.triggerFakeTouchEvent("touchmove", component.content(), [{x: SVG_WIDTH * 2, y: SVG_HEIGHT * 2}]);
         TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-        assert.isTrue(callbackCalled, "callback called even if moved outside component (touch)");
+        assert.isTrue(callbackCalled, "callback called even if moved outside component");
 
         svg.remove();
       });
@@ -95,8 +105,8 @@ describe("Interactions", () => {
         TestMethods.triggerFakeMouseEvent("mouseup", component.content(), 0, 0);
         assert.isTrue(callbackWasCalled, "Click interaction should trigger the callback");
 
-        clickInteraction.offClick(callback);
         callbackWasCalled = false;
+        clickInteraction.offClick(callback);
         TestMethods.triggerFakeMouseEvent("mousedown", component.content(), 0, 0);
         TestMethods.triggerFakeMouseEvent("mouseup", component.content(), 0, 0);
         assert.isFalse(callbackWasCalled, "Callback should be disconnected from the click interaction");
@@ -120,9 +130,9 @@ describe("Interactions", () => {
         assert.isTrue(callback1WasCalled, "Click interaction should trigger the first callback");
         assert.isTrue(callback2WasCalled, "Click interaction should trigger the second callback");
 
-        clickInteraction.offClick(callback1);
         callback1WasCalled = false;
         callback2WasCalled = false;
+        clickInteraction.offClick(callback1);
         TestMethods.triggerFakeMouseEvent("mousedown", component.content(), 0, 0);
         TestMethods.triggerFakeMouseEvent("mouseup", component.content(), 0, 0);
         assert.isFalse(callback1WasCalled, "Callback1 should be disconnected from the click interaction");

--- a/test/interactions/clickInteractionTests.ts
+++ b/test/interactions/clickInteractionTests.ts
@@ -19,7 +19,7 @@ describe("Interactions", () => {
         clickInteraction.attachTo(component);
       });
 
-      it("can register interaction using onClick()", () => {
+      it("can register callback using onClick()", () => {
         let callbackCalled = false;
         let lastPoint: Plottable.Point;
         let callback = function(point: Plottable.Point) {
@@ -37,27 +37,27 @@ describe("Interactions", () => {
         lastPoint = null;
         TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
         TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH / 4, SVG_HEIGHT / 4);
-        assert.isTrue(callbackCalled, "callback called on clicking and releasing inside the component");
+        assert.isTrue(callbackCalled, "callback called on clicking and releasing inside the Component");
         assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed mouseup point");
 
         callbackCalled = false;
         TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
         TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
-        assert.isFalse(callbackCalled, "callback not called if released outside component");
+        assert.isFalse(callbackCalled, "callback not called if mouse is released outside Component");
 
         TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
         TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
-        assert.isFalse(callbackCalled, "callback not called if started outside component");
+        assert.isFalse(callbackCalled, "callback not called if click was started outside Component");
 
         TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
         TestMethods.triggerFakeMouseEvent("mousemove", component.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
         TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
-        assert.isTrue(callbackCalled, "callback called even if moved outside component");
+        assert.isTrue(callbackCalled, "callback still called if the mouse is moved out then back inside the Component before releasing");
 
         svg.remove();
       });
 
-      it("treats touch events same as click events for interactions registered with onClick()", () => {
+      it("treats touch events same as click events for callbacks registered with onClick()", () => {
         let callbackCalled = false;
         let lastPoint: Plottable.Point;
         let callback = function(point: Plottable.Point) {
@@ -75,28 +75,28 @@ describe("Interactions", () => {
         lastPoint = null;
         TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
         TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4}]);
-        assert.isTrue(callbackCalled, "callback called on clicking and releasing inside the component");
+        assert.isTrue(callbackCalled, "callback called on clicking and releasing inside the Component");
         assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed mouseup point");
 
         callbackCalled = false;
         TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
         TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: SVG_WIDTH * 2, y: SVG_HEIGHT * 2}]);
-        assert.isFalse(callbackCalled, "callback not called if released outside component");
+        assert.isFalse(callbackCalled, "callback not called if released outside Component");
 
         callbackCalled = false;
         TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: SVG_WIDTH * 2, y: SVG_HEIGHT * 2}]);
         TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-        assert.isFalse(callbackCalled, "callback not called if started outside component");
+        assert.isFalse(callbackCalled, "callback not called if started outside Component");
 
         TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
         TestMethods.triggerFakeTouchEvent("touchmove", component.content(), [{x: SVG_WIDTH * 2, y: SVG_HEIGHT * 2}]);
         TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-        assert.isTrue(callbackCalled, "callback called even if moved outside component");
+        assert.isTrue(callbackCalled, "callback called even if moved outside Component");
 
         svg.remove();
       });
 
-      it("can deregister interaction using offClick()", () => {
+      it("can deregister callback using offClick()", () => {
         let callbackWasCalled = false;
         let callback = () => callbackWasCalled = true;
 
@@ -114,7 +114,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can register multiple interaction listeners for the same component", () => {
+      it("can register multiple callbacks listeners for the same Component", () => {
         clickInteraction.attachTo(component);
 
         let callback1WasCalled = false;
@@ -141,7 +141,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("cancels ongoing clicks by cancelling touches", () => {
+      it("does not trigger callback when touch event is cancelled", () => {
         let callbackCalled = false;
         let callback = () => callbackCalled = true;
         clickInteraction.onClick(callback);

--- a/test/interactions/clickInteractionTests.ts
+++ b/test/interactions/clickInteractionTests.ts
@@ -1,160 +1,149 @@
 ///<reference path="../testReference.ts" />
 
 describe("Interactions", () => {
-  describe("Click", () => {
-    let SVG_WIDTH = 400;
-    let SVG_HEIGHT = 400;
+  describe("Click Interaction", () => {
+    describe("Basic Usage", () => {
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 400;
 
-    it("onClick", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let c = new Plottable.Component();
-      c.renderTo(svg);
+      let svg: d3.Selection<void>;
+      let component: Plottable.Component;
+      let clickInteraction: Plottable.Interactions.Click;
 
-      let clickInteraction = new Plottable.Interactions.Click();
-      clickInteraction.attachTo(c);
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        component = new Plottable.Component();
+        component.renderTo(svg);
 
-      let callbackCalled = false;
-      let lastPoint: Plottable.Point;
-      let callback = function(p: Plottable.Point) {
-        callbackCalled = true;
-        lastPoint = p;
-      };
-      clickInteraction.onClick(callback);
+        clickInteraction = new Plottable.Interactions.Click();
+        clickInteraction.attachTo(component);
+      });
 
-      TestMethods.triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
-      TestMethods.triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
-      assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
-      assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (mouse)");
+      it("onClick", () => {
+        let callbackCalled = false;
+        let lastPoint: Plottable.Point;
+        let callback = function(p: Plottable.Point) {
+          callbackCalled = true;
+          lastPoint = p;
+        };
+        clickInteraction.onClick(callback);
 
-      callbackCalled = false;
-      lastPoint = null;
-      TestMethods.triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
-      TestMethods.triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH / 4, SVG_HEIGHT / 4);
-      assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
-      assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed mouseup point (mouse)");
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
+        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (mouse)");
 
-      callbackCalled = false;
-      TestMethods.triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
-      TestMethods.triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
-      assert.isFalse(callbackCalled, "callback not called if released outside component (mouse)");
+        callbackCalled = false;
+        lastPoint = null;
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH / 4, SVG_HEIGHT / 4);
+        assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
+        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed mouseup point (mouse)");
 
-      TestMethods.triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
-      TestMethods.triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
-      assert.isFalse(callbackCalled, "callback not called if started outside component (mouse)");
+        callbackCalled = false;
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
+        assert.isFalse(callbackCalled, "callback not called if released outside component (mouse)");
 
-      TestMethods.triggerFakeMouseEvent("mousedown", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
-      TestMethods.triggerFakeMouseEvent("mousemove", c.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
-      TestMethods.triggerFakeMouseEvent("mouseup", c.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
-      assert.isTrue(callbackCalled, "callback called even if moved outside component (mouse)");
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        assert.isFalse(callbackCalled, "callback not called if started outside component (mouse)");
 
-      callbackCalled = false;
-      lastPoint = null;
-      TestMethods.triggerFakeTouchEvent("touchstart", c.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-      TestMethods.triggerFakeTouchEvent("touchend", c.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-      assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
-      assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (touch)");
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        TestMethods.triggerFakeMouseEvent("mousemove", component.content(), SVG_WIDTH * 2, SVG_HEIGHT * 2);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        assert.isTrue(callbackCalled, "callback called even if moved outside component (mouse)");
 
-      callbackCalled = false;
-      lastPoint = null;
-      TestMethods.triggerFakeTouchEvent("touchstart", c.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-      TestMethods.triggerFakeTouchEvent("touchend", c.content(), [{x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4}]);
-      assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
-      assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed mouseup point (touch)");
+        callbackCalled = false;
+        lastPoint = null;
+        TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
+        TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
+        assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
+        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (touch)");
 
-      callbackCalled = false;
-      TestMethods.triggerFakeTouchEvent("touchstart", c.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-      TestMethods.triggerFakeTouchEvent("touchend", c.content(), [{x: SVG_WIDTH * 2, y: SVG_HEIGHT * 2}]);
-      assert.isFalse(callbackCalled, "callback not called if released outside component (touch)");
+        callbackCalled = false;
+        lastPoint = null;
+        TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
+        TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4}]);
+        assert.isTrue(callbackCalled, "callback called on clicking Component (mouse)");
+        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed mouseup point (touch)");
 
-      callbackCalled = false;
-      TestMethods.triggerFakeTouchEvent("touchstart", c.content(), [{x: SVG_WIDTH * 2, y: SVG_HEIGHT * 2}]);
-      TestMethods.triggerFakeTouchEvent("touchend", c.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-      assert.isFalse(callbackCalled, "callback not called if started outside component (touch)");
+        callbackCalled = false;
+        TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
+        TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: SVG_WIDTH * 2, y: SVG_HEIGHT * 2}]);
+        assert.isFalse(callbackCalled, "callback not called if released outside component (touch)");
 
-      TestMethods.triggerFakeTouchEvent("touchstart", c.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-      TestMethods.triggerFakeTouchEvent("touchmove", c.content(), [{x: SVG_WIDTH * 2, y: SVG_HEIGHT * 2}]);
-      TestMethods.triggerFakeTouchEvent("touchend", c.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-      assert.isTrue(callbackCalled, "callback called even if moved outside component (touch)");
+        callbackCalled = false;
+        TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: SVG_WIDTH * 2, y: SVG_HEIGHT * 2}]);
+        TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
+        assert.isFalse(callbackCalled, "callback not called if started outside component (touch)");
 
-      svg.remove();
-    });
+        TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
+        TestMethods.triggerFakeTouchEvent("touchmove", component.content(), [{x: SVG_WIDTH * 2, y: SVG_HEIGHT * 2}]);
+        TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
+        assert.isTrue(callbackCalled, "callback called even if moved outside component (touch)");
 
-    it("offClick()", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let component = new Plottable.Component();
-      component.renderTo(svg);
-      let clickInteraction = new Plottable.Interactions.Click();
+        svg.remove();
+      });
 
-      clickInteraction.attachTo(component);
+      it("offClick()", () => {
+        let callbackWasCalled = false;
+        let callback = () => callbackWasCalled = true;
 
-      let callbackWasCalled = false;
-      let callback = () => callbackWasCalled = true;
+        clickInteraction.onClick(callback);
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), 0, 0);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), 0, 0);
+        assert.isTrue(callbackWasCalled, "Click interaction should trigger the callback");
 
-      clickInteraction.onClick(callback);
-      TestMethods.triggerFakeMouseEvent("mousedown", component.content(), 0, 0);
-      TestMethods.triggerFakeMouseEvent("mouseup", component.content(), 0, 0);
-      assert.isTrue(callbackWasCalled, "Click interaction should trigger the callback");
+        clickInteraction.offClick(callback);
+        callbackWasCalled = false;
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), 0, 0);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), 0, 0);
+        assert.isFalse(callbackWasCalled, "Callback should be disconnected from the click interaction");
 
-      clickInteraction.offClick(callback);
-      callbackWasCalled = false;
-      TestMethods.triggerFakeMouseEvent("mousedown", component.content(), 0, 0);
-      TestMethods.triggerFakeMouseEvent("mouseup", component.content(), 0, 0);
-      assert.isFalse(callbackWasCalled, "Callback should be disconnected from the click interaction");
+        svg.remove();
+      });
 
-      svg.remove();
-    });
+      it("multiple click listeners", () => {
+        clickInteraction.attachTo(component);
 
-    it("multiple click listeners", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let component = new Plottable.Component();
-      component.renderTo(svg);
-      let clickInteraction = new Plottable.Interactions.Click();
+        let callback1WasCalled = false;
+        let callback1 = () => callback1WasCalled = true;
 
-      clickInteraction.attachTo(component);
+        let callback2WasCalled = false;
+        let callback2 = () => callback2WasCalled = true;
 
-      let callback1WasCalled = false;
-      let callback1 = () => callback1WasCalled = true;
+        clickInteraction.onClick(callback1);
+        clickInteraction.onClick(callback2);
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), 0, 0);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), 0, 0);
+        assert.isTrue(callback1WasCalled, "Click interaction should trigger the first callback");
+        assert.isTrue(callback2WasCalled, "Click interaction should trigger the second callback");
 
-      let callback2WasCalled = false;
-      let callback2 = () => callback2WasCalled = true;
+        clickInteraction.offClick(callback1);
+        callback1WasCalled = false;
+        callback2WasCalled = false;
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), 0, 0);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), 0, 0);
+        assert.isFalse(callback1WasCalled, "Callback1 should be disconnected from the click interaction");
+        assert.isTrue(callback2WasCalled, "Callback2 should still exist on the click interaction");
 
-      clickInteraction.onClick(callback1);
-      clickInteraction.onClick(callback2);
-      TestMethods.triggerFakeMouseEvent("mousedown", component.content(), 0, 0);
-      TestMethods.triggerFakeMouseEvent("mouseup", component.content(), 0, 0);
-      assert.isTrue(callback1WasCalled, "Click interaction should trigger the first callback");
-      assert.isTrue(callback2WasCalled, "Click interaction should trigger the second callback");
+        svg.remove();
 
-      clickInteraction.offClick(callback1);
-      callback1WasCalled = false;
-      callback2WasCalled = false;
-      TestMethods.triggerFakeMouseEvent("mousedown", component.content(), 0, 0);
-      TestMethods.triggerFakeMouseEvent("mouseup", component.content(), 0, 0);
-      assert.isFalse(callback1WasCalled, "Callback1 should be disconnected from the click interaction");
-      assert.isTrue(callback2WasCalled, "Callback2 should still exist on the click interaction");
+      });
 
-      svg.remove();
+      it("cancelling touches cancels any ongoing clicks", () => {
+        let callbackCalled = false;
+        let callback = () => callbackCalled = true;
+        clickInteraction.onClick(callback);
 
-    });
+        TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
+        TestMethods.triggerFakeTouchEvent("touchcancel", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
+        TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
+        assert.isFalse(callbackCalled, "callback not called since click was interrupted");
 
-    it("cancelling touches cancels any ongoing clicks", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let c = new Plottable.Component();
-      c.renderTo(svg);
-
-      let clickInteraction = new Plottable.Interactions.Click();
-      clickInteraction.attachTo(c);
-
-      let callbackCalled = false;
-      let callback = () => callbackCalled = true;
-      clickInteraction.onClick(callback);
-
-      TestMethods.triggerFakeTouchEvent("touchstart", c.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-      TestMethods.triggerFakeTouchEvent("touchcancel", c.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-      TestMethods.triggerFakeTouchEvent("touchend", c.content(), [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-      assert.isFalse(callbackCalled, "callback not called since click was interrupted");
-
-      svg.remove();
+        svg.remove();
+      });
     });
   });
 });


### PR DESCRIPTION
Part of #2628

I will be doing 2 passes because I will get more context (and better sense of best practices) by refactoring other files. However, please flag anything that seems unusual.

As part of this: 
- **Test semantics: hierarchy, naming, testing, but no coverage check**
- Applied best practices from the wiki page
- Factored out common code into `beforeEach()` clauses
- No nested `beforeEach()`es
- Cleaned the console
- Remade hierarchy as shown bellow
![screen shot 2015-08-31 at 12 09 24 pm](https://cloud.githubusercontent.com/assets/3248682/9587780/2e38a19c-4fd9-11e5-9bf6-32f4b2277da1.png)
