### PR TITLE
Higher retry rate for saucelabs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -282,6 +282,8 @@ module.exports = function(grunt) {
       options: {
         urls: ["http://127.0.0.1:9999/test/tests.html"],
         testname: "Plottable Sauce Unit Tests",
+        pollInterval: 5000,
+        statusCheckAttempts: 60,
         browsers: [{
           browserName: "firefox",
           platform: "linux"


### PR DESCRIPTION
This is to account for the tests being slow on iPad. Increased the upper bound from 3 min to 5 min. 

Settings taken from here https://github.com/axemclion/grunt-saucelabs

I also played around with other environments taken from here https://docs.saucelabs.com/reference/platforms-configurator/ . It seems like all of them need between 2:03 and 3:00 + to run all the tests so a higher upper bound make sense.

The reason why we did not have this issue before was less tests. Right now the tests need 60% more time compared to what we had when we released `1.0.0`, due to new features. 