### PR TITLE
[SelectionBoxLayer] - remove errors on getters

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -4640,9 +4640,6 @@ declare module Plottable {
             yScale<D extends number | {
                 valueOf(): number;
             }>(yScale: QuantitativeScale<D>): SelectionBoxLayer;
-            yExtent(): (number | {
-                valueOf(): number;
-            })[];
         }
     }
 }
@@ -4667,9 +4664,6 @@ declare module Plottable {
             xScale<D extends number | {
                 valueOf(): number;
             }>(xScale: QuantitativeScale<D>): SelectionBoxLayer;
-            xExtent(): (number | {
-                valueOf(): number;
-            })[];
         }
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -12255,12 +12255,9 @@ var Plottable;
             };
             XDragBoxLayer.prototype.yScale = function (yScale) {
                 if (yScale == null) {
-                    throw new Error("XDragBoxLayer has no yScale");
+                    return _super.prototype.yScale.call(this);
                 }
                 throw new Error("yScales cannot be set on an XDragBoxLayer");
-            };
-            XDragBoxLayer.prototype.yExtent = function () {
-                throw new Error("XDragBoxLayer has no yExtent");
             };
             return XDragBoxLayer;
         })(Components.DragBoxLayer);
@@ -12313,12 +12310,9 @@ var Plottable;
             };
             YDragBoxLayer.prototype.xScale = function (xScale) {
                 if (xScale == null) {
-                    throw new Error("YDragBoxLayer has no xScale");
+                    return _super.prototype.xScale.call(this);
                 }
                 throw new Error("xScales cannot be set on an YDragBoxLayer");
-            };
-            YDragBoxLayer.prototype.xExtent = function () {
-                throw new Error("YDragBoxLayer has no xExtent");
             };
             return YDragBoxLayer;
         })(Components.DragBoxLayer);

--- a/src/components/xDragBoxLayer.ts
+++ b/src/components/xDragBoxLayer.ts
@@ -40,15 +40,10 @@ export module Components {
     public yScale<D extends number | { valueOf(): number }>(yScale: QuantitativeScale<D>): SelectionBoxLayer;
     public yScale<D extends number | { valueOf(): number }>(yScale?: QuantitativeScale<D>): any {
       if (yScale == null) {
-        throw new Error("XDragBoxLayer has no yScale");
+        return super.yScale();
       }
       throw new Error("yScales cannot be set on an XDragBoxLayer");
     }
-
-    public yExtent(): (number | { valueOf(): number })[] {
-      throw new Error("XDragBoxLayer has no yExtent");
-    }
-
   }
 }
 }

--- a/src/components/yDragBoxLayer.ts
+++ b/src/components/yDragBoxLayer.ts
@@ -40,15 +40,10 @@ export module Components {
     public xScale<D extends number | { valueOf(): number }>(xScale: QuantitativeScale<D>): SelectionBoxLayer;
     public xScale<D extends number | { valueOf(): number }>(xScale?: QuantitativeScale<D>): any {
       if (xScale == null) {
-        throw new Error("YDragBoxLayer has no xScale");
+        return super.xScale();
       }
       throw new Error("xScales cannot be set on an YDragBoxLayer");
     }
-
-    public xExtent(): (number | { valueOf(): number })[] {
-      throw new Error("YDragBoxLayer has no xExtent");
-    }
-
   }
 }
 }

--- a/test/components/xDragBoxLayerTests.ts
+++ b/test/components/xDragBoxLayerTests.ts
@@ -88,18 +88,8 @@ describe("Layer Components", () => {
         svg.remove();
       });
 
-      it("throws error on getting y scale", () => {
-        assert.throws(() => dbl.yScale(), "no yScale");
-        svg.remove();
-      });
-
       it("throws error on setting y scale", () => {
         assert.throws(() => dbl.yScale(new Plottable.Scales.Linear()), "yScales cannot be set");
-        svg.remove();
-      });
-
-      it("throws error on getting y extent", () => {
-        assert.throws(() => dbl.yExtent(), "no yExtent");
         svg.remove();
       });
 

--- a/test/components/xDragBoxLayerTests.ts
+++ b/test/components/xDragBoxLayerTests.ts
@@ -88,8 +88,18 @@ describe("Layer Components", () => {
         svg.remove();
       });
 
+      it("does not error on getting y scale", () => {
+        assert.doesNotThrow(() => dbl.yScale(), Error, "getting yScale should not error");
+        svg.remove();
+      });
+
       it("throws error on setting y scale", () => {
         assert.throws(() => dbl.yScale(new Plottable.Scales.Linear()), "yScales cannot be set");
+        svg.remove();
+      });
+
+      it("does not error on getting y extent", () => {
+        assert.doesNotThrow(() => dbl.yExtent(), Error, "getting yExtent should not error");
         svg.remove();
       });
 

--- a/test/components/yDragBoxLayerTests.ts
+++ b/test/components/yDragBoxLayerTests.ts
@@ -88,18 +88,8 @@ describe("Layer Components", () => {
         svg.remove();
       });
 
-      it("throws error on getting x scale", () => {
-        assert.throws(() => dbl.xScale(), "no xScale");
-        svg.remove();
-      });
-
       it("throws error on setting x scale", () => {
         assert.throws(() => dbl.xScale(new Plottable.Scales.Linear()), "xScales cannot be set");
-        svg.remove();
-      });
-
-      it("throws error on getting x extent", () => {
-        assert.throws(() => dbl.xExtent(), "no xExtent");
         svg.remove();
       });
 

--- a/test/components/yDragBoxLayerTests.ts
+++ b/test/components/yDragBoxLayerTests.ts
@@ -88,8 +88,18 @@ describe("Layer Components", () => {
         svg.remove();
       });
 
+      it("does not error on getting x scale", () => {
+        assert.doesNotThrow(() => dbl.xScale(), Error, "getting xScale should not error");
+        svg.remove();
+      });
+
       it("throws error on setting x scale", () => {
         assert.throws(() => dbl.xScale(new Plottable.Scales.Linear()), "xScales cannot be set");
+        svg.remove();
+      });
+
+      it("does not error on getting x extent", () => {
+        assert.doesNotThrow(() => dbl.xExtent(), Error, "getting xExtent should not error");
         svg.remove();
       });
 


### PR DESCRIPTION
Having the getters on a class error can be incredibly disruptive, and so this pull request seeks to remove these from the appropriate getters.  This is disruptive since the variables in association with the getters are private, which means that if one just wants to query if the variable exists, then javascript would error.

This is highly relevant on classes like `SelectionBoxLayer`, which depending on the situation might want to query the `xScale()` or `yScale()` and then operate on it if it is not null.

Closes #2734 