### PR TITLE
clipPath now updates on render

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -6463,6 +6463,7 @@ var Plottable;
                 this._bindBoxDataValues();
             };
             SelectionBoxLayer.prototype.renderImmediately = function () {
+                _super.prototype.renderImmediately.call(this);
                 if (this._boxVisible) {
                     var t = this._boxBounds.topLeft.y;
                     var b = this._boxBounds.bottomRight.y;

--- a/plottable.js
+++ b/plottable.js
@@ -3165,7 +3165,7 @@ var Plottable;
          * Renders the Component without waiting for the next frame.
          */
         Component.prototype.renderImmediately = function () {
-            if (this._clipPathEnabled && this._updateClipPath != null) {
+            if (this._clipPathEnabled) {
                 this._updateClipPath();
             }
             return this;
@@ -3263,19 +3263,18 @@ var Plottable;
             return box;
         };
         Component.prototype._generateClipPath = function () {
-            var _this = this;
             // The clip path will prevent content from overflowing its Component space.
-            var clipPathId = Plottable.Utils.DOM.generateUniqueClipPathId();
-            var clipPathParent = this._boxContainer.append("clipPath").attr("id", clipPathId);
+            this._clipPathID = Plottable.Utils.DOM.generateUniqueClipPathId();
+            var clipPathParent = this._boxContainer.append("clipPath").attr("id", this._clipPathID);
             this._addBox("clip-rect", clipPathParent);
-            this._updateClipPath = function () {
-                // HACKHACK: IE <= 9 does not respect the HTML base element in SVG.
-                // They don't need the current URL in the clip path reference.
-                var prefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
-                prefix = prefix.split("#")[0]; // To fix cases where an anchor tag was used
-                _this._element.attr("clip-path", "url(\"" + prefix + "#" + clipPathId + "\")");
-            };
             this._updateClipPath();
+        };
+        Component.prototype._updateClipPath = function () {
+            // HACKHACK: IE <= 9 does not respect the HTML base element in SVG.
+            // They don't need the current URL in the clip path reference.
+            var prefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
+            prefix = prefix.split("#")[0]; // To fix cases where an anchor tag was used
+            this._element.attr("clip-path", "url(\"" + prefix + "#" + this._clipPathID + "\")");
         };
         /**
          * Checks if the Component has a given CSS class.

--- a/plottable.js
+++ b/plottable.js
@@ -6834,6 +6834,7 @@ var Plottable;
             return h;
         };
         Plot.prototype.renderImmediately = function () {
+            _super.prototype.renderImmediately.call(this);
             if (this._isAnchored) {
                 this._paint();
                 this._dataChanged = false;

--- a/plottable.js
+++ b/plottable.js
@@ -3165,6 +3165,9 @@ var Plottable;
          * Renders the Component without waiting for the next frame.
          */
         Component.prototype.renderImmediately = function () {
+            if (this._clipPathEnabled && this._updateClipPath != null) {
+                this._updateClipPath();
+            }
             return this;
         };
         /**
@@ -3260,16 +3263,19 @@ var Plottable;
             return box;
         };
         Component.prototype._generateClipPath = function () {
+            var _this = this;
             // The clip path will prevent content from overflowing its Component space.
-            // HACKHACK: IE <=9 does not respect the HTML base element in SVG.
-            // They don't need the current URL in the clip path reference.
-            var prefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
-            prefix = prefix.split("#")[0]; // To fix cases where an anchor tag was used
             var clipPathId = Plottable.Utils.DOM.generateUniqueClipPathId();
-            this._element.attr("clip-path", "url(\"" + prefix + "#" + clipPathId + "\")");
-            var clipPathParent = this._boxContainer.append("clipPath")
-                .attr("id", clipPathId);
+            var clipPathParent = this._boxContainer.append("clipPath").attr("id", clipPathId);
             this._addBox("clip-rect", clipPathParent);
+            this._updateClipPath = function () {
+                // HACKHACK: IE <= 9 does not respect the HTML base element in SVG.
+                // They don't need the current URL in the clip path reference.
+                var prefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
+                prefix = prefix.split("#")[0]; // To fix cases where an anchor tag was used
+                _this._element.attr("clip-path", "url(\"" + prefix + "#" + clipPathId + "\")");
+            };
+            this._updateClipPath();
         };
         /**
          * Checks if the Component has a given CSS class.

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -46,7 +46,7 @@ export class Component {
   private _height: number;
   private _cssClasses = new Utils.Set<string>();
   private _destroyed = false;
-  private _updateClipPath: () => void;
+  private _clipPathID: string;
   private _onAnchorCallbacks = new Utils.CallbackSet<ComponentCallback>();
   private _onDetachCallbacks = new Utils.CallbackSet<ComponentCallback>();
 
@@ -235,7 +235,7 @@ export class Component {
    * Renders the Component without waiting for the next frame.
    */
   public renderImmediately() {
-    if (this._clipPathEnabled && this._updateClipPath != null) {
+    if (this._clipPathEnabled) {
       this._updateClipPath();
     }
     return this;
@@ -360,17 +360,18 @@ export class Component {
 
   private _generateClipPath() {
     // The clip path will prevent content from overflowing its Component space.
-    let clipPathId = Utils.DOM.generateUniqueClipPathId();
-    let clipPathParent = this._boxContainer.append("clipPath").attr("id", clipPathId);
+    this._clipPathID = Utils.DOM.generateUniqueClipPathId();
+    let clipPathParent = this._boxContainer.append("clipPath").attr("id", this._clipPathID);
     this._addBox("clip-rect", clipPathParent);
-    this._updateClipPath = () => {
-      // HACKHACK: IE <= 9 does not respect the HTML base element in SVG.
-      // They don't need the current URL in the clip path reference.
-      let prefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
-      prefix = prefix.split("#")[0]; // To fix cases where an anchor tag was used
-      this._element.attr("clip-path", "url(\"" + prefix + "#" + clipPathId + "\")");
-    };
     this._updateClipPath();
+  }
+
+  private _updateClipPath() {
+    // HACKHACK: IE <= 9 does not respect the HTML base element in SVG.
+    // They don't need the current URL in the clip path reference.
+    let prefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
+    prefix = prefix.split("#")[0]; // To fix cases where an anchor tag was used
+    this._element.attr("clip-path", "url(\"" + prefix + "#" + this._clipPathID + "\")");
   }
 
   /**

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -46,6 +46,7 @@ export class Component {
   private _height: number;
   private _cssClasses = new Utils.Set<string>();
   private _destroyed = false;
+  private _updateClipPath: () => void;
   private _onAnchorCallbacks = new Utils.CallbackSet<ComponentCallback>();
   private _onDetachCallbacks = new Utils.CallbackSet<ComponentCallback>();
 
@@ -234,6 +235,9 @@ export class Component {
    * Renders the Component without waiting for the next frame.
    */
   public renderImmediately() {
+    if (this._clipPathEnabled && this._updateClipPath != null) {
+      this._updateClipPath();
+    }
     return this;
   }
 
@@ -356,15 +360,17 @@ export class Component {
 
   private _generateClipPath() {
     // The clip path will prevent content from overflowing its Component space.
-    // HACKHACK: IE <=9 does not respect the HTML base element in SVG.
-    // They don't need the current URL in the clip path reference.
-    let prefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
-    prefix = prefix.split("#")[0]; // To fix cases where an anchor tag was used
     let clipPathId = Utils.DOM.generateUniqueClipPathId();
-    this._element.attr("clip-path", "url(\"" + prefix + "#" + clipPathId + "\")");
-    let clipPathParent = this._boxContainer.append("clipPath")
-                                           .attr("id", clipPathId);
+    let clipPathParent = this._boxContainer.append("clipPath").attr("id", clipPathId);
     this._addBox("clip-rect", clipPathParent);
+    this._updateClipPath = () => {
+      // HACKHACK: IE <= 9 does not respect the HTML base element in SVG.
+      // They don't need the current URL in the clip path reference.
+      let prefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
+      prefix = prefix.split("#")[0]; // To fix cases where an anchor tag was used
+      this._element.attr("clip-path", "url(\"" + prefix + "#" + clipPathId + "\")");
+    };
+    this._updateClipPath();
   }
 
   /**

--- a/src/components/selectionBoxLayer.ts
+++ b/src/components/selectionBoxLayer.ts
@@ -87,6 +87,7 @@ export module Components {
     }
 
     public renderImmediately() {
+      super.renderImmediately();
       if (this._boxVisible) {
         let t = this._boxBounds.topLeft.y;
         let b = this._boxBounds.bottomRight.y;
@@ -138,7 +139,7 @@ export module Components {
     public xScale(): QuantitativeScale<number | { valueOf(): number }>;
     /**
      * Sets the x scale for this SelectionBoxLayer.
-     * 
+     *
      * @returns {SelectionBoxLayer} The calling SelectionBoxLayer.
      */
     public xScale(xScale: QuantitativeScale<number | { valueOf(): number }>): SelectionBoxLayer;
@@ -161,7 +162,7 @@ export module Components {
     public yScale(): QuantitativeScale<number | { valueOf(): number }>;
     /**
      * Sets the y scale for this SelectionBoxLayer.
-     * 
+     *
      * @returns {SelectionBoxLayer} The calling SelectionBoxLayer.
      */
     public yScale(yScale: QuantitativeScale<number | { valueOf(): number }>): SelectionBoxLayer;

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -197,6 +197,7 @@ export class Plot extends Component {
   }
 
   public renderImmediately() {
+    super.renderImmediately();
     if (this._isAnchored) {
       this._paint();
       this._dataChanged = false;

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -818,7 +818,7 @@ describe("Component", () => {
     });
 
     it("updates the clipPath reference when render()-ed", () => {
-      if (window.history) { // not supported on IE9 (http://caniuse.com/#feat=history)
+      if (window.history && window.history.replaceState) { // not supported on IE9 (http://caniuse.com/#feat=history)
         clippedComponent.renderTo(svg);
 
         let originalState = window.history.state;

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -818,26 +818,29 @@ describe("Component", () => {
     });
 
     it("updates the clipPath reference when render()-ed", () => {
-      if (window.history && window.history.replaceState) { // not supported on IE9 (http://caniuse.com/#feat=history)
-        clippedComponent.renderTo(svg);
-
-        let originalState = window.history.state;
-        let originalTitle = document.title;
-        let originalLocation = document.location.href;
-        window.history.replaceState(null, null, "clipPathTest");
-        clippedComponent.render();
-
-        let clipPathId = (<any> clippedComponent)._boxContainer[0][0].firstChild.id;
-        let expectedPrefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
-        expectedPrefix = expectedPrefix.replace(/#.*/g, "");
-        let expectedClipPathURL = "url(" + expectedPrefix + "#" + clipPathId + ")";
-
-        window.history.replaceState(originalState, originalTitle, originalLocation);
-
-        let normalizeClipPath = (s: string) => s.replace(/"/g, "");
-        assert.strictEqual(normalizeClipPath((<any> clippedComponent)._element.attr("clip-path")), expectedClipPathURL,
-          "the clipPath reference was updated");
+      if (window.history == null ||  window.history.replaceState == null) { // not supported on IE9 (http://caniuse.com/#feat=history)
+        svg.remove();
+        return;
       }
+
+      clippedComponent.renderTo(svg);
+
+      let originalState = window.history.state;
+      let originalTitle = document.title;
+      let originalLocation = document.location.href;
+      window.history.replaceState(null, null, "clipPathTest");
+      clippedComponent.render();
+
+      let clipPathId = (<any> clippedComponent)._boxContainer[0][0].firstChild.id;
+      let expectedPrefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
+      expectedPrefix = expectedPrefix.replace(/#.*/g, "");
+      let expectedClipPathURL = "url(" + expectedPrefix + "#" + clipPathId + ")";
+
+      window.history.replaceState(originalState, originalTitle, originalLocation);
+
+      let normalizeClipPath = (s: string) => s.replace(/"/g, "");
+      assert.strictEqual(normalizeClipPath((<any> clippedComponent)._element.attr("clip-path")), expectedClipPathURL,
+        "the clipPath reference was updated");
       svg.remove();
     });
   });

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -799,6 +799,8 @@ describe("Component", () => {
 
     beforeEach(() => {
       clippedComponent = new Plottable.Component();
+      // HACKHACK #2777: Can't use a Mocks Compnoent here because they descend from a different Plottable,
+      // which has the wrong RenderPolicy in coverage.html
       (<any> clippedComponent)._clipPathEnabled = true;
       svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
     });

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -798,8 +798,7 @@ describe("Component", () => {
     let svg: d3.Selection<void>;
 
     beforeEach(() => {
-      clippedComponent = new Plottable.Component();
-      (<any> clippedComponent)._clipPathEnabled = true;
+      clippedComponent = new Mocks.ClippedComponent();
       svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
     });
 

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -794,20 +794,50 @@ describe("Component", () => {
 
   describe("restricting rendering through clipPath", () => {
 
-    let c: Plottable.Component;
+    let clippedComponent: Plottable.Component;
     let svg: d3.Selection<void>;
 
     beforeEach(() => {
-      c = new Plottable.Component();
+      clippedComponent = new Plottable.Component();
+      (<any> clippedComponent)._clipPathEnabled = true;
       svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
     });
 
     it("generates a clipPath element if it is enabled", () => {
-      (<any> c)._clipPathEnabled = true;
-      c.anchor(svg);
+      clippedComponent.anchor(svg);
       let componentElement = svg.select(".component");
       assert.isNotNull(componentElement.attr("clip-path"), "clip-path attribute set");
-      c.destroy();
+      clippedComponent.destroy();
+      svg.remove();
+    });
+
+    it("uses the correct clipPath", () => {
+      clippedComponent.renderTo(svg);
+      TestMethods.verifyClipPath(clippedComponent);
+      svg.remove();
+    });
+
+    it("updates the clipPath reference when render()-ed", () => {
+      if (window.history) { // not supported on IE9 (http://caniuse.com/#feat=history)
+        clippedComponent.renderTo(svg);
+
+        let originalState = window.history.state;
+        let originalTitle = document.title;
+        let originalLocation = document.location.href;
+        window.history.replaceState(null, null, "clipPathTest");
+        clippedComponent.render();
+
+        let clipPathId = (<any> clippedComponent)._boxContainer[0][0].firstChild.id;
+        let expectedPrefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
+        expectedPrefix = expectedPrefix.replace(/#.*/g, "");
+        let expectedClipPathURL = "url(" + expectedPrefix + "#" + clipPathId + ")";
+
+        window.history.replaceState(originalState, originalTitle, originalLocation);
+
+        let normalizeClipPath = (s: string) => s.replace(/"/g, "");
+        assert.strictEqual(normalizeClipPath((<any> clippedComponent)._element.attr("clip-path")), expectedClipPathURL,
+          "the clipPath reference was updated");
+      }
       svg.remove();
     });
   });

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -798,7 +798,8 @@ describe("Component", () => {
     let svg: d3.Selection<void>;
 
     beforeEach(() => {
-      clippedComponent = new Mocks.ClippedComponent();
+      clippedComponent = new Plottable.Component();
+      (<any> clippedComponent)._clipPathEnabled = true;
       svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
     });
 

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -63,7 +63,7 @@ describe("Interactive Components", () => {
       });
 
       it("updates the clipPath reference when render()-ed", () => {
-        if (window.history) { // not supported on IE9 (http://caniuse.com/#feat=history)
+        if (window.history && window.history.replaceState) { // not supported on IE9 (http://caniuse.com/#feat=history)
           dbl.renderTo(svg);
 
           let originalState = window.history.state;

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -62,6 +62,30 @@ describe("Interactive Components", () => {
         svg.remove();
       });
 
+      it("updates the clipPath reference when render()-ed", () => {
+        if (window.history) { // not supported on IE9 (http://caniuse.com/#feat=history)
+          dbl.renderTo(svg);
+
+          let originalState = window.history.state;
+          let originalTitle = document.title;
+          let originalLocation = document.location.href;
+          window.history.replaceState(null, null, "clipPathTest");
+          dbl.render();
+
+          let clipPathId = (<any> dbl)._boxContainer[0][0].firstChild.id;
+          let expectedPrefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
+          expectedPrefix = expectedPrefix.replace(/#.*/g, "");
+          let expectedClipPathURL = "url(" + expectedPrefix + "#" + clipPathId + ")";
+
+          window.history.replaceState(originalState, originalTitle, originalLocation);
+
+          let normalizeClipPath = (s: string) => s.replace(/"/g, "");
+          assert.strictEqual(normalizeClipPath((<any> dbl)._element.attr("clip-path")), expectedClipPathURL,
+            "the clipPath reference was updated");
+        }
+        svg.remove();
+      });
+
       it("can get and set the detection radius", () => {
         assert.strictEqual(dbl.detectionRadius(), 3, "there is a default detection radius");
         assert.doesNotThrow(() => dbl.detectionRadius(4), Error, "can set detection radius before anchoring");

--- a/test/components/dragBoxLayerTests.ts
+++ b/test/components/dragBoxLayerTests.ts
@@ -63,26 +63,29 @@ describe("Interactive Components", () => {
       });
 
       it("updates the clipPath reference when render()-ed", () => {
-        if (window.history && window.history.replaceState) { // not supported on IE9 (http://caniuse.com/#feat=history)
-          dbl.renderTo(svg);
-
-          let originalState = window.history.state;
-          let originalTitle = document.title;
-          let originalLocation = document.location.href;
-          window.history.replaceState(null, null, "clipPathTest");
-          dbl.render();
-
-          let clipPathId = (<any> dbl)._boxContainer[0][0].firstChild.id;
-          let expectedPrefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
-          expectedPrefix = expectedPrefix.replace(/#.*/g, "");
-          let expectedClipPathURL = "url(" + expectedPrefix + "#" + clipPathId + ")";
-
-          window.history.replaceState(originalState, originalTitle, originalLocation);
-
-          let normalizeClipPath = (s: string) => s.replace(/"/g, "");
-          assert.strictEqual(normalizeClipPath((<any> dbl)._element.attr("clip-path")), expectedClipPathURL,
-            "the clipPath reference was updated");
+        if (window.history == null ||  window.history.replaceState == null) { // not supported on IE9 (http://caniuse.com/#feat=history)
+          svg.remove();
+          return;
         }
+
+        dbl.renderTo(svg);
+
+        let originalState = window.history.state;
+        let originalTitle = document.title;
+        let originalLocation = document.location.href;
+        window.history.replaceState(null, null, "clipPathTest");
+        dbl.render();
+
+        let clipPathId = (<any> dbl)._boxContainer[0][0].firstChild.id;
+        let expectedPrefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
+        expectedPrefix = expectedPrefix.replace(/#.*/g, "");
+        let expectedClipPathURL = "url(" + expectedPrefix + "#" + clipPathId + ")";
+
+        window.history.replaceState(originalState, originalTitle, originalLocation);
+
+        let normalizeClipPath = (s: string) => s.replace(/"/g, "");
+        assert.strictEqual(normalizeClipPath((<any> dbl)._element.attr("clip-path")), expectedClipPathURL,
+          "the clipPath reference was updated");
         svg.remove();
       });
 

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -26,8 +26,4 @@ module Mocks {
       return true;
     }
   }
-
-  export class ClippedComponent extends Plottable.Component {
-    protected _clipPathEnabled = true;
-  }
 }

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -26,4 +26,8 @@ module Mocks {
       return true;
     }
   }
+
+  export class ClippedComponent extends Plottable.Component {
+    protected _clipPathEnabled = true;
+  }
 }

--- a/test/plots/plotTests.ts
+++ b/test/plots/plotTests.ts
@@ -535,29 +535,31 @@ describe("Plots", () => {
       });
 
       it("updates the clipPath reference when render()-ed", () => {
-        if (window.history && window.history.replaceState) { // not supported on IE9 (http://caniuse.com/#feat=history)
-          let svg = TestMethods.generateSVG();
-          let plot = new Plottable.Plot();
-          plot.renderTo(svg);
-
-          let originalState = window.history.state;
-          let originalTitle = document.title;
-          let originalLocation = document.location.href;
-          window.history.replaceState(null, null, "clipPathTest");
-          plot.render();
-
-          let clipPathId = (<any> plot)._boxContainer[0][0].firstChild.id;
-          let expectedPrefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
-          expectedPrefix = expectedPrefix.replace(/#.*/g, "");
-          let expectedClipPathURL = "url(" + expectedPrefix + "#" + clipPathId + ")";
-
-          window.history.replaceState(originalState, originalTitle, originalLocation);
-
-          let normalizeClipPath = (s: string) => s.replace(/"/g, "");
-          assert.strictEqual(normalizeClipPath((<any> plot)._element.attr("clip-path")), expectedClipPathURL,
-            "the clipPath reference was updated");
-          svg.remove();
+        if (window.history == null || window.history.replaceState == null) { // not supported on IE9 (http://caniuse.com/#feat=history)
+          return;
         }
+
+        let svg = TestMethods.generateSVG();
+        let plot = new Plottable.Plot();
+        plot.renderTo(svg);
+
+        let originalState = window.history.state;
+        let originalTitle = document.title;
+        let originalLocation = document.location.href;
+        window.history.replaceState(null, null, "clipPathTest");
+        plot.render();
+
+        let clipPathId = (<any> plot)._boxContainer[0][0].firstChild.id;
+        let expectedPrefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
+        expectedPrefix = expectedPrefix.replace(/#.*/g, "");
+        let expectedClipPathURL = "url(" + expectedPrefix + "#" + clipPathId + ")";
+
+        window.history.replaceState(originalState, originalTitle, originalLocation);
+
+        let normalizeClipPath = (s: string) => s.replace(/"/g, "");
+        assert.strictEqual(normalizeClipPath((<any> plot)._element.attr("clip-path")), expectedClipPathURL,
+          "the clipPath reference was updated");
+        svg.remove();
       });
     });
   });

--- a/test/plots/plotTests.ts
+++ b/test/plots/plotTests.ts
@@ -524,5 +524,41 @@ describe("Plots", () => {
       plot.animated(false);
       assert.strictEqual(plot.animated(), false, "animated toggled off");
     });
+
+    describe("clipPath", () => {
+      it("uses the correct clipPath", () => {
+        let svg = TestMethods.generateSVG();
+        let plot = new Plottable.Plot();
+        plot.renderTo(svg);
+        TestMethods.verifyClipPath(plot);
+        svg.remove();
+      });
+
+      it("updates the clipPath reference when render()-ed", () => {
+        if (window.history) { // not supported on IE9 (http://caniuse.com/#feat=history)
+          let svg = TestMethods.generateSVG();
+          let plot = new Plottable.Plot();
+          plot.renderTo(svg);
+
+          let originalState = window.history.state;
+          let originalTitle = document.title;
+          let originalLocation = document.location.href;
+          window.history.replaceState(null, null, "clipPathTest");
+          plot.render();
+
+          let clipPathId = (<any> plot)._boxContainer[0][0].firstChild.id;
+          let expectedPrefix = /MSIE [5-9]/.test(navigator.userAgent) ? "" : document.location.href;
+          expectedPrefix = expectedPrefix.replace(/#.*/g, "");
+          let expectedClipPathURL = "url(" + expectedPrefix + "#" + clipPathId + ")";
+
+          window.history.replaceState(originalState, originalTitle, originalLocation);
+
+          let normalizeClipPath = (s: string) => s.replace(/"/g, "");
+          assert.strictEqual(normalizeClipPath((<any> plot)._element.attr("clip-path")), expectedClipPathURL,
+            "the clipPath reference was updated");
+          svg.remove();
+        }
+      });
+    });
   });
 });

--- a/test/plots/plotTests.ts
+++ b/test/plots/plotTests.ts
@@ -535,7 +535,7 @@ describe("Plots", () => {
       });
 
       it("updates the clipPath reference when render()-ed", () => {
-        if (window.history) { // not supported on IE9 (http://caniuse.com/#feat=history)
+        if (window.history && window.history.replaceState) { // not supported on IE9 (http://caniuse.com/#feat=history)
           let svg = TestMethods.generateSVG();
           let plot = new Plottable.Plot();
           plot.renderTo(svg);


### PR DESCRIPTION
Previously, if the URL changed without reloading the page, any `Component` that was re-anchored would lose its reference to its `clipPath`, because Plottable uses an absolute reference to the `clipPath` (due to https://github.com/palantir/plottable/pull/865). Now, `Component`s with `clipPath`s will update their references on rendering.

Before: http://jsfiddle.net/mpqwxg4n/7/
After: http://jsfiddle.net/4mrzogsp/

**NOTE**: For some reason, the bug currently only manifests on Firefox, even though less than 24 hours ago I saw it on Chrome too...

Close #2733.