### PR TITLE
Updating scale should auto domain

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -6789,25 +6789,27 @@ var Plottable;
             return this;
         };
         Plot.prototype._bindProperty = function (property, value, scale) {
-            var _this = this;
-            var updateExtentsForKey = function () { return _this._updateExtentsForProperty(property); };
-            this._bind(property, value, scale, this._propertyBindings, this._propertyExtents, updateExtentsForKey);
-        };
-        Plot.prototype._bindAttr = function (attr, value, scale) {
-            var _this = this;
-            var updateExtentsForKey = function () { return _this._updateExtentsForAttr(attr); };
-            this._bind(attr, value, scale, this._attrBindings, this._attrExtents, updateExtentsForKey);
-        };
-        Plot.prototype._bind = function (key, value, scale, bindings, extents, updateExtentsForKey) {
-            var binding = bindings.get(key);
+            var binding = this._propertyBindings.get(property);
             var oldScale = binding != null ? binding.scale : null;
-            bindings.set(key, { accessor: d3.functor(value), scale: scale });
-            updateExtentsForKey(key);
+            this._propertyBindings.set(property, { accessor: d3.functor(value), scale: scale });
+            this._updateExtentsForProperty(property);
             if (oldScale != null) {
-                this._uninstallScaleForKey(oldScale, key);
+                this._uninstallScaleForKey(oldScale, property);
             }
             if (scale != null) {
-                this._installScaleForKey(scale, key);
+                this._installScaleForKey(scale, property);
+            }
+        };
+        Plot.prototype._bindAttr = function (attr, value, scale) {
+            var binding = this._attrBindings.get(attr);
+            var oldScale = binding != null ? binding.scale : null;
+            this._attrBindings.set(attr, { accessor: d3.functor(value), scale: scale });
+            this._updateExtentsForAttr(attr);
+            if (oldScale != null) {
+                this._uninstallScaleForKey(oldScale, attr);
+            }
+            if (scale != null) {
+                this._installScaleForKey(scale, attr);
             }
         };
         Plot.prototype._generateAttrToProjector = function () {

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -155,19 +155,23 @@ export class Plot extends Component {
   }
 
   protected _bindProperty(property: string, value: any, scale: Scale<any, any>) {
-    this._bind(property, value, scale, this._propertyBindings, this._propertyExtents);
-    this._updateExtentsForProperty(property);
+    let updateExtentsForKey = () => this._updateExtentsForProperty(property);
+    this._bind(property, value, scale, this._propertyBindings, this._propertyExtents, updateExtentsForKey);
   }
 
   private _bindAttr(attr: string, value: any, scale: Scale<any, any>) {
-    this._bind(attr, value, scale, this._attrBindings, this._attrExtents);
-    this._updateExtentsForAttr(attr);
+    let updateExtentsForKey = () => this._updateExtentsForAttr(attr);
+    this._bind(attr, value, scale, this._attrBindings, this._attrExtents, updateExtentsForKey);
   }
 
   private _bind(key: string, value: any, scale: Scale<any, any>,
-                    bindings: d3.Map<Plots.AccessorScaleBinding<any, any>>, extents: d3.Map<any[]>) {
+                bindings: d3.Map<Plots.AccessorScaleBinding<any, any>>, extents: d3.Map<any[]>,
+                updateExtentsForKey: (key: string) => void) {
     let binding = bindings.get(key);
     let oldScale = binding != null ? binding.scale : null;
+
+    bindings.set(key, { accessor: d3.functor(value), scale: scale });
+    updateExtentsForKey(key);
 
     if (oldScale != null) {
       this._uninstallScaleForKey(oldScale, key);
@@ -175,8 +179,6 @@ export class Plot extends Component {
     if (scale != null) {
       this._installScaleForKey(scale, key);
     }
-
-    bindings.set(key, { accessor: d3.functor(value), scale: scale });
   }
 
   protected _generateAttrToProjector(): AttributeToProjector {

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -155,29 +155,32 @@ export class Plot extends Component {
   }
 
   protected _bindProperty(property: string, value: any, scale: Scale<any, any>) {
-    let updateExtentsForKey = () => this._updateExtentsForProperty(property);
-    this._bind(property, value, scale, this._propertyBindings, this._propertyExtents, updateExtentsForKey);
+    let binding = this._propertyBindings.get(property);
+    let oldScale = binding != null ? binding.scale : null;
+
+    this._propertyBindings.set(property, { accessor: d3.functor(value), scale: scale });
+    this._updateExtentsForProperty(property);
+
+    if (oldScale != null) {
+      this._uninstallScaleForKey(oldScale, property);
+    }
+    if (scale != null) {
+      this._installScaleForKey(scale, property);
+    }
   }
 
   private _bindAttr(attr: string, value: any, scale: Scale<any, any>) {
-    let updateExtentsForKey = () => this._updateExtentsForAttr(attr);
-    this._bind(attr, value, scale, this._attrBindings, this._attrExtents, updateExtentsForKey);
-  }
-
-  private _bind(key: string, value: any, scale: Scale<any, any>,
-                bindings: d3.Map<Plots.AccessorScaleBinding<any, any>>, extents: d3.Map<any[]>,
-                updateExtentsForKey: (key: string) => void) {
-    let binding = bindings.get(key);
+    let binding = this._attrBindings.get(attr);
     let oldScale = binding != null ? binding.scale : null;
 
-    bindings.set(key, { accessor: d3.functor(value), scale: scale });
-    updateExtentsForKey(key);
+    this._attrBindings.set(attr, { accessor: d3.functor(value), scale: scale });
+    this._updateExtentsForAttr(attr);
 
     if (oldScale != null) {
-      this._uninstallScaleForKey(oldScale, key);
+      this._uninstallScaleForKey(oldScale, attr);
     }
     if (scale != null) {
-      this._installScaleForKey(scale, key);
+      this._installScaleForKey(scale, attr);
     }
   }
 

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -148,7 +148,13 @@ export class XYPlot<X, Y> extends Plot {
     if (x == null) {
       return this._propertyBindings.get(XYPlot._X_KEY);
     }
+
     this._bindProperty(XYPlot._X_KEY, x, xScale);
+
+    let width = this.width();
+    if (xScale != null && width != null) {
+      xScale.range([0, width]);
+    }
     if (this._autoAdjustYScaleDomain) {
       this._updateYExtentsAndAutodomain();
     }
@@ -183,6 +189,15 @@ export class XYPlot<X, Y> extends Plot {
     }
 
     this._bindProperty(XYPlot._Y_KEY, y, yScale);
+
+    let height = this.height();
+    if (yScale != null && height != null) {
+      if (yScale instanceof Scales.Category) {
+        yScale.range([0, height]);
+      } else {
+        yScale.range([height, 0]);
+      }
+    }
     if (this._autoAdjustXScaleDomain) {
       this._updateXExtentsAndAutodomain();
     }
@@ -296,10 +311,10 @@ export class XYPlot<X, Y> extends Plot {
     let yBinding = this.y();
     let yScale = yBinding && yBinding.scale;
     if (yScale != null) {
-      if (this.y().scale instanceof Scales.Category) {
-        this.y().scale.range([0, this.height()]);
+      if (yScale instanceof Scales.Category) {
+        yScale.range([0, this.height()]);
       } else {
-        this.y().scale.range([this.height(), 0]);
+        yScale.range([this.height(), 0]);
       }
     }
     return this;

--- a/test/plots/plotTests.ts
+++ b/test/plots/plotTests.ts
@@ -133,7 +133,7 @@ describe("Plots", () => {
 
     });
 
-    it("sets the scale domain automatically", () => {
+    it("sets the domain automatically when attaching a Scale to an attr", () => {
       let dataset = new Plottable.Dataset([{x: 5}, {x: 10}]);
       let plot = new Plottable.Plot();
       let svg = TestMethods.generateSVG();

--- a/test/plots/plotTests.ts
+++ b/test/plots/plotTests.ts
@@ -134,22 +134,22 @@ describe("Plots", () => {
     });
 
     it("sets the domain automatically when attaching a Scale to an attr", () => {
-      let dataset = new Plottable.Dataset([{x: 5}, {x: 10}]);
+      let xMin = 5;
+      let xMax = 10;
+      let dataset = new Plottable.Dataset([{x: xMin}, {x: xMax}]);
       let plot = new Plottable.Plot();
       let svg = TestMethods.generateSVG();
       (<any> plot)._createDrawer = (dataset: Plottable.Dataset) => createMockDrawer(dataset);
       plot.addDataset(dataset);
 
-      let scale = new Plottable.Scales.Linear();
-      let defaultDomain = [0, 1];
+      let scale = new Plottable.Scales.Linear().padProportion(0).snappingDomainEnabled(false);
 
       plot.attr("x", (d) => d.x);
       plot.attr("y", (d) => 1);
       plot.renderTo(svg);
-      assert.deepEqual(scale.domain(), defaultDomain, "scale domain scale is same as default");
 
       plot.attr("x", (d) => d.x, scale);
-      assert.deepEqual(scale.domain(), [4.5, 10.5], "scale domain scale is auto updated");
+      assert.deepEqual(scale.domain(), [xMin, xMax], "scale domain scale is auto updated");
       svg.remove();
     });
 

--- a/test/plots/plotTests.ts
+++ b/test/plots/plotTests.ts
@@ -133,6 +133,26 @@ describe("Plots", () => {
 
     });
 
+    it("sets the scale domain automatically", () => {
+      let dataset = new Plottable.Dataset([{x: 5}, {x: 10}]);
+      let plot = new Plottable.Plot();
+      let svg = TestMethods.generateSVG();
+      (<any> plot)._createDrawer = (dataset: Plottable.Dataset) => createMockDrawer(dataset);
+      plot.addDataset(dataset);
+
+      let scale = new Plottable.Scales.Linear();
+      let defaultDomain = [0, 1];
+
+      plot.attr("x", (d) => d.x);
+      plot.attr("y", (d) => 1);
+      plot.renderTo(svg);
+      assert.deepEqual(scale.domain(), defaultDomain, "scale domain scale is same as default");
+
+      plot.attr("x", (d) => d.x, scale);
+      assert.deepEqual(scale.domain(), [4.5, 10.5], "scale domain scale is auto updated");
+      svg.remove();
+    });
+
     it("Plot.project works as intended", () => {
       let r = new Plottable.Plot();
       (<any> r)._createDrawer = (dataset: Plottable.Dataset) => createMockDrawer(dataset);

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -128,15 +128,15 @@ describe("Plots", () => {
       });
     });
 
-    describe("Automatic domain and range adjustmnet", () => {
-      const SVG_HEIGHT = 400;
-      const SVG_WIDTH = 400;
+    describe("Automatic domain and range adjustment for X and Y Scales", () => {
+      let SVG_HEIGHT = 400;
+      let SVG_WIDTH = 400;
       let svg: d3.Selection<void>;
       let xScale: Plottable.Scales.Linear;
       let yScale: Plottable.Scales.Linear;
       let plot: Plottable.XYPlot<number, number>;
       let dataset: Plottable.Dataset;
-      let defalutInterval = [0, 1];
+      let defaultInterval = [0, 1];
 
       beforeEach(() => {
         svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
@@ -156,29 +156,22 @@ describe("Plots", () => {
       it("automatically adjusts domain and range after rendering to DOM", () => {
         plot.x((d: any) => d.a, xScale)
             .y((d: any) => d.b, yScale);
-        assert.deepEqual(xScale.domain(), defalutInterval, "X domain has not been set automatically");
-        assert.deepEqual(xScale.range(), defalutInterval, "X range has not been set automatically");
-        assert.deepEqual(yScale.domain(), defalutInterval, "Y domain has not been set automatically");
-        assert.deepEqual(yScale.range(), defalutInterval, "Y range has not been set automatically");
+        assert.deepEqual(xScale.domain(), defaultInterval, "X domain is not changed before rendering");
+        assert.deepEqual(xScale.range(), defaultInterval, "X range is not changed before rendering");
+        assert.deepEqual(yScale.domain(), defaultInterval, "Y domain is not changed before rendering");
+        assert.deepEqual(yScale.range(), defaultInterval, "Y range is not changed before rendering");
 
         plot.renderTo(svg);
-        assert.deepEqual(xScale.domain(), [-7, 7], "X domain has been set automatically");
-        assert.deepEqual(xScale.range(), [0, SVG_WIDTH], "X range has been set automatically");
-        assert.deepEqual(yScale.domain(), [-7, 7], "Y domain has been set automatically");
-        assert.deepEqual(yScale.range(), [SVG_HEIGHT, 0], "Y range has been set automatically");
+        assert.deepEqual(xScale.domain(), [-7, 7], "X domain has been set automatically after rendering");
+        assert.deepEqual(xScale.range(), [0, SVG_WIDTH], "X range has been set automatically after rendering");
+        assert.deepEqual(yScale.domain(), [-7, 7], "Y domain has been set automatically after rendering");
+        assert.deepEqual(yScale.range(), [SVG_HEIGHT, 0], "Y range has been set automatically after rendering");
         svg.remove();
       });
 
       it("automatically adjusts range when a Scale is attached after rendering", () => {
-        (<any> window).scale1 = xScale;
-        (<any> window).scale2 = yScale;
         plot.x((d: any) => d.a)
             .y((d: any) => d.b);
-
-        assert.deepEqual(xScale.domain(), defalutInterval, "X domain has not been set automatically");
-        assert.deepEqual(xScale.range(), defalutInterval, "X range has not been set automatically");
-        assert.deepEqual(yScale.domain(), defalutInterval, "Y domain has not been set automatically");
-        assert.deepEqual(yScale.range(), defalutInterval, "Y range has not been set automatically");
 
         plot.renderTo(svg);
         plot.x((d: any) => d.a, xScale)

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -128,6 +128,70 @@ describe("Plots", () => {
       });
     });
 
+    describe("Automatic domain and range adjustmnet", () => {
+      const SVG_HEIGHT = 400;
+      const SVG_WIDTH = 400;
+      let svg: d3.Selection<void>;
+      let xScale: Plottable.Scales.Linear;
+      let yScale: Plottable.Scales.Linear;
+      let plot: Plottable.XYPlot<number, number>;
+      let dataset: Plottable.Dataset;
+      let defalutInterval = [0, 1];
+
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        xScale = new Plottable.Scales.Linear();
+        yScale = new Plottable.Scales.Linear();
+        dataset = new Plottable.Dataset([
+          { a: -6, b: 6 },
+          { a: -2, b: 2 },
+          { a: 2, b: -2 },
+          { a: 6, b: -6 }
+        ]);
+        plot = new Plottable.XYPlot<number, number>();
+        (<any> plot)._createDrawer = (dataset: Plottable.Dataset) => createMockDrawer(dataset);
+        plot.addDataset(dataset);
+      });
+
+      it("automatically adjusts domain and range after rendering to DOM", () => {
+        plot.x((d: any) => d.a, xScale)
+            .y((d: any) => d.b, yScale);
+        assert.deepEqual(xScale.domain(), defalutInterval, "X domain has not been set automatically");
+        assert.deepEqual(xScale.range(), defalutInterval, "X range has not been set automatically");
+        assert.deepEqual(yScale.domain(), defalutInterval, "Y domain has not been set automatically");
+        assert.deepEqual(yScale.range(), defalutInterval, "Y range has not been set automatically");
+
+        plot.renderTo(svg);
+        assert.deepEqual(xScale.domain(), [-7, 7], "X domain has been set automatically");
+        assert.deepEqual(xScale.range(), [0, SVG_WIDTH], "X range has been set automatically");
+        assert.deepEqual(yScale.domain(), [-7, 7], "Y domain has been set automatically");
+        assert.deepEqual(yScale.range(), [SVG_HEIGHT, 0], "Y range has been set automatically");
+        svg.remove();
+      });
+
+      it("automatically adjusts range when a Scale is attached after rendering", () => {
+        (<any> window).scale1 = xScale;
+        (<any> window).scale2 = yScale;
+        plot.x((d: any) => d.a)
+            .y((d: any) => d.b);
+
+        assert.deepEqual(xScale.domain(), defalutInterval, "X domain has not been set automatically");
+        assert.deepEqual(xScale.range(), defalutInterval, "X range has not been set automatically");
+        assert.deepEqual(yScale.domain(), defalutInterval, "Y domain has not been set automatically");
+        assert.deepEqual(yScale.range(), defalutInterval, "Y range has not been set automatically");
+
+        plot.renderTo(svg);
+        plot.x((d: any) => d.a, xScale)
+            .y((d: any) => d.b, yScale);
+
+        assert.deepEqual(xScale.domain(), [-7, 7], "X domain has been set automatically");
+        assert.deepEqual(xScale.range(), [0, SVG_WIDTH], "X range has been set automatically");
+        assert.deepEqual(yScale.domain(), [-7, 7], "Y domain has been set automatically");
+        assert.deepEqual(yScale.range(), [SVG_HEIGHT, 0], "Y range has been set automatically");
+        svg.remove();
+      });
+    });
+
     describe("Deferred Rendering", () => {
       let svg: d3.Selection<void>;
       let xScale: Plottable.Scales.Linear;


### PR DESCRIPTION
fix auto-domaining of scale on bind for Plots.Plot
auto-range scale on set for Plots.XYPlot
#2396

before: http://jsfiddle.net/x7x05L4k/
after: http://jsfiddle.net/x7x05L4k/1/