### PR TITLE
Setting to add title elements to Plottable's legend

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -376,7 +376,7 @@ declare module Plottable {
          */
         var SHOW_WARNINGS: boolean;
         /**
-         * Specifies if Plottable should add title elements.
+         * Specifies if Plottable should add <title> elements to text.
          */
         var ADD_TITLE_ELEMENTS: boolean;
     }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -375,6 +375,10 @@ declare module Plottable {
          * Specifies if Plottable should show warnings.
          */
         var SHOW_WARNINGS: boolean;
+        /**
+         * Specifies if Plottable should add title elements.
+         */
+        var ADD_TITLE_ELEMENTS: boolean;
     }
 }
 

--- a/plottable.js
+++ b/plottable.js
@@ -899,6 +899,10 @@ var Plottable;
          * Specifies if Plottable should show warnings.
          */
         Configs.SHOW_WARNINGS = true;
+        /**
+         * Specifies if Plottable should add title elements.
+         */
+        Configs.ADD_TITLE_ELEMENTS = true;
     })(Configs = Plottable.Configs || (Plottable.Configs = {}));
 })(Plottable || (Plottable = {}));
 
@@ -5174,7 +5178,7 @@ var Plottable;
                 fakeLegendEntry.append("text");
                 this._measurer = new SVGTypewriter.Measurers.Measurer(fakeLegendRow);
                 this._wrapper = new SVGTypewriter.Wrappers.Wrapper().maxLines(1);
-                this._writer = new SVGTypewriter.Writers.Writer(this._measurer, this._wrapper).addTitleElement(true);
+                this._writer = new SVGTypewriter.Writers.Writer(this._measurer, this._wrapper).addTitleElement(Plottable.Configs.ADD_TITLE_ELEMENTS);
             };
             Legend.prototype.maxEntriesPerRow = function (maxEntriesPerRow) {
                 if (maxEntriesPerRow == null) {
@@ -5342,7 +5346,6 @@ var Plottable;
                 var padding = this._padding;
                 var textContainers = entries.select("g.text-container");
                 textContainers.text(""); // clear out previous results
-                textContainers.append("title").text(function (value) { return value; });
                 var self = this;
                 textContainers.attr("transform", "translate(" + layout.textHeight + ", 0)")
                     .each(function (value) {

--- a/plottable.js
+++ b/plottable.js
@@ -900,7 +900,7 @@ var Plottable;
          */
         Configs.SHOW_WARNINGS = true;
         /**
-         * Specifies if Plottable should add title elements.
+         * Specifies if Plottable should add <title> elements to text.
          */
         Configs.ADD_TITLE_ELEMENTS = true;
     })(Configs = Plottable.Configs || (Plottable.Configs = {}));

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -59,7 +59,7 @@ export module Components {
       fakeLegendEntry.append("text");
       this._measurer = new SVGTypewriter.Measurers.Measurer(fakeLegendRow);
       this._wrapper = new SVGTypewriter.Wrappers.Wrapper().maxLines(1);
-      this._writer = new SVGTypewriter.Writers.Writer(this._measurer, this._wrapper).addTitleElement(true);
+      this._writer = new SVGTypewriter.Writers.Writer(this._measurer, this._wrapper).addTitleElement(Configs.ADD_TITLE_ELEMENTS);
     }
 
     /**
@@ -288,7 +288,6 @@ export module Components {
       let padding = this._padding;
       let textContainers = entries.select("g.text-container");
       textContainers.text(""); // clear out previous results
-      textContainers.append("title").text((value: string) => value);
       let self = this;
       textContainers.attr("transform", "translate(" + layout.textHeight + ", 0)")
                     .each(function(value: string) {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -6,5 +6,10 @@ export module Configs {
    * Specifies if Plottable should show warnings.
    */
   export var SHOW_WARNINGS = true;
+
+  /**
+   * Specifies if Plottable should add title elements.
+   */
+  export var ADD_TITLE_ELEMENTS = true;
 }
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -8,7 +8,7 @@ export module Configs {
   export var SHOW_WARNINGS = true;
 
   /**
-   * Specifies if Plottable should add title elements.
+   * Specifies if Plottable should add <title> elements to text.
    */
   export var ADD_TITLE_ELEMENTS = true;
 }

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -420,26 +420,28 @@ describe("Legend", () => {
 
     let entries = (<any> legend)._element.selectAll(entrySelector);
     let titles = entries.selectAll("title");
-    assert.strictEqual(titles[0].length, 1, "only one title node per legend entry should be present");
-    assert.strictEqual(titles.length, color.domain().length, "same number of title tags as legend entries");
+    assert.strictEqual(titles.size(), color.domain().length, "same number of title tags as legend entries");
 
     entries.each(function(d: any, i: number) {
       let d3this = d3.select(this);
       let text = d3this.select("text").text();
-      let titleText = d3this.select("title").text();
-      assert.strictEqual(text, titleText, "the text and title node have the same text");
+      let titles = d3this.selectAll("title");
+      assert.strictEqual(titles.size(), 1, "only one title node per legend entry should be present");
+      assert.strictEqual(text, titles.text(), "the text and title node have the same text");
     });
     svg.remove();
   });
 
   it("No title elements are created if configuration is set to false", () => {
     color.domain(["foo", "bar", "baz"]);
+    let originalSetting = Plottable.Configs.ADD_TITLE_ELEMENTS;
     Plottable.Configs.ADD_TITLE_ELEMENTS = false;
     legend.renderTo(svg);
+    Plottable.Configs.ADD_TITLE_ELEMENTS = originalSetting;
 
     let entries = (<any> legend)._element.selectAll(entrySelector);
     let titles = entries.selectAll("title");
-    assert.strictEqual(titles[0].length, 0, "no titles should be rendered");
+    assert.strictEqual(titles.size(), 0, "no titles should be rendered");
     svg.remove();
   });
 });

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -413,4 +413,33 @@ describe("Legend", () => {
     legend.renderTo(svg);
     svg.remove();
   });
+
+  it("Title elements are created by default", () => {
+    color.domain(["foo", "bar", "baz"]);
+    legend.renderTo(svg);
+
+    let entries = (<any> legend)._element.selectAll(entrySelector);
+    let titles = entries.selectAll("title");
+    assert.strictEqual(titles[0].length, 1, "only one title node per legend entry should be present");
+    assert.strictEqual(titles.length, color.domain().length, "same number of title tags as legend entries");
+
+    entries.each(function(d: any, i: number) {
+      let d3this = d3.select(this);
+      let text = d3this.select("text").text();
+      let titleText = d3this.select("title").text();
+      assert.strictEqual(text, titleText, "the text and title node have the same text");
+    });
+    svg.remove();
+  });
+
+  it("No title elements are created if configuration is set to false", () => {
+    color.domain(["foo", "bar", "baz"]);
+    Plottable.Configs.ADD_TITLE_ELEMENTS = false;
+    legend.renderTo(svg);
+
+    let entries = (<any> legend)._element.selectAll(entrySelector);
+    let titles = entries.selectAll("title");
+    assert.strictEqual(titles[0].length, 0, "no titles should be rendered");
+    svg.remove();
+  });
 });


### PR DESCRIPTION
This pull request allows specifying whether to create title elements on a Legend component.

It addresses an issue where the title element appears when hovering over the chart area on safari (http://jsfiddle.net/alyssa/q319g8ww). Was traced by @jtlan as an [open bug on safari](https://bugs.webkit.org/show_bug.cgi?id=139690).

Pull request also removes a line where 2 title elements were created per legend entry (screenshot below).
![screen shot 2015-08-29 at 6 49 18 pm](https://cloud.githubusercontent.com/assets/2819448/9561960/b9a71eac-4e8f-11e5-9d05-16ccf46b2246.png)