### PR TITLE
Refactor key interaction tests - Pass 1

### DIFF
--- a/test/interactions/keyInteractionTests.ts
+++ b/test/interactions/keyInteractionTests.ts
@@ -107,7 +107,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can remove only the specified keypress callbacks", () => {
+      it("removes only the specified callback", () => {
         let aKeyCodeCallback1Called = false;
         let aKeyCodeCallback1 = () => aKeyCodeCallback1Called = true;
         let aKeyCodeCallback2Called = false;
@@ -145,7 +145,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("does not fire the callback if the key is pressed and held down outside, then the mouse moved inside", () => {
+      it("does not fire the callback when component is initially out of focus", () => {
         keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
@@ -179,6 +179,20 @@ describe("Interactions", () => {
         component.renderTo(svg);
       });
 
+      it("fires the callback upon releasing the key", () => {
+        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
+        keyInteraction.attachTo(component);
+
+        TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was not called before releasing the key");
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was released");
+
+        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback);
+        svg.remove();
+      });
+
       it("doesn't fire callback if key was released without being pressed", () => {
         assert.strictEqual(keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback), keyInteraction,
           "setting the keyRelease callback returns the interaction");
@@ -191,18 +205,6 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("fires callback if key was released after being pressed", () => {
-        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
-        keyInteraction.attachTo(component);
-
-        TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
-        assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was released");
-
-        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback);
-        svg.remove();
-      });
 
       it("only fires callback for key that has been released", () => {
         let bKeyCode = 66;

--- a/test/interactions/keyInteractionTests.ts
+++ b/test/interactions/keyInteractionTests.ts
@@ -1,32 +1,32 @@
 ///<reference path="../testReference.ts" />
 
 describe("Interactions", () => {
-  describe("KeyInteraction", () => {
-    let svg: d3.Selection<void>;
-    let component: Plottable.Component;
-    let keyInteraction: Plottable.Interactions.Key;
-    let aCode: number;
-    let bCode: number;
-
-    let aCallbackCalled: boolean;
-    let bCallbackCalled: boolean;
-    let aCallback: Plottable.KeyCallback;
-    let bCallback: Plottable.KeyCallback;
-
-    beforeEach(() => {
-      aCode = 65;
-      bCode = 66;
-      component = new Plottable.Component();
-      svg = TestMethods.generateSVG(400, 400);
-      keyInteraction = new Plottable.Interactions.Key();
-      aCallback = () => aCallbackCalled = true;
-      bCallback = () => bCallbackCalled = true;
-      component.renderTo(svg);
-      aCallbackCalled = false;
-      bCallbackCalled = false;
-    });
-
+  describe("Key Interaction", () => {
     describe("onKeyPress", () => {
+      let svg: d3.Selection<void>;
+      let component: Plottable.Component;
+      let keyInteraction: Plottable.Interactions.Key;
+      let aCode: number;
+      let bCode: number;
+
+      let aCallbackCalled: boolean;
+      let bCallbackCalled: boolean;
+      let aCallback: Plottable.KeyCallback;
+      let bCallback: Plottable.KeyCallback;
+
+      beforeEach(() => {
+        aCode = 65;
+        bCode = 66;
+        component = new Plottable.Component();
+        svg = TestMethods.generateSVG(400, 400);
+        keyInteraction = new Plottable.Interactions.Key();
+        aCallback = () => aCallbackCalled = true;
+        bCallback = () => bCallbackCalled = true;
+        component.renderTo(svg);
+        aCallbackCalled = false;
+        bCallbackCalled = false;
+      });
+
       it("only fires callback for \"a\" when \"a\" key is pressed", () => {
         keyInteraction.onKeyPress(aCode, aCallback);
         keyInteraction.onKeyPress(bCode, bCallback);
@@ -149,6 +149,30 @@ describe("Interactions", () => {
     });
 
     describe("onKeyRelease", () => {
+      let svg: d3.Selection<void>;
+      let component: Plottable.Component;
+      let keyInteraction: Plottable.Interactions.Key;
+      let aCode: number;
+      let bCode: number;
+
+      let aCallbackCalled: boolean;
+      let bCallbackCalled: boolean;
+      let aCallback: Plottable.KeyCallback;
+      let bCallback: Plottable.KeyCallback;
+
+      beforeEach(() => {
+        aCode = 65;
+        bCode = 66;
+        component = new Plottable.Component();
+        svg = TestMethods.generateSVG(400, 400);
+        keyInteraction = new Plottable.Interactions.Key();
+        aCallback = () => aCallbackCalled = true;
+        bCallback = () => bCallbackCalled = true;
+        component.renderTo(svg);
+        aCallbackCalled = false;
+        bCallbackCalled = false;
+      });
+
       it("doesn't fire callback if key was released without being pressed", () => {
         keyInteraction.onKeyRelease(aCode, aCallback);
         keyInteraction.attachTo(component);

--- a/test/interactions/keyInteractionTests.ts
+++ b/test/interactions/keyInteractionTests.ts
@@ -205,7 +205,6 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-
       it("only fires callback for key that has been released", () => {
         let bKeyCode = 66;
         let bKeyCodeCallbackCalled = false;

--- a/test/interactions/keyInteractionTests.ts
+++ b/test/interactions/keyInteractionTests.ts
@@ -21,13 +21,25 @@ describe("Interactions", () => {
         component.renderTo(svg);
       });
 
+      it("fires callback for key press", () => {
+        assert.strictEqual(keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback), keyInteraction,
+          "setting the keyPress callback returns the interaction");
+        keyInteraction.attachTo(component);
+
+        TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was pressed");
+
+        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback);
+        svg.remove();
+      });
+
       it("only fires callback for \"a\" when \"a\" key is pressed", () => {
         let bKeyCode = 66;
         let bKeyCodeCallbackCalled = false;
         let bKeyCodeCallback = () => bKeyCodeCallbackCalled = true;
 
-        assert.strictEqual(keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback), keyInteraction,
-          "setting the keyPress callback returns the interaction");
+        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback);
         keyInteraction.onKeyPress(bKeyCode, bKeyCodeCallback);
         keyInteraction.attachTo(component);
 
@@ -53,7 +65,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can remove keyPress callbacks", () => {
+      it("can remove and reattach keyPress callbacks", () => {
         keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
@@ -61,7 +73,8 @@ describe("Interactions", () => {
         TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
         assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was pressed");
 
-        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback);
+        assert.strictEqual(keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback), keyInteraction,
+          "unsetting the keyPress callback returns the interaction");
         aKeyCodeCallbackCalled = false;
         TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
         assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was disconnected from the interaction");
@@ -70,12 +83,11 @@ describe("Interactions", () => {
         TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
         assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was properly connected back to the interaction");
 
-        assert.strictEqual(keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback), keyInteraction,
-          "unsetting the keyPress callback returns the interaction");
+        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback);
         svg.remove();
       });
 
-      it("can attach multiple keyPress callbacks", () => {
+      it("can attach multiple keyPress callbacks on the same key code", () => {
         let aKeyCodeCallback1Called = false;
         let aKeyCodeCallback1 = () => aKeyCodeCallback1Called = true;
         let aKeyCodeCallback2Called = false;
@@ -95,7 +107,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can remove only one of the registered keypress callbacks", () => {
+      it("can remove only the specified keypress callbacks", () => {
         let aKeyCodeCallback1Called = false;
         let aKeyCodeCallback1 = () => aKeyCodeCallback1Called = true;
         let aKeyCodeCallback2Called = false;
@@ -253,7 +265,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can remove keyRelease callbacks", () => {
+      it("can remove and reattach keyRelease callbacks", () => {
         keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 

--- a/test/interactions/keyInteractionTests.ts
+++ b/test/interactions/keyInteractionTests.ts
@@ -7,143 +7,143 @@ describe("Interactions", () => {
       let component: Plottable.Component;
       let keyInteraction: Plottable.Interactions.Key;
 
-      let aCode: number;
-      let aCallbackCalled: boolean;
-      let aCallback: Plottable.KeyCallback;
+      let aKeyCode: number;
+      let aKeyCodeCallbackCalled: boolean;
+      let aKeyCodeCallback: Plottable.KeyCallback;
 
       beforeEach(() => {
         component = new Plottable.Component();
         keyInteraction = new Plottable.Interactions.Key();
-        aCode = 65;
-        aCallbackCalled = false;
-        aCallback = () => aCallbackCalled = true;
+        aKeyCode = 65;
+        aKeyCodeCallbackCalled = false;
+        aKeyCodeCallback = () => aKeyCodeCallbackCalled = true;
         svg = TestMethods.generateSVG();
         component.renderTo(svg);
       });
 
       it("only fires callback for \"a\" when \"a\" key is pressed", () => {
-        let bCode = 66;
-        let bCallbackCalled = false;
-        let bCallback = () => bCallbackCalled = true;
+        let bKeyCode = 66;
+        let bKeyCodeCallbackCalled = false;
+        let bKeyCodeCallback = () => bKeyCodeCallbackCalled = true;
 
-        assert.strictEqual(keyInteraction.onKeyPress(aCode, aCallback), keyInteraction,
+        assert.strictEqual(keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback), keyInteraction,
           "setting the keyPress callback returns the interaction");
-        keyInteraction.onKeyPress(bCode, bCallback);
+        keyInteraction.onKeyPress(bKeyCode, bKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        assert.isTrue(aCallbackCalled, "callback for \"a\" was called when \"a\" key was pressed");
-        assert.isFalse(bCallbackCalled, "callback for \"b\" was not called when \"a\" key was pressed");
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was pressed");
+        assert.isFalse(bKeyCodeCallbackCalled, "callback for \"b\" was not called when \"a\" key was pressed");
 
-        keyInteraction.offKeyPress(aCode, aCallback);
-        keyInteraction.offKeyPress(bCode, bCallback);
+        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback);
+        keyInteraction.offKeyPress(bKeyCode, bKeyCodeCallback);
         svg.remove();
       });
 
       it("does not fire callback when the key is pressed outside of the component", () => {
-        keyInteraction.onKeyPress(aCode, aCallback);
+        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseout", component.background(), -100, -100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        assert.isFalse(aCallbackCalled, "callback for \"a\" was not called when not moused over the Component");
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was not called when not moused over the Component");
 
-        keyInteraction.offKeyPress(aCode, aCallback);
+        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback);
         svg.remove();
       });
 
       it("can remove keyPress callbacks", () => {
-        keyInteraction.onKeyPress(aCode, aCallback);
+        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        assert.isTrue(aCallbackCalled, "callback for \"a\" was called when \"a\" key was pressed");
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was pressed");
 
-        keyInteraction.offKeyPress(aCode, aCallback);
-        aCallbackCalled = false;
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        assert.isFalse(aCallbackCalled, "callback for \"a\" was disconnected from the interaction");
+        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback);
+        aKeyCodeCallbackCalled = false;
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was disconnected from the interaction");
 
-        keyInteraction.onKeyPress(aCode, aCallback);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        assert.isTrue(aCallbackCalled, "callback for \"a\" was properly connected back to the interaction");
+        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was properly connected back to the interaction");
 
-        assert.strictEqual(keyInteraction.offKeyPress(aCode, aCallback), keyInteraction,
+        assert.strictEqual(keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback), keyInteraction,
           "unsetting the keyPress callback returns the interaction");
         svg.remove();
       });
 
       it("can attach multiple keyPress callbacks", () => {
-        let aCallback1Called = false;
-        let aCallback1 = () => aCallback1Called = true;
-        let aCallback2Called = false;
-        let aCallback2 = () => aCallback2Called = true;
+        let aKeyCodeCallback1Called = false;
+        let aKeyCodeCallback1 = () => aKeyCodeCallback1Called = true;
+        let aKeyCodeCallback2Called = false;
+        let aKeyCodeCallback2 = () => aKeyCodeCallback2Called = true;
 
-        keyInteraction.onKeyPress(aCode, aCallback1);
-        keyInteraction.onKeyPress(aCode, aCallback2);
+        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback1);
+        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback2);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        assert.isTrue(aCallback1Called, "callback 1 for \"a\" was called when \"a\" key was pressed");
-        assert.isTrue(aCallback2Called, "callback 2 for \"a\" was called when \"a\" key was pressed");
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        assert.isTrue(aKeyCodeCallback1Called, "callback 1 for \"a\" was called when \"a\" key was pressed");
+        assert.isTrue(aKeyCodeCallback2Called, "callback 2 for \"a\" was called when \"a\" key was pressed");
 
-        keyInteraction.offKeyPress(aCode, aCallback1);
-        keyInteraction.offKeyPress(aCode, aCallback2);
+        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback1);
+        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback2);
         svg.remove();
       });
 
       it("can remove only one of the registered keypress callbacks", () => {
-        let aCallback1Called = false;
-        let aCallback1 = () => aCallback1Called = true;
-        let aCallback2Called = false;
-        let aCallback2 = () => aCallback2Called = true;
+        let aKeyCodeCallback1Called = false;
+        let aKeyCodeCallback1 = () => aKeyCodeCallback1Called = true;
+        let aKeyCodeCallback2Called = false;
+        let aKeyCodeCallback2 = () => aKeyCodeCallback2Called = true;
 
-        keyInteraction.onKeyPress(aCode, aCallback1);
-        keyInteraction.onKeyPress(aCode, aCallback2);
+        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback1);
+        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback2);
         keyInteraction.attachTo(component);
-        keyInteraction.offKeyPress(aCode, aCallback1);
+        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback1);
 
-        aCallback1Called = false;
-        aCallback2Called = false;
+        aKeyCodeCallback1Called = false;
+        aKeyCodeCallback2Called = false;
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        assert.isFalse(aCallback1Called, "callback 1 for \"a\" was disconnected from the interaction");
-        assert.isTrue(aCallback2Called, "callback 2 for \"a\" is still connected to the interaction");
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        assert.isFalse(aKeyCodeCallback1Called, "callback 1 for \"a\" was disconnected from the interaction");
+        assert.isTrue(aKeyCodeCallback2Called, "callback 2 for \"a\" is still connected to the interaction");
 
-        keyInteraction.offKeyPress(aCode, aCallback2);
+        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback2);
         svg.remove();
       });
 
       it("is only triggered once when the key is pressed", () => {
-        keyInteraction.onKeyPress(aCode, aCallback);
+        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        assert.isTrue(aCallbackCalled, "callback for \"a\" was called when \"a\" key was pressed");
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was pressed");
 
-        aCallbackCalled = false;
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode, { repeat : true });
-        assert.isFalse(aCallbackCalled, "callback for \"a\" was not called when keydown was fired the second time");
+        aKeyCodeCallbackCalled = false;
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode, { repeat : true });
+        assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was not called when keydown was fired the second time");
 
-        keyInteraction.offKeyPress(aCode, aCallback);
+        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback);
         svg.remove();
       });
 
       it("does not fire the callback if the key is pressed and held down outside, then the mouse moved inside", () => {
-        keyInteraction.onKeyPress(aCode, aCallback);
+        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseout", component.background(), -100, -100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode, { repeat : true });
-        assert.isFalse(aCallbackCalled, "callback for \"a\" was not called");
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode, { repeat : true });
+        assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was not called");
 
-        keyInteraction.offKeyPress(aCode, aCallback);
+        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback);
         svg.remove();
       });
     });
@@ -153,172 +153,172 @@ describe("Interactions", () => {
       let component: Plottable.Component;
       let keyInteraction: Plottable.Interactions.Key;
 
-      let aCode: number;
-      let aCallbackCalled: boolean;
-      let aCallback: Plottable.KeyCallback;
+      let aKeyCode: number;
+      let aKeyCodeCallbackCalled: boolean;
+      let aKeyCodeCallback: Plottable.KeyCallback;
 
       beforeEach(() => {
-        aCode = 65;
+        aKeyCode = 65;
         component = new Plottable.Component();
         keyInteraction = new Plottable.Interactions.Key();
-        aCallbackCalled = false;
-        aCallback = () => aCallbackCalled = true;
+        aKeyCodeCallbackCalled = false;
+        aKeyCodeCallback = () => aKeyCodeCallbackCalled = true;
         svg = TestMethods.generateSVG();
         component.renderTo(svg);
       });
 
       it("doesn't fire callback if key was released without being pressed", () => {
-        assert.strictEqual(keyInteraction.onKeyRelease(aCode, aCallback), keyInteraction,
+        assert.strictEqual(keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback), keyInteraction,
           "setting the keyRelease callback returns the interaction");
         keyInteraction.attachTo(component);
 
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
-        assert.isFalse(aCallbackCalled, "callback for \"a\" was not called when \"a\" key was released");
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was not called when \"a\" key was released");
 
-        keyInteraction.offKeyRelease(aCode, aCallback);
+        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback);
         svg.remove();
       });
 
       it("fires callback if key was released after being pressed", () => {
-        keyInteraction.onKeyRelease(aCode, aCallback);
+        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
-        assert.isTrue(aCallbackCalled, "callback for \"a\" was called when \"a\" key was released");
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was released");
 
-        keyInteraction.offKeyRelease(aCode, aCallback);
+        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback);
         svg.remove();
       });
 
       it("only fires callback for key that has been released", () => {
-        let bCode = 66;
-        let bCallbackCalled = false;
-        let bCallback = () => bCallbackCalled = true;
+        let bKeyCode = 66;
+        let bKeyCodeCallbackCalled = false;
+        let bKeyCodeCallback = () => bKeyCodeCallbackCalled = true;
 
-        keyInteraction.onKeyRelease(aCode, aCallback);
-        keyInteraction.onKeyRelease(bCode, bCallback);
+        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
+        keyInteraction.onKeyRelease(bKeyCode, bKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
-        assert.isTrue(aCallbackCalled, "callback for \"a\" was called when \"a\" key was released");
-        assert.isFalse(bCallbackCalled, "callback for \"b\" was not called when \"a\" key was released");
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was released");
+        assert.isFalse(bKeyCodeCallbackCalled, "callback for \"b\" was not called when \"a\" key was released");
 
-        keyInteraction.offKeyRelease(aCode, aCallback);
-        keyInteraction.offKeyRelease(bCode, bCallback);
+        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback);
+        keyInteraction.offKeyRelease(bKeyCode, bKeyCodeCallback);
         svg.remove();
       });
 
       it("fires callback if key was released outside of component after being pressed inside", () => {
-        keyInteraction.onKeyRelease(aCode, aCallback);
+        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
         TestMethods.triggerFakeMouseEvent("mouseout", component.background(), -100, -100);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
-        assert.isTrue(aCallbackCalled, "callback for \"a\" was called when \"a\" key was released");
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was released");
 
-        keyInteraction.offKeyRelease(aCode, aCallback);
+        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback);
         svg.remove();
       });
 
       it("doesn't fire callback if key was released after being pressed outside", () => {
-        keyInteraction.onKeyRelease(aCode, aCallback);
+        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseout", component.background(), -100, -100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
-        assert.isFalse(aCallbackCalled, "callback for \"a\" was not called when \"a\" key was released");
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was not called when \"a\" key was released");
 
-        keyInteraction.offKeyRelease(aCode, aCallback);
+        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback);
         svg.remove();
       });
 
       it("doesn't fire callback key was released inside after being pressed outside", () => {
-        keyInteraction.onKeyRelease(aCode, aCallback);
+        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseout", component.background(), -100, -100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
-        assert.isFalse(aCallbackCalled, "callback for \"a\" was not called when \"a\" key was released");
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was not called when \"a\" key was released");
 
-        keyInteraction.offKeyRelease(aCode, aCallback);
+        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback);
         svg.remove();
       });
 
       it("can remove keyRelease callbacks", () => {
-        keyInteraction.onKeyRelease(aCode, aCallback);
+        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
-        assert.isTrue(aCallbackCalled, "callback for \"a\" was called when \"a\" key was released");
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was released");
 
-        assert.strictEqual(keyInteraction.offKeyRelease(aCode, aCallback), keyInteraction,
+        assert.strictEqual(keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback), keyInteraction,
           "unsetting the keyRelease callback returns the interaction");
-        aCallbackCalled = false;
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
-        assert.isFalse(aCallbackCalled, "callback for \"a\" was disconnected from the interaction");
+        aKeyCodeCallbackCalled = false;
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was disconnected from the interaction");
 
-        keyInteraction.onKeyRelease(aCode, aCallback);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
-        assert.isTrue(aCallbackCalled, "callback for \"a\" was properly connected back to the interaction");
+        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was properly connected back to the interaction");
 
-        keyInteraction.offKeyRelease(aCode, aCallback);
+        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback);
         svg.remove();
       });
 
       it("can register multiple keyRelease callbacks", () => {
-        let aCallback1Called = false;
-        let aCallback1 = () => aCallback1Called = true;
-        let aCallback2Called = false;
-        let aCallback2 = () => aCallback2Called = true;
+        let aKeyCodeCallback1Called = false;
+        let aKeyCodeCallback1 = () => aKeyCodeCallback1Called = true;
+        let aKeyCodeCallback2Called = false;
+        let aKeyCodeCallback2 = () => aKeyCodeCallback2Called = true;
 
-        keyInteraction.onKeyRelease(aCode, aCallback1);
-        keyInteraction.onKeyRelease(aCode, aCallback2);
+        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback1);
+        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback2);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
-        assert.isTrue(aCallback1Called, "callback 1 for \"a\" was called when \"a\" key was released");
-        assert.isTrue(aCallback2Called, "callback 2 for \"a\" was called when \"a\" key was released");
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        assert.isTrue(aKeyCodeCallback1Called, "callback 1 for \"a\" was called when \"a\" key was released");
+        assert.isTrue(aKeyCodeCallback2Called, "callback 2 for \"a\" was called when \"a\" key was released");
 
-        keyInteraction.offKeyRelease(aCode, aCallback1);
-        keyInteraction.offKeyRelease(aCode, aCallback2);
+        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback1);
+        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback2);
         svg.remove();
       });
 
       it("can remove only one of the registered keyRelease callbacks", () => {
-        let aCallback1Called = false;
-        let aCallback1 = () => aCallback1Called = true;
-        let aCallback2Called = false;
-        let aCallback2 = () => aCallback2Called = true;
+        let aKeyCodeCallback1Called = false;
+        let aKeyCodeCallback1 = () => aKeyCodeCallback1Called = true;
+        let aKeyCodeCallback2Called = false;
+        let aKeyCodeCallback2 = () => aKeyCodeCallback2Called = true;
 
-        keyInteraction.onKeyRelease(aCode, aCallback1);
-        keyInteraction.onKeyRelease(aCode, aCallback2);
+        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback1);
+        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback2);
         keyInteraction.attachTo(component);
 
-        keyInteraction.offKeyRelease(aCode, aCallback1);
-        aCallback1Called = false;
-        aCallback2Called = false;
+        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback1);
+        aKeyCodeCallback1Called = false;
+        aKeyCodeCallback2Called = false;
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
-        assert.isFalse(aCallback1Called, "callback 1 for \"a\" was disconnected from the interaction");
-        assert.isTrue(aCallback2Called, "callback 2 for \"a\" is still connected to the interaction");
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        assert.isFalse(aKeyCodeCallback1Called, "callback 1 for \"a\" was disconnected from the interaction");
+        assert.isTrue(aKeyCodeCallback2Called, "callback 2 for \"a\" is still connected to the interaction");
 
-        keyInteraction.offKeyRelease(aCode, aCallback2);
+        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback2);
         svg.remove();
       });
     });

--- a/test/interactions/keyInteractionTests.ts
+++ b/test/interactions/keyInteractionTests.ts
@@ -18,17 +18,18 @@ describe("Interactions", () => {
         aCode = 65;
         bCode = 66;
         component = new Plottable.Component();
-        svg = TestMethods.generateSVG(400, 400);
         keyInteraction = new Plottable.Interactions.Key();
-        aCallback = () => aCallbackCalled = true;
-        bCallback = () => bCallbackCalled = true;
-        component.renderTo(svg);
         aCallbackCalled = false;
         bCallbackCalled = false;
+        aCallback = () => aCallbackCalled = true;
+        bCallback = () => bCallbackCalled = true;
+        svg = TestMethods.generateSVG();
+        component.renderTo(svg);
       });
 
       it("only fires callback for \"a\" when \"a\" key is pressed", () => {
-        keyInteraction.onKeyPress(aCode, aCallback);
+        assert.strictEqual(keyInteraction.onKeyPress(aCode, aCallback), keyInteraction,
+          "setting the keyPress callback returns the interaction");
         keyInteraction.onKeyPress(bCode, bCallback);
         keyInteraction.attachTo(component);
 
@@ -37,7 +38,8 @@ describe("Interactions", () => {
         assert.isTrue(aCallbackCalled, "callback for \"a\" was called when \"a\" key was pressed");
         assert.isFalse(bCallbackCalled, "callback for \"b\" was not called when \"a\" key was pressed");
 
-        keyInteraction.offKeyPress(aCode, aCallback);
+        assert.strictEqual(keyInteraction.offKeyPress(aCode, aCallback), keyInteraction,
+          "unsetting the keyPress callback returns the interaction");
         keyInteraction.offKeyPress(bCode, bCallback);
         svg.remove();
       });
@@ -54,7 +56,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("removing keyPress callbacks is possible", () => {
+      it("can remove keyPress callbacks", () => {
         keyInteraction.onKeyPress(aCode, aCallback);
         keyInteraction.attachTo(component);
 
@@ -75,7 +77,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("multiple keyPress callbacks are possible", () => {
+      it("can attach multiple multiple keyPress callbacks", () => {
         let aCallback1Called = false;
         let aCallback1 = () => aCallback1Called = true;
         let aCallback2Called = false;
@@ -164,23 +166,25 @@ describe("Interactions", () => {
         aCode = 65;
         bCode = 66;
         component = new Plottable.Component();
-        svg = TestMethods.generateSVG(400, 400);
         keyInteraction = new Plottable.Interactions.Key();
-        aCallback = () => aCallbackCalled = true;
-        bCallback = () => bCallbackCalled = true;
-        component.renderTo(svg);
         aCallbackCalled = false;
         bCallbackCalled = false;
+        aCallback = () => aCallbackCalled = true;
+        bCallback = () => bCallbackCalled = true;
+        svg = TestMethods.generateSVG();
+        component.renderTo(svg);
       });
 
       it("doesn't fire callback if key was released without being pressed", () => {
-        keyInteraction.onKeyRelease(aCode, aCallback);
+        assert.strictEqual(keyInteraction.onKeyRelease(aCode, aCallback), keyInteraction,
+          "setting the keyRelease callback returns the interaction");
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
         assert.isFalse(aCallbackCalled, "callback for \"a\" was not called when \"a\" key was released");
 
-        keyInteraction.offKeyRelease(aCode, aCallback);
+        assert.strictEqual(keyInteraction.offKeyRelease(aCode, aCallback), keyInteraction,
+          "unsetting the keyRelease callback returns the interaction");
         svg.remove();
       });
 
@@ -254,7 +258,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("removing keyRelease callbacks is possible", () => {
+      it("can remove removing keyRelease callbacks", () => {
         keyInteraction.onKeyRelease(aCode, aCallback);
         keyInteraction.attachTo(component);
 
@@ -278,7 +282,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("multiple keyRelease callbacks are possible", () => {
+      it("can register multiple keyRelease callbacks", () => {
         let aCallback1Called = false;
         let aCallback1 = () => aCallback1Called = true;
         let aCallback2Called = false;
@@ -299,7 +303,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can remove only one of the registered keyrelease callback", () => {
+      it("can remove only one of the registered keyRelease callbacks", () => {
         let aCallback1Called = false;
         let aCallback1 = () => aCallback1Called = true;
         let aCallback2Called = false;
@@ -322,5 +326,6 @@ describe("Interactions", () => {
         svg.remove();
       });
     });
+
   });
 });

--- a/test/interactions/keyInteractionTests.ts
+++ b/test/interactions/keyInteractionTests.ts
@@ -6,28 +6,26 @@ describe("Interactions", () => {
       let svg: d3.Selection<void>;
       let component: Plottable.Component;
       let keyInteraction: Plottable.Interactions.Key;
-      let aCode: number;
-      let bCode: number;
 
+      let aCode: number;
       let aCallbackCalled: boolean;
-      let bCallbackCalled: boolean;
       let aCallback: Plottable.KeyCallback;
-      let bCallback: Plottable.KeyCallback;
 
       beforeEach(() => {
-        aCode = 65;
-        bCode = 66;
         component = new Plottable.Component();
         keyInteraction = new Plottable.Interactions.Key();
+        aCode = 65;
         aCallbackCalled = false;
-        bCallbackCalled = false;
         aCallback = () => aCallbackCalled = true;
-        bCallback = () => bCallbackCalled = true;
         svg = TestMethods.generateSVG();
         component.renderTo(svg);
       });
 
       it("only fires callback for \"a\" when \"a\" key is pressed", () => {
+        let bCode = 66;
+        let bCallbackCalled = false;
+        let bCallback = () => bCallbackCalled = true;
+
         assert.strictEqual(keyInteraction.onKeyPress(aCode, aCallback), keyInteraction,
           "setting the keyPress callback returns the interaction");
         keyInteraction.onKeyPress(bCode, bCallback);
@@ -38,8 +36,7 @@ describe("Interactions", () => {
         assert.isTrue(aCallbackCalled, "callback for \"a\" was called when \"a\" key was pressed");
         assert.isFalse(bCallbackCalled, "callback for \"b\" was not called when \"a\" key was pressed");
 
-        assert.strictEqual(keyInteraction.offKeyPress(aCode, aCallback), keyInteraction,
-          "unsetting the keyPress callback returns the interaction");
+        keyInteraction.offKeyPress(aCode, aCallback);
         keyInteraction.offKeyPress(bCode, bCallback);
         svg.remove();
       });
@@ -73,11 +70,12 @@ describe("Interactions", () => {
         TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
         assert.isTrue(aCallbackCalled, "callback for \"a\" was properly connected back to the interaction");
 
-        keyInteraction.offKeyPress(aCode, aCallback);
+        assert.strictEqual(keyInteraction.offKeyPress(aCode, aCallback), keyInteraction,
+          "unsetting the keyPress callback returns the interaction");
         svg.remove();
       });
 
-      it("can attach multiple multiple keyPress callbacks", () => {
+      it("can attach multiple keyPress callbacks", () => {
         let aCallback1Called = false;
         let aCallback1 = () => aCallback1Called = true;
         let aCallback2Called = false;
@@ -154,23 +152,17 @@ describe("Interactions", () => {
       let svg: d3.Selection<void>;
       let component: Plottable.Component;
       let keyInteraction: Plottable.Interactions.Key;
-      let aCode: number;
-      let bCode: number;
 
+      let aCode: number;
       let aCallbackCalled: boolean;
-      let bCallbackCalled: boolean;
       let aCallback: Plottable.KeyCallback;
-      let bCallback: Plottable.KeyCallback;
 
       beforeEach(() => {
         aCode = 65;
-        bCode = 66;
         component = new Plottable.Component();
         keyInteraction = new Plottable.Interactions.Key();
         aCallbackCalled = false;
-        bCallbackCalled = false;
         aCallback = () => aCallbackCalled = true;
-        bCallback = () => bCallbackCalled = true;
         svg = TestMethods.generateSVG();
         component.renderTo(svg);
       });
@@ -183,8 +175,7 @@ describe("Interactions", () => {
         TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
         assert.isFalse(aCallbackCalled, "callback for \"a\" was not called when \"a\" key was released");
 
-        assert.strictEqual(keyInteraction.offKeyRelease(aCode, aCallback), keyInteraction,
-          "unsetting the keyRelease callback returns the interaction");
+        keyInteraction.offKeyRelease(aCode, aCallback);
         svg.remove();
       });
 
@@ -202,6 +193,10 @@ describe("Interactions", () => {
       });
 
       it("only fires callback for key that has been released", () => {
+        let bCode = 66;
+        let bCallbackCalled = false;
+        let bCallback = () => bCallbackCalled = true;
+
         keyInteraction.onKeyRelease(aCode, aCallback);
         keyInteraction.onKeyRelease(bCode, bCallback);
         keyInteraction.attachTo(component);
@@ -258,7 +253,7 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can remove removing keyRelease callbacks", () => {
+      it("can remove keyRelease callbacks", () => {
         keyInteraction.onKeyRelease(aCode, aCallback);
         keyInteraction.attachTo(component);
 
@@ -267,7 +262,8 @@ describe("Interactions", () => {
         TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);
         assert.isTrue(aCallbackCalled, "callback for \"a\" was called when \"a\" key was released");
 
-        keyInteraction.offKeyRelease(aCode, aCallback);
+        assert.strictEqual(keyInteraction.offKeyRelease(aCode, aCallback), keyInteraction,
+          "unsetting the keyRelease callback returns the interaction");
         aCallbackCalled = false;
         TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aCode);
         TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aCode);

--- a/test/interactions/keyInteractionTests.ts
+++ b/test/interactions/keyInteractionTests.ts
@@ -7,14 +7,14 @@ describe("Interactions", () => {
       let component: Plottable.Component;
       let keyInteraction: Plottable.Interactions.Key;
 
-      let aKeyCode: number;
+      let A_KEY_CODE = 65;
+      let B_KEY_CODE = 66;
       let aKeyCodeCallbackCalled: boolean;
       let aKeyCodeCallback: Plottable.KeyCallback;
 
       beforeEach(() => {
         component = new Plottable.Component();
         keyInteraction = new Plottable.Interactions.Key();
-        aKeyCode = 65;
         aKeyCodeCallbackCalled = false;
         aKeyCodeCallback = () => aKeyCodeCallbackCalled = true;
         svg = TestMethods.generateSVG();
@@ -22,68 +22,67 @@ describe("Interactions", () => {
       });
 
       it("fires callback for key press", () => {
-        assert.strictEqual(keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback), keyInteraction,
+        assert.strictEqual(keyInteraction.onKeyPress(A_KEY_CODE, aKeyCodeCallback), keyInteraction,
           "setting the keyPress callback returns the interaction");
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
         assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was pressed");
 
-        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback);
+        keyInteraction.offKeyPress(A_KEY_CODE, aKeyCodeCallback);
         svg.remove();
       });
 
       it("only fires callback for \"a\" when \"a\" key is pressed", () => {
-        let bKeyCode = 66;
         let bKeyCodeCallbackCalled = false;
         let bKeyCodeCallback = () => bKeyCodeCallbackCalled = true;
 
-        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback);
-        keyInteraction.onKeyPress(bKeyCode, bKeyCodeCallback);
+        keyInteraction.onKeyPress(A_KEY_CODE, aKeyCodeCallback);
+        keyInteraction.onKeyPress(B_KEY_CODE, bKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
         assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was pressed");
         assert.isFalse(bKeyCodeCallbackCalled, "callback for \"b\" was not called when \"a\" key was pressed");
 
-        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback);
-        keyInteraction.offKeyPress(bKeyCode, bKeyCodeCallback);
+        keyInteraction.offKeyPress(A_KEY_CODE, aKeyCodeCallback);
+        keyInteraction.offKeyPress(B_KEY_CODE, bKeyCodeCallback);
         svg.remove();
       });
 
       it("does not fire callback when the key is pressed outside of the component", () => {
-        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback);
+        keyInteraction.onKeyPress(A_KEY_CODE, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseout", component.background(), -100, -100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
         assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was not called when not moused over the Component");
 
-        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback);
+        keyInteraction.offKeyPress(A_KEY_CODE, aKeyCodeCallback);
         svg.remove();
       });
 
       it("can remove and reattach keyPress callbacks", () => {
-        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback);
+        keyInteraction.onKeyPress(A_KEY_CODE, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
         assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was pressed");
 
-        assert.strictEqual(keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback), keyInteraction,
+        assert.strictEqual(keyInteraction.offKeyPress(A_KEY_CODE, aKeyCodeCallback), keyInteraction,
           "unsetting the keyPress callback returns the interaction");
         aKeyCodeCallbackCalled = false;
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
         assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was disconnected from the interaction");
 
-        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        keyInteraction.onKeyPress(A_KEY_CODE, aKeyCodeCallback);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
         assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was properly connected back to the interaction");
 
-        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback);
+        keyInteraction.offKeyPress(A_KEY_CODE, aKeyCodeCallback);
         svg.remove();
       });
 
@@ -93,17 +92,17 @@ describe("Interactions", () => {
         let aKeyCodeCallback2Called = false;
         let aKeyCodeCallback2 = () => aKeyCodeCallback2Called = true;
 
-        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback1);
-        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback2);
+        keyInteraction.onKeyPress(A_KEY_CODE, aKeyCodeCallback1);
+        keyInteraction.onKeyPress(A_KEY_CODE, aKeyCodeCallback2);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
         assert.isTrue(aKeyCodeCallback1Called, "callback 1 for \"a\" was called when \"a\" key was pressed");
         assert.isTrue(aKeyCodeCallback2Called, "callback 2 for \"a\" was called when \"a\" key was pressed");
 
-        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback1);
-        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback2);
+        keyInteraction.offKeyPress(A_KEY_CODE, aKeyCodeCallback1);
+        keyInteraction.offKeyPress(A_KEY_CODE, aKeyCodeCallback2);
         svg.remove();
       });
 
@@ -113,49 +112,49 @@ describe("Interactions", () => {
         let aKeyCodeCallback2Called = false;
         let aKeyCodeCallback2 = () => aKeyCodeCallback2Called = true;
 
-        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback1);
-        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback2);
+        keyInteraction.onKeyPress(A_KEY_CODE, aKeyCodeCallback1);
+        keyInteraction.onKeyPress(A_KEY_CODE, aKeyCodeCallback2);
         keyInteraction.attachTo(component);
-        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback1);
+        keyInteraction.offKeyPress(A_KEY_CODE, aKeyCodeCallback1);
 
         aKeyCodeCallback1Called = false;
         aKeyCodeCallback2Called = false;
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
         assert.isFalse(aKeyCodeCallback1Called, "callback 1 for \"a\" was disconnected from the interaction");
         assert.isTrue(aKeyCodeCallback2Called, "callback 2 for \"a\" is still connected to the interaction");
 
-        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback2);
+        keyInteraction.offKeyPress(A_KEY_CODE, aKeyCodeCallback2);
         svg.remove();
       });
 
       it("is only triggered once when the key is pressed", () => {
-        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback);
+        keyInteraction.onKeyPress(A_KEY_CODE, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
         assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was pressed");
 
         aKeyCodeCallbackCalled = false;
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode, { repeat : true });
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE, { repeat : true });
         assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was not called when keydown was fired the second time");
 
-        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback);
+        keyInteraction.offKeyPress(A_KEY_CODE, aKeyCodeCallback);
         svg.remove();
       });
 
       it("does not fire the callback when component is initially out of focus", () => {
-        keyInteraction.onKeyPress(aKeyCode, aKeyCodeCallback);
+        keyInteraction.onKeyPress(A_KEY_CODE, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseout", component.background(), -100, -100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode, { repeat : true });
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE, { repeat : true });
         assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was not called");
 
-        keyInteraction.offKeyPress(aKeyCode, aKeyCodeCallback);
+        keyInteraction.offKeyPress(A_KEY_CODE, aKeyCodeCallback);
         svg.remove();
       });
     });
@@ -165,12 +164,12 @@ describe("Interactions", () => {
       let component: Plottable.Component;
       let keyInteraction: Plottable.Interactions.Key;
 
-      let aKeyCode: number;
+      let A_KEY_CODE = 65;
+      let B_KEY_CODE = 66;
       let aKeyCodeCallbackCalled: boolean;
       let aKeyCodeCallback: Plottable.KeyCallback;
 
       beforeEach(() => {
-        aKeyCode = 65;
         component = new Plottable.Component();
         keyInteraction = new Plottable.Interactions.Key();
         aKeyCodeCallbackCalled = false;
@@ -180,114 +179,113 @@ describe("Interactions", () => {
       });
 
       it("fires the callback upon releasing the key", () => {
-        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
+        keyInteraction.onKeyRelease(A_KEY_CODE, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
         assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was not called before releasing the key");
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), A_KEY_CODE);
         assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was released");
 
-        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback);
+        keyInteraction.offKeyRelease(A_KEY_CODE, aKeyCodeCallback);
         svg.remove();
       });
 
       it("doesn't fire callback if key was released without being pressed", () => {
-        assert.strictEqual(keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback), keyInteraction,
+        assert.strictEqual(keyInteraction.onKeyRelease(A_KEY_CODE, aKeyCodeCallback), keyInteraction,
           "setting the keyRelease callback returns the interaction");
         keyInteraction.attachTo(component);
 
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), A_KEY_CODE);
         assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was not called when \"a\" key was released");
 
-        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback);
+        keyInteraction.offKeyRelease(A_KEY_CODE, aKeyCodeCallback);
         svg.remove();
       });
 
       it("only fires callback for key that has been released", () => {
-        let bKeyCode = 66;
         let bKeyCodeCallbackCalled = false;
         let bKeyCodeCallback = () => bKeyCodeCallbackCalled = true;
 
-        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
-        keyInteraction.onKeyRelease(bKeyCode, bKeyCodeCallback);
+        keyInteraction.onKeyRelease(A_KEY_CODE, aKeyCodeCallback);
+        keyInteraction.onKeyRelease(B_KEY_CODE, bKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), A_KEY_CODE);
         assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was released");
         assert.isFalse(bKeyCodeCallbackCalled, "callback for \"b\" was not called when \"a\" key was released");
 
-        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback);
-        keyInteraction.offKeyRelease(bKeyCode, bKeyCodeCallback);
+        keyInteraction.offKeyRelease(A_KEY_CODE, aKeyCodeCallback);
+        keyInteraction.offKeyRelease(B_KEY_CODE, bKeyCodeCallback);
         svg.remove();
       });
 
       it("fires callback if key was released outside of component after being pressed inside", () => {
-        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
+        keyInteraction.onKeyRelease(A_KEY_CODE, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
         TestMethods.triggerFakeMouseEvent("mouseout", component.background(), -100, -100);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), A_KEY_CODE);
         assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was released");
 
-        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback);
+        keyInteraction.offKeyRelease(A_KEY_CODE, aKeyCodeCallback);
         svg.remove();
       });
 
       it("doesn't fire callback if key was released after being pressed outside", () => {
-        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
+        keyInteraction.onKeyRelease(A_KEY_CODE, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseout", component.background(), -100, -100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), A_KEY_CODE);
         assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was not called when \"a\" key was released");
 
-        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback);
+        keyInteraction.offKeyRelease(A_KEY_CODE, aKeyCodeCallback);
         svg.remove();
       });
 
       it("doesn't fire callback key was released inside after being pressed outside", () => {
-        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
+        keyInteraction.onKeyRelease(A_KEY_CODE, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseout", component.background(), -100, -100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), A_KEY_CODE);
         assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was not called when \"a\" key was released");
 
-        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback);
+        keyInteraction.offKeyRelease(A_KEY_CODE, aKeyCodeCallback);
         svg.remove();
       });
 
       it("can remove and reattach keyRelease callbacks", () => {
-        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
+        keyInteraction.onKeyRelease(A_KEY_CODE, aKeyCodeCallback);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), A_KEY_CODE);
         assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was called when \"a\" key was released");
 
-        assert.strictEqual(keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback), keyInteraction,
+        assert.strictEqual(keyInteraction.offKeyRelease(A_KEY_CODE, aKeyCodeCallback), keyInteraction,
           "unsetting the keyRelease callback returns the interaction");
         aKeyCodeCallbackCalled = false;
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), A_KEY_CODE);
         assert.isFalse(aKeyCodeCallbackCalled, "callback for \"a\" was disconnected from the interaction");
 
-        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        keyInteraction.onKeyRelease(A_KEY_CODE, aKeyCodeCallback);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), A_KEY_CODE);
         assert.isTrue(aKeyCodeCallbackCalled, "callback for \"a\" was properly connected back to the interaction");
 
-        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback);
+        keyInteraction.offKeyRelease(A_KEY_CODE, aKeyCodeCallback);
         svg.remove();
       });
 
@@ -297,18 +295,18 @@ describe("Interactions", () => {
         let aKeyCodeCallback2Called = false;
         let aKeyCodeCallback2 = () => aKeyCodeCallback2Called = true;
 
-        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback1);
-        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback2);
+        keyInteraction.onKeyRelease(A_KEY_CODE, aKeyCodeCallback1);
+        keyInteraction.onKeyRelease(A_KEY_CODE, aKeyCodeCallback2);
         keyInteraction.attachTo(component);
 
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), A_KEY_CODE);
         assert.isTrue(aKeyCodeCallback1Called, "callback 1 for \"a\" was called when \"a\" key was released");
         assert.isTrue(aKeyCodeCallback2Called, "callback 2 for \"a\" was called when \"a\" key was released");
 
-        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback1);
-        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback2);
+        keyInteraction.offKeyRelease(A_KEY_CODE, aKeyCodeCallback1);
+        keyInteraction.offKeyRelease(A_KEY_CODE, aKeyCodeCallback2);
         svg.remove();
       });
 
@@ -318,20 +316,20 @@ describe("Interactions", () => {
         let aKeyCodeCallback2Called = false;
         let aKeyCodeCallback2 = () => aKeyCodeCallback2Called = true;
 
-        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback1);
-        keyInteraction.onKeyRelease(aKeyCode, aKeyCodeCallback2);
+        keyInteraction.onKeyRelease(A_KEY_CODE, aKeyCodeCallback1);
+        keyInteraction.onKeyRelease(A_KEY_CODE, aKeyCodeCallback2);
         keyInteraction.attachTo(component);
 
-        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback1);
+        keyInteraction.offKeyRelease(A_KEY_CODE, aKeyCodeCallback1);
         aKeyCodeCallback1Called = false;
         aKeyCodeCallback2Called = false;
         TestMethods.triggerFakeMouseEvent("mouseover", component.background(), 100, 100);
-        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), aKeyCode);
-        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), aKeyCode);
+        TestMethods.triggerFakeKeyboardEvent("keydown", component.background(), A_KEY_CODE);
+        TestMethods.triggerFakeKeyboardEvent("keyup", component.background(), A_KEY_CODE);
         assert.isFalse(aKeyCodeCallback1Called, "callback 1 for \"a\" was disconnected from the interaction");
         assert.isTrue(aKeyCodeCallback2Called, "callback 2 for \"a\" is still connected to the interaction");
 
-        keyInteraction.offKeyRelease(aKeyCode, aKeyCodeCallback2);
+        keyInteraction.offKeyRelease(A_KEY_CODE, aKeyCodeCallback2);
         svg.remove();
       });
     });


### PR DESCRIPTION
Part of #2628

I will be doing 2 passes because I will get more context (and better sense of best practices) by refactoring other files. However, please flag anything that seems unusual.

As part of this: 
- **Test semantics: hierarchy, naming, testing, but no coverage check**
- Applied best practices from the wiki page
- Factored out common code into `beforeEach()` clauses
- No nested `beforeEach()`es
- Cleaned the console
- Remade hierarchy as shown bellow
  ![screen shot 2015-09-11 at 12 35 35 pm](https://cloud.githubusercontent.com/assets/3248682/9824439/af75f15a-5881-11e5-9482-ee2b7fb7bcf0.png)
