### PR TITLE
detach DragInteraction on DragBoxLayer.destroy()

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -4606,6 +4606,8 @@ declare module Plottable {
              */
             enabled(): boolean;
             destroy(): void;
+            detach(): Component;
+            anchor(selection: d3.Selection<void>): Component;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -4605,6 +4605,7 @@ declare module Plottable {
              * Gets the enabled state.
              */
             enabled(): boolean;
+            destroy(): void;
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -12207,16 +12207,19 @@ var Plottable;
                 this._disconnectInteraction();
             };
             DragBoxLayer.prototype.detach = function () {
-                this.bounds({
-                    topLeft: { x: 0, y: 0 },
-                    bottomRight: { x: 0, y: 0 }
-                });
+                this._resetBound();
                 this._dragInteraction.detachFrom(this);
                 return _super.prototype.detach.call(this);
             };
             DragBoxLayer.prototype.anchor = function (selection) {
                 this._dragInteraction.attachTo(this);
                 return _super.prototype.anchor.call(this, selection);
+            };
+            DragBoxLayer.prototype._resetBound = function () {
+                this.bounds({
+                    topLeft: { x: 0, y: 0 },
+                    bottomRight: { x: 0, y: 0 }
+                });
             };
             return DragBoxLayer;
         })(Components.SelectionBoxLayer);

--- a/plottable.js
+++ b/plottable.js
@@ -12206,6 +12206,18 @@ var Plottable;
                 this._dragEndCallbacks.forEach(function (callback) { return _this._dragEndCallbacks.delete(callback); });
                 this._disconnectInteraction();
             };
+            DragBoxLayer.prototype.detach = function () {
+                this.bounds({
+                    topLeft: { x: 0, y: 0 },
+                    bottomRight: { x: 0, y: 0 }
+                });
+                this._dragInteraction.detachFrom(this);
+                return _super.prototype.detach.call(this);
+            };
+            DragBoxLayer.prototype.anchor = function (selection) {
+                this._dragInteraction.attachTo(this);
+                return _super.prototype.anchor.call(this, selection);
+            };
             return DragBoxLayer;
         })(Components.SelectionBoxLayer);
         Components.DragBoxLayer = DragBoxLayer;

--- a/plottable.js
+++ b/plottable.js
@@ -12189,6 +12189,10 @@ var Plottable;
                 this._setMovableClass();
                 return this;
             };
+            DragBoxLayer.prototype.destroy = function () {
+                _super.prototype.destroy.call(this);
+                this._dragInteraction.detachFrom(this);
+            };
             return DragBoxLayer;
         })(Components.SelectionBoxLayer);
         Components.DragBoxLayer = DragBoxLayer;

--- a/plottable.js
+++ b/plottable.js
@@ -12207,7 +12207,7 @@ var Plottable;
                 this._disconnectInteraction();
             };
             DragBoxLayer.prototype.detach = function () {
-                this._resetBound();
+                this._resetState();
                 this._dragInteraction.detachFrom(this);
                 return _super.prototype.detach.call(this);
             };
@@ -12215,7 +12215,7 @@ var Plottable;
                 this._dragInteraction.attachTo(this);
                 return _super.prototype.anchor.call(this, selection);
             };
-            DragBoxLayer.prototype._resetBound = function () {
+            DragBoxLayer.prototype._resetState = function () {
                 this.bounds({
                     topLeft: { x: 0, y: 0 },
                     bottomRight: { x: 0, y: 0 }

--- a/src/components/dragBoxLayer.ts
+++ b/src/components/dragBoxLayer.ts
@@ -437,6 +437,19 @@ export module Components {
       this._disconnectInteraction();
     }
 
+    public detach() {
+      this.bounds({
+        topLeft: { x: 0, y: 0 },
+        bottomRight: { x: 0, y: 0 }
+      });
+      this._dragInteraction.detachFrom(this);
+      return super.detach();
+    }
+
+    public anchor(selection: d3.Selection<void>) {
+      this._dragInteraction.attachTo(this);
+      return super.anchor(selection);
+    }
   }
 }
 }

--- a/src/components/dragBoxLayer.ts
+++ b/src/components/dragBoxLayer.ts
@@ -438,7 +438,7 @@ export module Components {
     }
 
     public detach() {
-      this._resetBound();
+      this._resetState();
       this._dragInteraction.detachFrom(this);
       return super.detach();
     }
@@ -448,7 +448,7 @@ export module Components {
       return super.anchor(selection);
     }
 
-    private _resetBound() {
+    private _resetState() {
       this.bounds({
         topLeft: { x: 0, y: 0 },
         bottomRight: { x: 0, y: 0 }

--- a/src/components/dragBoxLayer.ts
+++ b/src/components/dragBoxLayer.ts
@@ -438,10 +438,7 @@ export module Components {
     }
 
     public detach() {
-      this.bounds({
-        topLeft: { x: 0, y: 0 },
-        bottomRight: { x: 0, y: 0 }
-      });
+      this._resetBound();
       this._dragInteraction.detachFrom(this);
       return super.detach();
     }
@@ -449,6 +446,13 @@ export module Components {
     public anchor(selection: d3.Selection<void>) {
       this._dragInteraction.attachTo(this);
       return super.anchor(selection);
+    }
+
+    private _resetBound() {
+      this.bounds({
+        topLeft: { x: 0, y: 0 },
+        bottomRight: { x: 0, y: 0 }
+      });
     }
   }
 }

--- a/src/components/dragBoxLayer.ts
+++ b/src/components/dragBoxLayer.ts
@@ -31,6 +31,7 @@ export module Components {
     private _dragStartCallbacks: Utils.CallbackSet<DragBoxCallback>;
     private _dragCallbacks: Utils.CallbackSet<DragBoxCallback>;
     private _dragEndCallbacks: Utils.CallbackSet<DragBoxCallback>;
+    private _disconnectInteraction: () => void;
 
     /**
      * Constructs a DragBoxLayer.
@@ -74,7 +75,7 @@ export module Components {
       };
       let mode = DRAG_MODES.newBox;
 
-      this._dragInteraction.onDragStart((startPoint: Point) => {
+      let onDragStartCallback = (startPoint: Point) => {
         resizingEdges = this._getResizingEdges(startPoint);
 
         let bounds = this.bounds();
@@ -100,9 +101,9 @@ export module Components {
         bottomRight = { x: bounds.bottomRight.x, y: bounds.bottomRight.y };
         lastEndPoint = startPoint;
         this._dragStartCallbacks.callCallbacks(bounds);
-      });
+      };
 
-      this._dragInteraction.onDrag((startPoint: Point, endPoint: Point) => {
+      let onDragCallback = (startPoint: Point, endPoint: Point) => {
         switch (mode) {
           case DRAG_MODES.newBox:
             bottomRight.x = endPoint.x;
@@ -138,15 +139,26 @@ export module Components {
         });
 
         this._dragCallbacks.callCallbacks(this.bounds());
-      });
+      };
 
-      this._dragInteraction.onDragEnd((startPoint: Point, endPoint: Point) => {
+      let onDragEndCallback = (startPoint: Point, endPoint: Point) => {
         if (mode === DRAG_MODES.newBox && startPoint.x === endPoint.x && startPoint.y === endPoint.y) {
           this.boxVisible(false);
         }
 
         this._dragEndCallbacks.callCallbacks(this.bounds());
-      });
+      };
+
+      this._dragInteraction.onDragStart(onDragStartCallback);
+      this._dragInteraction.onDrag(onDragCallback);
+      this._dragInteraction.onDragEnd(onDragEndCallback);
+
+      this._disconnectInteraction = () => {
+        this._dragInteraction.offDragStart(onDragStartCallback);
+        this._dragInteraction.offDrag(onDragCallback);
+        this._dragInteraction.offDragEnd(onDragEndCallback);
+        this._dragInteraction.detachFrom(this);
+      };
     }
 
     protected _setup() {
@@ -419,7 +431,10 @@ export module Components {
 
     public destroy() {
       super.destroy();
-      this._dragInteraction.detachFrom(this);
+      this._dragStartCallbacks.forEach((callback) => this._dragCallbacks.delete(callback));
+      this._dragCallbacks.forEach((callback) => this._dragCallbacks.delete(callback));
+      this._dragEndCallbacks.forEach((callback) => this._dragEndCallbacks.delete(callback));
+      this._disconnectInteraction();
     }
 
   }

--- a/src/components/dragBoxLayer.ts
+++ b/src/components/dragBoxLayer.ts
@@ -416,6 +416,12 @@ export module Components {
       this._setMovableClass();
       return this;
     }
+
+    public destroy() {
+      super.destroy();
+      this._dragInteraction.detachFrom(this);
+    }
+
   }
 }
 }

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -106,7 +106,7 @@ describe("Layer Components", () => {
         svg.remove();
       });
 
-      it("does not call callbacks after destroy() is called", () => {
+      it("does not call callbacks when dragBoxLayer is destroy()-ed", () => {
         // rendered in a Group so that drag sequence can be simulated on Group background after DragBoxLayer is destroyed
         let group = new Plottable.Components.Group([dbl]).renderTo(svg);
         let target = group.background();

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -1,6 +1,6 @@
 ///<reference path="../testReference.ts" />
 
-describe("Interactive Components", () => {
+describe("Layer Components", () => {
   describe("DragBoxLayer", () => {
 
     describe("Basics usage", () => {
@@ -126,12 +126,49 @@ describe("Interactive Components", () => {
         onDragCallbackCalled = false;
         onDragEndcallbackCalled = false;
         dbl.destroy();
-        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
 
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
         assert.isFalse(onDragStartCallbackCalled, "onDragStart callback is not called");
         assert.isFalse(onDragCallbackCalled, "onDrag callback is not called");
         assert.isFalse(onDragEndcallbackCalled, "onDragEnd callback is not called");
 
+        svg.remove();
+      });
+
+      it("does not call callbacks when dragBoxLayer is detach()-ed", () => {
+        // rendered in a Group so that drag sequence can be simulated on Group background after DragBoxLayer is destroyed
+        let group = new Plottable.Components.Group([dbl]);
+        group.renderTo(svg);
+        let target = group.background();
+        let onDragStartCallbackCalled = false;
+        let onDragCallbackCalled = false;
+        let onDragEndcallbackCalled = false;
+        dbl.onDragStart(() => onDragStartCallbackCalled = true);
+        dbl.onDrag(() => onDragCallbackCalled = true);
+        dbl.onDragEnd(() => onDragEndcallbackCalled = true);
+
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+        assert.isTrue(onDragStartCallbackCalled, "onDragStart callback is called");
+        assert.isTrue(onDragCallbackCalled, "onDrag callback is called");
+        assert.isTrue(onDragEndcallbackCalled, "onDragEnd callback is called");
+
+        onDragStartCallbackCalled = false;
+        onDragCallbackCalled = false;
+        onDragEndcallbackCalled = false;
+        dbl.detach();
+
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+        assert.isFalse(onDragStartCallbackCalled, "onDragStart callback is not called");
+        assert.isFalse(onDragCallbackCalled, "onDrag callback is not called");
+        assert.isFalse(onDragEndcallbackCalled, "onDragEnd callback is not called");
+
+        group.append(dbl);
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+        assert.isTrue(onDragStartCallbackCalled, "onDragStart callback is called when re-anchor()");
+        assert.isTrue(onDragCallbackCalled, "onDrag callback is called when re-anchor()");
+        assert.isTrue(onDragEndcallbackCalled, "onDragEnd callback is called when re-anchor()");
+
+        dbl.destroy();
         svg.remove();
       });
 

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -116,6 +116,14 @@ describe("Interactive Components", () => {
         dbl.onDrag(() => onDragCallbackCalled = true);
         dbl.onDragEnd(() => onDragEndcallbackCalled = true);
 
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+        assert.isTrue(onDragStartCallbackCalled, "onDragStart callback is called");
+        assert.isTrue(onDragCallbackCalled, "onDrag callback is called");
+        assert.isTrue(onDragEndcallbackCalled, "onDragEnd callback is called");
+
+        onDragStartCallbackCalled = false;
+        onDragCallbackCalled = false;
+        onDragEndcallbackCalled = false;
         dbl.destroy();
         TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
 

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -106,6 +106,26 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
+      it("does not call callbacks after destroy() is called", () => {
+        let group = new Plottable.Components.Group([dbl]).renderTo(svg);
+        let target = group.background();
+        let onDragStartCallbackCalled = false;
+        let onDragCallbackCalled = false;
+        let onDragEndcallbackCalled = false;
+        dbl.onDragStart(() => onDragStartCallbackCalled = true);
+        dbl.onDrag(() => onDragCallbackCalled = true);
+        dbl.onDragEnd(() => onDragEndcallbackCalled = true);
+
+        dbl.destroy();
+        TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+
+        assert.isFalse(onDragStartCallbackCalled, "onDragStart callback is not called");
+        assert.isFalse(onDragCallbackCalled, "onDrag callback is not called");
+        assert.isFalse(onDragEndcallbackCalled, "onDragEnd callback is not called");
+
+        svg.remove();
+      });
+
       it("calls the onDragStart callback", () => {
         dbl.renderTo(svg);
 

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -107,6 +107,7 @@ describe("Interactive Components", () => {
       });
 
       it("does not call callbacks after destroy() is called", () => {
+        // rendered in a Group so that drag sequence can be simulated on Group background after DragBoxLayer is destroyed
         let group = new Plottable.Components.Group([dbl]).renderTo(svg);
         let target = group.background();
         let onDragStartCallbackCalled = false;


### PR DESCRIPTION
closes #2553 
detach all dragInteractions on a DragBoxLayer when it's destroyed or detached

destroyed:
original: http://jsfiddle.net/fee6p9w0/6/
fixed: http://jsfiddle.net/fee6p9w0/16/
note that after clicking destroy button, there's still console log indicating interaction callback being fired in the original fiddle when drag events happen.

detached:
original: http://jsfiddle.net/fee6p9w0/24/
fixed: http://jsfiddle.net/fee6p9w0/25/
after clicking `detach` button there shouldn't be any console log while dragging, clicking `attach` will bring interaction and dbl back.
