### PR TITLE
Deprecation documentation in JSDocs

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -695,7 +695,7 @@ declare module Plottable {
          */
         function time(specifier: string): Formatter;
         /**
-         * @deprecated As of release 1.3.0, not safe for use with time zones.
+         * @deprecated As of release v1.3.0, not safe for use with time zones.
          *
          * Creates a formatter for relative dates.
          *
@@ -1804,7 +1804,7 @@ declare module Plottable {
          */
         formatter(formatter: Formatter): Axis<D>;
         /**
-         * @deprecated As of release 1.3.0, replaced by innerTickLength()
+         * @deprecated As of release v1.3.0, replaced by innerTickLength()
          *
          * Gets the tick mark length in pixels.
          */
@@ -2735,7 +2735,7 @@ declare module Plottable {
          */
         entityNearest(queryPoint: Point): Plots.PlotEntity;
         /**
-         * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+         * @deprecated As of release v1.1.0, replaced by _entityVisibleOnPlot()
          */
         protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
         protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;
@@ -3158,7 +3158,7 @@ declare module Plottable {
             symbol(symbol: Accessor<SymbolFactory>): Plots.Scatter<X, Y>;
             protected _generateDrawSteps(): Drawers.DrawStep[];
             /**
-             * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+             * @deprecated As of release v1.1.0, replaced by _entityVisibleOnPlot()
              */
             protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
             protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;
@@ -3277,7 +3277,7 @@ declare module Plottable {
              */
             entityNearest(queryPoint: Point): PlotEntity;
             /**
-             * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+             * @deprecated As of release v1.1.0, replaced by _entityVisibleOnPlot()
              */
             protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
             protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -695,6 +695,8 @@ declare module Plottable {
          */
         function time(specifier: string): Formatter;
         /**
+         * @deprecated As of release 1.3.0, not safe for use with time zones.
+         *
          * Creates a formatter for relative dates.
          *
          * @param {number} baseValue The start date (as epoch time) used in computing relative dates (default 0)
@@ -1802,7 +1804,7 @@ declare module Plottable {
          */
         formatter(formatter: Formatter): Axis<D>;
         /**
-         * @deprecated As of release 1.3, replaced by innerTickLength()
+         * @deprecated As of release 1.3.0, replaced by innerTickLength()
          *
          * Gets the tick mark length in pixels.
          */
@@ -2732,6 +2734,9 @@ declare module Plottable {
          * @returns {Plots.PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
          */
         entityNearest(queryPoint: Point): Plots.PlotEntity;
+        /**
+         * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+         */
         protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
         protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;
         protected _uninstallScaleForKey(scale: Scale<any, any>, key: string): void;
@@ -3152,6 +3157,9 @@ declare module Plottable {
              */
             symbol(symbol: Accessor<SymbolFactory>): Plots.Scatter<X, Y>;
             protected _generateDrawSteps(): Drawers.DrawStep[];
+            /**
+             * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+             */
             protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
             protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;
             protected _propertyProjectors(): AttributeToProjector;
@@ -3268,6 +3276,9 @@ declare module Plottable {
              * @returns {PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
              */
             entityNearest(queryPoint: Point): PlotEntity;
+            /**
+             * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+             */
             protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
             protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;
             /**

--- a/plottable.js
+++ b/plottable.js
@@ -1385,6 +1385,8 @@ var Plottable;
         }
         Formatters.time = time;
         /**
+         * @deprecated As of release 1.3.0, not safe for use with time zones.
+         *
          * Creates a formatter for relative dates.
          *
          * @param {number} baseValue The start date (as epoch time) used in computing relative dates (default 0)
@@ -7117,8 +7119,11 @@ var Plottable;
             });
             return this._lightweightPlotEntityToPlotEntity(closestPointEntity);
         };
+        /**
+         * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+         */
         Plot.prototype._visibleOnPlot = function (datum, pixelPoint, selection) {
-            Plottable.Utils.Window.deprecated("Plot._visibleOnPlot()", "v1.1.0");
+            Plottable.Utils.Window.deprecated("Plot._visibleOnPlot()", "v1.1.0", "replaced by _entityVisibleOnPlot()");
             return !(pixelPoint.x < 0 || pixelPoint.y < 0 ||
                 pixelPoint.x > this.width() || pixelPoint.y > this.height());
         };
@@ -8192,8 +8197,11 @@ var Plottable;
                 drawSteps.push({ attrToProjector: this._generateAttrToProjector(), animator: this._getAnimator(Plots.Animator.MAIN) });
                 return drawSteps;
             };
+            /**
+             * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+             */
             Scatter.prototype._visibleOnPlot = function (datum, pixelPoint, selection) {
-                Plottable.Utils.Window.deprecated("Scatter._visibleOnPlot()", "v1.1.0");
+                Plottable.Utils.Window.deprecated("Scatter._visibleOnPlot()", "v1.1.0", "replaced by _entityVisibleOnPlot()");
                 var xRange = { min: 0, max: this.width() };
                 var yRange = { min: 0, max: this.height() };
                 var translation = d3.transform(selection.attr("transform")).translate;
@@ -8513,8 +8521,11 @@ var Plottable;
                 });
                 return closest;
             };
+            /**
+             * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+             */
             Bar.prototype._visibleOnPlot = function (datum, pixelPoint, selection) {
-                Plottable.Utils.Window.deprecated("Bar._visibleOnPlot()", "v1.1.0");
+                Plottable.Utils.Window.deprecated("Bar._visibleOnPlot()", "v1.1.0", "replaced by _entityVisibleOnPlot()");
                 var xRange = { min: 0, max: this.width() };
                 var yRange = { min: 0, max: this.height() };
                 var barBBox = Plottable.Utils.DOM.elementBBox(selection);

--- a/plottable.js
+++ b/plottable.js
@@ -1385,7 +1385,7 @@ var Plottable;
         }
         Formatters.time = time;
         /**
-         * @deprecated As of release 1.3.0, not safe for use with time zones.
+         * @deprecated As of release v1.3.0, not safe for use with time zones.
          *
          * Creates a formatter for relative dates.
          *
@@ -1399,7 +1399,7 @@ var Plottable;
             if (baseValue === void 0) { baseValue = 0; }
             if (increment === void 0) { increment = Plottable.MILLISECONDS_IN_ONE_DAY; }
             if (label === void 0) { label = ""; }
-            Plottable.Utils.Window.deprecated("relativeDate()", "1.3", "Not safe for use with time zones.");
+            Plottable.Utils.Window.deprecated("relativeDate()", "v1.3.0", "Not safe for use with time zones.");
             return function (d) {
                 var relativeDate = Math.round((d.valueOf() - baseValue) / increment);
                 return relativeDate.toString() + label;
@@ -7120,7 +7120,7 @@ var Plottable;
             return this._lightweightPlotEntityToPlotEntity(closestPointEntity);
         };
         /**
-         * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+         * @deprecated As of release v1.1.0, replaced by _entityVisibleOnPlot()
          */
         Plot.prototype._visibleOnPlot = function (datum, pixelPoint, selection) {
             Plottable.Utils.Window.deprecated("Plot._visibleOnPlot()", "v1.1.0", "replaced by _entityVisibleOnPlot()");
@@ -8198,7 +8198,7 @@ var Plottable;
                 return drawSteps;
             };
             /**
-             * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+             * @deprecated As of release v1.1.0, replaced by _entityVisibleOnPlot()
              */
             Scatter.prototype._visibleOnPlot = function (datum, pixelPoint, selection) {
                 Plottable.Utils.Window.deprecated("Scatter._visibleOnPlot()", "v1.1.0", "replaced by _entityVisibleOnPlot()");
@@ -8522,7 +8522,7 @@ var Plottable;
                 return closest;
             };
             /**
-             * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+             * @deprecated As of release v1.1.0, replaced by _entityVisibleOnPlot()
              */
             Bar.prototype._visibleOnPlot = function (datum, pixelPoint, selection) {
                 Plottable.Utils.Window.deprecated("Bar._visibleOnPlot()", "v1.1.0", "replaced by _entityVisibleOnPlot()");

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -582,7 +582,7 @@ export class Axis<D> extends Component {
   }
 
   /**
-   * @deprecated As of release 1.3.0, replaced by innerTickLength()
+   * @deprecated As of release v1.3.0, replaced by innerTickLength()
    *
    * Gets the tick mark length in pixels.
    */

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -582,7 +582,7 @@ export class Axis<D> extends Component {
   }
 
   /**
-   * @deprecated As of release 1.3, replaced by innerTickLength()
+   * @deprecated As of release 1.3.0, replaced by innerTickLength()
    *
    * Gets the tick mark length in pixels.
    */

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -244,6 +244,8 @@ export module Formatters {
   }
 
   /**
+   * @deprecated As of release 1.3.0, not safe for use with time zones.
+   *
    * Creates a formatter for relative dates.
    *
    * @param {number} baseValue The start date (as epoch time) used in computing relative dates (default 0)

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -244,7 +244,7 @@ export module Formatters {
   }
 
   /**
-   * @deprecated As of release 1.3.0, not safe for use with time zones.
+   * @deprecated As of release v1.3.0, not safe for use with time zones.
    *
    * Creates a formatter for relative dates.
    *
@@ -255,7 +255,7 @@ export module Formatters {
    * @returns {Formatter} A formatter for time/date values.
    */
   export function relativeDate(baseValue: number = 0, increment: number = MILLISECONDS_IN_ONE_DAY, label: string = "") {
-    Plottable.Utils.Window.deprecated("relativeDate()", "1.3", "Not safe for use with time zones.");
+    Plottable.Utils.Window.deprecated("relativeDate()", "v1.3.0", "Not safe for use with time zones.");
     return (d: any) => {
       let relativeDate = Math.round((d.valueOf() - baseValue) / increment);
       return relativeDate.toString() + label;

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -314,7 +314,7 @@ export module Plots {
     }
 
     /**
-     * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+     * @deprecated As of release v1.1.0, replaced by _entityVisibleOnPlot()
      */
     protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean {
       Utils.Window.deprecated("Bar._visibleOnPlot()", "v1.1.0", "replaced by _entityVisibleOnPlot()");

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -313,8 +313,11 @@ export module Plots {
       return closest;
     }
 
+    /**
+     * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+     */
     protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean {
-      Utils.Window.deprecated("Bar._visibleOnPlot()", "v1.1.0");
+      Utils.Window.deprecated("Bar._visibleOnPlot()", "v1.1.0", "replaced by _entityVisibleOnPlot()");
       let xRange = { min: 0, max: this.width() };
       let yRange = { min: 0, max: this.height() };
       let barBBox = Utils.DOM.elementBBox(selection);

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -545,7 +545,7 @@ export class Plot extends Component {
   }
 
   /**
-   * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+   * @deprecated As of release v1.1.0, replaced by _entityVisibleOnPlot()
    */
   protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean {
     Utils.Window.deprecated("Plot._visibleOnPlot()", "v1.1.0", "replaced by _entityVisibleOnPlot()");

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -544,8 +544,11 @@ export class Plot extends Component {
     return this._lightweightPlotEntityToPlotEntity(closestPointEntity);
   }
 
+  /**
+   * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+   */
   protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean {
-    Utils.Window.deprecated("Plot._visibleOnPlot()", "v1.1.0");
+    Utils.Window.deprecated("Plot._visibleOnPlot()", "v1.1.0", "replaced by _entityVisibleOnPlot()");
     return !(pixelPoint.x < 0 || pixelPoint.y < 0 ||
       pixelPoint.x > this.width() || pixelPoint.y > this.height());
   }

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -93,8 +93,11 @@ export module Plots {
       return drawSteps;
     }
 
+    /**
+     * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+     */
     protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean {
-      Utils.Window.deprecated("Scatter._visibleOnPlot()", "v1.1.0");
+      Utils.Window.deprecated("Scatter._visibleOnPlot()", "v1.1.0", "replaced by _entityVisibleOnPlot()");
       let xRange = { min: 0, max: this.width() };
       let yRange = { min: 0, max: this.height() };
 

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -94,7 +94,7 @@ export module Plots {
     }
 
     /**
-     * @deprecated As of release 1.1.0, replaced by _entityVisibleOnPlot()
+     * @deprecated As of release v1.1.0, replaced by _entityVisibleOnPlot()
      */
     protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean {
       Utils.Window.deprecated("Scatter._visibleOnPlot()", "v1.1.0", "replaced by _entityVisibleOnPlot()");


### PR DESCRIPTION
Closes #2750

- Added better deprecated documentation for deprecated methods
- Synced the versioning number between existing comments and the `deprecate()` method
- Added missing deprecation messages