### PR TITLE
Change name of arguments in siSuffix and general function in Formatter

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -654,10 +654,10 @@ declare module Plottable {
          */
         function percentage(precision?: number): (d: any) => string;
         /**
-         * Creates a formatter for values that displays [precision] significant figures
+         * Creates a formatter for values that displays [numberOfSignificantFigures] significant figures
          * and puts SI notation.
          *
-         * @param {number} [precision] The number of significant figures to show (default 3).
+         * @param {number} [numberOfSignificantFigures] The number of significant figures to show (default 3).
          *
          * @returns {Formatter} A formatter for SI values.
          */

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -631,13 +631,13 @@ declare module Plottable {
         function fixed(precision?: number): (d: any) => string;
         /**
          * Creates a formatter that formats numbers to show no more than
-         * [precision] decimal places. All other values are stringified.
+         * [maxNumberOfDecimalPlaces] decimal places. All other values are stringified.
          *
-         * @param {number} [precision] The number of decimal places to show (default 3).
+         * @param {number} [maxNumberOfDecimalPlaces] The number of decimal places to show (default 3).
          *
          * @returns {Formatter} A formatter for general values.
          */
-        function general(precision?: number): (d: any) => string;
+        function general(maxNumberOfDecimalPlaces?: number): (d: any) => string;
         /**
          * Creates a formatter that stringifies its input.
          *
@@ -661,7 +661,7 @@ declare module Plottable {
          *
          * @returns {Formatter} A formatter for SI values.
          */
-        function siSuffix(precision?: number): (d: any) => string;
+        function siSuffix(numberOfSignificantFigures?: number): (d: any) => string;
         /**
          * Creates a formatter for values that displays abbreviated values
          * and uses standard short scale suffixes

--- a/plottable.js
+++ b/plottable.js
@@ -1,5 +1,5 @@
 /*!
-Plottable 1.11.0 (https://github.com/palantir/plottable)
+Plottable 1.10.0 (https://github.com/palantir/plottable)
 Copyright 2014-2015 Palantir Technologies
 Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
 */
@@ -909,7 +909,7 @@ var Plottable;
 ///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
-    Plottable.version = "1.11.0";
+    Plottable.version = "1.10.0";
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
@@ -1203,18 +1203,18 @@ var Plottable;
         Formatters.fixed = fixed;
         /**
          * Creates a formatter that formats numbers to show no more than
-         * [precision] decimal places. All other values are stringified.
+         * [maxNumberOfDecimalPlaces] decimal places. All other values are stringified.
          *
-         * @param {number} [precision] The number of decimal places to show (default 3).
+         * @param {number} [maxNumberOfDecimalPlaces] The number of decimal places to show (default 3).
          *
          * @returns {Formatter} A formatter for general values.
          */
-        function general(precision) {
-            if (precision === void 0) { precision = 3; }
-            verifyPrecision(precision);
+        function general(maxNumberOfDecimalPlaces) {
+            if (maxNumberOfDecimalPlaces === void 0) { maxNumberOfDecimalPlaces = 3; }
+            verifyPrecision(maxNumberOfDecimalPlaces);
             return function (d) {
                 if (typeof d === "number") {
-                    var multiplier = Math.pow(10, precision);
+                    var multiplier = Math.pow(10, maxNumberOfDecimalPlaces);
                     return String(Math.round(d * multiplier) / multiplier);
                 }
                 else {
@@ -1261,10 +1261,10 @@ var Plottable;
          *
          * @returns {Formatter} A formatter for SI values.
          */
-        function siSuffix(precision) {
-            if (precision === void 0) { precision = 3; }
-            verifyPrecision(precision);
-            return function (d) { return d3.format("." + precision + "s")(d); };
+        function siSuffix(numberOfSignificantFigures) {
+            if (numberOfSignificantFigures === void 0) { numberOfSignificantFigures = 3; }
+            verifyPrecision(numberOfSignificantFigures);
+            return function (d) { return d3.format("." + numberOfSignificantFigures + "s")(d); };
         }
         Formatters.siSuffix = siSuffix;
         /**

--- a/plottable.js
+++ b/plottable.js
@@ -1,5 +1,5 @@
 /*!
-Plottable 1.11.0 (https://github.com/palantir/plottable)
+Plottable 1.10.0 (https://github.com/palantir/plottable)
 Copyright 2014-2015 Palantir Technologies
 Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
 */
@@ -909,7 +909,7 @@ var Plottable;
 ///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
-    Plottable.version = "1.11.0";
+    Plottable.version = "1.10.0";
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
@@ -1254,10 +1254,10 @@ var Plottable;
         }
         Formatters.percentage = percentage;
         /**
-         * Creates a formatter for values that displays [precision] significant figures
+         * Creates a formatter for values that displays [numberOfSignificantFigures] significant figures
          * and puts SI notation.
          *
-         * @param {number} [precision] The number of significant figures to show (default 3).
+         * @param {number} [numberOfSignificantFigures] The number of significant figures to show (default 3).
          *
          * @returns {Formatter} A formatter for SI values.
          */

--- a/plottable.js
+++ b/plottable.js
@@ -1,5 +1,5 @@
 /*!
-Plottable 1.10.0 (https://github.com/palantir/plottable)
+Plottable 1.11.0 (https://github.com/palantir/plottable)
 Copyright 2014-2015 Palantir Technologies
 Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
 */
@@ -909,7 +909,7 @@ var Plottable;
 ///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
-    Plottable.version = "1.10.0";
+    Plottable.version = "1.11.0";
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -64,17 +64,17 @@ export module Formatters {
 
   /**
    * Creates a formatter that formats numbers to show no more than
-   * [precision] decimal places. All other values are stringified.
+   * [maxNumberOfDecimalPlaces] decimal places. All other values are stringified.
    *
-   * @param {number} [precision] The number of decimal places to show (default 3).
+   * @param {number} [maxNumberOfDecimalPlaces] The number of decimal places to show (default 3).
    *
    * @returns {Formatter} A formatter for general values.
    */
-  export function general(precision = 3) {
-    verifyPrecision(precision);
+  export function general(maxNumberOfDecimalPlaces = 3) {
+    verifyPrecision(maxNumberOfDecimalPlaces);
     return (d: any) => {
       if (typeof d === "number") {
-        let multiplier = Math.pow(10, precision);
+        let multiplier = Math.pow(10, maxNumberOfDecimalPlaces);
         return String(Math.round(d * multiplier) / multiplier);
       } else {
         return String(d);
@@ -121,9 +121,9 @@ export module Formatters {
    *
    * @returns {Formatter} A formatter for SI values.
    */
-  export function siSuffix(precision = 3) {
-    verifyPrecision(precision);
-    return (d: any) => d3.format("." + precision + "s")(d);
+  export function siSuffix(numberOfSignificantFigures = 3) {
+    verifyPrecision(numberOfSignificantFigures);
+    return (d: any) => d3.format("." + numberOfSignificantFigures + "s")(d);
   }
 
   /**

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -114,10 +114,10 @@ export module Formatters {
   }
 
   /**
-   * Creates a formatter for values that displays [precision] significant figures
+   * Creates a formatter for values that displays [numberOfSignificantFigures] significant figures
    * and puts SI notation.
    *
-   * @param {number} [precision] The number of significant figures to show (default 3).
+   * @param {number} [numberOfSignificantFigures] The number of significant figures to show (default 3).
    *
    * @returns {Formatter} A formatter for SI values.
    */


### PR DESCRIPTION
**Issue**
The argument `precision` in `Formatter.siSuffix` and `Formatter.general` is not clear.

**Fix** 
In `siSuffix`, `precision` is change to `maxNumberOfDecimalPlaces`
In `general`, `precision` is change to `numberOfSignificantFigures`.

close #2594