### PR TITLE
Refactor key dispatcher tests - Pass 1

### DIFF
--- a/test/dispatchers/keyDispatcherTests.ts
+++ b/test/dispatchers/keyDispatcherTests.ts
@@ -35,7 +35,7 @@ describe("Dispatchers", () => {
         let keyDowned = false;
         let callback = () => keyDowned = true;
 
-        assert.strictEqual(keyDispatcher.onKeyDown(callback), keyDispatcher, "setting the keyDown callback returns the dispatcher");
+        keyDispatcher.onKeyDown(callback);
 
         TestMethods.triggerFakeKeyboardEvent("keydown", body, keyCodeToSend);
         assert.isTrue(keyDowned, "callback when a key was pressed");

--- a/test/dispatchers/keyDispatcherTests.ts
+++ b/test/dispatchers/keyDispatcherTests.ts
@@ -4,51 +4,57 @@ describe("Dispatchers", () => {
   describe("Key Dispatcher", () => {
 
     describe("Basic usage", () => {
-      it("triggers callback on keydown", () => {
-        let ked = Plottable.Dispatchers.Key.getDispatcher();
-        let keyCodeToSend = 65;
+      let keyCodeToSend: number;
+      let keyDispatcher: Plottable.Dispatchers.Key;
+
+      let body: d3.Selection<void>;
+
+      beforeEach(() => {
+        keyCodeToSend = 65;
+        keyDispatcher = Plottable.Dispatchers.Key.getDispatcher();
+        body = d3.select("body");
+      });
+
+      it("calls the onKeydown callback", () => {
         let keyDowned = false;
-        let body = d3.select("body");
-        let callback = (code: number, e: KeyboardEvent) => {
+        let callback = (code: number, event: KeyboardEvent) => {
           keyDowned = true;
           assert.strictEqual(code, keyCodeToSend, "correct keycode was passed");
-          assert.isNotNull(e, "key event was passed to the callback");
+          assert.isNotNull(event, "key event was passed to the callback");
         };
 
-        ked.onKeyDown(callback);
+        assert.strictEqual(keyDispatcher.onKeyDown(callback), keyDispatcher, "setting the keyDown callback returns the dispatcher");
 
         TestMethods.triggerFakeKeyboardEvent("keydown", body, keyCodeToSend);
         assert.isTrue(keyDowned, "callback when a key was pressed");
 
-        ked.offKeyDown(callback);
-
+        assert.strictEqual(keyDispatcher.offKeyDown(callback), keyDispatcher, "unsetting the keyDown callback returns the dispatcher");
         keyDowned = false;
+
         TestMethods.triggerFakeKeyboardEvent("keydown", body, keyCodeToSend);
         assert.isFalse(keyDowned, "nothing happens when a key was pressed");
       });
 
-      it("triggers callback on keyup", () => {
-        let ked = Plottable.Dispatchers.Key.getDispatcher();
-        let keyCodeToSend = 65;
+      it("calls the onKeyup callback", () => {
         let keyUped = false;
-        let body = d3.select("body");
-        let callback = (code: number, e: KeyboardEvent) => {
+        let callback = (code: number, event: KeyboardEvent) => {
           keyUped = true;
           assert.strictEqual(code, keyCodeToSend, "correct keycode was passed");
-          assert.isNotNull(e, "key event was passed to the callback");
+          assert.isNotNull(event, "key event was passed to the callback");
         };
 
-        ked.onKeyUp(callback);
+        assert.strictEqual(keyDispatcher.onKeyUp(callback), keyDispatcher, "setting the keyUp callback returns the dispatcher");
 
         TestMethods.triggerFakeKeyboardEvent("keyup", body, keyCodeToSend);
         assert.isTrue(keyUped, "callback when a key was release");
 
-        ked.offKeyUp(callback);
-
+        assert.strictEqual(keyDispatcher.offKeyUp(callback), keyDispatcher, "unsetting the keyUp callback returns the dispatcher");
         keyUped = false;
+
         TestMethods.triggerFakeKeyboardEvent("keyup", body, keyCodeToSend);
         assert.isFalse(keyUped, "nothing happens when a key was release");
       });
     });
+
   });
 });

--- a/test/dispatchers/keyDispatcherTests.ts
+++ b/test/dispatchers/keyDispatcherTests.ts
@@ -15,7 +15,7 @@ describe("Dispatchers", () => {
         body = d3.select("body");
       });
 
-      it("calls the onKeydown callback", () => {
+      it("calls the keydown callback", () => {
         let keyDowned = false;
         let callback = (code: number, event: KeyboardEvent) => {
           keyDowned = true;
@@ -28,14 +28,26 @@ describe("Dispatchers", () => {
         TestMethods.triggerFakeKeyboardEvent("keydown", body, keyCodeToSend);
         assert.isTrue(keyDowned, "callback when a key was pressed");
 
-        assert.strictEqual(keyDispatcher.offKeyDown(callback), keyDispatcher, "unsetting the keyDown callback returns the dispatcher");
-        keyDowned = false;
+        keyDispatcher.offKeyDown(callback);
+      });
 
+      it("can remove keydown listener", () => {
+        let keyDowned = false;
+        let callback = () => keyDowned = true;
+
+        assert.strictEqual(keyDispatcher.onKeyDown(callback), keyDispatcher, "setting the keyDown callback returns the dispatcher");
+
+        TestMethods.triggerFakeKeyboardEvent("keydown", body, keyCodeToSend);
+        assert.isTrue(keyDowned, "callback when a key was pressed");
+
+        assert.strictEqual(keyDispatcher.offKeyDown(callback), keyDispatcher, "unsetting the keyDown callback returns the dispatcher");
+
+        keyDowned = false;
         TestMethods.triggerFakeKeyboardEvent("keydown", body, keyCodeToSend);
         assert.isFalse(keyDowned, "nothing happens when a key was pressed");
       });
 
-      it("calls the onKeyup callback", () => {
+      it("calls the keyup callback", () => {
         let keyUped = false;
         let callback = (code: number, event: KeyboardEvent) => {
           keyUped = true;
@@ -46,13 +58,25 @@ describe("Dispatchers", () => {
         assert.strictEqual(keyDispatcher.onKeyUp(callback), keyDispatcher, "setting the keyUp callback returns the dispatcher");
 
         TestMethods.triggerFakeKeyboardEvent("keyup", body, keyCodeToSend);
-        assert.isTrue(keyUped, "callback when a key was release");
+        assert.isTrue(keyUped, "callback when a key was released");
 
-        assert.strictEqual(keyDispatcher.offKeyUp(callback), keyDispatcher, "unsetting the keyUp callback returns the dispatcher");
-        keyUped = false;
+        keyDispatcher.offKeyUp(callback);
+      });
+
+      it("can remove keyup listener", () => {
+        let keyUped = false;
+        let callback = () => keyUped = true;
+
+        keyDispatcher.onKeyUp(callback);
 
         TestMethods.triggerFakeKeyboardEvent("keyup", body, keyCodeToSend);
-        assert.isFalse(keyUped, "nothing happens when a key was release");
+        assert.isTrue(keyUped, "callback when a key was released");
+
+        assert.strictEqual(keyDispatcher.offKeyUp(callback), keyDispatcher, "unsetting the keyup callback returns the dispatcher");
+
+        keyUped = false;
+        TestMethods.triggerFakeKeyboardEvent("keyup", body, keyCodeToSend);
+        assert.isFalse(keyUped, "nothing happens when a key was released");
       });
     });
 

--- a/test/dispatchers/keyDispatcherTests.ts
+++ b/test/dispatchers/keyDispatcherTests.ts
@@ -15,7 +15,7 @@ describe("Dispatchers", () => {
         body = d3.select("body");
       });
 
-      it("calls the keydown callback", () => {
+      it("can set a callback to be called when a key is pressed down", () => {
         let keyDowned = false;
         let callback = (code: number, event: KeyboardEvent) => {
           keyDowned = true;
@@ -31,7 +31,7 @@ describe("Dispatchers", () => {
         keyDispatcher.offKeyDown(callback);
       });
 
-      it("can remove keydown listener", () => {
+      it("can remove the keydown listener", () => {
         let keyDowned = false;
         let callback = () => keyDowned = true;
 
@@ -47,7 +47,7 @@ describe("Dispatchers", () => {
         assert.isFalse(keyDowned, "nothing happens when a key was pressed");
       });
 
-      it("calls the keyup callback", () => {
+      it("can set a callback to be called when the key is released", () => {
         let keyUped = false;
         let callback = (code: number, event: KeyboardEvent) => {
           keyUped = true;
@@ -63,7 +63,7 @@ describe("Dispatchers", () => {
         keyDispatcher.offKeyUp(callback);
       });
 
-      it("can remove keyup listener", () => {
+      it("can remove the keyup listener", () => {
         let keyUped = false;
         let callback = () => keyUped = true;
 

--- a/test/dispatchers/keyDispatcherTests.ts
+++ b/test/dispatchers/keyDispatcherTests.ts
@@ -2,50 +2,53 @@
 
 describe("Dispatchers", () => {
   describe("Key Dispatcher", () => {
-    it("triggers callback on keydown", () => {
-      let ked = Plottable.Dispatchers.Key.getDispatcher();
-      let keyCodeToSend = 65;
-      let keyDowned = false;
-      let body = d3.select("body");
-      let callback = (code: number, e: KeyboardEvent) => {
-        keyDowned = true;
-        assert.strictEqual(code, keyCodeToSend, "correct keycode was passed");
-        assert.isNotNull(e, "key event was passed to the callback");
-      };
 
-      ked.onKeyDown(callback);
+    describe("Basic usage", () => {
+      it("triggers callback on keydown", () => {
+        let ked = Plottable.Dispatchers.Key.getDispatcher();
+        let keyCodeToSend = 65;
+        let keyDowned = false;
+        let body = d3.select("body");
+        let callback = (code: number, e: KeyboardEvent) => {
+          keyDowned = true;
+          assert.strictEqual(code, keyCodeToSend, "correct keycode was passed");
+          assert.isNotNull(e, "key event was passed to the callback");
+        };
 
-      TestMethods.triggerFakeKeyboardEvent("keydown", body, keyCodeToSend);
-      assert.isTrue(keyDowned, "callback when a key was pressed");
+        ked.onKeyDown(callback);
 
-      ked.offKeyDown(callback);
+        TestMethods.triggerFakeKeyboardEvent("keydown", body, keyCodeToSend);
+        assert.isTrue(keyDowned, "callback when a key was pressed");
 
-      keyDowned = false;
-      TestMethods.triggerFakeKeyboardEvent("keydown", body, keyCodeToSend);
-      assert.isFalse(keyDowned, "nothing happens when a key was pressed");
-    });
+        ked.offKeyDown(callback);
 
-    it("triggers callback on keyup", () => {
-      let ked = Plottable.Dispatchers.Key.getDispatcher();
-      let keyCodeToSend = 65;
-      let keyUped = false;
-      let body = d3.select("body");
-      let callback = (code: number, e: KeyboardEvent) => {
-        keyUped = true;
-        assert.strictEqual(code, keyCodeToSend, "correct keycode was passed");
-        assert.isNotNull(e, "key event was passed to the callback");
-      };
+        keyDowned = false;
+        TestMethods.triggerFakeKeyboardEvent("keydown", body, keyCodeToSend);
+        assert.isFalse(keyDowned, "nothing happens when a key was pressed");
+      });
 
-      ked.onKeyUp(callback);
+      it("triggers callback on keyup", () => {
+        let ked = Plottable.Dispatchers.Key.getDispatcher();
+        let keyCodeToSend = 65;
+        let keyUped = false;
+        let body = d3.select("body");
+        let callback = (code: number, e: KeyboardEvent) => {
+          keyUped = true;
+          assert.strictEqual(code, keyCodeToSend, "correct keycode was passed");
+          assert.isNotNull(e, "key event was passed to the callback");
+        };
 
-      TestMethods.triggerFakeKeyboardEvent("keyup", body, keyCodeToSend);
-      assert.isTrue(keyUped, "callback when a key was release");
+        ked.onKeyUp(callback);
 
-      ked.offKeyUp(callback);
+        TestMethods.triggerFakeKeyboardEvent("keyup", body, keyCodeToSend);
+        assert.isTrue(keyUped, "callback when a key was release");
 
-      keyUped = false;
-      TestMethods.triggerFakeKeyboardEvent("keyup", body, keyCodeToSend);
-      assert.isFalse(keyUped, "nothing happens when a key was release");
+        ked.offKeyUp(callback);
+
+        keyUped = false;
+        TestMethods.triggerFakeKeyboardEvent("keyup", body, keyCodeToSend);
+        assert.isFalse(keyUped, "nothing happens when a key was release");
+      });
     });
   });
 });


### PR DESCRIPTION
Part of #2628

I will be doing 2 passes because I will get more context (and better sense of best practices) by refactoring other files. However, please flag anything that seems unusual.

As part of this: 
- **Test semantics: hierarchy, naming, testing, but no coverage check**
- Applied best practices from the wiki page
- Factored out common code into `beforeEach()` clauses
- No nested `beforeEach()`es
- Cleaned the console
- Remade hierarchy as shown bellow

![screen shot 2015-09-11 at 4 42 34 pm](https://cloud.githubusercontent.com/assets/3248682/9828563/304add1e-58a4-11e5-8c78-d8c17c7b85df.png)
