### PR TITLE
timeAxis size now includes annotation space

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -4358,7 +4358,7 @@ var Plottable;
                 var tierHeights = this._tierHeights.reduce(function (prevValue, currValue, index, arr) {
                     return (prevValue + currValue > size.height) ? prevValue : (prevValue + currValue);
                 });
-                size.height = Math.min(size.height, tierHeights + this.margin());
+                size.height = Math.min(size.height, tierHeights + this.margin() + this._annotationTierHeight());
                 return size;
             };
             Time.prototype._setup = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -4358,7 +4358,8 @@ var Plottable;
                 var tierHeights = this._tierHeights.reduce(function (prevValue, currValue, index, arr) {
                     return (prevValue + currValue > size.height) ? prevValue : (prevValue + currValue);
                 });
-                size.height = Math.min(size.height, tierHeights + this.margin() + this._annotationTierHeight());
+                var nonCoreHeight = this.margin() + (this.annotationsEnabled() ? this.annotationTierCount() * this._annotationTierHeight() : 0);
+                size.height = Math.min(size.height, tierHeights + nonCoreHeight);
                 return size;
             };
             Time.prototype._setup = function () {

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -313,7 +313,7 @@ export module Axes {
       let tierHeights = this._tierHeights.reduce((prevValue, currValue, index, arr) => {
         return (prevValue + currValue > size.height) ? prevValue : (prevValue + currValue);
       });
-      size.height = Math.min(size.height, tierHeights + this.margin());
+      size.height = Math.min(size.height, tierHeights + this.margin() + this.annotationTierCount() * this._annotationTierHeight());
       return size;
     }
 

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -313,7 +313,8 @@ export module Axes {
       let tierHeights = this._tierHeights.reduce((prevValue, currValue, index, arr) => {
         return (prevValue + currValue > size.height) ? prevValue : (prevValue + currValue);
       });
-      size.height = Math.min(size.height, tierHeights + this.margin() + this.annotationTierCount() * this._annotationTierHeight());
+      let nonCoreHeight = this.margin() + (this.annotationsEnabled() ? this.annotationTierCount() * this._annotationTierHeight() : 0);
+      size.height = Math.min(size.height, tierHeights + nonCoreHeight);
       return size;
     }
 

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -305,8 +305,8 @@ describe("TimeAxis", () => {
     });
 
     it("includes the annotation space in the final size calculation", () => {
-      const SVG_WIDTH = 400;
-      const SVG_HEIGHT = 400;
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 400;
       let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       let xScale = new Plottable.Scales.Time();
       let xAxis = new Plottable.Axes.Time(xScale, "bottom");

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -305,7 +305,9 @@ describe("TimeAxis", () => {
     });
 
     it("includes the annotation space in the final size calculation", () => {
-      let svg = TestMethods.generateSVG(400, 400);
+      let svgWidth = 400;
+      let svgHeight = 400;
+      let svg = TestMethods.generateSVG(svgWidth, svgHeight);
       let xScale = new Plottable.Scales.Time();
       let xAxis = new Plottable.Axes.Time(xScale, "bottom");
       xAxis.margin(100);
@@ -313,7 +315,7 @@ describe("TimeAxis", () => {
       xAxis.annotationTierCount(3);
 
       xAxis.anchor(svg);
-      xAxis.computeLayout({ x: 0, y: 0}, 400, 400);
+      xAxis.computeLayout({ x: 0, y: 0}, svgWidth, svgHeight);
       let coreHeight = xAxis.tickLabelPadding() + xAxis.innerTickLength();
       let annotationHeight = xAxis.annotationTierCount() * (<any> xAxis)._annotationTierHeight();
       let minimumHeight = coreHeight + xAxis.margin() + annotationHeight;

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -303,6 +303,24 @@ describe("TimeAxis", () => {
         assert.strictEqual(annotationFormatter(testDate), "Sun Dec 17, 1995", "formats to a default customized time formatter");
       });
     });
+
+    it("includes the annotation space in the final size calculation", () => {
+      let svg = TestMethods.generateSVG(400, 400);
+      let xScale = new Plottable.Scales.Time();
+      let xAxis = new Plottable.Axes.Time(xScale, "bottom");
+      xAxis.margin(100);
+      xAxis.annotationsEnabled(true);
+      xAxis.annotationTierCount(3);
+
+      xAxis.anchor(svg);
+      xAxis.computeLayout({ x: 0, y: 0}, 400, 400);
+      let coreHeight = xAxis.tickLabelPadding() + xAxis.innerTickLength();
+      let annotationHeight = xAxis.annotationTierCount() * (<any> xAxis)._annotationTierHeight();
+      let minimumHeight = coreHeight + xAxis.margin() + annotationHeight;
+      assert.operator(xAxis.height(), ">=", minimumHeight, "height includes all relevant pieces");
+      xAxis.destroy();
+      svg.remove();
+    });
   });
 
 });

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -305,9 +305,9 @@ describe("TimeAxis", () => {
     });
 
     it("includes the annotation space in the final size calculation", () => {
-      let svgWidth = 400;
-      let svgHeight = 400;
-      let svg = TestMethods.generateSVG(svgWidth, svgHeight);
+      const SVG_WIDTH = 400;
+      const SVG_HEIGHT = 400;
+      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
       let xScale = new Plottable.Scales.Time();
       let xAxis = new Plottable.Axes.Time(xScale, "bottom");
       xAxis.margin(100);
@@ -315,7 +315,7 @@ describe("TimeAxis", () => {
       xAxis.annotationTierCount(3);
 
       xAxis.anchor(svg);
-      xAxis.computeLayout({ x: 0, y: 0}, svgWidth, svgHeight);
+      xAxis.computeLayout({ x: 0, y: 0}, SVG_WIDTH, SVG_HEIGHT);
       let coreHeight = xAxis.tickLabelPadding() + xAxis.innerTickLength();
       let annotationHeight = xAxis.annotationTierCount() * (<any> xAxis)._annotationTierHeight();
       let minimumHeight = coreHeight + xAxis.margin() + annotationHeight;


### PR DESCRIPTION
`Axis.Time` has a bug where if annotations are enabled, then the axis would not allocate the space required for those annotations, resulting in a few weird bugs where margin is forced in order to show annotations but then the margin also appears, leaving the Axis in a mess...