### PR TITLE
Support Formatter on Legend

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2160,6 +2160,17 @@ declare module Plottable {
             constructor(colorScale: Scales.Color);
             protected _setup(): void;
             /**
+             * Gets the Formatter for the text.
+             */
+            formatter(): Formatter;
+            /**
+             * Sets the Formatter for the text.
+             *
+             * @param {Formatter} formatter
+             * @returns {Legend} The calling Legend.
+             */
+            formatter(formatter: Formatter): Legend;
+            /**
              * Gets the maximum number of entries per row.
              *
              * @returns {number}

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2160,11 +2160,11 @@ declare module Plottable {
             constructor(colorScale: Scales.Color);
             protected _setup(): void;
             /**
-             * Gets the Formatter for the text.
+             * Gets the Formatter for the entry texts.
              */
             formatter(): Formatter;
             /**
-             * Sets the Formatter for the text.
+             * Sets the Formatter for the entry texts.
              *
              * @param {Formatter} formatter
              * @returns {Legend} The calling Legend.

--- a/plottable.js
+++ b/plottable.js
@@ -5503,8 +5503,12 @@ var Plottable;
                 var _this = this;
                 var textHeight = this._measurer.measure().height;
                 var availableWidthForEntries = Math.max(0, (availableWidth - this._padding));
-                var entryNames = this._colorScale.domain().slice();
-                entryNames.sort(this.comparator());
+                var entryLabels = d3.map();
+                this._colorScale.domain().slice().forEach(function (d) {
+                    entryLabels.set(_this._formatter(d), d);
+                });
+                var entryNames = entryLabels.keys();
+                entryNames = entryNames.sort(this.comparator()).map(function (d) { return entryLabels.get(d); });
                 var entryLengths = d3.map();
                 var untruncatedEntryLengths = d3.map();
                 entryNames.forEach(function (entryName) {

--- a/plottable.js
+++ b/plottable.js
@@ -5442,7 +5442,7 @@ var Plottable;
                 this._colorScale.onUpdate(this._redrawCallback);
                 this._formatter = Plottable.Formatters.identity();
                 this.xAlignment("right").yAlignment("top");
-                this.comparator(function (a, b) { return _this._colorScale.domain().indexOf(a) - _this._colorScale.domain().indexOf(b); });
+                this.comparator(function (a, b) { return 0; });
                 this._symbolFactoryAccessor = function () { return Plottable.SymbolFactories.circle(); };
                 this._symbolOpacityAccessor = function () { return 1; };
             }

--- a/plottable.js
+++ b/plottable.js
@@ -5456,7 +5456,7 @@ var Plottable;
                 this._writer = new SVGTypewriter.Writers.Writer(this._measurer, this._wrapper).addTitleElement(Plottable.Configs.ADD_TITLE_ELEMENTS);
             };
             Legend.prototype.formatter = function (formatter) {
-                if (formatter === undefined) {
+                if (formatter == null) {
                     return this._formatter;
                 }
                 this._formatter = formatter;

--- a/plottable.js
+++ b/plottable.js
@@ -5456,7 +5456,7 @@ var Plottable;
                 this._writer = new SVGTypewriter.Writers.Writer(this._measurer, this._wrapper).addTitleElement(Plottable.Configs.ADD_TITLE_ELEMENTS);
             };
             Legend.prototype.formatter = function (formatter) {
-                if (formatter === null) {
+                if (formatter === undefined) {
                     return this._formatter;
                 }
                 this._formatter = formatter;
@@ -5735,7 +5735,7 @@ var Plottable;
                 this._scale.offUpdate(this._redrawCallback);
             };
             InterpolatedColorLegend.prototype.formatter = function (formatter) {
-                if (formatter === null) {
+                if (formatter === undefined) {
                     return this._formatter;
                 }
                 this._formatter = formatter;

--- a/plottable.js
+++ b/plottable.js
@@ -5507,8 +5507,7 @@ var Plottable;
                 this._colorScale.domain().slice().forEach(function (d) {
                     entryLabels.set(_this._formatter(d), d);
                 });
-                var entryNames = entryLabels.keys();
-                entryNames = entryNames.sort(this.comparator()).map(function (d) { return entryLabels.get(d); });
+                var entryNames = entryLabels.keys().sort(this.comparator()).map(function (d) { return entryLabels.get(d); });
                 var entryLengths = d3.map();
                 var untruncatedEntryLengths = d3.map();
                 entryNames.forEach(function (entryName) {

--- a/plottable.js
+++ b/plottable.js
@@ -5503,11 +5503,7 @@ var Plottable;
                 var _this = this;
                 var textHeight = this._measurer.measure().height;
                 var availableWidthForEntries = Math.max(0, (availableWidth - this._padding));
-                var entryLabels = d3.map();
-                this._colorScale.domain().slice().forEach(function (d) {
-                    entryLabels.set(_this._formatter(d), d);
-                });
-                var entryNames = entryLabels.keys().sort(this.comparator()).map(function (d) { return entryLabels.get(d); });
+                var entryNames = this._colorScale.domain().slice().sort(function (a, b) { return _this._comparator(_this._formatter(a), _this._formatter(b)); });
                 var entryLengths = d3.map();
                 var untruncatedEntryLengths = d3.map();
                 entryNames.forEach(function (entryName) {

--- a/plottable.js
+++ b/plottable.js
@@ -5440,6 +5440,7 @@ var Plottable;
                 this._colorScale = colorScale;
                 this._redrawCallback = function (scale) { return _this.redraw(); };
                 this._colorScale.onUpdate(this._redrawCallback);
+                this._formatter = Plottable.Formatters.identity();
                 this.xAlignment("right").yAlignment("top");
                 this.comparator(function (a, b) { return _this._colorScale.domain().indexOf(a) - _this._colorScale.domain().indexOf(b); });
                 this._symbolFactoryAccessor = function () { return Plottable.SymbolFactories.circle(); };
@@ -5453,6 +5454,14 @@ var Plottable;
                 this._measurer = new SVGTypewriter.Measurers.Measurer(fakeLegendRow);
                 this._wrapper = new SVGTypewriter.Wrappers.Wrapper().maxLines(1);
                 this._writer = new SVGTypewriter.Writers.Writer(this._measurer, this._wrapper).addTitleElement(Plottable.Configs.ADD_TITLE_ELEMENTS);
+            };
+            Legend.prototype.formatter = function (formatter) {
+                if (formatter === null) {
+                    return this._formatter;
+                }
+                this._formatter = formatter;
+                this.redraw();
+                return this;
             };
             Legend.prototype.maxEntriesPerRow = function (maxEntriesPerRow) {
                 if (maxEntriesPerRow == null) {
@@ -5499,7 +5508,7 @@ var Plottable;
                 var entryLengths = d3.map();
                 var untruncatedEntryLengths = d3.map();
                 entryNames.forEach(function (entryName) {
-                    var untruncatedEntryLength = textHeight + _this._measurer.measure(entryName).width + _this._padding;
+                    var untruncatedEntryLength = textHeight + _this._measurer.measure(_this._formatter(entryName)).width + _this._padding;
                     var entryLength = Math.min(untruncatedEntryLength, availableWidthForEntries);
                     entryLengths.set(entryName, entryLength);
                     untruncatedEntryLengths.set(entryName, untruncatedEntryLength);
@@ -5631,7 +5640,7 @@ var Plottable;
                         yAlign: "top",
                         textRotation: 0
                     };
-                    self._writer.write(value, maxTextLength, self.height(), writeOptions);
+                    self._writer.write(self._formatter(value), maxTextLength, self.height(), writeOptions);
                 });
                 return this;
             };
@@ -5726,7 +5735,7 @@ var Plottable;
                 this._scale.offUpdate(this._redrawCallback);
             };
             InterpolatedColorLegend.prototype.formatter = function (formatter) {
-                if (formatter === undefined) {
+                if (formatter === null) {
                     return this._formatter;
                 }
                 this._formatter = formatter;

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -68,7 +68,7 @@ export module Components {
      */
     public formatter(formatter: Formatter): InterpolatedColorLegend;
     public formatter(formatter?: Formatter): any {
-      if (formatter === null) {
+      if (formatter === undefined) {
         return this._formatter;
       }
       this._formatter = formatter;

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -68,7 +68,7 @@ export module Components {
      */
     public formatter(formatter: Formatter): InterpolatedColorLegend;
     public formatter(formatter?: Formatter): any {
-      if (formatter == null) {
+      if (formatter === undefined) {
         return this._formatter;
       }
       this._formatter = formatter;

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -68,7 +68,7 @@ export module Components {
      */
     public formatter(formatter: Formatter): InterpolatedColorLegend;
     public formatter(formatter?: Formatter): any {
-      if (formatter === undefined) {
+      if (formatter === null) {
         return this._formatter;
       }
       this._formatter = formatter;

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -68,7 +68,7 @@ export module Components {
      */
     public formatter(formatter: Formatter): InterpolatedColorLegend;
     public formatter(formatter?: Formatter): any {
-      if (formatter === undefined) {
+      if (formatter == null) {
         return this._formatter;
       }
       this._formatter = formatter;

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -168,9 +168,8 @@ export module Components {
       this._colorScale.domain().slice().forEach((d) => {
         entryLabels.set(this._formatter(d), d);
       });
-      let entryNames = entryLabels.keys();
-      entryNames = entryNames.sort(this.comparator()).map((d) => entryLabels.get(d));
-
+      let formattedEntryNames = entryLabels.keys();
+      let entryNames = formattedEntryNames.sort(this.comparator()).map((d) => entryLabels.get(d));
       let entryLengths: d3.Map<number> = d3.map<number>();
       let untruncatedEntryLengths: d3.Map<number> = d3.map<number>();
       entryNames.forEach((entryName) => {

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -75,7 +75,7 @@ export module Components {
      */
     public formatter(formatter: Formatter): Legend;
     public formatter(formatter?: Formatter): any {
-      if (formatter === undefined) {
+      if (formatter == null) {
         return this._formatter;
       }
       this._formatter = formatter;

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -18,6 +18,7 @@ export module Components {
 
     private _padding = 5;
     private _colorScale: Scales.Color;
+    private _formatter: Formatter;
     private _maxEntriesPerRow: number;
     private _comparator: (a: string, b: string) => number;
     private _measurer: SVGTypewriter.Measurers.Measurer;
@@ -45,7 +46,7 @@ export module Components {
       this._colorScale = colorScale;
       this._redrawCallback = (scale) => this.redraw();
       this._colorScale.onUpdate(this._redrawCallback);
-
+      this._formatter = Formatters.identity();
       this.xAlignment("right").yAlignment("top");
       this.comparator((a: string, b: string) => this._colorScale.domain().indexOf(a) - this._colorScale.domain().indexOf(b));
       this._symbolFactoryAccessor = () => SymbolFactories.circle();
@@ -62,6 +63,25 @@ export module Components {
       this._writer = new SVGTypewriter.Writers.Writer(this._measurer, this._wrapper).addTitleElement(Configs.ADD_TITLE_ELEMENTS);
     }
 
+    /**
+     * Gets the Formatter for the text.
+     */
+    public formatter(): Formatter;
+    /**
+     * Sets the Formatter for the text.
+     *
+     * @param {Formatter} formatter
+     * @returns {Legend} The calling Legend.
+     */
+    public formatter(formatter: Formatter): Legend;
+    public formatter(formatter?: Formatter): any {
+      if (formatter === null) {
+        return this._formatter;
+      }
+      this._formatter = formatter;
+      this.redraw();
+      return this;
+    }
     /**
      * Gets the maximum number of entries per row.
      *
@@ -150,7 +170,7 @@ export module Components {
       let entryLengths: d3.Map<number> = d3.map<number>();
       let untruncatedEntryLengths: d3.Map<number> = d3.map<number>();
       entryNames.forEach((entryName) => {
-        let untruncatedEntryLength = textHeight + this._measurer.measure(entryName).width + this._padding;
+        let untruncatedEntryLength = textHeight + this._measurer.measure(this._formatter(entryName)).width + this._padding;
         let entryLength = Math.min(untruncatedEntryLength, availableWidthForEntries);
         entryLengths.set(entryName, entryLength);
         untruncatedEntryLengths.set(entryName, untruncatedEntryLength);
@@ -299,8 +319,7 @@ export module Components {
                         yAlign: "top",
                         textRotation: 0
                       };
-
-                      self._writer.write(value, maxTextLength, self.height(), writeOptions);
+                      self._writer.write(self._formatter(value), maxTextLength, self.height(), writeOptions);
                     });
       return this;
     }

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -64,11 +64,11 @@ export module Components {
     }
 
     /**
-     * Gets the Formatter for the text.
+     * Gets the Formatter for the entry texts.
      */
     public formatter(): Formatter;
     /**
-     * Sets the Formatter for the text.
+     * Sets the Formatter for the entry texts.
      *
      * @param {Formatter} formatter
      * @returns {Legend} The calling Legend.

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -75,7 +75,7 @@ export module Components {
      */
     public formatter(formatter: Formatter): Legend;
     public formatter(formatter?: Formatter): any {
-      if (formatter === null) {
+      if (formatter === undefined) {
         return this._formatter;
       }
       this._formatter = formatter;

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -164,12 +164,7 @@ export module Components {
 
       let availableWidthForEntries = Math.max(0, (availableWidth - this._padding));
 
-      let entryLabels: d3.Map<string> = d3.map<string>();
-      this._colorScale.domain().slice().forEach((d) => {
-        entryLabels.set(this._formatter(d), d);
-      });
-      let formattedEntryNames = entryLabels.keys();
-      let entryNames = formattedEntryNames.sort(this.comparator()).map((d) => entryLabels.get(d));
+      let entryNames = this._colorScale.domain().slice().sort((a,b) => this._comparator(this._formatter(a), this._formatter(b)));
       let entryLengths: d3.Map<number> = d3.map<number>();
       let untruncatedEntryLengths: d3.Map<number> = d3.map<number>();
       entryNames.forEach((entryName) => {

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -164,7 +164,7 @@ export module Components {
 
       let availableWidthForEntries = Math.max(0, (availableWidth - this._padding));
 
-      let entryNames = this._colorScale.domain().slice().sort((a,b) => this._comparator(this._formatter(a), this._formatter(b)));
+      let entryNames = this._colorScale.domain().slice().sort((a, b) => this._comparator(this._formatter(a), this._formatter(b)));
       let entryLengths: d3.Map<number> = d3.map<number>();
       let untruncatedEntryLengths: d3.Map<number> = d3.map<number>();
       entryNames.forEach((entryName) => {

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -164,8 +164,12 @@ export module Components {
 
       let availableWidthForEntries = Math.max(0, (availableWidth - this._padding));
 
-      let entryNames = this._colorScale.domain().slice();
-      entryNames.sort(this.comparator());
+      let entryLabels: d3.Map<string> = d3.map<string>();
+      this._colorScale.domain().slice().forEach((d) => {
+        entryLabels.set(this._formatter(d), d);
+      });
+      let entryNames = entryLabels.keys();
+      entryNames = entryNames.sort(this.comparator()).map((d) => entryLabels.get(d));
 
       let entryLengths: d3.Map<number> = d3.map<number>();
       let untruncatedEntryLengths: d3.Map<number> = d3.map<number>();

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -48,7 +48,7 @@ export module Components {
       this._colorScale.onUpdate(this._redrawCallback);
       this._formatter = Formatters.identity();
       this.xAlignment("right").yAlignment("top");
-      this.comparator((a: string, b: string) => this._colorScale.domain().indexOf(a) - this._colorScale.domain().indexOf(b));
+      this.comparator((a: string, b: string) => 0);
       this._symbolFactoryAccessor = () => SymbolFactories.circle();
       this._symbolOpacityAccessor = () => 1;
     }

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -268,7 +268,7 @@ describe("Legend", () => {
       let expectText = formatter(legend.colorScale().domain()[i]);
       assert.strictEqual(this.text(), expectText, `formatter output ${this.text} should be displayed`);
     });
-     svg.remove();
+    svg.remove();
   });
 
 it("can get formatter of the legend using formatter()", () => {

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -256,7 +256,7 @@ describe("Legend", () => {
 
   it("can set which formatter to use to change how entry labels are displayed", () => {
     color.domain(["jtao", "mschafer", "kfalter"]);
-    let data: { [id: string]: string; } = {"jtao": "Joy", "mschafer":  "Mark", "kfalter": "Kelsey"};
+    let data: {[id: string]: string; } = {"jtao": "Joy", "mschafer":  "Mark", "kfalter": "Kelsey"};
     let formatter = (id: string) => {
         return data[id];
     };
@@ -271,9 +271,9 @@ describe("Legend", () => {
     svg.remove();
   });
 
-it("can get formatter of the legend using formatter()", () => {
+  it("can get formatter of the legend using formatter()", () => {
     color.domain(["jtao", "mschafer", "kfalter"]);
-    let data: { [id: string]: string; } = {"jtao": "Joy", "mschafer": "Mark", "kfalter": "Kelsey"};
+    let data: {[id: string]: string; } = {"jtao": "Joy", "mschafer": "Mark", "kfalter": "Kelsey"};
     let formatter = (id: string) => {
         return data[id];
     };
@@ -281,7 +281,7 @@ it("can get formatter of the legend using formatter()", () => {
     legend.renderTo(svg);
     assert.strictEqual(legend.formatter(), formatter, "formatter() return the formatter of legend correctly");
     svg.remove();
-});
+  });
 
   describe("entitiesAt()", () => {
     function computeExpectedSymbolPosition(legend: Plottable.Components.Legend, rowIndex: number, entryIndexWithinRow: number) {

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -254,15 +254,14 @@ describe("Legend", () => {
     svg.remove();
   });
 
-  it("can set which formatter to use to change how entry labels are displayed", () => {
+  it("can set formatter and change how entry labels are displayed", () => {
     color.domain(["jtao", "mschafer", "kfalter"]);
     let data: {[id: string]: string; } = {"jtao": "Joy", "mschafer":  "Mark", "kfalter": "Kelsey"};
-    let formatter = (id: string) => {
-        return data[id];
-    };
+    let formatter = (id: string) => data[id];
     legend.formatter(formatter);
     legend.renderTo(svg);
     let legendRows = svg.selectAll(entrySelector);
+    assert.operator(legendRows, ">=", 1, "There is at least one entry in the test");
     legendRows.each(function(d: Element, i: number){
       let expectText = formatter(legend.colorScale().domain()[i]);
       assert.strictEqual(d3.select(this).select("text").text(), expectText,
@@ -274,11 +273,9 @@ describe("Legend", () => {
   it("can get formatter of the legend using formatter()", () => {
     color.domain(["jtao", "mschafer", "kfalter"]);
     let data: {[id: string]: string; } = {"jtao": "Joy", "mschafer": "Mark", "kfalter": "Kelsey"};
-    let formatter = (id: string) => {
-        return data[id];
-    };
+    let formatter = (id: string) => data[id];
     legend.formatter(formatter);
-    assert.strictEqual(legend.formatter(), formatter, "formatter() return the formatter of legend correctly");
+    assert.strictEqual(legend.formatter(), formatter, "formatter() returns the formatter of legend correctly");
     svg.remove();
   });
 
@@ -293,7 +290,7 @@ describe("Legend", () => {
     legend.renderTo(svg);
     let entryTexts = svg.selectAll(entrySelector)[0].map((node: Element) => d3.select(node).select("text").text());
     expectedTexts.sort(comparator);
-    assert.deepEqual(expectedTexts, entryTexts, "formatted entry has been sorted as expected");
+    assert.deepEqual(expectedTexts, entryTexts, "formatted entries have been sorted as expected");
     svg.remove();
   });
 

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -265,7 +265,7 @@ describe("Legend", () => {
     legendRows.each(function(d: Element, i: number){
       let expectText = formatter(legend.colorScale().domain()[i]);
       assert.strictEqual(d3.select(this).select("text").text(), expectText,
-        `formatter output ${d3.select(this).select("text").text()} should be displayed`);
+        `formatter output ${expectText} should be displayed`);
     });
     svg.remove();
   });

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -262,11 +262,11 @@ describe("Legend", () => {
     };
     legend.formatter(formatter);
     legend.renderTo(svg);
-
-    let legendRows = svg.selectAll(".legend_row");
+    let legendRows = svg.selectAll(entrySelector);
     legendRows.each(function(d: Element, i: number){
       let expectText = formatter(legend.colorScale().domain()[i]);
-      assert.strictEqual(this.text(), expectText, `formatter output ${this.text} should be displayed`);
+      assert.strictEqual(d3.select(this).select("text").text(), expectText,
+        `formatter output ${d3.select(this).select("text").text()} should be displayed`);
     });
     svg.remove();
   });
@@ -278,8 +278,22 @@ describe("Legend", () => {
         return data[id];
     };
     legend.formatter(formatter);
-    legend.renderTo(svg);
     assert.strictEqual(legend.formatter(), formatter, "formatter() return the formatter of legend correctly");
+    svg.remove();
+  });
+
+  it("comparator() works as expected when customized formatter is applied", () => {
+    let colorDomain = ["A", "B", "C"];
+    color.domain(colorDomain);
+    let expectedTexts = ["Z", "Y", "X"];
+    let formatter = (d: string) => expectedTexts[colorDomain.indexOf(d)];
+    legend.formatter(formatter);
+    let comparator = (a: string, b: string) => a.localeCompare(b);
+    legend.comparator(comparator);
+    legend.renderTo(svg);
+    let entryTexts = svg.selectAll(entrySelector)[0].map((node: Element) => d3.select(node).select("text").text());
+    expectedTexts.sort(comparator);
+    assert.deepEqual(expectedTexts, entryTexts, "formatted entry has been sorted as expected");
     svg.remove();
   });
 

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -270,7 +270,7 @@ describe("Legend", () => {
   });
 
   it("can get formatter of the legend using formatter()", () => {
-    let formatter = (id: string) => String.fromCharCode(id.charCodeAt(0) + 1);
+    let formatter = (id: string) => `${id}foo`;
     legend.formatter(formatter);
     assert.strictEqual(legend.formatter(), formatter, "formatter() returns the formatter of legend correctly");
     svg.remove();

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -254,33 +254,34 @@ describe("Legend", () => {
     svg.remove();
   });
 
-  it("accept formatter and show entity labels correcly", () => {
+  it("can set which formatter to use to change how entry labels are displayed", () => {
     color.domain(["jtao", "mschafer", "kfalter"]);
-    let data = [
-      {id: "jtao", name: "Joy Tao", score: 13},
-      {id: "mschafer", name: "Mark Schafer", score: 15},
-      {id: "kfalter", name: "Kelsey Falter", score: 11}
-    ];
-    let f = (id: string) => {
-      let pickedEntity = data.filter(function(d) {return (d.id === id); });
-      if (pickedEntity.length > 0) {
-          return pickedEntity[0].name;
-        }else {
-          return "NA";
-        }
+    let data : { [id: string]: string; } = {"jtao":"Joy", "mschafer":"Mark", "kfalter":"Kelsey"};
+    let formatter = (id: string) => {
+        return data[id];
     };
-    legend.formatter(f);
+    legend.formatter(formatter);
     legend.renderTo(svg);
 
-    let texts = svg.selectAll("title")[0].map(function(text: Element) {return text.textContent; });
-    data.forEach(function(d, i) {
-      let idExist = (texts.indexOf(d.id) !== -1);
-      let nameExist = (texts.indexOf(d.name) !== -1);
-      assert.isTrue(nameExist, `formatter output ${d.name} should be drawn`);
-      assert.isFalse(idExist, ` formatter input ${d.id} should not be drawn`);
-    });
+    let legendRows = svg.selectAll(".legend_row");
+    legendRows.each(function(d:Element, i:number){
+      let expectText = formatter(legend.colorScale().domain()[i]);
+      assert.strictEqual(this.text(), expectText,`formatter ${this.text} show correctly`);
+    })
      svg.remove();
   });
+  
+it("can get formatter of the legend using formatter()", () => {
+    color.domain(["jtao", "mschafer", "kfalter"]);
+    let data : { [id: string]: string; } = {"jtao":"Joy", "mschafer":"Mark", "kfalter":"Kelsey"};
+    let formatter = (id: string) => {
+        return data[id];
+    };
+    legend.formatter(formatter);
+    legend.renderTo(svg);
+    assert.strictEqual(legend.formatter(), formatter, "formatter() return the formatter of legend correctly");
+    svg.remove();
+});
 
   describe("entitiesAt()", () => {
     function computeExpectedSymbolPosition(legend: Plottable.Components.Legend, rowIndex: number, entryIndexWithinRow: number) {

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -261,7 +261,7 @@ describe("Legend", () => {
     legend.renderTo(svg);
     let legendRows = svg.selectAll(entrySelector);
     assert.operator(legendRows.size(), ">=", 1, "There is at least one entry in the test");
-    legendRows.each(function(d: Element, i: number){
+    legendRows.each(function(d, i){
       let expectText = formatter(legend.colorScale().domain()[i]);
       assert.strictEqual(d3.select(this).select("text").text(), expectText,
         `formatter output ${expectText} should be displayed`);
@@ -276,7 +276,7 @@ describe("Legend", () => {
     svg.remove();
   });
 
-  it("can sort entry texts by displayed texts using comparator", () => {
+  it("can sort displayed texts using comparator()", () => {
     let colorDomain = ["A", "B", "C"];
     color.domain(colorDomain);
     let expectedTexts = ["Z", "Y", "X"];

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -256,7 +256,7 @@ describe("Legend", () => {
 
   it("can set which formatter to use to change how entry labels are displayed", () => {
     color.domain(["jtao", "mschafer", "kfalter"]);
-    let data : { [id: string]: string; } = {"jtao":"Joy", "mschafer":"Mark", "kfalter":"Kelsey"};
+    let data: { [id: string]: string; } = {"jtao": "Joy", "mschafer":  "Mark", "kfalter": "Kelsey"};
     let formatter = (id: string) => {
         return data[id];
     };
@@ -264,16 +264,16 @@ describe("Legend", () => {
     legend.renderTo(svg);
 
     let legendRows = svg.selectAll(".legend_row");
-    legendRows.each(function(d:Element, i:number){
+    legendRows.each(function(d: Element, i: number){
       let expectText = formatter(legend.colorScale().domain()[i]);
-      assert.strictEqual(this.text(), expectText,`formatter ${this.text} show correctly`);
-    })
+      assert.strictEqual(this.text(), expectText, `formatter output ${this.text} should be displayed`);
+    });
      svg.remove();
   });
-  
+
 it("can get formatter of the legend using formatter()", () => {
     color.domain(["jtao", "mschafer", "kfalter"]);
-    let data : { [id: string]: string; } = {"jtao":"Joy", "mschafer":"Mark", "kfalter":"Kelsey"};
+    let data: { [id: string]: string; } = {"jtao": "Joy", "mschafer": "Mark", "kfalter": "Kelsey"};
     let formatter = (id: string) => {
         return data[id];
     };

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -254,9 +254,9 @@ describe("Legend", () => {
     svg.remove();
   });
 
-  it("can set formatter and change how entry labels are displayed", () => {
+  it("can set formatter to change how entry labels are displayed", () => {
     color.domain(["A", "B", "C"]);
-    let formatter = (id: string) => String.fromCharCode(id.charCodeAt(0) + 1);
+    let formatter = (id: string) => `${id}foo`;
     legend.formatter(formatter);
     legend.renderTo(svg);
     let legendRows = svg.selectAll(entrySelector);

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -262,9 +262,9 @@ describe("Legend", () => {
     let legendRows = svg.selectAll(entrySelector);
     assert.operator(legendRows.size(), ">=", 1, "There is at least one entry in the test");
     legendRows.each(function(d, i){
-      let expectText = formatter(legend.colorScale().domain()[i]);
-      assert.strictEqual(d3.select(this).select("text").text(), expectText,
-        `formatter output ${expectText} should be displayed`);
+      let expectedText = formatter(legend.colorScale().domain()[i]);
+      assert.strictEqual(d3.select(this).select("text").text(), expectedText,
+        `formatter output ${expectedText} should be displayed`);
     });
     svg.remove();
   });

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -261,7 +261,7 @@ describe("Legend", () => {
     legend.formatter(formatter);
     legend.renderTo(svg);
     let legendRows = svg.selectAll(entrySelector);
-    assert.operator(legendRows, ">=", 1, "There is at least one entry in the test");
+    assert.operator(legendRows.size(), ">=", 1, "There is at least one entry in the test");
     legendRows.each(function(d: Element, i: number){
       let expectText = formatter(legend.colorScale().domain()[i]);
       assert.strictEqual(d3.select(this).select("text").text(), expectText,

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -254,6 +254,34 @@ describe("Legend", () => {
     svg.remove();
   });
 
+  it("accept formatter and show entity labels correcly", () => {
+    color.domain(["jtao", "mschafer", "kfalter"]);
+    let data = [
+      {id: "jtao", name: "Joy Tao", score: 13},
+      {id: "mschafer", name: "Mark Schafer", score: 15},
+      {id: "kfalter", name: "Kelsey Falter", score: 11}
+    ];
+    let f = (id: string) => {
+      let pickedEntity = data.filter(function(d) {return (d.id === id); });
+      if (pickedEntity.length > 0) {
+          return pickedEntity[0].name;
+        }else {
+          return "NA";
+        }
+    };
+    legend.formatter(f);
+    legend.renderTo(svg);
+
+    let texts = svg.selectAll("title")[0].map(function(text: Element) {return text.textContent; });
+    data.forEach(function(d, i) {
+      let idExist = (texts.indexOf(d.id) !== -1);
+      let nameExist = (texts.indexOf(d.name) !== -1);
+      assert.isTrue(nameExist, `formatter output ${d.name} should be drawn`);
+      assert.isFalse(idExist, ` formatter input ${d.id} should not be drawn`);
+    });
+     svg.remove();
+  });
+
   describe("entitiesAt()", () => {
     function computeExpectedSymbolPosition(legend: Plottable.Components.Legend, rowIndex: number, entryIndexWithinRow: number) {
       let row = d3.select(legend.content().selectAll(rowSelector)[0][rowIndex]);

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -255,9 +255,8 @@ describe("Legend", () => {
   });
 
   it("can set formatter and change how entry labels are displayed", () => {
-    color.domain(["jtao", "mschafer", "kfalter"]);
-    let data: {[id: string]: string; } = {"jtao": "Joy", "mschafer":  "Mark", "kfalter": "Kelsey"};
-    let formatter = (id: string) => data[id];
+    color.domain(["A", "B", "C"]);
+    let formatter = (id: string) => String.fromCharCode(id.charCodeAt(0) + 1);
     legend.formatter(formatter);
     legend.renderTo(svg);
     let legendRows = svg.selectAll(entrySelector);
@@ -271,26 +270,24 @@ describe("Legend", () => {
   });
 
   it("can get formatter of the legend using formatter()", () => {
-    color.domain(["jtao", "mschafer", "kfalter"]);
-    let data: {[id: string]: string; } = {"jtao": "Joy", "mschafer": "Mark", "kfalter": "Kelsey"};
-    let formatter = (id: string) => data[id];
+    let formatter = (id: string) => String.fromCharCode(id.charCodeAt(0) + 1);
     legend.formatter(formatter);
     assert.strictEqual(legend.formatter(), formatter, "formatter() returns the formatter of legend correctly");
     svg.remove();
   });
 
-  it("comparator() works as expected when customized formatter is applied", () => {
+  it("can sort entry texts by displayed texts using comparator", () => {
     let colorDomain = ["A", "B", "C"];
     color.domain(colorDomain);
     let expectedTexts = ["Z", "Y", "X"];
     let formatter = (d: string) => expectedTexts[colorDomain.indexOf(d)];
     legend.formatter(formatter);
-    let comparator = (a: string, b: string) => a.localeCompare(b);
+    let comparator = (a: string, b: string) => a.charCodeAt(0) - b.charCodeAt(0);
     legend.comparator(comparator);
     legend.renderTo(svg);
     let entryTexts = svg.selectAll(entrySelector)[0].map((node: Element) => d3.select(node).select("text").text());
     expectedTexts.sort(comparator);
-    assert.deepEqual(expectedTexts, entryTexts, "formatted entries have been sorted as expected");
+    assert.deepEqual(expectedTexts, entryTexts, "displayed texts should be sorted in alphabetic order");
     svg.remove();
   });
 


### PR DESCRIPTION
**Feature**
Display a different name on an ordinary Legend than the values in the colorScale domain using customized `Formatter`.`Formatter` is defined as `(d:any) => string`
```typescript
class Legend{
/**
* Gets the Formatter for the text.
*/
formatter(): Formatter;
/**
* Sets the Formatter for the text.
*
* @param {Formatter} formatter
* @returns {Legend} The calling Legend.
*/
formatter(formatter: Formatter): Legend;
}
```

Using  `formatter` will affect the behavior of `comparator`. We decide to make `comparator` work on formatted texts.

**JSFiddle**
Before:http://jsfiddle.net/yunhaolucky/cmf3ut7g/4/
After:http://jsfiddle.net/yunhaolucky/cmf3ut7g/3/

close #2125