### PR TITLE
throw an error with invalid annotation tier count

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -1,5 +1,5 @@
 /*!
-Plottable 1.11.0 (https://github.com/palantir/plottable)
+Plottable 1.10.0 (https://github.com/palantir/plottable)
 Copyright 2014-2015 Palantir Technologies
 Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
 */
@@ -909,7 +909,7 @@ var Plottable;
 ///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
-    Plottable.version = "1.11.0";
+    Plottable.version = "1.10.0";
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
@@ -3838,6 +3838,9 @@ var Plottable;
         Axis.prototype.annotationTierCount = function (annotationTierCount) {
             if (annotationTierCount == null) {
                 return this._annotationTierCount;
+            }
+            if (annotationTierCount < 0) {
+                throw new Error("annotationTierCount " + annotationTierCount + " is not valid, should be positive or 0");
             }
             this._annotationTierCount = annotationTierCount;
             this.redraw();

--- a/plottable.js
+++ b/plottable.js
@@ -3840,7 +3840,7 @@ var Plottable;
                 return this._annotationTierCount;
             }
             if (annotationTierCount < 0) {
-                throw new Error("annotationTierCount " + annotationTierCount + " is not valid, should be positive or 0");
+                throw new Error("annotationTierCount " + annotationTierCount + " cannot be negative");
             }
             this._annotationTierCount = annotationTierCount;
             this.redraw();

--- a/plottable.js
+++ b/plottable.js
@@ -1,5 +1,5 @@
 /*!
-Plottable 1.10.0 (https://github.com/palantir/plottable)
+Plottable 1.11.0 (https://github.com/palantir/plottable)
 Copyright 2014-2015 Palantir Technologies
 Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
 */
@@ -909,7 +909,7 @@ var Plottable;
 ///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
-    Plottable.version = "1.10.0";
+    Plottable.version = "1.11.0";
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />

--- a/plottable.js
+++ b/plottable.js
@@ -3840,7 +3840,7 @@ var Plottable;
                 return this._annotationTierCount;
             }
             if (annotationTierCount < 0) {
-                throw new Error("annotationTierCount " + annotationTierCount + " cannot be negative");
+                throw new Error("annotationTierCount cannot be negative");
             }
             this._annotationTierCount = annotationTierCount;
             this.redraw();

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -273,7 +273,7 @@ export class Axis<D> extends Component {
     if (annotationTierCount == null) {
       return this._annotationTierCount;
     }
-    if (annotationTierCount < 0){
+    if (annotationTierCount < 0) {
       throw new Error(`annotationTierCount ${annotationTierCount} is not valid, should be positive or 0`);
     }
     this._annotationTierCount = annotationTierCount;

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -274,7 +274,7 @@ export class Axis<D> extends Component {
       return this._annotationTierCount;
     }
     if (annotationTierCount < 0) {
-      throw new Error(`annotationTierCount ${annotationTierCount} cannot be negative`);
+      throw new Error(`annotationTierCount cannot be negative`);
     }
     this._annotationTierCount = annotationTierCount;
     this.redraw();

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -274,7 +274,7 @@ export class Axis<D> extends Component {
       return this._annotationTierCount;
     }
     if (annotationTierCount < 0) {
-      throw new Error(`annotationTierCount ${annotationTierCount} is not valid, should be positive or 0`);
+      throw new Error(`annotationTierCount ${annotationTierCount} cannot be negative`);
     }
     this._annotationTierCount = annotationTierCount;
     this.redraw();

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -273,6 +273,9 @@ export class Axis<D> extends Component {
     if (annotationTierCount == null) {
       return this._annotationTierCount;
     }
+    if (annotationTierCount < 0){
+      throw new Error(`annotationTierCount ${annotationTierCount} is not valid, should be positive or 0`);
+    }
     this._annotationTierCount = annotationTierCount;
     this.redraw();
     return this;

--- a/test/axes/baseAxisTests.ts
+++ b/test/axes/baseAxisTests.ts
@@ -269,11 +269,13 @@ describe("BaseAxis", () => {
 
       it("throws an error when annotation tier count is not valid", () => {
         let axis = new Plottable.Axis(new Plottable.Scale<{}, number>(), "bottom");
-        let annotationTierCount = [-1, -100];
-        annotationTierCount.forEach(function(tierCount) {
-          let currentTierCount = axis.annotationTierCount();
-          assert.throw(() => axis.annotationTierCount(tierCount), `annotationTierCount ${tierCount} is not valid, should be positive or 0`);
-          assert.strictEqual(axis.annotationTierCount(), currentTierCount, "annotationTierCound should not be changed to invalid values");
+        let invalidAnnotationTierCounts = [-1, -100];
+        invalidAnnotationTierCounts.forEach(function(annotationTierCount) {
+          let currentAnnotationTierCount = axis.annotationTierCount();
+          assert.throws(() => axis.annotationTierCount(annotationTierCount),
+          `annotationTierCount ${annotationTierCount} cannot be negative`);
+          assert.strictEqual(axis.annotationTierCount(), currentAnnotationTierCount,
+          "annotationTierCound should not be changed to invalid values");
         });
       });
     });

--- a/test/axes/baseAxisTests.ts
+++ b/test/axes/baseAxisTests.ts
@@ -266,17 +266,16 @@ describe("BaseAxis", () => {
         assert.strictEqual(axis.annotationTierCount(annotationTierCount), axis, "setting annotation tier count returns calling axis");
         assert.deepEqual(axis.annotationTierCount(), annotationTierCount, "can set the annotation tier count");
       });
-      
+
       it("throws an error when annotation tier count is not valid", () => {
         let axis = new Plottable.Axis(new Plottable.Scale<{}, number>(), "bottom");
         let annotationTierCount = [-1, -100];
-        annotationTierCount.forEach(function(tierCount){
-          let currentAnnotationTierCount = axis.annotationTierCount(); 
-          console.log(tierCount);
+        annotationTierCount.forEach(function(tierCount) {
+          let currentTierCount = axis.annotationTierCount();
           assert.throw(() => axis.annotationTierCount(tierCount), `annotationTierCount ${tierCount} is not valid, should be positive or 0`);
-          assert.strictEqual(axis.annotationTierCount(), currentAnnotationTierCount, "annotationTierCound should not be changed to invalid values");
+          assert.strictEqual(axis.annotationTierCount(), currentTierCount, "annotationTierCound should not be changed to invalid values");
         });
-      })
+      });
     });
 
     describe("rendering annotations", () => {

--- a/test/axes/baseAxisTests.ts
+++ b/test/axes/baseAxisTests.ts
@@ -275,7 +275,7 @@ describe("BaseAxis", () => {
           assert.throws(() => axis.annotationTierCount(annotationTierCount),
           `annotationTierCount ${annotationTierCount} cannot be negative`);
           assert.strictEqual(axis.annotationTierCount(), currentAnnotationTierCount,
-          "annotationTierCound should not be changed to invalid values");
+          "annotationTierCount should not be changed to invalid values");
         });
       });
     });

--- a/test/axes/baseAxisTests.ts
+++ b/test/axes/baseAxisTests.ts
@@ -273,7 +273,7 @@ describe("BaseAxis", () => {
         invalidAnnotationTierCounts.forEach(function(annotationTierCount) {
           let currentAnnotationTierCount = axis.annotationTierCount();
           assert.throws(() => axis.annotationTierCount(annotationTierCount),
-          `annotationTierCount ${annotationTierCount} cannot be negative`);
+          `annotationTierCount cannot be negative`);
           assert.strictEqual(axis.annotationTierCount(), currentAnnotationTierCount,
           "annotationTierCount should not be changed to invalid values");
         });

--- a/test/axes/baseAxisTests.ts
+++ b/test/axes/baseAxisTests.ts
@@ -266,6 +266,17 @@ describe("BaseAxis", () => {
         assert.strictEqual(axis.annotationTierCount(annotationTierCount), axis, "setting annotation tier count returns calling axis");
         assert.deepEqual(axis.annotationTierCount(), annotationTierCount, "can set the annotation tier count");
       });
+      
+      it("throws an error when annotation tier count is not valid", () => {
+        let axis = new Plottable.Axis(new Plottable.Scale<{}, number>(), "bottom");
+        let annotationTierCount = [-1, -100];
+        annotationTierCount.forEach(function(tierCount){
+          let currentAnnotationTierCount = axis.annotationTierCount(); 
+          console.log(tierCount);
+          assert.throw(() => axis.annotationTierCount(tierCount), `annotationTierCount ${tierCount} is not valid, should be positive or 0`);
+          assert.strictEqual(axis.annotationTierCount(), currentAnnotationTierCount, "annotationTierCound should not be changed to invalid values");
+        });
+      })
     });
 
     describe("rendering annotations", () => {


### PR DESCRIPTION
**Issue**
`annotationTierCount()` will not reject negative values and a negative annotation tier count will result in negative height. 

**Fix**
In `annotationTierCount(annotationTierCount:number)`, if `annotationTierCount` is negative, throw an error.

**JSFiddle**
Before: https://jsfiddle.net/nup2ya6w/6/
After: https://jsfiddle.net/drq123db/1/

Close #2730 