### PR TITLE
Refactor drag interaction tests - Pass 1

### DIFF
--- a/test/interactions/dragInteractionTests.ts
+++ b/test/interactions/dragInteractionTests.ts
@@ -173,6 +173,7 @@ describe("Interactions", () => {
 
         let target = component.background();
 
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
         TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
         assert.isTrue(moveCallback1Called, "callback 1 was called on dragging (mousemove)");
         assert.isTrue(moveCallback2Called, "callback 2 was called on dragging (mousemove)");
@@ -180,6 +181,7 @@ describe("Interactions", () => {
         moveCallback1Called = false;
         moveCallback2Called = false;
         dragInteraction.offDrag(moveCallback1);
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
         TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
         assert.isFalse(moveCallback1Called, "callback 1 was disconnected from drag interaction");
         assert.isTrue(moveCallback2Called, "callback 2 is still connected to the drag interaction");
@@ -248,6 +250,7 @@ describe("Interactions", () => {
 
         let target = component.background();
 
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
         TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y);
         assert.isTrue(endCallback1Called, "callback 1 was called on drag ending (mouseup)");
         assert.isTrue(endCallback2Called, "callback 2 was called on drag ending (mouseup)");
@@ -255,6 +258,7 @@ describe("Interactions", () => {
         endCallback1Called = false;
         endCallback2Called = false;
         dragInteraction.offDragEnd(endCallback1);
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
         TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y);
         assert.isFalse(endCallback1Called, "callback 1 was disconnected from the drag end interaction");
         assert.isTrue(endCallback2Called, "callback 2 is still connected to the drag end interaction");

--- a/test/interactions/dragInteractionTests.ts
+++ b/test/interactions/dragInteractionTests.ts
@@ -44,12 +44,12 @@ describe("Interactions", () => {
         dragInteraction = new Plottable.Interactions.Drag();
       });
 
-      it("onDragStart()", () => {
+      it("calls the onDragStart() callback", () => {
         let startCallbackCalled = false;
         let receivedStart: Plottable.Point;
-        let startCallback = (p: Plottable.Point) => {
+        let startCallback = (point: Plottable.Point) => {
           startCallbackCalled = true;
-          receivedStart = p;
+          receivedStart = point;
         };
         dragInteraction.onDragStart(startCallback);
         dragInteraction.attachTo(component);
@@ -93,7 +93,33 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("onDrag()", () => {
+      it("can register two onDragStart() callbacks on the same component", () => {
+        let startCallback1Called = false;
+        let startCallback2Called = false;
+        let startCallback1 = () => startCallback1Called = true;
+        let startCallback2 = () => startCallback2Called = true;
+
+        dragInteraction.onDragStart(startCallback1);
+        dragInteraction.onDragStart(startCallback2);
+
+        dragInteraction.attachTo(component);
+
+        let target = component.background();
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        assert.isTrue(startCallback1Called, "callback 1 was called on beginning drag (mousedown)");
+        assert.isTrue(startCallback2Called, "callback 2 was called on beginning drag (mousedown)");
+
+        startCallback1Called = false;
+        startCallback2Called = false;
+        dragInteraction.offDragStart(startCallback1);
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        assert.isFalse(startCallback1Called, "callback 1 was disconnected from drag start interaction");
+        assert.isTrue(startCallback2Called, "callback 2 is still connected to the drag start interaction");
+
+        svg.remove();
+      });
+
+      it("calls the onDrag() callback", () => {
         let moveCallbackCalled = false;
         let receivedStart: Plottable.Point;
         let receivedEnd: Plottable.Point;
@@ -134,7 +160,34 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("onDragEnd()", () => {
+      it("can register two onDrag() callbacks on the same component", () => {
+        let moveCallback1Called = false;
+        let moveCallback2Called = false;
+        let moveCallback1 = () => moveCallback1Called = true;
+        let moveCallback2 = () => moveCallback2Called = true;
+
+        dragInteraction.onDrag(moveCallback1);
+        dragInteraction.onDrag(moveCallback2);
+
+        dragInteraction.attachTo(component);
+
+        let target = component.background();
+
+        TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
+        assert.isTrue(moveCallback1Called, "callback 1 was called on dragging (mousemove)");
+        assert.isTrue(moveCallback2Called, "callback 2 was called on dragging (mousemove)");
+
+        moveCallback1Called = false;
+        moveCallback2Called = false;
+        dragInteraction.offDrag(moveCallback1);
+        TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
+        assert.isFalse(moveCallback1Called, "callback 1 was disconnected from drag interaction");
+        assert.isTrue(moveCallback2Called, "callback 2 is still connected to the drag interaction");
+
+        svg.remove();
+      });
+
+      it("calls the onDragEnd() callback", () => {
         let endCallbackCalled = false;
         let receivedStart: Plottable.Point;
         let receivedEnd: Plottable.Point;
@@ -182,65 +235,67 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("multiple interactions on drag", () => {
-        let startCallback1Called = false;
-        let startCallback2Called = false;
-        let moveCallback1Called = false;
-        let moveCallback2Called = false;
+      it("can register two onDragEnd() callbacks on the same component", () => {
         let endCallback1Called = false;
         let endCallback2Called = false;
-
-        let startCallback1 = () => startCallback1Called = true;
-        let startCallback2 = () => startCallback2Called = true;
-        let moveCallback1 = () => moveCallback1Called = true;
-        let moveCallback2 = () => moveCallback2Called = true;
         let endCallback1 = () => endCallback1Called = true;
         let endCallback2 = () => endCallback2Called = true;
 
-        dragInteraction.onDragStart(startCallback1);
-        dragInteraction.onDragStart(startCallback2);
-        dragInteraction.onDrag(moveCallback1);
-        dragInteraction.onDrag(moveCallback2);
         dragInteraction.onDragEnd(endCallback1);
         dragInteraction.onDragEnd(endCallback2);
 
         dragInteraction.attachTo(component);
 
         let target = component.background();
-        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-        assert.isTrue(startCallback1Called, "callback 1 was called on beginning drag (mousedown)");
-        assert.isTrue(startCallback2Called, "callback 2 was called on beginning drag (mousedown)");
-
-        TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
-        assert.isTrue(moveCallback1Called, "callback 1 was called on dragging (mousemove)");
-        assert.isTrue(moveCallback2Called, "callback 2 was called on dragging (mousemove)");
 
         TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y);
         assert.isTrue(endCallback1Called, "callback 1 was called on drag ending (mouseup)");
         assert.isTrue(endCallback2Called, "callback 2 was called on drag ending (mouseup)");
 
-        startCallback1Called = false;
-        startCallback2Called = false;
-        moveCallback1Called = false;
-        moveCallback2Called = false;
         endCallback1Called = false;
         endCallback2Called = false;
-
-        dragInteraction.offDragStart(startCallback1);
-        dragInteraction.offDrag(moveCallback1);
         dragInteraction.offDragEnd(endCallback1);
-
-        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-        assert.isFalse(startCallback1Called, "callback 1 was disconnected from drag start interaction");
-        assert.isTrue(startCallback2Called, "callback 2 is still connected to the drag start interaction");
-
-        TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
-        assert.isFalse(moveCallback1Called, "callback 1 was disconnected from drag interaction");
-        assert.isTrue(moveCallback2Called, "callback 2 is still connected to the drag interaction");
-
         TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y);
         assert.isFalse(endCallback1Called, "callback 1 was disconnected from the drag end interaction");
         assert.isTrue(endCallback2Called, "callback 2 is still connected to the drag end interaction");
+
+        svg.remove();
+      });
+
+      it("calls all the drag interaction callbacks when needed", () => {
+        let startCallbackCalled = false;
+        let moveCallbackCalled = false;
+        let endCallbackCalled = false;
+        let startCallback = () => startCallbackCalled = true;
+        let moveCallback = () => moveCallbackCalled = true;
+        let endCallback = () => endCallbackCalled = true;
+
+        dragInteraction.onDragStart(startCallback);
+        dragInteraction.onDrag(moveCallback);
+        dragInteraction.onDragEnd(endCallback);
+
+        dragInteraction.attachTo(component);
+
+        let target = component.background();
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        assert.isTrue(startCallbackCalled, "callback for drag start was called");
+        TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
+        assert.isTrue(moveCallbackCalled, "callback for drag was called");
+        TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y);
+        assert.isTrue(endCallbackCalled, "callback for drag end was called");
+
+        startCallbackCalled = false;
+        moveCallbackCalled = false;
+        endCallbackCalled = false;
+        dragInteraction.offDragStart(startCallback);
+        dragInteraction.offDrag(moveCallback);
+
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        assert.isFalse(startCallbackCalled, "callback for drag start was disconnected");
+        TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
+        assert.isFalse(moveCallbackCalled, "callback for drag was disconnected");
+        TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y);
+        assert.isTrue(endCallbackCalled, "callback for drag end is still connected");
 
         svg.remove();
       });

--- a/test/interactions/dragInteractionTests.ts
+++ b/test/interactions/dragInteractionTests.ts
@@ -14,7 +14,6 @@ describe("Interactions", () => {
         x: SVG_WIDTH / 2,
         y: SVG_HEIGHT / 2
       };
-
       let outsidePointPos = {
         x: SVG_WIDTH * 1.5,
         y: SVG_HEIGHT * 1.5
@@ -51,7 +50,9 @@ describe("Interactions", () => {
           startCallbackCalled = true;
           receivedStart = point;
         };
-        dragInteraction.onDragStart(startCallback);
+
+        assert.strictEqual(dragInteraction.onDragStart(startCallback), dragInteraction,
+          "setting onDragStart callback returns the drag interaction");
         dragInteraction.attachTo(component);
 
         let target = component.background();
@@ -128,7 +129,9 @@ describe("Interactions", () => {
           receivedStart = start;
           receivedEnd = end;
         };
-        dragInteraction.onDrag(moveCallback);
+
+        assert.strictEqual(dragInteraction.onDrag(moveCallback), dragInteraction,
+          "setting onDrag callback returns the drag interaction");
         dragInteraction.attachTo(component);
 
         let target = component.background();
@@ -198,7 +201,8 @@ describe("Interactions", () => {
           receivedStart = start;
           receivedEnd = end;
         };
-        dragInteraction.onDragEnd(endCallback);
+        assert.strictEqual(dragInteraction.onDragEnd(endCallback), dragInteraction,
+          "setting onDragEnd callback returns the drag interaction");
         dragInteraction.attachTo(component);
 
         let target = component.background();

--- a/test/interactions/dragInteractionTests.ts
+++ b/test/interactions/dragInteractionTests.ts
@@ -94,7 +94,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can register two onDragStart() callbacks on the same component", () => {
+      it("can register two onDragStart() callbacks on the same Component", () => {
         let startCallback1Called = false;
         let startCallback2Called = false;
         let startCallback1 = () => startCallback1Called = true;
@@ -163,7 +163,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can register two onDrag() callbacks on the same component", () => {
+      it("can register two onDrag() callbacks on the same Component", () => {
         let moveCallback1Called = false;
         let moveCallback2Called = false;
         let moveCallback1 = () => moveCallback1Called = true;
@@ -241,7 +241,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can register two onDragEnd() callbacks on the same component", () => {
+      it("can register two onDragEnd() callbacks on the same Component", () => {
         let endCallback1Called = false;
         let endCallback2Called = false;
         let endCallback1 = () => endCallback1Called = true;
@@ -270,7 +270,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("calls all the drag interaction callbacks when needed", () => {
+      it("can register multiple callbacks", () => {
         let startCallbackCalled = false;
         let moveCallbackCalled = false;
         let endCallbackCalled = false;

--- a/test/interactions/dragInteractionTests.ts
+++ b/test/interactions/dragInteractionTests.ts
@@ -18,17 +18,9 @@ describe("Interactions", () => {
         x: SVG_WIDTH * 1.5,
         y: SVG_HEIGHT * 1.5
       };
-      let constrainedPos = {
-        x: SVG_WIDTH,
-        y: SVG_HEIGHT
-      };
       let outsidePointNeg = {
         x: -SVG_WIDTH / 2,
         y: -SVG_HEIGHT / 2
-      };
-      let constrainedNeg = {
-        x: 0,
-        y: 0
       };
 
       let svg: d3.Selection<void>;
@@ -308,36 +300,33 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("constrainToComponent()", () => {
-        assert.isTrue(dragInteraction.constrainedToComponent(), "constrains by default");
+      it("constraints the drag interaction to the Component space", () => {
+        let constrainedPos = { x: SVG_WIDTH, y: SVG_HEIGHT };
+        let constrainedNeg = { x: 0, y: 0 };
 
-        let receivedStart: Plottable.Point;
         let receivedEnd: Plottable.Point;
-        let moveCallback = (start: Plottable.Point, end: Plottable.Point) => {
-          receivedStart = start;
-          receivedEnd = end;
-        };
-        dragInteraction.onDrag(moveCallback);
-        let endCallback = (start: Plottable.Point, end: Plottable.Point) => {
-          receivedStart = start;
-          receivedEnd = end;
-        };
-        dragInteraction.onDragEnd(endCallback);
+        dragInteraction.onDrag((startPoint, endPoint) => receivedEnd = endPoint);
+        dragInteraction.onDragEnd((startPoint, endPoint) => receivedEnd = endPoint);
 
         dragInteraction.attachTo(component);
         let target = component.content();
+
+        assert.isTrue(dragInteraction.constrainedToComponent(), "constrains by default");
 
         TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
         TestMethods.triggerFakeMouseEvent("mousemove", target, outsidePointPos.x, outsidePointPos.y);
         assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (mousemove)");
         TestMethods.triggerFakeMouseEvent("mousemove", target, outsidePointNeg.x, outsidePointNeg.y);
         assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (mousemove)");
+        TestMethods.triggerFakeMouseEvent("mouseup", target, startPoint.x, startPoint.y);
 
         receivedEnd = null;
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
         TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
         assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (touchmove)");
         TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
         assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (touchmove)");
+        TestMethods.triggerFakeTouchEvent("touchend", target, [{x: startPoint.x, y: startPoint.y}]);
 
         receivedEnd = null;
         TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
@@ -359,39 +348,35 @@ describe("Interactions", () => {
 
         TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
         TestMethods.triggerFakeMouseEvent("mousemove", target, outsidePointPos.x, outsidePointPos.y);
-        assert.deepEqual(receivedEnd, outsidePointPos,
-                         "dragging outside the Component is no longer constrained (positive) (mousemove)");
+        assert.deepEqual(receivedEnd, outsidePointPos, "dragging outside the Component is no longer constrained (positive) (mousemove)");
         TestMethods.triggerFakeMouseEvent("mousemove", target, outsidePointNeg.x, outsidePointNeg.y);
-        assert.deepEqual(receivedEnd, outsidePointNeg,
-                         "dragging outside the Component is no longer constrained (negative) (mousemove)");
+        assert.deepEqual(receivedEnd, outsidePointNeg, "dragging outside the Component is no longer constrained (negative) (mousemove)");
+        TestMethods.triggerFakeMouseEvent("mouseup", target, startPoint.x, startPoint.y);
 
         receivedEnd = null;
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
         TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
-        assert.deepEqual(receivedEnd, outsidePointPos,
-                         "dragging outside the Component is no longer constrained (positive) (touchmove)");
+        assert.deepEqual(receivedEnd, outsidePointPos, "dragging outside the Component is no longer constrained (positive) (touchmove)");
         TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
-        assert.deepEqual(receivedEnd, outsidePointNeg,
-                         "dragging outside the Component is no longer constrained (negative) (touchmove)");
+        assert.deepEqual(receivedEnd, outsidePointNeg, "dragging outside the Component is no longer constrained (negative) (touchmove)");
+        TestMethods.triggerFakeTouchEvent("touchend", target, [{x: startPoint.x, y: startPoint.y}]);
 
         receivedEnd = null;
         TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
         TestMethods.triggerFakeMouseEvent("mouseup", target, outsidePointPos.x, outsidePointPos.y);
-        assert.deepEqual(receivedEnd, outsidePointPos,
-                         "dragging outside the Component is no longer constrained (positive) (mouseup)");
+        assert.deepEqual(receivedEnd, outsidePointPos, "dragging outside the Component is no longer constrained (positive) (mouseup)");
         TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
         TestMethods.triggerFakeMouseEvent("mouseup", target, outsidePointNeg.x, outsidePointNeg.y);
-        assert.deepEqual(receivedEnd, outsidePointNeg,
-                         "dragging outside the Component is no longer constrained (negative) (mouseup)");
+        assert.deepEqual(receivedEnd, outsidePointNeg, "dragging outside the Component is no longer constrained (negative) (mouseup)");
 
         receivedEnd = null;
         TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
         TestMethods.triggerFakeTouchEvent("touchend", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
-        assert.deepEqual(receivedEnd, outsidePointPos,
-                         "dragging outside the Component is no longer constrained (positive) (touchend)");
+        assert.deepEqual(receivedEnd, outsidePointPos, "dragging outside the Component is no longer constrained (positive) (touchend)");
         TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
         TestMethods.triggerFakeTouchEvent("touchend", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
-        assert.deepEqual(receivedEnd, outsidePointNeg,
-                         "dragging outside the Component is no longer constrained (negative) (touchend)");
+        assert.deepEqual(receivedEnd, outsidePointNeg, "dragging outside the Component is no longer constrained (negative) (touchend)");
+
         svg.remove();
       });
 

--- a/test/interactions/dragInteractionTests.ts
+++ b/test/interactions/dragInteractionTests.ts
@@ -14,11 +14,11 @@ describe("Interactions", () => {
         x: SVG_WIDTH / 2,
         y: SVG_HEIGHT / 2
       };
-      let outsidePointPos = {
+      let positiveOutsidePoint = {
         x: SVG_WIDTH * 1.5,
         y: SVG_HEIGHT * 1.5
       };
-      let outsidePointNeg = {
+      let negativeOutsidePoint = {
         x: -SVG_WIDTH / 2,
         y: -SVG_HEIGHT / 2
       };
@@ -64,14 +64,14 @@ describe("Interactions", () => {
         assert.deepEqual(receivedStart, startPoint, "was passed the correct point");
 
         startCallbackCalled = false;
-        TestMethods.triggerFakeMouseEvent("mousedown", target, outsidePointPos.x, outsidePointPos.y);
+        TestMethods.triggerFakeMouseEvent("mousedown", target, positiveOutsidePoint.x, positiveOutsidePoint.y);
         assert.isFalse(startCallbackCalled, "does not trigger callback if drag starts outside the Component (positive) (mousedown)");
-        TestMethods.triggerFakeMouseEvent("mousedown", target, outsidePointNeg.x, outsidePointNeg.y);
+        TestMethods.triggerFakeMouseEvent("mousedown", target, negativeOutsidePoint.x, negativeOutsidePoint.y);
         assert.isFalse(startCallbackCalled, "does not trigger callback if drag starts outside the Component (negative) (mousedown)");
 
-        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: positiveOutsidePoint.x, y: positiveOutsidePoint.y}]);
         assert.isFalse(startCallbackCalled, "does not trigger callback if drag starts outside the Component (positive) (touchstart)");
-        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: negativeOutsidePoint.x, y: negativeOutsidePoint.y}]);
         assert.isFalse(startCallbackCalled, "does not trigger callback if drag starts outside the Component (negative) (touchstart)");
 
         dragInteraction.offDragStart(startCallback);
@@ -314,68 +314,76 @@ describe("Interactions", () => {
         assert.isTrue(dragInteraction.constrainedToComponent(), "constrains by default");
 
         TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-        TestMethods.triggerFakeMouseEvent("mousemove", target, outsidePointPos.x, outsidePointPos.y);
+        TestMethods.triggerFakeMouseEvent("mousemove", target, positiveOutsidePoint.x, positiveOutsidePoint.y);
         assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (mousemove)");
-        TestMethods.triggerFakeMouseEvent("mousemove", target, outsidePointNeg.x, outsidePointNeg.y);
+        TestMethods.triggerFakeMouseEvent("mousemove", target, negativeOutsidePoint.x, negativeOutsidePoint.y);
         assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (mousemove)");
         TestMethods.triggerFakeMouseEvent("mouseup", target, startPoint.x, startPoint.y);
 
         receivedEnd = null;
         TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
-        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
+        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: positiveOutsidePoint.x, y: positiveOutsidePoint.y}]);
         assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (touchmove)");
-        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
+        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: negativeOutsidePoint.x, y: negativeOutsidePoint.y}]);
         assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (touchmove)");
         TestMethods.triggerFakeTouchEvent("touchend", target, [{x: startPoint.x, y: startPoint.y}]);
 
         receivedEnd = null;
         TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-        TestMethods.triggerFakeMouseEvent("mouseup", target, outsidePointPos.x, outsidePointPos.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", target, positiveOutsidePoint.x, positiveOutsidePoint.y);
         assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (mouseup)");
         TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-        TestMethods.triggerFakeMouseEvent("mouseup", target, outsidePointNeg.x, outsidePointNeg.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", target, negativeOutsidePoint.x, negativeOutsidePoint.y);
         assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (mouseup)");
 
         receivedEnd = null;
         TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
-        TestMethods.triggerFakeTouchEvent("touchend", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
+        TestMethods.triggerFakeTouchEvent("touchend", target, [{x: positiveOutsidePoint.x, y: positiveOutsidePoint.y}]);
         assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (touchend)");
         TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
-        TestMethods.triggerFakeTouchEvent("touchend", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
+        TestMethods.triggerFakeTouchEvent("touchend", target, [{x: negativeOutsidePoint.x, y: negativeOutsidePoint.y}]);
         assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (touchend)");
 
         dragInteraction.constrainedToComponent(false);
 
         TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-        TestMethods.triggerFakeMouseEvent("mousemove", target, outsidePointPos.x, outsidePointPos.y);
-        assert.deepEqual(receivedEnd, outsidePointPos, "dragging outside the Component is no longer constrained (positive) (mousemove)");
-        TestMethods.triggerFakeMouseEvent("mousemove", target, outsidePointNeg.x, outsidePointNeg.y);
-        assert.deepEqual(receivedEnd, outsidePointNeg, "dragging outside the Component is no longer constrained (negative) (mousemove)");
+        TestMethods.triggerFakeMouseEvent("mousemove", target, positiveOutsidePoint.x, positiveOutsidePoint.y);
+        assert.deepEqual(receivedEnd, positiveOutsidePoint,
+          "dragging outside the Component is no longer constrained (positive) (mousemove)");
+        TestMethods.triggerFakeMouseEvent("mousemove", target, negativeOutsidePoint.x, negativeOutsidePoint.y);
+        assert.deepEqual(receivedEnd, negativeOutsidePoint,
+          "dragging outside the Component is no longer constrained (negative) (mousemove)");
         TestMethods.triggerFakeMouseEvent("mouseup", target, startPoint.x, startPoint.y);
 
         receivedEnd = null;
         TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
-        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
-        assert.deepEqual(receivedEnd, outsidePointPos, "dragging outside the Component is no longer constrained (positive) (touchmove)");
-        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
-        assert.deepEqual(receivedEnd, outsidePointNeg, "dragging outside the Component is no longer constrained (negative) (touchmove)");
+        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: positiveOutsidePoint.x, y: positiveOutsidePoint.y}]);
+        assert.deepEqual(receivedEnd, positiveOutsidePoint,
+          "dragging outside the Component is no longer constrained (positive) (touchmove)");
+        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: negativeOutsidePoint.x, y: negativeOutsidePoint.y}]);
+        assert.deepEqual(receivedEnd, negativeOutsidePoint,
+          "dragging outside the Component is no longer constrained (negative) (touchmove)");
         TestMethods.triggerFakeTouchEvent("touchend", target, [{x: startPoint.x, y: startPoint.y}]);
 
         receivedEnd = null;
         TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-        TestMethods.triggerFakeMouseEvent("mouseup", target, outsidePointPos.x, outsidePointPos.y);
-        assert.deepEqual(receivedEnd, outsidePointPos, "dragging outside the Component is no longer constrained (positive) (mouseup)");
+        TestMethods.triggerFakeMouseEvent("mouseup", target, positiveOutsidePoint.x, positiveOutsidePoint.y);
+        assert.deepEqual(receivedEnd, positiveOutsidePoint,
+          "dragging outside the Component is no longer constrained (positive) (mouseup)");
         TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-        TestMethods.triggerFakeMouseEvent("mouseup", target, outsidePointNeg.x, outsidePointNeg.y);
-        assert.deepEqual(receivedEnd, outsidePointNeg, "dragging outside the Component is no longer constrained (negative) (mouseup)");
+        TestMethods.triggerFakeMouseEvent("mouseup", target, negativeOutsidePoint.x, negativeOutsidePoint.y);
+        assert.deepEqual(receivedEnd, negativeOutsidePoint,
+          "dragging outside the Component is no longer constrained (negative) (mouseup)");
 
         receivedEnd = null;
         TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
-        TestMethods.triggerFakeTouchEvent("touchend", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
-        assert.deepEqual(receivedEnd, outsidePointPos, "dragging outside the Component is no longer constrained (positive) (touchend)");
+        TestMethods.triggerFakeTouchEvent("touchend", target, [{x: positiveOutsidePoint.x, y: positiveOutsidePoint.y}]);
+        assert.deepEqual(receivedEnd, positiveOutsidePoint,
+          "dragging outside the Component is no longer constrained (positive) (touchend)");
         TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
-        TestMethods.triggerFakeTouchEvent("touchend", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
-        assert.deepEqual(receivedEnd, outsidePointNeg, "dragging outside the Component is no longer constrained (negative) (touchend)");
+        TestMethods.triggerFakeTouchEvent("touchend", target, [{x: negativeOutsidePoint.x, y: negativeOutsidePoint.y}]);
+        assert.deepEqual(receivedEnd, negativeOutsidePoint,
+          "dragging outside the Component is no longer constrained (negative) (touchend)");
 
         svg.remove();
       });

--- a/test/interactions/dragInteractionTests.ts
+++ b/test/interactions/dragInteractionTests.ts
@@ -1,376 +1,360 @@
 ///<reference path="../testReference.ts" />
 
 describe("Interactions", () => {
-  describe("Drag", () => {
-    let SVG_WIDTH = 400;
-    let SVG_HEIGHT = 400;
+  describe("Drag Interaction", () => {
+    describe("Basic Usage", () => {
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 400;
 
-    let startPoint = {
-      x: SVG_WIDTH / 4,
-      y: SVG_HEIGHT / 4
-    };
-    let endPoint = {
-      x: SVG_WIDTH / 2,
-      y: SVG_HEIGHT / 2
-    };
-
-    let outsidePointPos = {
-      x: SVG_WIDTH * 1.5,
-      y: SVG_HEIGHT * 1.5
-    };
-    let constrainedPos = {
-      x: SVG_WIDTH,
-      y: SVG_HEIGHT
-    };
-    let outsidePointNeg = {
-      x: -SVG_WIDTH / 2,
-      y: -SVG_HEIGHT / 2
-    };
-    let constrainedNeg = {
-      x: 0,
-      y: 0
-    };
-
-    it("onDragStart()", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let c = new Plottable.Component();
-      c.renderTo(svg);
-
-      let drag = new Plottable.Interactions.Drag();
-      let startCallbackCalled = false;
-      let receivedStart: Plottable.Point;
-      let startCallback = (p: Plottable.Point) => {
-        startCallbackCalled = true;
-        receivedStart = p;
+      let startPoint = {
+        x: SVG_WIDTH / 4,
+        y: SVG_HEIGHT / 4
       };
-      drag.onDragStart(startCallback);
-      drag.attachTo(c);
-
-      let target = c.background();
-      TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-      assert.isTrue(startCallbackCalled, "callback was called on beginning drag (mousedown)");
-      assert.deepEqual(receivedStart, startPoint, "was passed the correct point");
-
-      startCallbackCalled = false;
-      receivedStart = null;
-      TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y, 2);
-      assert.isFalse(startCallbackCalled, "callback is not called on right-click");
-
-      startCallbackCalled = false;
-      receivedStart = null;
-      TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
-      assert.isTrue(startCallbackCalled, "callback was called on beginning drag (touchstart)");
-      assert.deepEqual(receivedStart, startPoint, "was passed the correct point");
-
-      startCallbackCalled = false;
-      TestMethods.triggerFakeMouseEvent("mousedown", target, outsidePointPos.x, outsidePointPos.y);
-      assert.isFalse(startCallbackCalled, "does not trigger callback if drag starts outside the Component (positive) (mousedown)");
-      TestMethods.triggerFakeMouseEvent("mousedown", target, outsidePointNeg.x, outsidePointNeg.y);
-      assert.isFalse(startCallbackCalled, "does not trigger callback if drag starts outside the Component (negative) (mousedown)");
-
-      TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
-      assert.isFalse(startCallbackCalled, "does not trigger callback if drag starts outside the Component (positive) (touchstart)");
-      TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
-      assert.isFalse(startCallbackCalled, "does not trigger callback if drag starts outside the Component (negative) (touchstart)");
-
-      drag.offDragStart(startCallback);
-
-      startCallbackCalled = false;
-      TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-      assert.isFalse(startCallbackCalled, "callback was decoupled from the interaction");
-
-      TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
-      assert.isFalse(startCallbackCalled, "callback was decoupled from the interaction");
-
-      svg.remove();
-    });
-
-    it("onDrag()", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let c = new Plottable.Component();
-      c.renderTo(svg);
-
-      let drag = new Plottable.Interactions.Drag();
-      let moveCallbackCalled = false;
-      let receivedStart: Plottable.Point;
-      let receivedEnd: Plottable.Point;
-      let moveCallback = (start: Plottable.Point, end: Plottable.Point) => {
-        moveCallbackCalled = true;
-        receivedStart = start;
-        receivedEnd = end;
+      let endPoint = {
+        x: SVG_WIDTH / 2,
+        y: SVG_HEIGHT / 2
       };
-      drag.onDrag(moveCallback);
-      drag.attachTo(c);
 
-      let target = c.background();
-      TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-      TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
-      assert.isTrue(moveCallbackCalled, "callback was called on dragging (mousemove)");
-      assert.deepEqual(receivedStart, startPoint, "was passed the correct starting point");
-      assert.deepEqual(receivedEnd, endPoint, "was passed the correct current point");
-
-      receivedStart = null;
-      receivedEnd = null;
-      TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
-      TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: endPoint.x, y: endPoint.y}]);
-      assert.isTrue(moveCallbackCalled, "callback was called on dragging (touchmove)");
-      assert.deepEqual(receivedStart, startPoint, "was passed the correct starting point");
-      assert.deepEqual(receivedEnd, endPoint, "was passed the correct current point");
-
-      drag.offDrag(moveCallback);
-
-      moveCallbackCalled = false;
-      TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-      TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
-      assert.isFalse(moveCallbackCalled, "callback was decoupled from interaction");
-
-      TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
-      TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: endPoint.x, y: endPoint.y}]);
-      assert.isFalse(moveCallbackCalled, "callback was decoupled from interaction");
-
-      svg.remove();
-    });
-
-    it("onDragEnd()", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let c = new Plottable.Component();
-      c.renderTo(svg);
-
-      let drag = new Plottable.Interactions.Drag();
-      let endCallbackCalled = false;
-      let receivedStart: Plottable.Point;
-      let receivedEnd: Plottable.Point;
-      let endCallback = (start: Plottable.Point, end: Plottable.Point) => {
-        endCallbackCalled = true;
-        receivedStart = start;
-        receivedEnd = end;
+      let outsidePointPos = {
+        x: SVG_WIDTH * 1.5,
+        y: SVG_HEIGHT * 1.5
       };
-      drag.onDragEnd(endCallback);
-      drag.attachTo(c);
-
-      let target = c.background();
-      TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-      TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y);
-      assert.isTrue(endCallbackCalled, "callback was called on drag ending (mouseup)");
-      assert.deepEqual(receivedStart, startPoint, "was passed the correct starting point");
-      assert.deepEqual(receivedEnd, endPoint, "was passed the correct current point");
-
-      receivedStart = null;
-      receivedEnd = null;
-      TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-      TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y, 2);
-      assert.isTrue(endCallbackCalled, "callback was not called on mouseup from the right-click button");
-      TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y); // end the drag
-
-      receivedStart = null;
-      receivedEnd = null;
-      TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
-      TestMethods.triggerFakeTouchEvent("touchend", target, [{x: endPoint.x, y: endPoint.y}]);
-      assert.isTrue(endCallbackCalled, "callback was called on drag ending (touchend)");
-      assert.deepEqual(receivedStart, startPoint, "was passed the correct starting point");
-      assert.deepEqual(receivedEnd, endPoint, "was passed the correct current point");
-
-      drag.offDragEnd(endCallback);
-
-      endCallbackCalled = false;
-      TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-      TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y);
-      assert.isFalse(endCallbackCalled, "callback was called on drag ending (mouseup)");
-
-      TestMethods.triggerFakeTouchEvent("touchstart", target, [{ x: startPoint.x, y: startPoint.y }]);
-      TestMethods.triggerFakeTouchEvent("touchend", target, [{ x: endPoint.x, y: endPoint.y }]);
-      assert.isFalse(endCallbackCalled, "callback decoupled from interaction");
-
-      svg.remove();
-    });
-
-    it("multiple interactions on drag", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let component = new Plottable.Component();
-      component.renderTo(svg);
-
-      let drag = new Plottable.Interactions.Drag();
-      let startCallback1Called = false;
-      let startCallback2Called = false;
-      let moveCallback1Called = false;
-      let moveCallback2Called = false;
-      let endCallback1Called = false;
-      let endCallback2Called = false;
-
-      let startCallback1 = () => startCallback1Called = true;
-      let startCallback2 = () => startCallback2Called = true;
-      let moveCallback1 = () => moveCallback1Called = true;
-      let moveCallback2 = () => moveCallback2Called = true;
-      let endCallback1 = () => endCallback1Called = true;
-      let endCallback2 = () => endCallback2Called = true;
-
-      drag.onDragStart(startCallback1);
-      drag.onDragStart(startCallback2);
-      drag.onDrag(moveCallback1);
-      drag.onDrag(moveCallback2);
-      drag.onDragEnd(endCallback1);
-      drag.onDragEnd(endCallback2);
-
-      drag.attachTo(component);
-
-      let target = component.background();
-      TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-      assert.isTrue(startCallback1Called, "callback 1 was called on beginning drag (mousedown)");
-      assert.isTrue(startCallback2Called, "callback 2 was called on beginning drag (mousedown)");
-
-      TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
-      assert.isTrue(moveCallback1Called, "callback 1 was called on dragging (mousemove)");
-      assert.isTrue(moveCallback2Called, "callback 2 was called on dragging (mousemove)");
-
-      TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y);
-      assert.isTrue(endCallback1Called, "callback 1 was called on drag ending (mouseup)");
-      assert.isTrue(endCallback2Called, "callback 2 was called on drag ending (mouseup)");
-
-      startCallback1Called = false;
-      startCallback2Called = false;
-      moveCallback1Called = false;
-      moveCallback2Called = false;
-      endCallback1Called = false;
-      endCallback2Called = false;
-
-      drag.offDragStart(startCallback1);
-      drag.offDrag(moveCallback1);
-      drag.offDragEnd(endCallback1);
-
-      TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-      assert.isFalse(startCallback1Called, "callback 1 was disconnected from drag start interaction");
-      assert.isTrue(startCallback2Called, "callback 2 is still connected to the drag start interaction");
-
-      TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
-      assert.isFalse(moveCallback1Called, "callback 1 was disconnected from drag interaction");
-      assert.isTrue(moveCallback2Called, "callback 2 is still connected to the drag interaction");
-
-      TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y);
-      assert.isFalse(endCallback1Called, "callback 1 was disconnected from the drag end interaction");
-      assert.isTrue(endCallback2Called, "callback 2 is still connected to the drag end interaction");
-
-      svg.remove();
-    });
-
-    it("constrainToComponent()", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let c = new Plottable.Component();
-      c.renderTo(svg);
-
-      let drag = new Plottable.Interactions.Drag();
-      assert.isTrue(drag.constrainedToComponent(), "constrains by default");
-
-      let receivedStart: Plottable.Point;
-      let receivedEnd: Plottable.Point;
-      let moveCallback = (start: Plottable.Point, end: Plottable.Point) => {
-        receivedStart = start;
-        receivedEnd = end;
+      let constrainedPos = {
+        x: SVG_WIDTH,
+        y: SVG_HEIGHT
       };
-      drag.onDrag(moveCallback);
-      let endCallback = (start: Plottable.Point, end: Plottable.Point) => {
-        receivedStart = start;
-        receivedEnd = end;
+      let outsidePointNeg = {
+        x: -SVG_WIDTH / 2,
+        y: -SVG_HEIGHT / 2
       };
-      drag.onDragEnd(endCallback);
-
-      drag.attachTo(c);
-      let target = c.content();
-
-      TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-      TestMethods.triggerFakeMouseEvent("mousemove", target, outsidePointPos.x, outsidePointPos.y);
-      assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (mousemove)");
-      TestMethods.triggerFakeMouseEvent("mousemove", target, outsidePointNeg.x, outsidePointNeg.y);
-      assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (mousemove)");
-
-      receivedEnd = null;
-      TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
-      assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (touchmove)");
-      TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
-      assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (touchmove)");
-
-      receivedEnd = null;
-      TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-      TestMethods.triggerFakeMouseEvent("mouseup", target, outsidePointPos.x, outsidePointPos.y);
-      assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (mouseup)");
-      TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-      TestMethods.triggerFakeMouseEvent("mouseup", target, outsidePointNeg.x, outsidePointNeg.y);
-      assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (mouseup)");
-
-      receivedEnd = null;
-      TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
-      TestMethods.triggerFakeTouchEvent("touchend", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
-      assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (touchend)");
-      TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
-      TestMethods.triggerFakeTouchEvent("touchend", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
-      assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (touchend)");
-
-      drag.constrainedToComponent(false);
-
-      TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-      TestMethods.triggerFakeMouseEvent("mousemove", target, outsidePointPos.x, outsidePointPos.y);
-      assert.deepEqual(receivedEnd, outsidePointPos,
-                       "dragging outside the Component is no longer constrained (positive) (mousemove)");
-      TestMethods.triggerFakeMouseEvent("mousemove", target, outsidePointNeg.x, outsidePointNeg.y);
-      assert.deepEqual(receivedEnd, outsidePointNeg,
-                       "dragging outside the Component is no longer constrained (negative) (mousemove)");
-
-      receivedEnd = null;
-      TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
-      assert.deepEqual(receivedEnd, outsidePointPos,
-                       "dragging outside the Component is no longer constrained (positive) (touchmove)");
-      TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
-      assert.deepEqual(receivedEnd, outsidePointNeg,
-                       "dragging outside the Component is no longer constrained (negative) (touchmove)");
-
-      receivedEnd = null;
-      TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-      TestMethods.triggerFakeMouseEvent("mouseup", target, outsidePointPos.x, outsidePointPos.y);
-      assert.deepEqual(receivedEnd, outsidePointPos,
-                       "dragging outside the Component is no longer constrained (positive) (mouseup)");
-      TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
-      TestMethods.triggerFakeMouseEvent("mouseup", target, outsidePointNeg.x, outsidePointNeg.y);
-      assert.deepEqual(receivedEnd, outsidePointNeg,
-                       "dragging outside the Component is no longer constrained (negative) (mouseup)");
-
-      receivedEnd = null;
-      TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
-      TestMethods.triggerFakeTouchEvent("touchend", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
-      assert.deepEqual(receivedEnd, outsidePointPos,
-                       "dragging outside the Component is no longer constrained (positive) (touchend)");
-      TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
-      TestMethods.triggerFakeTouchEvent("touchend", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
-      assert.deepEqual(receivedEnd, outsidePointNeg,
-                       "dragging outside the Component is no longer constrained (negative) (touchend)");
-      svg.remove();
-    });
-
-    it("touchcancel cancels the current drag", () => {
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      let c = new Plottable.Component();
-      c.renderTo(svg);
-
-      let drag = new Plottable.Interactions.Drag();
-      let moveCallbackCalled = false;
-      let receivedStart: Plottable.Point;
-      let receivedEnd: Plottable.Point;
-      let moveCallback = (start: Plottable.Point, end: Plottable.Point) => {
-        moveCallbackCalled = true;
-        receivedStart = start;
-        receivedEnd = end;
+      let constrainedNeg = {
+        x: 0,
+        y: 0
       };
-      drag.onDrag(moveCallback);
-      drag.attachTo(c);
 
-      let target = c.background();
-      receivedStart = null;
-      receivedEnd = null;
-      TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
-      TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: endPoint.x - 10, y: endPoint.y - 10}]);
-      TestMethods.triggerFakeTouchEvent("touchcancel", target, [{x: endPoint.x - 10, y: endPoint.y - 10}]);
-      TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: endPoint.x, y: endPoint.y}]);
-      assert.notEqual(receivedEnd, endPoint, "was not passed touch point after cancelled");
+      let svg: d3.Selection<void>;
+      let component: Plottable.Component;
+      let dragInteraction: Plottable.Interactions.Drag;
 
-      svg.remove();
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        component = new Plottable.Component();
+        component.renderTo(svg);
+
+        dragInteraction = new Plottable.Interactions.Drag();
+      });
+
+      it("onDragStart()", () => {
+        let startCallbackCalled = false;
+        let receivedStart: Plottable.Point;
+        let startCallback = (p: Plottable.Point) => {
+          startCallbackCalled = true;
+          receivedStart = p;
+        };
+        dragInteraction.onDragStart(startCallback);
+        dragInteraction.attachTo(component);
+
+        let target = component.background();
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        assert.isTrue(startCallbackCalled, "callback was called on beginning drag (mousedown)");
+        assert.deepEqual(receivedStart, startPoint, "was passed the correct point");
+
+        startCallbackCalled = false;
+        receivedStart = null;
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y, 2);
+        assert.isFalse(startCallbackCalled, "callback is not called on right-click");
+
+        startCallbackCalled = false;
+        receivedStart = null;
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
+        assert.isTrue(startCallbackCalled, "callback was called on beginning drag (touchstart)");
+        assert.deepEqual(receivedStart, startPoint, "was passed the correct point");
+
+        startCallbackCalled = false;
+        TestMethods.triggerFakeMouseEvent("mousedown", target, outsidePointPos.x, outsidePointPos.y);
+        assert.isFalse(startCallbackCalled, "does not trigger callback if drag starts outside the Component (positive) (mousedown)");
+        TestMethods.triggerFakeMouseEvent("mousedown", target, outsidePointNeg.x, outsidePointNeg.y);
+        assert.isFalse(startCallbackCalled, "does not trigger callback if drag starts outside the Component (negative) (mousedown)");
+
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
+        assert.isFalse(startCallbackCalled, "does not trigger callback if drag starts outside the Component (positive) (touchstart)");
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
+        assert.isFalse(startCallbackCalled, "does not trigger callback if drag starts outside the Component (negative) (touchstart)");
+
+        dragInteraction.offDragStart(startCallback);
+
+        startCallbackCalled = false;
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        assert.isFalse(startCallbackCalled, "callback was decoupled from the interaction");
+
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
+        assert.isFalse(startCallbackCalled, "callback was decoupled from the interaction");
+
+        svg.remove();
+      });
+
+      it("onDrag()", () => {
+        let moveCallbackCalled = false;
+        let receivedStart: Plottable.Point;
+        let receivedEnd: Plottable.Point;
+        let moveCallback = (start: Plottable.Point, end: Plottable.Point) => {
+          moveCallbackCalled = true;
+          receivedStart = start;
+          receivedEnd = end;
+        };
+        dragInteraction.onDrag(moveCallback);
+        dragInteraction.attachTo(component);
+
+        let target = component.background();
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
+        assert.isTrue(moveCallbackCalled, "callback was called on dragging (mousemove)");
+        assert.deepEqual(receivedStart, startPoint, "was passed the correct starting point");
+        assert.deepEqual(receivedEnd, endPoint, "was passed the correct current point");
+
+        receivedStart = null;
+        receivedEnd = null;
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
+        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: endPoint.x, y: endPoint.y}]);
+        assert.isTrue(moveCallbackCalled, "callback was called on dragging (touchmove)");
+        assert.deepEqual(receivedStart, startPoint, "was passed the correct starting point");
+        assert.deepEqual(receivedEnd, endPoint, "was passed the correct current point");
+
+        dragInteraction.offDrag(moveCallback);
+
+        moveCallbackCalled = false;
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
+        assert.isFalse(moveCallbackCalled, "callback was decoupled from interaction");
+
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
+        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: endPoint.x, y: endPoint.y}]);
+        assert.isFalse(moveCallbackCalled, "callback was decoupled from interaction");
+
+        svg.remove();
+      });
+
+      it("onDragEnd()", () => {
+        let endCallbackCalled = false;
+        let receivedStart: Plottable.Point;
+        let receivedEnd: Plottable.Point;
+        let endCallback = (start: Plottable.Point, end: Plottable.Point) => {
+          endCallbackCalled = true;
+          receivedStart = start;
+          receivedEnd = end;
+        };
+        dragInteraction.onDragEnd(endCallback);
+        dragInteraction.attachTo(component);
+
+        let target = component.background();
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y);
+        assert.isTrue(endCallbackCalled, "callback was called on drag ending (mouseup)");
+        assert.deepEqual(receivedStart, startPoint, "was passed the correct starting point");
+        assert.deepEqual(receivedEnd, endPoint, "was passed the correct current point");
+
+        receivedStart = null;
+        receivedEnd = null;
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y, 2);
+        assert.isTrue(endCallbackCalled, "callback was not called on mouseup from the right-click button");
+        TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y); // end the drag
+
+        receivedStart = null;
+        receivedEnd = null;
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
+        TestMethods.triggerFakeTouchEvent("touchend", target, [{x: endPoint.x, y: endPoint.y}]);
+        assert.isTrue(endCallbackCalled, "callback was called on drag ending (touchend)");
+        assert.deepEqual(receivedStart, startPoint, "was passed the correct starting point");
+        assert.deepEqual(receivedEnd, endPoint, "was passed the correct current point");
+
+        dragInteraction.offDragEnd(endCallback);
+
+        endCallbackCalled = false;
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y);
+        assert.isFalse(endCallbackCalled, "callback was called on drag ending (mouseup)");
+
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{ x: startPoint.x, y: startPoint.y }]);
+        TestMethods.triggerFakeTouchEvent("touchend", target, [{ x: endPoint.x, y: endPoint.y }]);
+        assert.isFalse(endCallbackCalled, "callback decoupled from interaction");
+
+        svg.remove();
+      });
+
+      it("multiple interactions on drag", () => {
+        let startCallback1Called = false;
+        let startCallback2Called = false;
+        let moveCallback1Called = false;
+        let moveCallback2Called = false;
+        let endCallback1Called = false;
+        let endCallback2Called = false;
+
+        let startCallback1 = () => startCallback1Called = true;
+        let startCallback2 = () => startCallback2Called = true;
+        let moveCallback1 = () => moveCallback1Called = true;
+        let moveCallback2 = () => moveCallback2Called = true;
+        let endCallback1 = () => endCallback1Called = true;
+        let endCallback2 = () => endCallback2Called = true;
+
+        dragInteraction.onDragStart(startCallback1);
+        dragInteraction.onDragStart(startCallback2);
+        dragInteraction.onDrag(moveCallback1);
+        dragInteraction.onDrag(moveCallback2);
+        dragInteraction.onDragEnd(endCallback1);
+        dragInteraction.onDragEnd(endCallback2);
+
+        dragInteraction.attachTo(component);
+
+        let target = component.background();
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        assert.isTrue(startCallback1Called, "callback 1 was called on beginning drag (mousedown)");
+        assert.isTrue(startCallback2Called, "callback 2 was called on beginning drag (mousedown)");
+
+        TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
+        assert.isTrue(moveCallback1Called, "callback 1 was called on dragging (mousemove)");
+        assert.isTrue(moveCallback2Called, "callback 2 was called on dragging (mousemove)");
+
+        TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y);
+        assert.isTrue(endCallback1Called, "callback 1 was called on drag ending (mouseup)");
+        assert.isTrue(endCallback2Called, "callback 2 was called on drag ending (mouseup)");
+
+        startCallback1Called = false;
+        startCallback2Called = false;
+        moveCallback1Called = false;
+        moveCallback2Called = false;
+        endCallback1Called = false;
+        endCallback2Called = false;
+
+        dragInteraction.offDragStart(startCallback1);
+        dragInteraction.offDrag(moveCallback1);
+        dragInteraction.offDragEnd(endCallback1);
+
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        assert.isFalse(startCallback1Called, "callback 1 was disconnected from drag start interaction");
+        assert.isTrue(startCallback2Called, "callback 2 is still connected to the drag start interaction");
+
+        TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
+        assert.isFalse(moveCallback1Called, "callback 1 was disconnected from drag interaction");
+        assert.isTrue(moveCallback2Called, "callback 2 is still connected to the drag interaction");
+
+        TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y);
+        assert.isFalse(endCallback1Called, "callback 1 was disconnected from the drag end interaction");
+        assert.isTrue(endCallback2Called, "callback 2 is still connected to the drag end interaction");
+
+        svg.remove();
+      });
+
+      it("constrainToComponent()", () => {
+        assert.isTrue(dragInteraction.constrainedToComponent(), "constrains by default");
+
+        let receivedStart: Plottable.Point;
+        let receivedEnd: Plottable.Point;
+        let moveCallback = (start: Plottable.Point, end: Plottable.Point) => {
+          receivedStart = start;
+          receivedEnd = end;
+        };
+        dragInteraction.onDrag(moveCallback);
+        let endCallback = (start: Plottable.Point, end: Plottable.Point) => {
+          receivedStart = start;
+          receivedEnd = end;
+        };
+        dragInteraction.onDragEnd(endCallback);
+
+        dragInteraction.attachTo(component);
+        let target = component.content();
+
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        TestMethods.triggerFakeMouseEvent("mousemove", target, outsidePointPos.x, outsidePointPos.y);
+        assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (mousemove)");
+        TestMethods.triggerFakeMouseEvent("mousemove", target, outsidePointNeg.x, outsidePointNeg.y);
+        assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (mousemove)");
+
+        receivedEnd = null;
+        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
+        assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (touchmove)");
+        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
+        assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (touchmove)");
+
+        receivedEnd = null;
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", target, outsidePointPos.x, outsidePointPos.y);
+        assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (mouseup)");
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", target, outsidePointNeg.x, outsidePointNeg.y);
+        assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (mouseup)");
+
+        receivedEnd = null;
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
+        TestMethods.triggerFakeTouchEvent("touchend", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
+        assert.deepEqual(receivedEnd, constrainedPos, "dragging outside the Component is constrained (positive) (touchend)");
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
+        TestMethods.triggerFakeTouchEvent("touchend", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
+        assert.deepEqual(receivedEnd, constrainedNeg, "dragging outside the Component is constrained (negative) (touchend)");
+
+        dragInteraction.constrainedToComponent(false);
+
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        TestMethods.triggerFakeMouseEvent("mousemove", target, outsidePointPos.x, outsidePointPos.y);
+        assert.deepEqual(receivedEnd, outsidePointPos,
+                         "dragging outside the Component is no longer constrained (positive) (mousemove)");
+        TestMethods.triggerFakeMouseEvent("mousemove", target, outsidePointNeg.x, outsidePointNeg.y);
+        assert.deepEqual(receivedEnd, outsidePointNeg,
+                         "dragging outside the Component is no longer constrained (negative) (mousemove)");
+
+        receivedEnd = null;
+        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
+        assert.deepEqual(receivedEnd, outsidePointPos,
+                         "dragging outside the Component is no longer constrained (positive) (touchmove)");
+        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
+        assert.deepEqual(receivedEnd, outsidePointNeg,
+                         "dragging outside the Component is no longer constrained (negative) (touchmove)");
+
+        receivedEnd = null;
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", target, outsidePointPos.x, outsidePointPos.y);
+        assert.deepEqual(receivedEnd, outsidePointPos,
+                         "dragging outside the Component is no longer constrained (positive) (mouseup)");
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", target, outsidePointNeg.x, outsidePointNeg.y);
+        assert.deepEqual(receivedEnd, outsidePointNeg,
+                         "dragging outside the Component is no longer constrained (negative) (mouseup)");
+
+        receivedEnd = null;
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
+        TestMethods.triggerFakeTouchEvent("touchend", target, [{x: outsidePointPos.x, y: outsidePointPos.y}]);
+        assert.deepEqual(receivedEnd, outsidePointPos,
+                         "dragging outside the Component is no longer constrained (positive) (touchend)");
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
+        TestMethods.triggerFakeTouchEvent("touchend", target, [{x: outsidePointNeg.x, y: outsidePointNeg.y}]);
+        assert.deepEqual(receivedEnd, outsidePointNeg,
+                         "dragging outside the Component is no longer constrained (negative) (touchend)");
+        svg.remove();
+      });
+
+      it("touchcancel cancels the current drag", () => {
+        let moveCallbackCalled = false;
+        let receivedStart: Plottable.Point;
+        let receivedEnd: Plottable.Point;
+        let moveCallback = (start: Plottable.Point, end: Plottable.Point) => {
+          moveCallbackCalled = true;
+          receivedStart = start;
+          receivedEnd = end;
+        };
+        dragInteraction.onDrag(moveCallback);
+        dragInteraction.attachTo(component);
+
+        let target = component.background();
+        receivedStart = null;
+        receivedEnd = null;
+        TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
+        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: endPoint.x - 10, y: endPoint.y - 10}]);
+        TestMethods.triggerFakeTouchEvent("touchcancel", target, [{x: endPoint.x - 10, y: endPoint.y - 10}]);
+        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: endPoint.x, y: endPoint.y}]);
+        assert.notEqual(receivedEnd, endPoint, "was not passed touch point after cancelled");
+
+        svg.remove();
+      });
     });
   });
 });

--- a/test/interactions/dragInteractionTests.ts
+++ b/test/interactions/dragInteractionTests.ts
@@ -86,7 +86,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can register two onDragStart() callbacks on the same Component", () => {
+      it("can register two onDragStart() callbacks", () => {
         let startCallback1Called = false;
         let startCallback2Called = false;
         let startCallback1 = () => startCallback1Called = true;
@@ -155,7 +155,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can register two onDrag() callbacks on the same Component", () => {
+      it("can register two onDrag() callbacks", () => {
         let moveCallback1Called = false;
         let moveCallback2Called = false;
         let moveCallback1 = () => moveCallback1Called = true;
@@ -233,7 +233,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can register two onDragEnd() callbacks on the same Component", () => {
+      it("can register two onDragEnd() callbacks", () => {
         let endCallback1Called = false;
         let endCallback2Called = false;
         let endCallback1 = () => endCallback1Called = true;
@@ -262,7 +262,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can register multiple callbacks", () => {
+      it("can register start/move/end drag callbacks in the same time", () => {
         let startCallbackCalled = false;
         let moveCallbackCalled = false;
         let endCallbackCalled = false;
@@ -300,7 +300,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("constraints the drag interaction to the Component space", () => {
+      it("can constrain the drag to inside the Component's space", () => {
         let constrainedPos = { x: SVG_WIDTH, y: SVG_HEIGHT };
         let constrainedNeg = { x: 0, y: 0 };
 

--- a/test/interactions/dragInteractionTests.ts
+++ b/test/interactions/dragInteractionTests.ts
@@ -74,6 +74,21 @@ describe("Interactions", () => {
         TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: negativeOutsidePoint.x, y: negativeOutsidePoint.y}]);
         assert.isFalse(startCallbackCalled, "does not trigger callback if drag starts outside the Component (negative) (touchstart)");
 
+        svg.remove();
+      });
+
+      it("can de-register the onDragStart() interaction", () => {
+        dragInteraction.attachTo(component);
+
+        let startCallbackCalled = false;
+        let startCallback = () => startCallbackCalled = true;
+
+        dragInteraction.onDragStart(startCallback);
+
+        let target = component.background();
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        assert.isTrue(startCallbackCalled, "callback was called on beginning drag (mousedown)");
+
         dragInteraction.offDragStart(startCallback);
 
         startCallbackCalled = false;
@@ -140,6 +155,22 @@ describe("Interactions", () => {
         assert.isTrue(moveCallbackCalled, "callback was called on dragging (touchmove)");
         assert.deepEqual(receivedStart, startPoint, "was passed the correct starting point");
         assert.deepEqual(receivedEnd, endPoint, "was passed the correct current point");
+
+        svg.remove();
+      });
+
+      it("can de-register the onDrag() interaction", () => {
+        dragInteraction.attachTo(component);
+
+        let moveCallbackCalled = false;
+        let moveCallback = () => moveCallbackCalled = true;
+
+        dragInteraction.onDrag(moveCallback);
+
+        let target = component.background();
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        TestMethods.triggerFakeMouseEvent("mousemove", target, endPoint.x, endPoint.y);
+        assert.isTrue(moveCallbackCalled, "callback was called on beginning drag (mousedown)");
 
         dragInteraction.offDrag(moveCallback);
 
@@ -218,6 +249,22 @@ describe("Interactions", () => {
         assert.isTrue(endCallbackCalled, "callback was called on drag ending (touchend)");
         assert.deepEqual(receivedStart, startPoint, "was passed the correct starting point");
         assert.deepEqual(receivedEnd, endPoint, "was passed the correct current point");
+
+        svg.remove();
+      });
+
+      it("can de-register the onDragEnd() interaction", () => {
+        dragInteraction.attachTo(component);
+
+        let endCallbackCalled = false;
+        let endCallback = () => endCallbackCalled = true;
+
+        dragInteraction.onDragEnd(endCallback);
+
+        let target = component.background();
+        TestMethods.triggerFakeMouseEvent("mousedown", target, startPoint.x, startPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", target, endPoint.x, endPoint.y);
+        assert.isTrue(endCallbackCalled, "callback was called on beginning drag (mousedown)");
 
         dragInteraction.offDragEnd(endCallback);
 

--- a/test/interactions/dragInteractionTests.ts
+++ b/test/interactions/dragInteractionTests.ts
@@ -395,7 +395,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("touchcancel cancels the current drag", () => {
+      it("does not continue dragging once the touch is cancelled", () => {
         let moveCallbackCalled = false;
         let receivedStart: Plottable.Point;
         let receivedEnd: Plottable.Point;
@@ -413,8 +413,10 @@ describe("Interactions", () => {
         TestMethods.triggerFakeTouchEvent("touchstart", target, [{x: startPoint.x, y: startPoint.y}]);
         TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: endPoint.x - 10, y: endPoint.y - 10}]);
         TestMethods.triggerFakeTouchEvent("touchcancel", target, [{x: endPoint.x - 10, y: endPoint.y - 10}]);
-        TestMethods.triggerFakeTouchEvent("touchmove", target, [{x: endPoint.x, y: endPoint.y}]);
-        assert.notEqual(receivedEnd, endPoint, "was not passed touch point after cancelled");
+        TestMethods.triggerFakeTouchEvent("touchend", target, [{x: endPoint.x, y: endPoint.y}]);
+        assert.isTrue(moveCallbackCalled, "the callback is called");
+        assert.deepEqual(receivedStart, {x: startPoint.x, y: startPoint.y}, "1");
+        assert.deepEqual(receivedEnd, {x: endPoint.x - 10, y: endPoint.y - 10}, "2");
 
         svg.remove();
       });


### PR DESCRIPTION
Part of #2628

I will be doing 2 passes because I will get more context (and better sense of best practices) by refactoring other files. However, please flag anything that seems unusual.

As part of this: 
- **Test semantics: hierarchy, naming, testing, but no coverage check**
- Applied best practices from the wiki page
- Factored out common code into `beforeEach()` clauses
- No nested `beforeEach()`es
- Cleaned the console
- Remade hierarchy as shown bellow

![screen shot 2015-08-31 at 4 14 24 pm](https://cloud.githubusercontent.com/assets/3248682/9592794/658e816c-4ffb-11e5-9b2a-5ac1b926c783.png)
