### PR TITLE
Add DragZoomLayer

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -595,6 +595,9 @@ declare module Plottable {
         selection: d3.Selection<any>;
         component: C;
     }
+    type Numeric = number | {
+        valueOf(): number;
+    };
 }
 
 
@@ -2625,9 +2628,6 @@ declare module Plottable {
 
 declare module Plottable {
     module Components {
-        type Numeric = number | {
-            valueOf(): number;
-        };
         class DragZoomLayer extends Components.SelectionBoxLayer {
             constructor(xScale: QuantitativeScale<Numeric>, yScale: QuantitativeScale<Numeric>);
             animationTime(): number;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2449,6 +2449,12 @@ declare module Plottable {
         }
         class SelectionBoxLayer extends Component {
             protected _box: d3.Selection<void>;
+            protected _xScale: QuantitativeScale<number | {
+                valueOf(): number;
+            }>;
+            protected _yScale: QuantitativeScale<number | {
+                valueOf(): number;
+            }>;
             protected _xBoundsMode: PropertyMode;
             protected _yBoundsMode: PropertyMode;
             constructor();
@@ -2612,6 +2618,22 @@ declare module Plottable {
              */
             pixelPosition(pixelPosition: number): GuideLineLayer<D>;
             destroy(): void;
+        }
+    }
+}
+
+
+declare module Plottable {
+    module Components {
+        class DragZoomLayer extends Components.SelectionBoxLayer {
+            constructor(xScale: QuantitativeScale<number | {
+                valueOf(): number;
+            }>, yScale: QuantitativeScale<number | {
+                valueOf(): number;
+            }>);
+            animationTime(): number;
+            animationTime(animationTime: number): DragZoomLayer;
+            ease(fn: (t: number) => number): DragZoomLayer;
         }
     }
 }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2625,12 +2625,11 @@ declare module Plottable {
 
 declare module Plottable {
     module Components {
+        type Numeric = number | {
+            valueOf(): number;
+        };
         class DragZoomLayer extends Components.SelectionBoxLayer {
-            constructor(xScale: QuantitativeScale<number | {
-                valueOf(): number;
-            }>, yScale: QuantitativeScale<number | {
-                valueOf(): number;
-            }>);
+            constructor(xScale: QuantitativeScale<Numeric>, yScale: QuantitativeScale<Numeric>);
             animationTime(): number;
             animationTime(animationTime: number): DragZoomLayer;
             ease(fn: (t: number) => number): DragZoomLayer;

--- a/plottable.js
+++ b/plottable.js
@@ -6751,7 +6751,7 @@ var Plottable;
     (function (Components) {
         var DragZoomLayer = (function (_super) {
             __extends(DragZoomLayer, _super);
-            /* Constructs a SelectionBoxLayer with an attached DragInteraction and ClickInteraction.
+            /* Constructs a SelectionBoxLayer with an attached DragInteraction and DoubleClickInteraction.
              * On drag, it triggers an animated zoom into the box that was dragged.
              * On double click, it zooms back out to the original view, before any zooming.
              * The zoom animation uses an easing function (default d3.ease("cubic-in-out")) and is customizable.
@@ -6777,7 +6777,7 @@ var Plottable;
                 this._dragInteraction.onDragStart(function (startPoint) {
                     _this.bounds({
                         topLeft: startPoint,
-                        bottomRight: startPoint,
+                        bottomRight: startPoint
                     });
                 });
                 this._dragInteraction.onDrag(function (startPoint, endPoint) {
@@ -6793,7 +6793,7 @@ var Plottable;
                     }
                     dragging = false;
                 });
-                this._doubleClickInteraction.onDoubleClick(this.unzoom.bind(this));
+                this._doubleClickInteraction.onDoubleClick(function () { return _this.unzoom(); });
             };
             DragZoomLayer.prototype.animationTime = function (animationTime) {
                 if (animationTime == null) {
@@ -6853,7 +6853,9 @@ var Plottable;
                 var y1s = this._yScale.domain()[1].valueOf();
                 // Copy a ref to the ease fn, so that changing ease wont affect zooms in progress
                 var ease = this.easeFn;
-                var interpolator = function (a, b, p) { return d3.interpolateNumber(a, b)(ease(p)); };
+                var interpolator = function (a, b, p) {
+                    return d3.interpolateNumber(a.valueOf(), b.valueOf())(ease(p));
+                };
                 this.isZooming(true);
                 var start = Date.now();
                 var draw = function () {

--- a/plottable.js
+++ b/plottable.js
@@ -6747,6 +6747,148 @@ var __extends = (this && this.__extends) || function (d, b) {
 };
 var Plottable;
 (function (Plottable) {
+    var Components;
+    (function (Components) {
+        var DragZoomLayer = (function (_super) {
+            __extends(DragZoomLayer, _super);
+            /* Constructs a SelectionBoxLayer with an attached DragInteraction and ClickInteraction.
+             * On drag, it triggers an animated zoom into the box that was dragged.
+             * On double click, it zooms back out to the original view, before any zooming.
+             * The zoom animation uses an easing function (default d3.ease("cubic-in-out")) and is customizable.
+             * Usage: Construct the selection box layer and attach x and y scales, and then add the layer
+             * over the plot you are zooming on using a Component Group.
+             */
+            function DragZoomLayer(xScale, yScale) {
+                _super.call(this);
+                this.isZoomed = false;
+                this.easeFn = d3.ease("cubic-in-out");
+                this._animationTime = 750;
+                this.xScale(xScale);
+                this.yScale(yScale);
+                this._dragInteraction = new Plottable.Interactions.Drag();
+                this._dragInteraction.attachTo(this);
+                this._doubleClickInteraction = new Plottable.Interactions.DoubleClick();
+                this._doubleClickInteraction.attachTo(this);
+                this.setupCallbacks();
+            }
+            DragZoomLayer.prototype.setupCallbacks = function () {
+                var _this = this;
+                var dragging = false;
+                this._dragInteraction.onDragStart(function (startPoint) {
+                    _this.bounds({
+                        topLeft: startPoint,
+                        bottomRight: startPoint,
+                    });
+                });
+                this._dragInteraction.onDrag(function (startPoint, endPoint) {
+                    _this.bounds({ topLeft: startPoint, bottomRight: endPoint });
+                    _this.boxVisible(true);
+                    dragging = true;
+                });
+                this._dragInteraction.onDragEnd(function (startPoint, endPoint) {
+                    _this.boxVisible(false);
+                    _this.bounds({ topLeft: startPoint, bottomRight: endPoint });
+                    if (dragging) {
+                        _this.zoom();
+                    }
+                    dragging = false;
+                });
+                this._doubleClickInteraction.onDoubleClick(this.unzoom.bind(this));
+            };
+            DragZoomLayer.prototype.animationTime = function (animationTime) {
+                if (animationTime == null) {
+                    return this._animationTime;
+                }
+                if (animationTime < 0) {
+                    throw new Error("animationTime cannot be negative");
+                }
+                this._animationTime = animationTime;
+                return this;
+            };
+            /* Set the easing function, which determines how the zoom interpolates over time. */
+            DragZoomLayer.prototype.ease = function (fn) {
+                if (typeof (fn) !== "function") {
+                    throw new Error("ease function must be a function");
+                }
+                if (fn(0) !== 0 || fn(1) !== 1) {
+                    Plottable.Utils.Window.warn("Easing function does not maintain invariant f(0)==0 && f(1)==1. Bad behavior may result.");
+                }
+                this.easeFn = fn;
+                return this;
+            };
+            // Zoom into extent of the selection box bounds
+            DragZoomLayer.prototype.zoom = function () {
+                var x0 = this.xExtent()[0].valueOf();
+                var x1 = this.xExtent()[1].valueOf();
+                var y0 = this.yExtent()[1].valueOf();
+                var y1 = this.yExtent()[0].valueOf();
+                if (x0 === x1 || y0 === y1) {
+                    return;
+                }
+                if (!this.isZoomed) {
+                    this.isZoomed = true;
+                    this.xDomainToRestore = this._xScale.domain();
+                    this.yDomainToRestore = this._yScale.domain();
+                }
+                this.interpolateZoom(x0, x1, y0, y1);
+            };
+            // Restore the scales to their state before any zoom
+            DragZoomLayer.prototype.unzoom = function () {
+                if (!this.isZoomed) {
+                    return;
+                }
+                this.isZoomed = false;
+                this.interpolateZoom(this.xDomainToRestore[0], this.xDomainToRestore[1], this.yDomainToRestore[0], this.yDomainToRestore[1]);
+            };
+            // If we are zooming, disable interactions, to avoid contention
+            DragZoomLayer.prototype.isZooming = function (isZooming) {
+                this._dragInteraction.enabled(!isZooming);
+                this._doubleClickInteraction.enabled(!isZooming);
+            };
+            DragZoomLayer.prototype.interpolateZoom = function (x0f, x1f, y0f, y1f) {
+                var _this = this;
+                var x0s = this._xScale.domain()[0].valueOf();
+                var x1s = this._xScale.domain()[1].valueOf();
+                var y0s = this._yScale.domain()[0].valueOf();
+                var y1s = this._yScale.domain()[1].valueOf();
+                // Copy a ref to the ease fn, so that changing ease wont affect zooms in progress
+                var ease = this.easeFn;
+                var interpolator = function (a, b, p) { return d3.interpolateNumber(a, b)(ease(p)); };
+                this.isZooming(true);
+                var start = Date.now();
+                var draw = function () {
+                    var now = Date.now();
+                    var passed = now - start;
+                    var p = _this._animationTime === 0 ? 1 : Math.min(1, passed / _this._animationTime);
+                    var x0 = interpolator(x0s, x0f, p);
+                    var x1 = interpolator(x1s, x1f, p);
+                    var y0 = interpolator(y0s, y0f, p);
+                    var y1 = interpolator(y1s, y1f, p);
+                    _this._xScale.domain([x0, x1]);
+                    _this._yScale.domain([y0, y1]);
+                    if (p < 1) {
+                        Plottable.Utils.DOM.requestAnimationFramePolyfill(draw);
+                    }
+                    else {
+                        _this.isZooming(false);
+                    }
+                };
+                draw();
+            };
+            return DragZoomLayer;
+        })(Components.SelectionBoxLayer);
+        Components.DragZoomLayer = DragZoomLayer;
+    })(Components = Plottable.Components || (Plottable.Components = {}));
+})(Plottable || (Plottable = {}));
+
+///<reference path="../reference.ts" />
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var Plottable;
+(function (Plottable) {
     var Plots;
     (function (Plots) {
         var Animator;

--- a/src/components/dragZoomLayer.ts
+++ b/src/components/dragZoomLayer.ts
@@ -2,7 +2,6 @@
 
 module Plottable {
 export module Components {
-  export type Numeric = number | {valueOf(): number};
   export class DragZoomLayer extends Components.SelectionBoxLayer {
     private _dragInteraction: Interactions.Drag;
     private _doubleClickInteraction: Interactions.DoubleClick;

--- a/src/components/dragZoomLayer.ts
+++ b/src/components/dragZoomLayer.ts
@@ -1,0 +1,153 @@
+///<reference path="../reference.ts" />
+
+module Plottable {
+export module Components {
+  export class DragZoomLayer extends Components.SelectionBoxLayer {
+    private _dragInteraction: Interactions.Drag;
+    private _doubleClickInteraction: Interactions.DoubleClick;
+    private xDomainToRestore: any[];
+    private yDomainToRestore: any[];
+    private isZoomed = false;
+    private easeFn: (t: number) => number = d3.ease("cubic-in-out");
+    private _animationTime = 750;
+
+    /* Constructs a SelectionBoxLayer with an attached DragInteraction and ClickInteraction.
+     * On drag, it triggers an animated zoom into the box that was dragged.
+     * On double click, it zooms back out to the original view, before any zooming.
+     * The zoom animation uses an easing function (default d3.ease("cubic-in-out")) and is customizable.
+     * Usage: Construct the selection box layer and attach x and y scales, and then add the layer
+     * over the plot you are zooming on using a Component Group.
+     */
+    constructor(xScale: QuantitativeScale<number | { valueOf(): number }>,
+                yScale: QuantitativeScale<number | { valueOf(): number }>) {
+      super();
+      this.xScale(xScale);
+      this.yScale(yScale);
+      this._dragInteraction = new Interactions.Drag();
+      this._dragInteraction.attachTo(this);
+      this._doubleClickInteraction = new Interactions.DoubleClick();
+      this._doubleClickInteraction.attachTo(this);
+      this.setupCallbacks();
+    }
+
+    private setupCallbacks() {
+      let dragging = false;
+      this._dragInteraction.onDragStart((startPoint: Point) => {
+        this.bounds({
+          topLeft: startPoint,
+          bottomRight: startPoint,
+        });
+      });
+      this._dragInteraction.onDrag((startPoint, endPoint) => {
+        this.bounds({topLeft: startPoint, bottomRight: endPoint});
+        this.boxVisible(true);
+        dragging = true;
+      });
+      this._dragInteraction.onDragEnd((startPoint, endPoint) => {
+        this.boxVisible(false);
+        this.bounds({topLeft: startPoint, bottomRight: endPoint});
+        if (dragging) {
+          this.zoom();
+        }
+        dragging = false;
+      });
+
+      this._doubleClickInteraction.onDoubleClick(this.unzoom.bind(this));
+    }
+
+    /* Set the time (in ms) over which the zoom will interpolate.
+     * 0 implies no interpolation. (ie zoom is instant)
+     */
+    public animationTime(): number;
+    public animationTime(animationTime: number): DragZoomLayer;
+    public animationTime(animationTime?: number): any {
+      if (animationTime == null) {
+        return this._animationTime;
+      }
+      if (animationTime < 0) {
+        throw new Error("animationTime cannot be negative");
+      }
+      this._animationTime = animationTime;
+      return this;
+    }
+
+    /* Set the easing function, which determines how the zoom interpolates over time. */
+    public ease(fn: (t: number) => number): DragZoomLayer {
+      if (typeof(fn) !== "function") {
+        throw new Error("ease function must be a function");
+      }
+      if (fn(0) !== 0 || fn(1) !== 1) {
+        Utils.Window.warn("Easing function does not maintain invariant f(0)==0 && f(1)==1. Bad behavior may result.");
+      }
+      this.easeFn = fn;
+      return this;
+    }
+
+    // Zoom into extent of the selection box bounds
+    private zoom() {
+      let x0: number = this.xExtent()[0].valueOf();
+      let x1: number = this.xExtent()[1].valueOf();
+      let y0: number = this.yExtent()[1].valueOf();
+      let y1: number = this.yExtent()[0].valueOf();
+
+      if (x0 === x1 || y0 === y1) {
+        return;
+      }
+
+      if (!this.isZoomed) {
+        this.isZoomed = true;
+        this.xDomainToRestore = this._xScale.domain();
+        this.yDomainToRestore = this._yScale.domain();
+      }
+      this.interpolateZoom(x0, x1, y0, y1);
+    }
+
+    // Restore the scales to their state before any zoom
+    private unzoom() {
+      if (!this.isZoomed) {
+        return;
+      }
+      this.isZoomed = false;
+      this.interpolateZoom(this.xDomainToRestore[0], this.xDomainToRestore[1],
+                           this.yDomainToRestore[0], this.yDomainToRestore[1]);
+    }
+
+    // If we are zooming, disable interactions, to avoid contention
+    private isZooming(isZooming: boolean) {
+      this._dragInteraction.enabled(!isZooming);
+      this._doubleClickInteraction.enabled(!isZooming);
+    }
+
+    private interpolateZoom(x0f: number, x1f: number, y0f: number, y1f: number) {
+      let x0s: number = this._xScale.domain()[0].valueOf();
+      let x1s: number = this._xScale.domain()[1].valueOf();
+      let y0s: number = this._yScale.domain()[0].valueOf();
+      let y1s: number = this._yScale.domain()[1].valueOf();
+
+      // Copy a ref to the ease fn, so that changing ease wont affect zooms in progress
+      let ease = this.easeFn;
+      let interpolator = (a: number, b: number, p: number) => d3.interpolateNumber(a, b)(ease(p));
+
+      this.isZooming(true);
+      let start = Date.now();
+      let draw = () => {
+        let now = Date.now();
+        let passed = now - start;
+        let p = this._animationTime === 0 ? 1 : Math.min(1, passed / this._animationTime);
+        let x0 = interpolator(x0s, x0f, p);
+        let x1 = interpolator(x1s, x1f, p);
+        let y0 = interpolator(y0s, y0f, p);
+        let y1 = interpolator(y1s, y1f, p);
+        this._xScale.domain([x0, x1]);
+        this._yScale.domain([y0, y1]);
+        if (p < 1) {
+          Utils.DOM.requestAnimationFramePolyfill(draw);
+        } else {
+          this.isZooming(false);
+        }
+      };
+      draw();
+    }
+  }
+}
+}

--- a/src/components/selectionBoxLayer.ts
+++ b/src/components/selectionBoxLayer.ts
@@ -13,8 +13,8 @@ export module Components {
     };
     private _xExtent: (number | { valueOf(): number })[];
     private _yExtent: (number | { valueOf(): number })[];
-    private _xScale: QuantitativeScale<number | { valueOf(): number }>;
-    private _yScale: QuantitativeScale<number | { valueOf(): number }>;
+    protected _xScale: QuantitativeScale<number | { valueOf(): number }>;
+    protected _yScale: QuantitativeScale<number | { valueOf(): number }>;
     private _adjustBoundsCallback: ScaleCallback<QuantitativeScale<number | { valueOf(): number }>>;
     protected _xBoundsMode = PropertyMode.PIXEL;
     protected _yBoundsMode = PropertyMode.PIXEL;

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -72,4 +72,7 @@ export interface Entity<C extends Component> {
   selection: d3.Selection<any>;
   component: C;
 }
+
+export type Numeric = number | {valueOf(): number};
+
 }

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -58,6 +58,7 @@
 /// <reference path="components/table.ts" />
 /// <reference path="components/selectionBoxLayer.ts" />
 /// <reference path="components/guideLineLayer.ts" />
+/// <reference path="components/dragZoomLayer.ts" />
 
 /// <reference path="plots/plot.ts" />
 /// <reference path="plots/piePlot.ts" />

--- a/test/components/dragZoomLayerTests.ts
+++ b/test/components/dragZoomLayerTests.ts
@@ -1,0 +1,131 @@
+///<reference path="../testReference.ts" />
+
+describe("Interactive Components", () => {
+  describe("DragZoomLayer", () => {
+    let SVG_WIDTH = 400;
+    let SVG_HEIGHT = 400;
+
+    let svg: d3.Selection<void>;
+    let target: d3.Selection<void>;
+    let dzl: Plottable.Components.DragZoomLayer;
+    let quarterPoint: Plottable.Point;
+    let halfPoint: Plottable.Point;
+    let xScale: Plottable.Scales.Linear;
+    let yScale: Plottable.Scales.Linear;
+
+    beforeEach(() => {
+      svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      xScale = new Plottable.Scales.Linear();
+      yScale = new Plottable.Scales.Linear();
+      dzl = new Plottable.Components.DragZoomLayer(xScale, yScale);
+      quarterPoint = {
+        x: SVG_WIDTH / 4,
+        y: SVG_HEIGHT / 4
+      };
+      halfPoint = {
+        x: SVG_WIDTH / 2,
+        y: SVG_HEIGHT / 2
+      };
+      dzl.renderTo(svg);
+      dzl.animationTime(0);
+      target = dzl.background();
+      xScale.domain([0, 1]);
+      yScale.domain([0, 1]);
+      xScale.range([0, SVG_WIDTH]);
+      yScale.range([SVG_HEIGHT, 0]);
+    });
+
+    it("zooms on drag", () => {
+      TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+      assert.deepEqual(xScale.domain(), [0.25, 0.5]);
+      assert.deepEqual(yScale.domain(), [0.5, 0.75]);
+      svg.remove();
+    });
+
+    it("zooms on drag, unzooms on double click", () => {
+      TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+      doubleClick(target, halfPoint);
+      assert.deepEqual(xScale.domain(), [0, 1], "x zoomed back out to origin");
+      assert.deepEqual(yScale.domain(), [0, 1], "y zoomed back out to origin");
+      svg.remove();
+    });
+
+    it("zooms sequentially", () => {
+      TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+      TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+      assert.deepEqual(xScale.domain(), [0.3125, 0.375]);
+      assert.deepEqual(yScale.domain(), [0.625, 0.6875]);
+      svg.remove();
+    });
+
+    it("double click undoes sequential zooms", () => {
+      TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+      TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+      TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+      doubleClick(target, halfPoint);
+      assert.deepEqual(xScale.domain(), [0, 1], "x zoomed back out to origin");
+      assert.deepEqual(yScale.domain(), [0, 1], "y zoomed back out to origin");
+      svg.remove();
+    });
+
+    it("interpolates if animation time is not zero", (done) => {
+      // Implicitly verifies that the interpolated zoom eventually reaches the right
+      // domain, otherwise this test would timeout.
+      dzl.animationTime(30);
+      let interpolations = 0;
+      let step = () => {
+        interpolations++;
+        let domain = xScale.domain();
+        if (domain[0] === 0.25 && domain[1] === 0.5) {
+          assert.operator(interpolations, ">", 1, "multiple interpolation steps occured");
+          svg.remove();
+          done()
+        }
+      };
+      xScale.onUpdate(step);
+      TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+    });
+
+    it("interactions disabled when zooming", (done) => {
+      dzl.animationTime(30);
+      let step = () => {
+        let domain = xScale.domain();
+        if (domain[0] === 0.25 && domain[1] === 0.5) {
+          svg.remove();
+          done()
+        }
+      };
+      xScale.onUpdate(step);
+      TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+      let dragInteraction = (<any> dzl)._dragInteraction;
+      let clickInteraction = (<any> dzl)._doubleClickInteraction;
+      assert.isFalse(dragInteraction.enabled());
+      assert.isFalse(clickInteraction.enabled());
+    });
+
+    it("zoom out also interpolates", (done) => {
+      TestMethods.triggerFakeDragSequence(target, quarterPoint, halfPoint);
+      dzl.animationTime(30);
+      let interpolations = 0;
+      let step = () => {
+        interpolations++;
+        let domain = xScale.domain();
+        if (domain[0] === 0 && domain[1] === 1) {
+          svg.remove();
+          done()
+        }
+      };
+      xScale.onUpdate(step);
+      doubleClick(target, halfPoint);
+    });
+
+    function doubleClick(target: d3.Selection<void>, point: Plottable.Point) {
+      TestMethods.triggerFakeMouseEvent("mousedown", target, point.x, point.y);
+      TestMethods.triggerFakeMouseEvent("mouseup", target, point.x, point.y);
+      TestMethods.triggerFakeMouseEvent("mousedown", target, point.x, point.y);
+      TestMethods.triggerFakeMouseEvent("mouseup", target, point.x, point.y);
+      TestMethods.triggerFakeMouseEvent("dblclick", target, point.x, point.y);
+
+    }
+  });
+});

--- a/test/components/dragZoomLayerTests.ts
+++ b/test/components/dragZoomLayerTests.ts
@@ -15,9 +15,19 @@ describe("Interactive Components", () => {
 
     beforeEach(() => {
       svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+
       xScale = new Plottable.Scales.Linear();
       yScale = new Plottable.Scales.Linear();
+      xScale.domain([0, 1]);
+      yScale.domain([0, 1]);
+      xScale.range([0, SVG_WIDTH]);
+      yScale.range([SVG_HEIGHT, 0]);
+
       dzl = new Plottable.Components.DragZoomLayer(xScale, yScale);
+      dzl.animationTime(0);
+      dzl.renderTo(svg);
+      target = dzl.background();
+
       quarterPoint = {
         x: SVG_WIDTH / 4,
         y: SVG_HEIGHT / 4
@@ -26,13 +36,6 @@ describe("Interactive Components", () => {
         x: SVG_WIDTH / 2,
         y: SVG_HEIGHT / 2
       };
-      dzl.renderTo(svg);
-      dzl.animationTime(0);
-      target = dzl.background();
-      xScale.domain([0, 1]);
-      yScale.domain([0, 1]);
-      xScale.range([0, SVG_WIDTH]);
-      yScale.range([SVG_HEIGHT, 0]);
     });
 
     it("zooms on drag", () => {
@@ -79,7 +82,7 @@ describe("Interactive Components", () => {
         if (domain[0] === 0.25 && domain[1] === 0.5) {
           assert.operator(interpolations, ">", 1, "multiple interpolation steps occured");
           svg.remove();
-          done()
+          done();
         }
       };
       xScale.onUpdate(step);
@@ -92,7 +95,7 @@ describe("Interactive Components", () => {
         let domain = xScale.domain();
         if (domain[0] === 0.25 && domain[1] === 0.5) {
           svg.remove();
-          done()
+          done();
         }
       };
       xScale.onUpdate(step);
@@ -112,11 +115,18 @@ describe("Interactive Components", () => {
         let domain = xScale.domain();
         if (domain[0] === 0 && domain[1] === 1) {
           svg.remove();
-          done()
+          done();
         }
       };
       xScale.onUpdate(step);
       doubleClick(target, halfPoint);
+    });
+
+    it("complains if an invalid ease fn is used", () => {
+      let badEase = (x: number) => 2 * x;
+      let invalid = () => dzl.ease(badEase);
+      TestMethods.assertWarns(invalid, "Easing function does not maintain invariant", "should get warning");
+      svg.remove();
     });
 
     function doubleClick(target: d3.Selection<void>, point: Plottable.Point) {

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -29,6 +29,7 @@
 ///<reference path="components/componentTests.ts" />
 ///<reference path="components/tableTests.ts" />
 ///<reference path="components/guideLineLayerTests.ts" />
+///<reference path="components/dragZoomLayerTests.ts" />
 
 ///<reference path="plots/plotTests.ts" />
 ///<reference path="plots/xyPlotTests.ts" />


### PR DESCRIPTION
DragZoomLayer creates a SelectionBox that powers a drag-to-zoom interaction. When you drag a box, the scales zoom into the bounds drawn out in that box and the box disappears. The zoom can be animated over a variable amount of time (default 750ms) with a custom easing function (default d3.cubic-in-out). Tests included.
