### PR TITLE
Horizontal bar plots no longer autoDomain wrongly

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -1652,6 +1652,7 @@ var Plottable;
         };
         QuantitativeScale.prototype._getExtent = function () {
             var includedValues = this._getAllIncludedValues();
+            console.log(includedValues);
             var extent = this._defaultExtent();
             if (includedValues.length !== 0) {
                 var combinedExtent = [
@@ -8611,10 +8612,12 @@ var Plottable;
                     return extents;
                 }
                 var scale = accScaleBinding.scale;
+                console.log("aici", extents, scale.scale(extents[0][0]), scale.scale(extents[0][1]));
                 extents = extents.map(function (extent) { return [
                     scale.invert(scale.scale(extent[0]) - _this._barPixelWidth / 2),
                     scale.invert(scale.scale(extent[1]) + _this._barPixelWidth / 2),
                 ]; });
+                console.log("acolo", extents);
                 return extents;
             };
             Bar.prototype._drawLabels = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -1652,7 +1652,6 @@ var Plottable;
         };
         QuantitativeScale.prototype._getExtent = function () {
             var includedValues = this._getAllIncludedValues();
-            console.log(includedValues);
             var extent = this._defaultExtent();
             if (includedValues.length !== 0) {
                 var combinedExtent = [
@@ -8612,12 +8611,12 @@ var Plottable;
                     return extents;
                 }
                 var scale = accScaleBinding.scale;
-                console.log("aici", extents, scale.scale(extents[0][0]), scale.scale(extents[0][1]));
+                // console.log("aici", extents, scale.scale(extents[0][0]), scale.scale(extents[0][1]));
                 extents = extents.map(function (extent) { return [
                     scale.invert(scale.scale(extent[0]) - _this._barPixelWidth / 2),
                     scale.invert(scale.scale(extent[1]) + _this._barPixelWidth / 2),
                 ]; });
-                console.log("acolo", extents);
+                // console.log("acolo", extents);
                 return extents;
             };
             Bar.prototype._drawLabels = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -8611,12 +8611,13 @@ var Plottable;
                     return extents;
                 }
                 var scale = accScaleBinding.scale;
-                // console.log("aici", extents, scale.scale(extents[0][0]), scale.scale(extents[0][1]));
-                extents = extents.map(function (extent) { return [
+                // To account for inverted domains
+                extents = extents.map(function (extent) { return d3.extent([
                     scale.invert(scale.scale(extent[0]) - _this._barPixelWidth / 2),
-                    scale.invert(scale.scale(extent[1]) + _this._barPixelWidth / 2),
-                ]; });
-                // console.log("acolo", extents);
+                    scale.invert(scale.scale(extent[0]) + _this._barPixelWidth / 2),
+                    scale.invert(scale.scale(extent[1]) - _this._barPixelWidth / 2),
+                    scale.invert(scale.scale(extent[1]) + _this._barPixelWidth / 2)
+                ]); });
                 return extents;
             };
             Bar.prototype._drawLabels = function () {

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -438,13 +438,13 @@ export module Plots {
       }
 
       let scale = <QuantitativeScale<any>>accScaleBinding.scale;
-      // console.log("aici", extents, scale.scale(extents[0][0]), scale.scale(extents[0][1]));
-
-      extents = extents.map((extent) => [
+      // To account for inverted domains
+      extents = extents.map((extent) => d3.extent([
         scale.invert(scale.scale(extent[0]) - this._barPixelWidth / 2),
-        scale.invert(scale.scale(extent[1]) + this._barPixelWidth / 2),
-      ]);
-      // console.log("acolo", extents);
+        scale.invert(scale.scale(extent[0]) + this._barPixelWidth / 2),
+        scale.invert(scale.scale(extent[1]) - this._barPixelWidth / 2),
+        scale.invert(scale.scale(extent[1]) + this._barPixelWidth / 2)
+      ]));
 
       return extents;
     }

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -438,6 +438,7 @@ export module Plots {
       }
 
       let scale = <QuantitativeScale<any>>accScaleBinding.scale;
+
       // To account for inverted domains
       extents = extents.map((extent) => d3.extent([
         scale.invert(scale.scale(extent[0]) - this._barPixelWidth / 2),

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -438,13 +438,13 @@ export module Plots {
       }
 
       let scale = <QuantitativeScale<any>>accScaleBinding.scale;
-      console.log("aici", extents, scale.scale(extents[0][0]), scale.scale(extents[0][1]));
+      // console.log("aici", extents, scale.scale(extents[0][0]), scale.scale(extents[0][1]));
 
       extents = extents.map((extent) => [
         scale.invert(scale.scale(extent[0]) - this._barPixelWidth / 2),
         scale.invert(scale.scale(extent[1]) + this._barPixelWidth / 2),
       ]);
-      console.log("acolo", extents);
+      // console.log("acolo", extents);
 
       return extents;
     }

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -438,11 +438,13 @@ export module Plots {
       }
 
       let scale = <QuantitativeScale<any>>accScaleBinding.scale;
+      console.log("aici", extents, scale.scale(extents[0][0]), scale.scale(extents[0][1]));
 
       extents = extents.map((extent) => [
         scale.invert(scale.scale(extent[0]) - this._barPixelWidth / 2),
         scale.invert(scale.scale(extent[1]) + this._barPixelWidth / 2),
       ]);
+      console.log("acolo", extents);
 
       return extents;
     }

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -59,7 +59,6 @@ export class QuantitativeScale<D> extends Scale<D, number> {
 
   protected _getExtent(): D[] {
     let includedValues = this._getAllIncludedValues();
-    console.log(includedValues);
 
     let extent = this._defaultExtent();
     if (includedValues.length !== 0) {

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -59,7 +59,6 @@ export class QuantitativeScale<D> extends Scale<D, number> {
 
   protected _getExtent(): D[] {
     let includedValues = this._getAllIncludedValues();
-
     let extent = this._defaultExtent();
     if (includedValues.length !== 0) {
       let combinedExtent = [

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -59,6 +59,8 @@ export class QuantitativeScale<D> extends Scale<D, number> {
 
   protected _getExtent(): D[] {
     let includedValues = this._getAllIncludedValues();
+    console.log(includedValues);
+
     let extent = this._defaultExtent();
     if (includedValues.length !== 0) {
       let combinedExtent = [

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -794,12 +794,8 @@ describe("Plots", () => {
       });
 
       it("pads the domain in the correct direction", () => {
-
-        let data = Array.apply(null, Array(10)).map(function(d: any, i: any) {
-          return {
-            x: i + 1,
-            y: i
-          };
+        let data = Array.apply(null, Array(10)).map((d: any, i: number) => {
+          return { x: i + 1, y: i + 1 }
         });
         plot.addDataset(new Plottable.Dataset(data));
         plot.renderTo(svg);
@@ -810,12 +806,9 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("has the same size before and after autoDomain()-ing", () => {
-        let data = Array.apply(null, Array(10)).map(function(d: any, i: any) {
-          return {
-            x: i + 1,
-            y: i
-          };
+      it("computes the correct extent when autoDomain()-ing right after render", () => {
+        let data = Array.apply(null, Array(10)).map((d: any, i: number) => {
+          return { x: i + 1, y: i + 1 };
         });
         plot.addDataset(new Plottable.Dataset(data));
 
@@ -823,7 +816,6 @@ describe("Plots", () => {
 
         let initialYScaleDomain = yScale.domain();
         yScale.autoDomain();
-
         assert.deepEqual(initialYScaleDomain, yScale.domain(), "The domain did not change");
 
         svg.remove();

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -788,7 +788,7 @@ describe("Plots", () => {
         xScale = new Plottable.Scales.Linear();
         yScale = new Plottable.Scales.Linear();
 
-        plot = new Plottable.Plots.Bar<number, number>("horizontal");
+        plot = new Plottable.Plots.Bar<number, number>(Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
         plot.x((d) => d.x, xScale);
         plot.y((d) => d.y, yScale);
       });
@@ -811,7 +811,6 @@ describe("Plots", () => {
           return { x: i + 1, y: i + 1 };
         });
         plot.addDataset(new Plottable.Dataset(data));
-
         plot.renderTo(svg);
 
         let initialYScaleDomain = yScale.domain();

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -777,24 +777,47 @@ describe("Plots", () => {
 
     describe("Horizontal Bar Plot extent calculation", () => {
 
+      let svg: d3.Selection<void>;
+      let xScale: Plottable.Scales.Linear;
+      let yScale: Plottable.Scales.Linear;
+      let plot: Plottable.Plots.Bar<number, number>;
 
-      it("has the same size before and after autoDomain()-ing", () => {
-        let svg = TestMethods.generateSVG();
+      beforeEach(() => {
+        svg = TestMethods.generateSVG();
 
-        let xScale = new Plottable.Scales.Linear();
-        let yScale = new Plottable.Scales.Linear();
+        xScale = new Plottable.Scales.Linear();
+        yScale = new Plottable.Scales.Linear();
 
-        let plot = new Plottable.Plots.Bar<number, number>("horizontal");
-        var data = Array.apply(null, Array(10)).map(function(d: any, i: any) {
+        plot = new Plottable.Plots.Bar<number, number>("horizontal");
+        plot.x((d) => d.x, xScale);
+        plot.y((d) => d.y, yScale);
+      });
+
+      it("pads the domain in the correct direction", () => {
+
+        let data = Array.apply(null, Array(10)).map(function(d: any, i: any) {
           return {
             x: i + 1,
             y: i
           };
         });
-
         plot.addDataset(new Plottable.Dataset(data));
-        plot.x((d) => d.x, xScale);
-        plot.y((d) => d.y, yScale);
+        plot.renderTo(svg);
+
+        assert.operator(yScale.domain()[0], "<", data[0].y, "lower end of the domain is padded");
+        assert.operator(yScale.domain()[1], ">", data[data.length - 1].y, "higher end of the domain is padded");
+
+        svg.remove();
+      });
+
+      it("has the same size before and after autoDomain()-ing", () => {
+        let data = Array.apply(null, Array(10)).map(function(d: any, i: any) {
+          return {
+            x: i + 1,
+            y: i
+          };
+        });
+        plot.addDataset(new Plottable.Dataset(data));
 
         plot.renderTo(svg);
 
@@ -804,7 +827,6 @@ describe("Plots", () => {
         assert.deepEqual(initialYScaleDomain, yScale.domain(), "The domain did not change");
 
         svg.remove();
-
       });
     });
 

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -795,7 +795,7 @@ describe("Plots", () => {
 
       it("pads the domain in the correct direction", () => {
         let data = Array.apply(null, Array(10)).map((d: any, i: number) => {
-          return { x: i + 1, y: i + 1 }
+          return { x: i + 1, y: i + 1 };
         });
         plot.addDataset(new Plottable.Dataset(data));
         plot.renderTo(svg);

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -775,6 +775,39 @@ describe("Plots", () => {
       });
     });
 
+    describe("Horizontal Bar Plot extent calculation", () => {
+
+
+      it("has the same size before and after autoDomain()-ing", () => {
+        let svg = TestMethods.generateSVG();
+
+        let xScale = new Plottable.Scales.Linear();
+        let yScale = new Plottable.Scales.Linear();
+
+        let plot = new Plottable.Plots.Bar<number, number>("horizontal");
+        var data = Array.apply(null, Array(10)).map(function(d: any, i: any) {
+          return {
+            x: i + 1,
+            y: i
+          };
+        });
+
+        plot.addDataset(new Plottable.Dataset(data));
+        plot.x((d) => d.x, xScale);
+        plot.y((d) => d.y, yScale);
+
+        plot.renderTo(svg);
+
+        let initialYScaleDomain = yScale.domain();
+        yScale.autoDomain();
+
+        assert.deepEqual(initialYScaleDomain, yScale.domain(), "The domain did not change");
+
+        svg.remove();
+
+      });
+    });
+
     describe("Vertical Bar Plot With Bar Labels", () => {
       let plot: Plottable.Plots.Bar<string, number>;
       let data: any[];


### PR DESCRIPTION
Closes #2704
The issue is the following. 

When calculating the extent for a scale that backs up the major scale of a bar plot, that scale needs to take into account the width of the bars. This is done in pixel space to account for log scales. Now, the issue is sometime the scales are having inverted domain (most common scenario, all yScales have the lowest number in the domain corresponding to the highest number in pixel such that the origin is bottom - left).

Solved this in the most generic / readable possible way.

**QE:** Please let me know if more information is required. I should not have changed anything except auto domain calculation code for bar plot (and clustered bar and stacked bar) 

Fiddle tagged on this.
Before: http://jsfiddle.net/o3rzuqur/5/
After: http://jsfiddle.net/o3rzuqur/4/