### PR TITLE
change the background-fill pointer-events

### DIFF
--- a/plottable.css
+++ b/plottable.css
@@ -46,6 +46,7 @@ svg.plottable {
 
 .plottable .background-fill {
   fill: none;
+  pointer-events: none;
 }
 
 .plottable .bounding-box {

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -344,7 +344,7 @@ describe("Component behavior", () => {
     c.renderTo(svg);
     let backgroundFill = c.background().select(".background-fill").node();
     let pointerEvent = window.getComputedStyle(<Element>backgroundFill).pointerEvents;
-    assert.strictEqual(pointerEvent, "none", "background-fill's pointer-event is not set to none");
+    assert.strictEqual(pointerEvent, "none", "background-fill's pointer-event is set to none");
     svg.remove();
   });
 

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -340,6 +340,14 @@ describe("Component behavior", () => {
     svg.remove();
   });
 
+  it("background-fill's pointer-event is set to none", () => {
+    c.renderTo(svg);
+    let backgroundFill = c.background().select(".background-fill").node();
+    let pointerEvent = window.getComputedStyle(<Element>backgroundFill).pointerEvents;
+    assert.strictEqual(pointerEvent, "none", "background-fill's pointer-event is not set to none");
+    svg.remove();
+  });
+
   it("can't reuse component if it's been destroy()-ed", () => {
     let c1 = new Plottable.Component();
     c1.renderTo(svg);


### PR DESCRIPTION
**Issue** 
When there are several components in a group, the cursor style only show on the top component.

**Fix**
This issue happens because the `background-fill` in the `background` of the top component is blocking the `pointer-events` to lower components. I fix this by adding `pointer-events:none` to `background-fill` elements in css.

There still might be problems that `content` instead of `background`  is blocking the pointer-events, i.e. if we put a `label` on top of a `dragLineLayer`, the cursor style of `dragLineLayer` will not show correctly. But this is beyond the scope of this issue.

**JSFiddle**
A component is in front of the dragLineLayer.
Before:http://jsfiddle.net/7Lxzacoz/
After:http://jsfiddle.net/tm2oot96/1/

close #2647