### PR TITLE
Horizontal Bar Plot hides labels that are partially cut off in y

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -8672,6 +8672,7 @@ var Plottable;
                             labelPosition.x = x + w / 2 - measurement.width / 2;
                         }
                         else {
+                            labelPosition.y = y + h / 2 - measurement.height / 2;
                             if (!positive) {
                                 labelPosition.x = x + w - measurement.width;
                             }

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -452,7 +452,7 @@ export module Plots {
       let labelsTooWide = false;
       this.datasets().forEach((dataset) => labelsTooWide = labelsTooWide || this._drawLabel(dataToDraw.get(dataset), dataset));
       if (this._hideBarsIfAnyAreTooWide && labelsTooWide) {
-         this.datasets().forEach((dataset) => this._labelConfig.get(dataset).labelArea.selectAll("g").remove());
+        this.datasets().forEach((dataset) => this._labelConfig.get(dataset).labelArea.selectAll("g").remove());
       }
     }
 

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -452,7 +452,7 @@ export module Plots {
       let labelsTooWide = false;
       this.datasets().forEach((dataset) => labelsTooWide = labelsTooWide || this._drawLabel(dataToDraw.get(dataset), dataset));
       if (this._hideBarsIfAnyAreTooWide && labelsTooWide) {
-        this.datasets().forEach((dataset) => this._labelConfig.get(dataset).labelArea.selectAll("g").remove());
+         this.datasets().forEach((dataset) => this._labelConfig.get(dataset).labelArea.selectAll("g").remove());
       }
     }
 
@@ -489,7 +489,6 @@ export module Plots {
           } else {
             x += offset;
           }
-
           let showLabel = true;
           let labelPosition = {
             x: x,
@@ -499,6 +498,7 @@ export module Plots {
           if (this._isVertical) {
             labelPosition.x = x + w / 2 - measurement.width / 2;
           } else {
+            labelPosition.y = y + h / 2 - measurement.height / 2;
             if (!positive) {
               labelPosition.x = x + w - measurement.width;
             } else {

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -782,7 +782,7 @@ describe("Plots", () => {
 
         texts.each(function(d, i) {
           let textBounding = (<Element> this).getBoundingClientRect();
-          let svgBounding = (<Element> svg[0][0]).getBoundingClientRect();
+          let svgBounding = (<Element> barPlot.background().node()).getBoundingClientRect();
           let isLabelCutOff = (textBounding.top < svgBounding.top && textBounding.bottom > svgBounding.top)
             || (textBounding.top < svgBounding.bottom && textBounding.bottom > svgBounding.bottom);
           assert.isTrue(isLabelCutOff, `label ${i} is partially cut off`);

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -724,20 +724,20 @@ describe("Plots", () => {
 
     describe("Horizontal Bar Plot label visibility", () => {
       let svg: d3.Selection<void>;
-      let yScale: Plottable.Scales.Category;
+      let yScale: Plottable.Scales.Linear;
       let xScale: Plottable.Scales.Linear;
-      let barPlot: Plottable.Plots.Bar<number, string>;
+      let barPlot: Plottable.Plots.Bar<number, number>;
       beforeEach(() => {
         svg = TestMethods.generateSVG(600, 400);
-        yScale = new Plottable.Scales.Category().domain(["A", "B"]);
+        yScale = new Plottable.Scales.Linear();
         xScale = new Plottable.Scales.Linear();
 
         let data = [
-          {y: "A", x: -1.5},
-          {y: "B", x: 1},
+          {y: 1, x: -1.5},
+          {y: 2, x: 1},
         ];
 
-        barPlot = new Plottable.Plots.Bar<number, string>(Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
+        barPlot = new Plottable.Plots.Bar<number, number>(Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
         barPlot.addDataset(new Plottable.Dataset(data));
         barPlot.x((d) => d.x, xScale);
         barPlot.y((d) => d.y, yScale);
@@ -771,6 +771,20 @@ describe("Plots", () => {
 
         assert.strictEqual(label1.style("visibility"), "hidden", "label 2 is not visible");
         assert.include(["visible", "inherit"], label2.style("visibility"), "label 1 is visible");
+        svg.remove();
+      });
+
+      it("hides labels that are partially cut off in y", () => {
+        yScale.domain([1, 2]);
+        let texts = svg.selectAll("text");
+
+        assert.strictEqual(texts.size(), 2, "There should be two labels rendered");
+
+        let label1 = d3.select(texts[0][0]);
+        let label2 = d3.select(texts[0][1]);
+
+        assert.strictEqual(label1.style("visibility"), "hidden", "label 1 is not visible");
+        assert.strictEqual(label2.style("visibility"), "hidden", "label 2 is not visible");
         svg.remove();
       });
     });

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -776,15 +776,18 @@ describe("Plots", () => {
 
       it("hides labels that are partially cut off in y", () => {
         yScale.domain([1, 2]);
-        let texts = svg.selectAll("text");
+        let texts = barPlot.content().selectAll("text");
 
         assert.strictEqual(texts.size(), 2, "There should be two labels rendered");
 
-        let label1 = d3.select(texts[0][0]);
-        let label2 = d3.select(texts[0][1]);
-
-        assert.strictEqual(label1.style("visibility"), "hidden", "label 1 is not visible");
-        assert.strictEqual(label2.style("visibility"), "hidden", "label 2 is not visible");
+        texts.each(function(d, i) {
+          let textBounding = (<Element> this).getBoundingClientRect();
+          let svgBounding = (<Element> svg[0][0]).getBoundingClientRect();
+          let isLabelCutOff = (textBounding.top < svgBounding.top && textBounding.bottom > svgBounding.top)
+            || (textBounding.top < svgBounding.bottom && textBounding.bottom > svgBounding.bottom);
+          assert.isTrue(isLabelCutOff, `label ${i} is partially cut off`);
+          assert.strictEqual(d3.select(this).style("visibility"), "hidden", `label ${i} is not visible`);
+        });
         svg.remove();
       });
     });


### PR DESCRIPTION
**Issue**
In the horizontal bar plot, a label should be hidden if the bounding box is inside the chart area. The issue is sometimes a label is visible when there's space to show it while sometime it is partially cut off in y. 

**Fix**
The `labelPosition.y` is not set correctly in the `_drawLabel` function. I add one line to set  `labelPosition.y` to the center of the bar.

**JSFiddle**
*Case1*: 
Before: http://jsfiddle.net/ejzaqdcq/
<img width="402" alt="screen shot 2015-09-10 at 11 14 25 am" src="https://cloud.githubusercontent.com/assets/3696519/9796872/3697bf90-57ad-11e5-9278-5e9487da8d24.png">

After: http://jsfiddle.net/pnqm5hrb/1/
<img width="402" alt="screen shot 2015-09-10 at 11 14 34 am" src="https://cloud.githubusercontent.com/assets/3696519/9796875/39e99d4e-57ad-11e5-8f5d-901572daa7f0.png">

*Case2*:
Before: http://jsfiddle.net/ejzaqdcq/1/
<img width="402" alt="screen shot 2015-09-10 at 11 13 55 am" src="https://cloud.githubusercontent.com/assets/3696519/9796876/3f23249c-57ad-11e5-86c0-aa215804ff85.png">

After:http://jsfiddle.net/54rf5to1/1/
<img width="402" alt="screen shot 2015-09-10 at 11 14 07 am" src="https://cloud.githubusercontent.com/assets/3696519/9796880/40cc1704-57ad-11e5-8bf1-1ffae58369e4.png">




Close #2658.