### PR TITLE
Correct the label position with "center" tierlabelposition and "top" orientation

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -4428,17 +4428,15 @@ var Plottable;
                 var tickLabelsEnter = tickLabels.enter().append("g").classed(Plottable.Axis.TICK_LABEL_CLASS, true);
                 tickLabelsEnter.append("text");
                 var xTranslate = (this._tierLabelPositions[index] === "center" || config.step === 1) ? 0 : this.tickLabelPadding();
-                var yTranslate = 0;
+                var yTranslate;
                 if (this.orientation() === "bottom") {
                     yTranslate = d3.sum(this._tierHeights.slice(0, index + 1)) - this.tickLabelPadding();
                 }
+                else if (this._tierLabelPositions[index] === "center") {
+                    yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding() - this.innerTickLength();
+                }
                 else {
-                    if (this._tierLabelPositions[index] === "center") {
-                        yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding() - this.innerTickLength();
-                    }
-                    else {
-                        yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding();
-                    }
+                    yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding();
                 }
                 var textSelection = tickLabels.selectAll("text");
                 if (textSelection.size() > 0) {

--- a/plottable.js
+++ b/plottable.js
@@ -4432,11 +4432,13 @@ var Plottable;
                 if (this.orientation() === "bottom") {
                     yTranslate = d3.sum(this._tierHeights.slice(0, index + 1)) - this.tickLabelPadding();
                 }
-                else if (this._tierLabelPositions[index] === "center") {
-                    yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding() - this.innerTickLength();
-                }
                 else {
-                    yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding();
+                    if (this._tierLabelPositions[index] === "center") {
+                        yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding() - this.innerTickLength();
+                    }
+                    else {
+                        yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding();
+                    }
                 }
                 var textSelection = tickLabels.selectAll("text");
                 if (textSelection.size() > 0) {

--- a/plottable.js
+++ b/plottable.js
@@ -4428,9 +4428,18 @@ var Plottable;
                 var tickLabelsEnter = tickLabels.enter().append("g").classed(Plottable.Axis.TICK_LABEL_CLASS, true);
                 tickLabelsEnter.append("text");
                 var xTranslate = (this._tierLabelPositions[index] === "center" || config.step === 1) ? 0 : this.tickLabelPadding();
-                var yTranslate = this.orientation() === "bottom" ?
-                    d3.sum(this._tierHeights.slice(0, index + 1)) - this.tickLabelPadding() :
-                    this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding();
+                var yTranslate = 0;
+                if (this.orientation() === "bottom") {
+                    yTranslate = d3.sum(this._tierHeights.slice(0, index + 1)) - this.tickLabelPadding();
+                }
+                else {
+                    if (this._tierLabelPositions[index] === "center") {
+                        yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding() - this.innerTickLength();
+                    }
+                    else {
+                        yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding();
+                    }
+                }
                 var textSelection = tickLabels.selectAll("text");
                 if (textSelection.size() > 0) {
                     Plottable.Utils.DOM.translate(textSelection, xTranslate, yTranslate);

--- a/plottable.js
+++ b/plottable.js
@@ -4432,13 +4432,11 @@ var Plottable;
                 if (this.orientation() === "bottom") {
                     yTranslate = d3.sum(this._tierHeights.slice(0, index + 1)) - this.tickLabelPadding();
                 }
+                else if (this._tierLabelPositions[index] === "center") {
+                    yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding() - this.innerTickLength();
+                }
                 else {
-                    if (this._tierLabelPositions[index] === "center") {
-                        yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding() - this.innerTickLength();
-                    }
-                    else {
-                        yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding();
-                    }
+                    yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding();
                 }
                 var textSelection = tickLabels.selectAll("text");
                 if (textSelection.size() > 0) {

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -392,9 +392,17 @@ export module Axes {
       let tickLabelsEnter = tickLabels.enter().append("g").classed(Axis.TICK_LABEL_CLASS, true);
       tickLabelsEnter.append("text");
       let xTranslate = (this._tierLabelPositions[index] === "center" || config.step === 1) ? 0 : this.tickLabelPadding();
-      let yTranslate = this.orientation() === "bottom" ?
-          d3.sum(this._tierHeights.slice(0, index + 1)) - this.tickLabelPadding() :
-          this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding();
+
+      let yTranslate = 0;
+      if (this.orientation() === "bottom") {
+        yTranslate =  d3.sum(this._tierHeights.slice(0, index + 1)) - this.tickLabelPadding();
+      } else {
+          if (this._tierLabelPositions[index] === "center") {
+          yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding() - this.innerTickLength();
+        } else {
+          yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding();
+        }
+      }
 
       let textSelection = tickLabels.selectAll("text");
       if (textSelection.size() > 0) {

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -395,7 +395,7 @@ export module Axes {
 
       let yTranslate = 0;
       if (this.orientation() === "bottom") {
-        yTranslate =  d3.sum(this._tierHeights.slice(0, index + 1)) - this.tickLabelPadding();
+        yTranslate = d3.sum(this._tierHeights.slice(0, index + 1)) - this.tickLabelPadding();
       } else {
           if (this._tierLabelPositions[index] === "center") {
           yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding() - this.innerTickLength();

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -396,12 +396,10 @@ export module Axes {
       let yTranslate = 0;
       if (this.orientation() === "bottom") {
         yTranslate = d3.sum(this._tierHeights.slice(0, index + 1)) - this.tickLabelPadding();
-      } else {
-          if (this._tierLabelPositions[index] === "center") {
+      } else if (this._tierLabelPositions[index] === "center") {
           yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding() - this.innerTickLength();
-        } else {
+      } else {
           yTranslate = this.height() - d3.sum(this._tierHeights.slice(0, index)) - this.tickLabelPadding();
-        }
       }
 
       let textSelection = tickLabels.selectAll("text");

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -393,7 +393,7 @@ export module Axes {
       tickLabelsEnter.append("text");
       let xTranslate = (this._tierLabelPositions[index] === "center" || config.step === 1) ? 0 : this.tickLabelPadding();
 
-      let yTranslate = 0;
+      let yTranslate: number;
       if (this.orientation() === "bottom") {
         yTranslate = d3.sum(this._tierHeights.slice(0, index + 1)) - this.tickLabelPadding();
       } else if (this._tierLabelPositions[index] === "center") {

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -152,7 +152,7 @@ describe("TimeAxis", () => {
   it("tick labels do not overlap with tick marks in top orientation", () => {
      let svg = TestMethods.generateSVG(400, 100);
       scale = new Plottable.Scales.Time();
-      scale.domain([new Date("2015-09-02"), new Date("2015-09-03")]);
+      scale.domain([new Date(2015, 8, 2), new Date(2015, 8, 3)]);
       axis = new Plottable.Axes.Time(scale, "top");
 
       function checkTierDisplayPosition (tierDisplayPositions: any[]) {

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -167,12 +167,28 @@ describe("TimeAxis", () => {
           return window.getComputedStyle(this).visibility !== "hidden";
         });
         assert.operator(tickLabels.size(), ">=", 1, "There are more than one tick marks in the test");
-
+        
+        function myclientRectsOverlap(clientRectA:ClientRect, clientRectB:ClientRect) {
+                if (clientRectA.right < clientRectB.left + window.Pixel_CloseTo_Requirement) {
+                    return false;
+                }
+                if ( window.Pixel_CloseTo_Requirement + clientRectA.left > clientRectB.right) {
+                    return false;
+                }
+                if (clientRectA.bottom < clientRectB.top + window.Pixel_CloseTo_Requirement) {
+                    return false;
+                }
+                if (window.Pixel_CloseTo_Requirement + clientRectA.top > clientRectB.bottom) {
+                    return false;
+                }
+                return true;
+            }
+            
         tickMarks.each(function(tickMark) {
           let tickMarkRect = this.getBoundingClientRect();
           tickLabels.each(function(tickLabel) {
             let tickLabelRect = this.getBoundingClientRect();
-            let isOverlap = Plottable.Utils.DOM.clientRectsOverlap(tickMarkRect, tickLabelRect);
+            let isOverlap = myclientRectsOverlap(tickMarkRect, tickLabelRect);
             assert.isFalse(isOverlap, `Tick marks "${tickMark}" should not overlap with tick labels "${this.textContent}" `);
           });
         });

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -167,14 +167,30 @@ describe("TimeAxis", () => {
           return window.getComputedStyle(this).visibility !== "hidden";
         });
       assert.operator(tickLabels.size(), ">=", 1, "There are at least one tick labels in the test");
+
+      function clientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect) {
+        if (clientRectA.right < clientRectB.left + window.Pixel_CloseTo_Requirement) {
+          return false;
+        } else if (window.Pixel_CloseTo_Requirement + clientRectA.left > clientRectB.right) {
+          return false;
+        } else if (clientRectA.bottom < clientRectB.top + window.Pixel_CloseTo_Requirement) {
+          return false;
+        } else if (window.Pixel_CloseTo_Requirement + clientRectA.top > clientRectB.bottom) {
+          return false;
+        } else { 
+          return true;
+        }
+      }
+
       tickMarks.each(function(tickMark) {
         let tickMarkRect = this.getBoundingClientRect();
         tickLabels.each(function(tickLabel) {
           let tickLabelRect = this.getBoundingClientRect();
-          assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(tickMarkRect, tickLabelRect),
+          assert.isFalse(clientRectsOverlap(tickMarkRect, tickLabelRect), 
             `Tick marks "${tickMark}" should not overlap with tick labels "${this.textContent}" `);
         });
       });
+    style.remove();
     }
 
     checkTierDisplayPosition(["between", "between"]);

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -152,7 +152,7 @@ describe("TimeAxis", () => {
   it("tick labels do not overlap with tick marks in top orientation", () => {
      let svg = TestMethods.generateSVG(400, 100);
       scale = new Plottable.Scales.Time();
-      scale.domain([new Date("2015-09-01 12:00:00"), new Date("2015-09-03 12:00:00")]);
+      scale.domain([new Date("2010-01-01"), new Date("2014-01-01")]);
       axis = new Plottable.Axes.Time(scale, "top");
 
       function checkTierDisplayPosition (tierDisplayPositions: any[]) {

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -155,13 +155,13 @@ describe("TimeAxis", () => {
       scale.domain([new Date("2010-01-01"), new Date("2014-01-01")]);
       axis = new Plottable.Axes.Time(scale, "top");
 
-      let style = (<any> axis)._element.append("style");
-      style.attr("type", "text/css");
-      style.text(".plottable .axis.time-axis text { font-family: Arial; }");
-
       function checkTierDisplayPosition (tierDisplayPositions: any[]) {
         axis.tierLabelPositions(tierDisplayPositions);
         axis.renderTo(svg);
+
+        let style = (<any>axis)._element.append("style");
+        style.attr("type", "text/css");
+        style.text(".plottable .axis.time-axis text { font-family: Arial; }");
 
         let tickMarks = d3.selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}:not(.${Plottable.Axis.END_TICK_MARK_CLASS})`);
         assert.operator(tickMarks.size(), ">=", 1, "There are more than one tick marks in the test");

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -129,32 +129,28 @@ describe("TimeAxis", () => {
     assert.isTrue(lastTick.classed(Plottable.Axis.END_TICK_MARK_CLASS), "last end tick has the end-tick-mark class");
     svg.remove();
   });
-
-  it("tick labels do not overlap with tick marks", () => {
-    let svg = TestMethods.generateSVG(400, 100);
-    scale = new Plottable.Scales.Time();
-    scale.domain([new Date("2009-12-20"), new Date("2011-01-01")]);
-    axis = new Plottable.Axes.Time(scale, "bottom");
-    axis.renderTo(svg);
-    let tickRects = d3.selectAll("." + Plottable.Axis.TICK_MARK_CLASS)[0].map((mark: Element) => mark.getBoundingClientRect());
-    let labelRects = d3.selectAll("." + Plottable.Axis.TICK_LABEL_CLASS)
-        .filter(function(d: Element, i: number) {
-          return d3.select(this).style("visibility") === "visible";
-        })[0].map((label: Element) => label.getBoundingClientRect());
-    labelRects.forEach(function(labelRect: ClientRect) {
-      tickRects.forEach(function(tickRect: ClientRect) {
-        assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(labelRect, tickRect), "visible label does not overlap with a tick");
+  describe("tick labels and tick marks locations", () => {
+    it("tick labels do not overlap with tick marks", () => {
+      let svg = TestMethods.generateSVG(400, 100);
+      scale = new Plottable.Scales.Time();
+      scale.domain([new Date("2009-12-20"), new Date("2011-01-01")]);
+      axis = new Plottable.Axes.Time(scale, "bottom");
+      axis.renderTo(svg);
+      let tickRects = d3.selectAll("." + Plottable.Axis.TICK_MARK_CLASS)[0].map((mark: Element) => mark.getBoundingClientRect());
+      let labelRects = d3.selectAll("." + Plottable.Axis.TICK_LABEL_CLASS)
+          .filter(function(d: Element, i: number) {
+            return d3.select(this).style("visibility") === "visible";
+          })[0].map((label: Element) => label.getBoundingClientRect());
+      labelRects.forEach(function(labelRect: ClientRect) {
+        tickRects.forEach(function(tickRect: ClientRect) {
+          assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(labelRect, tickRect), "visible label does not overlap with a tick");
+        });
       });
+      svg.remove();
     });
-    svg.remove();
-  });
-
-  it("tick labels do not overlap with tick marks in top orientation", () => {
-    let svg = TestMethods.generateSVG(400, 100);
-    scale.domain([new Date("2010-01-01"), new Date("2014-01-01")]);
-    axis.orientation("top");
 
     function checkTierDisplayPosition (tierDisplayPositions: string[]) {
+      let svg = TestMethods.generateSVG(400, 100);
       axis.tierLabelPositions(tierDisplayPositions);
       axis.renderTo(svg);
       let style = (<any>axis)._element.append("style");
@@ -167,25 +163,28 @@ describe("TimeAxis", () => {
       });
       assert.operator(tickLabels.size(), ">=", 1, `There is at least one tick label in the test`);
 
-      function clientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect) {
-        return !(clientRectA.right < clientRectB.left + window.Pixel_CloseTo_Requirement)
-               && !(window.Pixel_CloseTo_Requirement + clientRectA.left > clientRectB.right)
-               && !(clientRectA.bottom < clientRectB.top + window.Pixel_CloseTo_Requirement)
-               && !(window.Pixel_CloseTo_Requirement + clientRectA.top > clientRectB.bottom);
-     }
-
       tickMarks.each(function(tickMark) {
         let tickMarkRect = this.getBoundingClientRect();
         tickLabels.each(function(tickLabel) {
           let tickLabelRect = this.getBoundingClientRect();
-          assert.isFalse(clientRectsOverlap(tickMarkRect, tickLabelRect),
+          assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(tickMarkRect, tickLabelRect),
             `Tick marks [${tickMark}] should not overlap with tick labels [${this.textContent}]`);
         });
       });
+      svg.remove();
     }
-    checkTierDisplayPosition(["between", "between"]);
-    checkTierDisplayPosition(["center", "center"]);
-    svg.remove();
+
+    it("tick labels do not overlap with tick marks in top orientation", () => {
+      scale.domain([new Date("2010-01-01"), new Date("2014-01-01")]);
+      axis.orientation("top");
+      checkTierDisplayPosition(["between", "between"]);
+    });
+
+    it("tick labels do not overlap with tick marks in top orientation", () => {
+      scale.domain([new Date("2010-01-01"), new Date("2014-01-01")]);
+      axis.orientation("top");
+      checkTierDisplayPosition(["center", "center"]);
+    });
   });
 
   it("if the time only uses one tier, there should be no space left for the second tier", () => {

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -150,50 +150,44 @@ describe("TimeAxis", () => {
   });
 
   it("tick labels do not overlap with tick marks in top orientation", () => {
-     let svg = TestMethods.generateSVG(400, 100);
-      scale = new Plottable.Scales.Time();
-      scale.domain([new Date("2010-01-01"), new Date("2014-01-01")]);
-      axis = new Plottable.Axes.Time(scale, "top");
+    let svg = TestMethods.generateSVG(400, 100);
+    scale.domain([new Date("2010-01-01"), new Date("2014-01-01")]);
+    axis = new Plottable.Axes.Time(scale, "top");
 
-      function checkTierDisplayPosition (tierDisplayPositions: any[]) {
-        axis.tierLabelPositions(tierDisplayPositions);
-        axis.renderTo(svg);
-
-        let style = (<any>axis)._element.append("style");
-        style.attr("type", "text/css");
-        style.text(".plottable .axis.time-axis text { font-family: Arial; }");
-
-        let tickMarks = d3.selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}:not(.${Plottable.Axis.END_TICK_MARK_CLASS})`);
-        assert.operator(tickMarks.size(), ">=", 1, "There are more than one tick marks in the test");
-
-        let tickLabels = d3.selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
-        .filter(function(d: Element, i: number){
+    function checkTierDisplayPosition(tierDisplayPositions: any[]) {
+      axis.tierLabelPositions(tierDisplayPositions);
+      axis.renderTo(svg);
+      let style = (<any>axis)._element.append("style");
+      style.attr("type", "text/css");
+      style.text(".plottable .axis .time-axis text { font-family: Arial; }");
+      let tickMarks = d3.selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}:not(.${Plottable.Axis.END_TICK_MARK_CLASS})`);
+      assert.operator(tickMarks.size(), ">=", 1, "There are at least one tick marks in the test");
+      let tickLabels = d3.selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
+        .filter(function(d, i){
           return window.getComputedStyle(this).visibility !== "hidden";
         });
-        assert.operator(tickLabels.size(), ">=", 1, "There are more than one tick labels in the test");
+      assert.operator(tickLabels.size(), ">=", 1, "There are at least one tick labels in the test");
 
-        function myclientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect) {
-                if (clientRectA.right < clientRectB.left + window.Pixel_CloseTo_Requirement) {
-                    return false;
-                }
-                if ( window.Pixel_CloseTo_Requirement + clientRectA.left > clientRectB.right) {
-                    return false;
-                }
-                if (clientRectA.bottom < clientRectB.top + window.Pixel_CloseTo_Requirement) {
-                    return false;
-                }
-                if (window.Pixel_CloseTo_Requirement + clientRectA.top > clientRectB.bottom) {
-                    return false;
-                }
-                return true;
-            }
+      function clientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect) {
+        if (clientRectA.right < clientRectB.left + window.Pixel_CloseTo_Requirement) {
+          return false;
+        } else if (window.Pixel_CloseTo_Requirement + clientRectA.left > clientRectB.right) {
+          return false;
+        } else if (clientRectA.bottom < clientRectB.top + window.Pixel_CloseTo_Requirement) {
+          return false;
+        } else if (window.Pixel_CloseTo_Requirement + clientRectA.top > clientRectB.bottom) {
+          return false;
+        } else { 
+           return true;
+        }
+      }
 
-        tickMarks.each(function(tickMark) {
+    tickMarks.each(function(tickMark) {
           let tickMarkRect = this.getBoundingClientRect();
           tickLabels.each(function(tickLabel) {
             let tickLabelRect = this.getBoundingClientRect();
-            let isOverlap = myclientRectsOverlap(tickMarkRect, tickLabelRect);
-            assert.isFalse(isOverlap, `Tick marks "${tickMark}" should not overlap with tick labels "${this.textContent}" `);
+            assert.isFalse(clientRectsOverlap(tickMarkRect, tickLabelRect), 
+              `Tick marks "${tickMark}" should not overlap with tick labels "${this.textContent}" `);
           });
         });
       }

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -152,7 +152,7 @@ describe("TimeAxis", () => {
   it("tick labels do not overlap with tick marks in top orientation", () => {
      let svg = TestMethods.generateSVG(400, 100);
       scale = new Plottable.Scales.Time();
-      scale.domain([new Date("2015-09-02"), new Date("2015-09-03")]);
+      scale.domain([new Date("2015-09-01"), new Date("2015-09-03")]);
       axis = new Plottable.Axes.Time(scale, "top");
 
       function checkTierDisplayPosition (tierDisplayPositions: any[]) {
@@ -166,7 +166,7 @@ describe("TimeAxis", () => {
         .filter(function(d: Element, i: number){
           return window.getComputedStyle(this).visibility !== "hidden";
         });
-        assert.operator(tickLabels.size(), ">=", 1, "There are more than one tick marks in the test");
+        assert.operator(tickLabels.size(), ">=", 1, "There are more than one tick label in the test");
 
         function myclientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect) {
                 if (clientRectA.right < clientRectB.left + window.Pixel_CloseTo_Requirement) {

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -177,7 +177,7 @@ describe("TimeAxis", () => {
           return false;
         } else if (window.Pixel_CloseTo_Requirement + clientRectA.top > clientRectB.bottom) {
           return false;
-        } else { 
+        } else {
           return true;
         }
       }
@@ -186,7 +186,7 @@ describe("TimeAxis", () => {
         let tickMarkRect = this.getBoundingClientRect();
         tickLabels.each(function(tickLabel) {
           let tickLabelRect = this.getBoundingClientRect();
-          assert.isFalse(clientRectsOverlap(tickMarkRect, tickLabelRect), 
+          assert.isFalse(clientRectsOverlap(tickMarkRect, tickLabelRect),
             `Tick marks "${tickMark}" should not overlap with tick labels "${this.textContent}" `);
         });
       });

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -162,7 +162,10 @@ describe("TimeAxis", () => {
         let tickMarks = d3.selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}:not(.${Plottable.Axis.END_TICK_MARK_CLASS})`);
         assert.operator(tickMarks.size(), ">=", 1, "There are more than one tick marks in the test");
 
-        let tickLabels = d3.selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
+        let tickLabels = d3.selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
+        .filter(function(d: Element, i: number){
+          return window.getComputedStyle(this).visibility === "visible";
+        });
         assert.operator(tickLabels.size(), ">=", 1, "There are more than one tick marks in the test");
 
         tickMarks.each(function(tickMark) {
@@ -175,7 +178,7 @@ describe("TimeAxis", () => {
         });
       }
 
-    //  checkTierDisplayPosition(["between", "between"]);
+      checkTierDisplayPosition(["between", "between"]);
       checkTierDisplayPosition(["center", "center"]);
       svg.remove();
   });

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -161,14 +161,14 @@ describe("TimeAxis", () => {
 
         let style = (<any>axis)._element.append("style");
         style.attr("type", "text/css");
-        style.text(".plottable .axis.time-axis text { font-family: Serif; }");
+        style.text(".plottable .axis.time-axis text { font-family: Arial; }");
 
         let tickMarks = d3.selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}:not(.${Plottable.Axis.END_TICK_MARK_CLASS})`);
         assert.operator(tickMarks.size(), ">=", 1, "There are more than one tick marks in the test");
 
         let tickLabels = d3.selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
         .filter(function(d: Element, i: number){
-          return window.getComputedStyle(this).visibility === "visible";
+          return window.getComputedStyle(this).visibility !== "hidden";
         });
         assert.operator(tickLabels.size(), ">=", 1, "There are more than one tick labels in the test");
 

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -154,7 +154,7 @@ describe("TimeAxis", () => {
     scale.domain([new Date("2010-01-01"), new Date("2014-01-01")]);
     axis = new Plottable.Axes.Time(scale, "top");
 
-    function checkTierDisplayPosition (tierDisplayPositions: any[]) {
+    function checkTierDisplayPosition (tierDisplayPositions: string[]) {
       axis.tierLabelPositions(tierDisplayPositions);
       axis.renderTo(svg);
       let style = (<any>axis)._element.append("style");
@@ -163,41 +163,40 @@ describe("TimeAxis", () => {
       let tickMarks = d3.selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}:not(.${Plottable.Axis.END_TICK_MARK_CLASS})`);
       assert.operator(tickMarks.size(), ">=", 1, "There are at least one tick marks in the test");
       let tickLabels = d3.selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
-        .filter(function(d, i){
-          return window.getComputedStyle(this).visibility !== "hidden";
-        });
-      assert.operator(tickLabels.size(), ">=", 1, "There are at least one tick labels in the test");
+      .filter(function(d, i){
+        return window.getComputedStyle(this).visibility !== "hidden";
+      });
+      assert.operator(tickLabels.size(), ">=", 1, `There are at least one tick labels in the test`);
 
-      function myclientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect) {
+      function clientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect) {
         if (clientRectA.right < clientRectB.left + window.Pixel_CloseTo_Requirement) {
-          return false;
+            return false;
         }
         if (window.Pixel_CloseTo_Requirement + clientRectA.left > clientRectB.right) {
-          return false;
+            return false;
         }
         if (clientRectA.bottom < clientRectB.top + window.Pixel_CloseTo_Requirement) {
-          return false;
+            return false;
         }
         if (window.Pixel_CloseTo_Requirement + clientRectA.top > clientRectB.bottom) {
-          return false;
+            return false;
         }
         return true;
-        }
-
+      }
       tickMarks.each(function(tickMark) {
         let tickMarkRect = this.getBoundingClientRect();
         tickLabels.each(function(tickLabel) {
           let tickLabelRect = this.getBoundingClientRect();
-          let isOverlap = myclientRectsOverlap(tickMarkRect, tickLabelRect);
-          assert.isFalse(isOverlap, `Tick marks "${tickMark}" should not overlap with tick labels "${this.textContent}" `);
+          let isOverlap = clientRectsOverlap(tickMarkRect, tickLabelRect);
+          assert.isFalse(isOverlap, `Tick marks "${tickMark}" should not overlap with tick labels "${this.textContent}"`);
         });
       });
-      style.remove();
     }
     checkTierDisplayPosition(["between", "between"]);
     checkTierDisplayPosition(["center", "center"]);
     svg.remove();
   });
+
 
   it("if the time only uses one tier, there should be no space left for the second tier", () => {
     let svg = TestMethods.generateSVG();

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -152,7 +152,7 @@ describe("TimeAxis", () => {
   it("tick labels do not overlap with tick marks in top orientation", () => {
     let svg = TestMethods.generateSVG(400, 100);
     scale.domain([new Date("2010-01-01"), new Date("2014-01-01")]);
-    axis = new Plottable.Axes.Time(scale, "top");
+    axis.orientation("top");
 
     function checkTierDisplayPosition (tierDisplayPositions: string[]) {
       axis.tierLabelPositions(tierDisplayPositions);
@@ -161,34 +161,25 @@ describe("TimeAxis", () => {
       style.attr("type", "text/css");
       style.text(".plottable .axis.time-axis text { font-family: Arial; }");
       let tickMarks = d3.selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}:not(.${Plottable.Axis.END_TICK_MARK_CLASS})`);
-      assert.operator(tickMarks.size(), ">=", 1, "There are at least one tick marks in the test");
-      let tickLabels = d3.selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
-      .filter(function(d, i){
+      assert.operator(tickMarks.size(), ">=", 1, "There is at least one tick mark in the test");
+      let tickLabels = d3.selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`).filter(function(d, i){
         return window.getComputedStyle(this).visibility !== "hidden";
       });
-      assert.operator(tickLabels.size(), ">=", 1, `There are at least one tick labels in the test`);
+      assert.operator(tickLabels.size(), ">=", 1, `There is at least one tick label in the test`);
 
       function clientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect) {
-        if (clientRectA.right < clientRectB.left + window.Pixel_CloseTo_Requirement) {
-            return false;
-        }
-        if (window.Pixel_CloseTo_Requirement + clientRectA.left > clientRectB.right) {
-            return false;
-        }
-        if (clientRectA.bottom < clientRectB.top + window.Pixel_CloseTo_Requirement) {
-            return false;
-        }
-        if (window.Pixel_CloseTo_Requirement + clientRectA.top > clientRectB.bottom) {
-            return false;
-        }
-        return true;
-      }
+        return !(clientRectA.right < clientRectB.left + window.Pixel_CloseTo_Requirement)
+               && !(window.Pixel_CloseTo_Requirement + clientRectA.left > clientRectB.right)
+               && !(clientRectA.bottom < clientRectB.top + window.Pixel_CloseTo_Requirement)
+               && !(window.Pixel_CloseTo_Requirement + clientRectA.top > clientRectB.bottom);
+     }
+
       tickMarks.each(function(tickMark) {
         let tickMarkRect = this.getBoundingClientRect();
         tickLabels.each(function(tickLabel) {
           let tickLabelRect = this.getBoundingClientRect();
-          let isOverlap = clientRectsOverlap(tickMarkRect, tickLabelRect);
-          assert.isFalse(isOverlap, `Tick marks "${tickMark}" should not overlap with tick labels "${this.textContent}"`);
+          assert.isFalse(clientRectsOverlap(tickMarkRect, tickLabelRect),
+            `Tick marks [${tickMark}] should not overlap with tick labels [${this.textContent}]`);
         });
       });
     }

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -167,34 +167,19 @@ describe("TimeAxis", () => {
           return window.getComputedStyle(this).visibility !== "hidden";
         });
       assert.operator(tickLabels.size(), ">=", 1, "There are at least one tick labels in the test");
-
-      function clientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect) {
-        if (clientRectA.right < clientRectB.left + window.Pixel_CloseTo_Requirement) {
-          return false;
-        } else if (window.Pixel_CloseTo_Requirement + clientRectA.left > clientRectB.right) {
-          return false;
-        } else if (clientRectA.bottom < clientRectB.top + window.Pixel_CloseTo_Requirement) {
-          return false;
-        } else if (window.Pixel_CloseTo_Requirement + clientRectA.top > clientRectB.bottom) {
-          return false;
-        } else { 
-           return true;
-        }
-      }
-
-    tickMarks.each(function(tickMark) {
-          let tickMarkRect = this.getBoundingClientRect();
-          tickLabels.each(function(tickLabel) {
-            let tickLabelRect = this.getBoundingClientRect();
-            assert.isFalse(clientRectsOverlap(tickMarkRect, tickLabelRect), 
-              `Tick marks "${tickMark}" should not overlap with tick labels "${this.textContent}" `);
-          });
+      tickMarks.each(function(tickMark) {
+        let tickMarkRect = this.getBoundingClientRect();
+        tickLabels.each(function(tickLabel) {
+          let tickLabelRect = this.getBoundingClientRect();
+          assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(tickMarkRect, tickLabelRect), 
+            `Tick marks "${tickMark}" should not overlap with tick labels "${this.textContent}" `);
         });
-      }
+      });
+    }
 
-      checkTierDisplayPosition(["between", "between"]);
-      checkTierDisplayPosition(["center", "center"]);
-      svg.remove();
+    checkTierDisplayPosition(["between", "between"]);
+    checkTierDisplayPosition(["center", "center"]);
+    svg.remove();
   });
 
   it("if the time only uses one tier, there should be no space left for the second tier", () => {

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -152,19 +152,17 @@ describe("TimeAxis", () => {
   it("tick labels do not overlap with tick marks in top orientation", () => {
      let svg = TestMethods.generateSVG(400, 100);
       scale = new Plottable.Scales.Time();
-      scale.domain([new Date("2015-09-02"), new Date("2015-09-05")]);
+      scale.domain([new Date("2015-09-02"), new Date("2015-09-03")]);
       axis = new Plottable.Axes.Time(scale, "top");
 
       function checkTierDisplayPosition (tierDisplayPositions: any[]) {
         axis.tierLabelPositions(tierDisplayPositions);
         axis.renderTo(svg);
 
-        let tickMarks = d3.selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
+        let tickMarks = d3.selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}:not(.${Plottable.Axis.END_TICK_MARK_CLASS})`);
         assert.operator(tickMarks.size(), ">=", 1, "There are more than one tick marks in the test");
 
-        let tickLabels = d3.selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`).filter(function(d: Element, i: number) {
-          return d3.select(this).style("visibility") === "visible";
-        });
+        let tickLabels = d3.selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
         assert.operator(tickLabels.size(), ">=", 1, "There are more than one tick marks in the test");
 
         tickMarks.each(function(tickMark) {
@@ -172,7 +170,7 @@ describe("TimeAxis", () => {
           tickLabels.each(function(tickLabel) {
             let tickLabelRect = this.getBoundingClientRect();
             let isOverlap = Plottable.Utils.DOM.clientRectsOverlap(tickMarkRect, tickLabelRect);
-            assert.isFalse(isOverlap, `Tick marks do not overlap with tick labels ${this.textContent} `);
+            assert.isFalse(isOverlap, `Tick marks "${tickMark}" should not overlap with tick labels "${this.textContent}" `);
           });
         });
       }

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -149,6 +149,39 @@ describe("TimeAxis", () => {
     svg.remove();
   });
 
+  it("tick labels do not overlap with tick marks in top orientation", () => {
+     let svg = TestMethods.generateSVG(400, 100);
+      scale = new Plottable.Scales.Time();
+      scale.domain([new Date("2015-09-02"), new Date("2015-09-05")]);
+      axis = new Plottable.Axes.Time(scale, "top");
+
+      function checkTierDisplayPosition (tierDisplayPositions: any[]) {
+        axis.tierLabelPositions(tierDisplayPositions);
+        axis.renderTo(svg);
+
+        let tickMarks = d3.selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
+        assert.operator(tickMarks.size(), ">=", 1, "There are more than one tick marks in the test");
+
+        let tickLabels = d3.selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`).filter(function(d: Element, i: number) {
+          return d3.select(this).style("visibility") === "visible";
+        });
+        assert.operator(tickLabels.size(), ">=", 1, "There are more than one tick marks in the test");
+
+        tickMarks.each(function(tickMark) {
+          let tickMarkRect = this.getBoundingClientRect();
+          tickLabels.each(function(tickLabel) {
+            let tickLabelRect = this.getBoundingClientRect();
+            let isOverlap = Plottable.Utils.DOM.clientRectsOverlap(tickMarkRect, tickLabelRect);
+            assert.isFalse(isOverlap, `Tick marks do not overlap with tick labels ${this.textContent} `);
+          });
+        });
+      }
+
+    //  checkTierDisplayPosition(["between", "between"]);
+      checkTierDisplayPosition(["center", "center"]);
+      svg.remove();
+  });
+
   it("if the time only uses one tier, there should be no space left for the second tier", () => {
     let svg = TestMethods.generateSVG();
     let xScale = new Plottable.Scales.Time();

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -155,6 +155,10 @@ describe("TimeAxis", () => {
       scale.domain([new Date("2010-01-01"), new Date("2014-01-01")]);
       axis = new Plottable.Axes.Time(scale, "top");
 
+      let style = (<any> axis)._element.append("style");
+      style.attr("type", "text/css");
+      style.text(".plottable .axis.time-axis text { font-family: Arial; }");
+
       function checkTierDisplayPosition (tierDisplayPositions: any[]) {
         axis.tierLabelPositions(tierDisplayPositions);
         axis.renderTo(svg);

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -171,7 +171,7 @@ describe("TimeAxis", () => {
         let tickMarkRect = this.getBoundingClientRect();
         tickLabels.each(function(tickLabel) {
           let tickLabelRect = this.getBoundingClientRect();
-          assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(tickMarkRect, tickLabelRect), 
+          assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(tickMarkRect, tickLabelRect),
             `Tick marks "${tickMark}" should not overlap with tick labels "${this.textContent}" `);
         });
       });

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -161,7 +161,7 @@ describe("TimeAxis", () => {
 
         let style = (<any>axis)._element.append("style");
         style.attr("type", "text/css");
-        style.text(".plottable .axis.time-axis text { font-family: Arial; }");
+        style.text(".plottable .axis.time-axis text { font-family: Serif; }");
 
         let tickMarks = d3.selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}:not(.${Plottable.Axis.END_TICK_MARK_CLASS})`);
         assert.operator(tickMarks.size(), ">=", 1, "There are more than one tick marks in the test");

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -152,7 +152,7 @@ describe("TimeAxis", () => {
   it("tick labels do not overlap with tick marks in top orientation", () => {
      let svg = TestMethods.generateSVG(400, 100);
       scale = new Plottable.Scales.Time();
-      scale.domain([new Date("2015-09-01"), new Date("2015-09-03")]);
+      scale.domain([new Date("2015-09-01 12:00:00"), new Date("2015-09-03 12:00:00")]);
       axis = new Plottable.Axes.Time(scale, "top");
 
       function checkTierDisplayPosition (tierDisplayPositions: any[]) {
@@ -164,9 +164,9 @@ describe("TimeAxis", () => {
 
         let tickLabels = d3.selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
         .filter(function(d: Element, i: number){
-          return window.getComputedStyle(this).visibility !== "hidden";
+          return window.getComputedStyle(this).visibility === "visible";
         });
-        assert.operator(tickLabels.size(), ">=", 1, "There are more than one tick label in the test");
+        assert.operator(tickLabels.size(), ">=", 1, "There are more than one tick labels in the test");
 
         function myclientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect) {
                 if (clientRectA.right < clientRectB.left + window.Pixel_CloseTo_Requirement) {

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -197,7 +197,6 @@ describe("TimeAxis", () => {
     svg.remove();
   });
 
-
   it("if the time only uses one tier, there should be no space left for the second tier", () => {
     let svg = TestMethods.generateSVG();
     let xScale = new Plottable.Scales.Time();

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -167,8 +167,8 @@ describe("TimeAxis", () => {
           return window.getComputedStyle(this).visibility !== "hidden";
         });
         assert.operator(tickLabels.size(), ">=", 1, "There are more than one tick marks in the test");
-        
-        function myclientRectsOverlap(clientRectA:ClientRect, clientRectB:ClientRect) {
+
+        function myclientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect) {
                 if (clientRectA.right < clientRectB.left + window.Pixel_CloseTo_Requirement) {
                     return false;
                 }
@@ -183,7 +183,7 @@ describe("TimeAxis", () => {
                 }
                 return true;
             }
-            
+
         tickMarks.each(function(tickMark) {
           let tickMarkRect = this.getBoundingClientRect();
           tickLabels.each(function(tickLabel) {

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -154,12 +154,12 @@ describe("TimeAxis", () => {
     scale.domain([new Date("2010-01-01"), new Date("2014-01-01")]);
     axis = new Plottable.Axes.Time(scale, "top");
 
-    function checkTierDisplayPosition(tierDisplayPositions: any[]) {
+    function checkTierDisplayPosition (tierDisplayPositions: any[]) {
       axis.tierLabelPositions(tierDisplayPositions);
       axis.renderTo(svg);
       let style = (<any>axis)._element.append("style");
       style.attr("type", "text/css");
-      style.text(".plottable .axis .time-axis text { font-family: Arial; }");
+      style.text(".plottable .axis.time-axis text { font-family: Arial; }");
       let tickMarks = d3.selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}:not(.${Plottable.Axis.END_TICK_MARK_CLASS})`);
       assert.operator(tickMarks.size(), ">=", 1, "There are at least one tick marks in the test");
       let tickLabels = d3.selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
@@ -168,31 +168,32 @@ describe("TimeAxis", () => {
         });
       assert.operator(tickLabels.size(), ">=", 1, "There are at least one tick labels in the test");
 
-      function clientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect) {
+      function myclientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect) {
         if (clientRectA.right < clientRectB.left + window.Pixel_CloseTo_Requirement) {
           return false;
-        } else if (window.Pixel_CloseTo_Requirement + clientRectA.left > clientRectB.right) {
-          return false;
-        } else if (clientRectA.bottom < clientRectB.top + window.Pixel_CloseTo_Requirement) {
-          return false;
-        } else if (window.Pixel_CloseTo_Requirement + clientRectA.top > clientRectB.bottom) {
-          return false;
-        } else {
-          return true;
         }
-      }
+        if (window.Pixel_CloseTo_Requirement + clientRectA.left > clientRectB.right) {
+          return false;
+        }
+        if (clientRectA.bottom < clientRectB.top + window.Pixel_CloseTo_Requirement) {
+          return false;
+        }
+        if (window.Pixel_CloseTo_Requirement + clientRectA.top > clientRectB.bottom) {
+          return false;
+        }
+        return true;
+        }
 
       tickMarks.each(function(tickMark) {
         let tickMarkRect = this.getBoundingClientRect();
         tickLabels.each(function(tickLabel) {
           let tickLabelRect = this.getBoundingClientRect();
-          assert.isFalse(clientRectsOverlap(tickMarkRect, tickLabelRect),
-            `Tick marks "${tickMark}" should not overlap with tick labels "${this.textContent}" `);
+          let isOverlap = myclientRectsOverlap(tickMarkRect, tickLabelRect);
+          assert.isFalse(isOverlap, `Tick marks "${tickMark}" should not overlap with tick labels "${this.textContent}" `);
         });
       });
-    style.remove();
+      style.remove();
     }
-
     checkTierDisplayPosition(["between", "between"]);
     checkTierDisplayPosition(["center", "center"]);
     svg.remove();

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -152,7 +152,7 @@ describe("TimeAxis", () => {
   it("tick labels do not overlap with tick marks in top orientation", () => {
      let svg = TestMethods.generateSVG(400, 100);
       scale = new Plottable.Scales.Time();
-      scale.domain([new Date(2015, 8, 2), new Date(2015, 8, 3)]);
+      scale.domain([new Date("2015-09-02"), new Date("2015-09-03")]);
       axis = new Plottable.Axes.Time(scale, "top");
 
       function checkTierDisplayPosition (tierDisplayPositions: any[]) {
@@ -164,7 +164,7 @@ describe("TimeAxis", () => {
 
         let tickLabels = d3.selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
         .filter(function(d: Element, i: number){
-          return window.getComputedStyle(this).visibility === "visible";
+          return window.getComputedStyle(this).visibility !== "hidden";
         });
         assert.operator(tickLabels.size(), ">=", 1, "There are more than one tick marks in the test");
 


### PR DESCRIPTION
**Issue**:
In a time axis with `top` orientation, the `y` value of label positions are not calculated correctly when its `tierlabelposition` is set to `center` . This is an issue because it makes tick marks overlap with tick labels and hide all labels as a result. 

**Fix**:
When calculate the `y` value of label positions, we do not consider the height of tick marks. I fix this.

**JSFiddle**:
Before:http://jsfiddle.net/o87wsq9h/2/
After:http://jsfiddle.net/o87wsq9h/3/

close #2772