### PR TITLE
[RenderControllerTests] - revamping

### DIFF
--- a/test/core/renderControllerTests.ts
+++ b/test/core/renderControllerTests.ts
@@ -1,8 +1,80 @@
 ///<reference path="../testReference.ts" />
 
 describe("RenderController", () => {
-  // HACKHACK: #2083
-  it.skip("Components whose render() is triggered by another Component's render() will be drawn", () => {
+  let SVG_WIDTH = 400;
+  let SVG_HEIGHT = 300;
+
+  describe("configuring the render policy", () => {
+    let oldWarn: (msg: string) => void;
+    let warned: boolean;
+
+    before(() => {
+      oldWarn = Plottable.Utils.Window.warn;
+      Plottable.Utils.Window.warn = () => {
+        warned = true;
+      };
+    });
+
+    beforeEach(() => {
+      warned = false;
+    });
+
+    after(() => {
+      Plottable.RenderController.renderPolicy(Plottable.RenderController.Policy.IMMEDIATE);
+      Plottable.Utils.Window.warn = oldWarn;
+    });
+
+    it("can set a render policy", () => {
+      let renderPolicy = Plottable.RenderController.Policy.TIMEOUT;
+      Plottable.RenderController.renderPolicy(renderPolicy);
+
+      assert.strictEqual(Object.getPrototypeOf(Plottable.RenderController.renderPolicy()),
+        Plottable.RenderPolicies.Timeout.prototype, "render policy is of the same type");
+    });
+
+    it("throws a warning for unrecognized render policies", () => {
+      let unrecognizedRenderPolicy = "foo";
+      Plottable.RenderController.renderPolicy(unrecognizedRenderPolicy);
+
+      assert.isTrue(warned, "warning sent for unrecognized render policy");
+    });
+  });
+
+  it("can queue a component to render", () => {
+    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+    let component = new Plottable.Component();
+    let rendered = false;
+    component.renderImmediately = () => {
+      rendered = true;
+      return component;
+    };
+    component.anchor(svg);
+    Plottable.RenderController.registerToRender(component);
+    assert.isTrue(rendered, "component has rendered");
+    component.destroy();
+    svg.remove();
+  });
+
+  it("can queue a component to undergo layout computation and render", () => {
+    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+    let component = new Plottable.Component();
+    let rendered = false;
+    component.renderImmediately = () => {
+      rendered = true;
+      return component;
+    };
+    component.anchor(svg);
+    Plottable.RenderController.registerToComputeLayout(component);
+    assert.isTrue(rendered, "component has rendered");
+    assert.deepEqual(component.origin(), {x: 0, y: 0}, "origin set");
+    assert.strictEqual(component.width(), SVG_WIDTH, "width set");
+    assert.strictEqual(component.height(), SVG_HEIGHT, "height set");
+    component.destroy();
+    svg.remove();
+  });
+
+  // HACKHACK: https://github.com/palantir/plottable/issues/2083
+  it.skip("can render components that are triggered by another component's render", () => {
     let link1 = new Plottable.Component();
     let svg1 = TestMethods.generateSVG();
     link1.anchor(svg1).computeLayout();

--- a/test/core/renderControllerTests.ts
+++ b/test/core/renderControllerTests.ts
@@ -43,14 +43,14 @@ describe("RenderController", () => {
   it("can queue a component to render", () => {
     let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
     let component = new Plottable.Component();
-    let rendered = false;
+    let renderedClass = "rendered";
     component.renderImmediately = () => {
-      rendered = true;
+      component.content().append("g").classed(renderedClass, true);
       return component;
     };
     component.anchor(svg);
     Plottable.RenderController.registerToRender(component);
-    assert.isTrue(rendered, "component has rendered");
+    assert.isFalse(component.content().select(`.${renderedClass}`).empty(), "component has rendered");
     component.destroy();
     svg.remove();
   });
@@ -58,14 +58,14 @@ describe("RenderController", () => {
   it("can queue a component to undergo layout computation and render", () => {
     let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
     let component = new Plottable.Component();
-    let rendered = false;
+    let renderedClass = "rendered";
     component.renderImmediately = () => {
-      rendered = true;
+      component.content().append("g").classed(renderedClass, true);
       return component;
     };
     component.anchor(svg);
     Plottable.RenderController.registerToComputeLayout(component);
-    assert.isTrue(rendered, "component has rendered");
+    assert.isFalse(component.content().select(`.${renderedClass}`).empty(), "component has rendered");
     assert.deepEqual(component.origin(), {x: 0, y: 0}, "origin set");
     assert.strictEqual(component.width(), SVG_WIDTH, "width set");
     assert.strictEqual(component.height(), SVG_HEIGHT, "height set");

--- a/test/core/renderControllerTests.ts
+++ b/test/core/renderControllerTests.ts
@@ -6,17 +6,17 @@ describe("RenderController", () => {
 
   describe("configuring the render policy", () => {
     let oldWarn: (msg: string) => void;
-    let warned: boolean;
+    let storedWarningMsg: string;
 
     before(() => {
       oldWarn = Plottable.Utils.Window.warn;
-      Plottable.Utils.Window.warn = () => {
-        warned = true;
+      Plottable.Utils.Window.warn = (warningMsg: string) => {
+        storedWarningMsg = warningMsg;
       };
     });
 
     beforeEach(() => {
-      warned = false;
+      storedWarningMsg = "";
     });
 
     after(() => {
@@ -36,7 +36,7 @@ describe("RenderController", () => {
       let unrecognizedRenderPolicy = "foo";
       Plottable.RenderController.renderPolicy(unrecognizedRenderPolicy);
 
-      assert.isTrue(warned, "warning sent for unrecognized render policy");
+      assert.include(storedWarningMsg, "Unrecognized renderPolicy", "warning sent for unrecognized render policy");
     });
   });
 

--- a/test/core/renderControllerTests.ts
+++ b/test/core/renderControllerTests.ts
@@ -5,23 +5,8 @@ describe("RenderController", () => {
   let SVG_HEIGHT = 300;
 
   describe("configuring the render policy", () => {
-    let oldWarn: (msg: string) => void;
-    let storedWarningMsg: string;
-
-    before(() => {
-      oldWarn = Plottable.Utils.Window.warn;
-      Plottable.Utils.Window.warn = (warningMsg: string) => {
-        storedWarningMsg = warningMsg;
-      };
-    });
-
-    beforeEach(() => {
-      storedWarningMsg = "";
-    });
-
     after(() => {
       Plottable.RenderController.renderPolicy(Plottable.RenderController.Policy.IMMEDIATE);
-      Plottable.Utils.Window.warn = oldWarn;
     });
 
     it("can set a render policy", () => {
@@ -34,9 +19,8 @@ describe("RenderController", () => {
 
     it("throws a warning for unrecognized render policies", () => {
       let unrecognizedRenderPolicy = "foo";
-      Plottable.RenderController.renderPolicy(unrecognizedRenderPolicy);
-
-      assert.include(storedWarningMsg, "Unrecognized renderPolicy", "warning sent for unrecognized render policy");
+      TestMethods.assertWarns(() => Plottable.RenderController.renderPolicy(unrecognizedRenderPolicy),
+        "Unrecognized renderPolicy", "warning sent for unrecognized render policy");
     });
   });
 

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -338,8 +338,8 @@ module TestMethods {
     let oldWarn = Plottable.Utils.Window.warn;
     Plottable.Utils.Window.warn = (msg: string) => receivedWarning = msg;
     funct();
-    assert.include(receivedWarning, warningMessage, assertMessage);
     Plottable.Utils.Window.warn = oldWarn;
+    assert.include(receivedWarning, warningMessage, assertMessage);
   }
 
 }

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -333,4 +333,13 @@ module TestMethods {
       return "#" + redHex + greenHex + blueHex;
   }
 
+  export function assertWarns(funct: Function, warningMessage: string, assertMessage: string) {
+    let receivedWarning = "";
+    let oldWarn = Plottable.Utils.Window.warn;
+    Plottable.Utils.Window.warn = (msg: string) => receivedWarning = msg;
+    funct();
+    assert.include(receivedWarning, warningMessage, assertMessage);
+    Plottable.Utils.Window.warn = oldWarn;
+  }
+
 }

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -333,12 +333,15 @@ module TestMethods {
       return "#" + redHex + greenHex + blueHex;
   }
 
-  export function assertWarns(funct: Function, warningMessage: string, assertMessage: string) {
+  export function assertWarns(fn: Function, warningMessage: string, assertMessage: string) {
     let receivedWarning = "";
     let oldWarn = Plottable.Utils.Window.warn;
     Plottable.Utils.Window.warn = (msg: string) => receivedWarning = msg;
-    funct();
-    Plottable.Utils.Window.warn = oldWarn;
+    try {
+      fn.call(this);
+    } finally {
+      Plottable.Utils.Window.warn = oldWarn;
+    }
     assert.include(receivedWarning, warningMessage, assertMessage);
   }
 


### PR DESCRIPTION
Mostly addition of non-existent tests.

Note that it is infeasible to test RenderPolicies since that would require very precise timing, which could itself be troublesome but it would also require a timeout in our tests.  Timeouts in our tests can be bad since test runners can take excruciatingly long if those tests fail.

Closes #2639 