### PR TITLE
Refactor double click interaction tests - Pass 1

### DIFF
--- a/test/interactions/doubleClickInteractionTests.ts
+++ b/test/interactions/doubleClickInteractionTests.ts
@@ -84,7 +84,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("works with touch events as well", () => {
+      it("works with touch events", () => {
         let doubleClickedPoint: Plottable.Point = null;
         let dblClickCallback = (point: Plottable.Point) => doubleClickedPoint = point;
         dblClickInteraction.onDoubleClick(dblClickCallback);

--- a/test/interactions/doubleClickInteractionTests.ts
+++ b/test/interactions/doubleClickInteractionTests.ts
@@ -1,18 +1,19 @@
 ///<reference path="../testReference.ts" />
 
 describe("Interactions", () => {
-  describe("DoubleClick", () => {
+  describe("DoubleClick Interaction", () => {
 
     describe("Basic Usage", () => {
-      let SVG_WIDTH = 400;
-      let SVG_HEIGHT = 400;
-
+      let userClickPoint: Plottable.Point;
       let svg: d3.Selection<void>;
       let dblClickInteraction: Plottable.Interactions.DoubleClick;
       let component: Plottable.Component;
 
       beforeEach(() => {
-        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        let svgWidth = 400;
+        let svgHeight = 400;
+        svg = TestMethods.generateSVG(svgWidth, svgHeight);
+        userClickPoint = {x: svgWidth / 2, y: svgHeight / 2};
         component = new Plottable.Component();
         component.renderTo(svg);
         dblClickInteraction = new Plottable.Interactions.DoubleClick();
@@ -20,8 +21,6 @@ describe("Interactions", () => {
       });
 
       it("calls callback and passes correct click position", () => {
-        let userClickPoint = {x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2};
-
         let doubleClickedPoint: Plottable.Point = null;
         let dblClickCallback = (point: Plottable.Point) => doubleClickedPoint = point;
         dblClickInteraction.onDoubleClick(dblClickCallback);
@@ -40,7 +39,6 @@ describe("Interactions", () => {
         let callbackWasCalled = false;
         let dblClickCallback = () => callbackWasCalled = true;
         dblClickInteraction.onDoubleClick(dblClickCallback);
-        let userClickPoint = {x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2};
 
         TestMethods.triggerFakeMouseEvent("mousedown", component.content(), userClickPoint.x, userClickPoint.y);
         TestMethods.triggerFakeMouseEvent("mouseup", component.content(), userClickPoint.x, userClickPoint.y);
@@ -52,9 +50,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can register multiple interaction listeners for the same component", () => {
-        let userClickPoint = {x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2};
-
+      it("can register multiple callback listeners for the same component", () => {
         let newCallback1WasCalled = false;
         let newCallback1 = () => newCallback1WasCalled = true;
 
@@ -92,7 +88,6 @@ describe("Interactions", () => {
         let doubleClickedPoint: Plottable.Point = null;
         let dblClickCallback = (point: Plottable.Point) => doubleClickedPoint = point;
         dblClickInteraction.onDoubleClick(dblClickCallback);
-        let userClickPoint = {x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2};
 
         TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: userClickPoint.x, y: userClickPoint.y}]);
         TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: userClickPoint.x, y: userClickPoint.y}]);
@@ -104,11 +99,10 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("cancels the callback by cancelling the touch interaction", () => {
+      it("does not trigger callback when touch event is cancelled", () => {
         let doubleClickedPoint: Plottable.Point = null;
         let dblClickCallback = (point: Plottable.Point) => doubleClickedPoint = point;
         dblClickInteraction.onDoubleClick(dblClickCallback);
-        let userClickPoint = {x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2};
 
         TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: userClickPoint.x, y: userClickPoint.y}]);
         TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: userClickPoint.x, y: userClickPoint.y}]);

--- a/test/interactions/doubleClickInteractionTests.ts
+++ b/test/interactions/doubleClickInteractionTests.ts
@@ -4,7 +4,7 @@ describe("Interactions", () => {
   describe("DoubleClick Interaction", () => {
 
     describe("Basic Usage", () => {
-      let userClickPoint: Plottable.Point;
+      let clickedPoint: Plottable.Point;
       let svg: d3.Selection<void>;
       let dblClickInteraction: Plottable.Interactions.DoubleClick;
       let component: Plottable.Component;
@@ -13,7 +13,7 @@ describe("Interactions", () => {
         let svgWidth = 400;
         let svgHeight = 400;
         svg = TestMethods.generateSVG(svgWidth, svgHeight);
-        userClickPoint = {x: svgWidth / 2, y: svgHeight / 2};
+        clickedPoint = {x: svgWidth / 2, y: svgHeight / 2};
         component = new Plottable.Component();
         component.renderTo(svg);
         dblClickInteraction = new Plottable.Interactions.DoubleClick();
@@ -25,12 +25,12 @@ describe("Interactions", () => {
         let dblClickCallback = (point: Plottable.Point) => doubleClickedPoint = point;
         dblClickInteraction.onDoubleClick(dblClickCallback);
 
-        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), userClickPoint.x, userClickPoint.y);
-        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), userClickPoint.x, userClickPoint.y);
-        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), userClickPoint.x, userClickPoint.y);
-        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), userClickPoint.x, userClickPoint.y);
-        TestMethods.triggerFakeMouseEvent("dblclick", component.content(), userClickPoint.x, userClickPoint.y);
-        assert.deepEqual(doubleClickedPoint, userClickPoint, "was passed correct point");
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), clickedPoint.x, clickedPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), clickedPoint.x, clickedPoint.y);
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), clickedPoint.x, clickedPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), clickedPoint.x, clickedPoint.y);
+        TestMethods.triggerFakeMouseEvent("dblclick", component.content(), clickedPoint.x, clickedPoint.y);
+        assert.deepEqual(doubleClickedPoint, clickedPoint, "was passed correct point");
 
         svg.remove();
       });
@@ -40,11 +40,11 @@ describe("Interactions", () => {
         let dblClickCallback = () => callbackWasCalled = true;
         dblClickInteraction.onDoubleClick(dblClickCallback);
 
-        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), userClickPoint.x, userClickPoint.y);
-        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), userClickPoint.x, userClickPoint.y);
-        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), userClickPoint.x + 10, userClickPoint.y + 10);
-        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), userClickPoint.x + 10, userClickPoint.y + 10);
-        TestMethods.triggerFakeMouseEvent("dblclick", component.content(), userClickPoint.x + 10, userClickPoint.y + 10);
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), clickedPoint.x, clickedPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), clickedPoint.x, clickedPoint.y);
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), clickedPoint.x + 10, clickedPoint.y + 10);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), clickedPoint.x + 10, clickedPoint.y + 10);
+        TestMethods.triggerFakeMouseEvent("dblclick", component.content(), clickedPoint.x + 10, clickedPoint.y + 10);
         assert.isFalse(callbackWasCalled, "callback was not called");
 
         svg.remove();
@@ -60,11 +60,11 @@ describe("Interactions", () => {
         dblClickInteraction.onDoubleClick(newCallback1);
         dblClickInteraction.onDoubleClick(newCallback2);
 
-        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), userClickPoint.x, userClickPoint.y);
-        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), userClickPoint.x, userClickPoint.y);
-        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), userClickPoint.x, userClickPoint.y);
-        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), userClickPoint.x, userClickPoint.y);
-        TestMethods.triggerFakeMouseEvent("dblclick", component.content(), userClickPoint.x, userClickPoint.y);
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), clickedPoint.x, clickedPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), clickedPoint.x, clickedPoint.y);
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), clickedPoint.x, clickedPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), clickedPoint.x, clickedPoint.y);
+        TestMethods.triggerFakeMouseEvent("dblclick", component.content(), clickedPoint.x, clickedPoint.y);
 
         assert.isTrue(newCallback1WasCalled, "Callback 1 should be called on double click");
         assert.isTrue(newCallback2WasCalled, "Callback 2 should be called on double click");
@@ -72,11 +72,11 @@ describe("Interactions", () => {
         newCallback1WasCalled = false;
         newCallback2WasCalled = false;
         dblClickInteraction.offDoubleClick(newCallback1);
-        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), userClickPoint.x, userClickPoint.y);
-        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), userClickPoint.x, userClickPoint.y);
-        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), userClickPoint.x, userClickPoint.y);
-        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), userClickPoint.x, userClickPoint.y);
-        TestMethods.triggerFakeMouseEvent("dblclick", component.content(), userClickPoint.x, userClickPoint.y);
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), clickedPoint.x, clickedPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), clickedPoint.x, clickedPoint.y);
+        TestMethods.triggerFakeMouseEvent("mousedown", component.content(), clickedPoint.x, clickedPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", component.content(), clickedPoint.x, clickedPoint.y);
+        TestMethods.triggerFakeMouseEvent("dblclick", component.content(), clickedPoint.x, clickedPoint.y);
 
         assert.isFalse(newCallback1WasCalled, "Callback 1 should be disconnected from the interaction");
         assert.isTrue(newCallback2WasCalled, "Callback 2 should still be connected to the interaction");
@@ -89,12 +89,12 @@ describe("Interactions", () => {
         let dblClickCallback = (point: Plottable.Point) => doubleClickedPoint = point;
         dblClickInteraction.onDoubleClick(dblClickCallback);
 
-        TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: userClickPoint.x, y: userClickPoint.y}]);
-        TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: userClickPoint.x, y: userClickPoint.y}]);
-        TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: userClickPoint.x, y: userClickPoint.y}]);
-        TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: userClickPoint.x, y: userClickPoint.y}]);
-        TestMethods.triggerFakeMouseEvent("dblclick", component.content(), userClickPoint.x, userClickPoint.y);
-        assert.deepEqual(doubleClickedPoint, userClickPoint, "was passed the correct point");
+        TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: clickedPoint.x, y: clickedPoint.y}]);
+        TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: clickedPoint.x, y: clickedPoint.y}]);
+        TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: clickedPoint.x, y: clickedPoint.y}]);
+        TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: clickedPoint.x, y: clickedPoint.y}]);
+        TestMethods.triggerFakeMouseEvent("dblclick", component.content(), clickedPoint.x, clickedPoint.y);
+        assert.deepEqual(doubleClickedPoint, clickedPoint, "was passed the correct point");
 
         svg.remove();
       });
@@ -104,12 +104,12 @@ describe("Interactions", () => {
         let dblClickCallback = (point: Plottable.Point) => doubleClickedPoint = point;
         dblClickInteraction.onDoubleClick(dblClickCallback);
 
-        TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: userClickPoint.x, y: userClickPoint.y}]);
-        TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: userClickPoint.x, y: userClickPoint.y}]);
-        TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: userClickPoint.x, y: userClickPoint.y}]);
-        TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: userClickPoint.x, y: userClickPoint.y}]);
-        TestMethods.triggerFakeTouchEvent("touchcancel", component.content(), [{x: userClickPoint.x, y: userClickPoint.y}]);
-        TestMethods.triggerFakeMouseEvent("dblclick", component.content(), userClickPoint.x, userClickPoint.y);
+        TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: clickedPoint.x, y: clickedPoint.y}]);
+        TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: clickedPoint.x, y: clickedPoint.y}]);
+        TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [{x: clickedPoint.x, y: clickedPoint.y}]);
+        TestMethods.triggerFakeTouchEvent("touchend", component.content(), [{x: clickedPoint.x, y: clickedPoint.y}]);
+        TestMethods.triggerFakeTouchEvent("touchcancel", component.content(), [{x: clickedPoint.x, y: clickedPoint.y}]);
+        TestMethods.triggerFakeMouseEvent("dblclick", component.content(), clickedPoint.x, clickedPoint.y);
         assert.deepEqual(doubleClickedPoint, null, "point never set");
 
         svg.remove();


### PR DESCRIPTION
Part of #2628

I will be doing 2 passes because I will get more context (and better sense of best practices) by refactoring other files. However, please flag anything that seems unusual.

As part of this: 
- **Test semantics: hierarchy, naming, testing, but no coverage check**
- Applied best practices from the wiki page
- Factored out common code into `beforeEach()` clauses
- No nested `beforeEach()`es
- Cleaned the console
- Remade hierarchy as shown bellow
![screen shot 2015-08-28 at 2 21 32 pm](https://cloud.githubusercontent.com/assets/3248682/9557364/4c4f6a94-4d90-11e5-9aa3-46d74ddfd846.png)

