### PR TITLE
Cropped Rendering Performance Option

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3410,6 +3410,19 @@ declare module Plottable {
             interpolator(interpolator: "cardinal-open"): Line<X>;
             interpolator(interpolator: "cardinal-closed"): Line<X>;
             interpolator(interpolator: "monotone"): Line<X>;
+            /**
+             * Gets the croppedRendering preformance option state.
+             *
+             * When croppedRendering option is enabled, lines that will not be visible in the viewport will not be
+             * drawn anymore (will not have corresponding SVG nodes). If only part of the data is in the viewport,
+             * then this option will boost of rendering. However, if all the data is rendered anyway, having this
+             * option enabled will cause a small overhead that can be noticed in the total render time.
+             */
+            croppedRenderingEnabled(): boolean;
+            /**
+             * Sets the croppedRendering performance option.
+             */
+            croppedRenderingEnabled(croppedRendering: boolean): Plots.Line<X>;
             protected _createDrawer(dataset: Dataset): Drawer;
             protected _extentsForProperty(property: string): any[];
             protected _getResetYFunction(): (d: any, i: number, dataset: Dataset) => number;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3414,8 +3414,6 @@ declare module Plottable {
              * Gets if croppedRendering is enabled
              *
              * When croppedRendering is enabled, lines that will not be visible in the viewport will not be drawn.
-             * Thus if only part of the data is in the viewport, then this option will boost of rendering.
-             * However if all the data will render, enabling will cause an insignificant overhead.
              */
             croppedRenderingEnabled(): boolean;
             /**

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3417,13 +3417,13 @@ declare module Plottable {
              * Thus if only part of the data is in the viewport, then this option will boost of rendering.
              * However if all the data will render, enabling will cause an insignificant overhead.
              */
-            croppedRendering(): boolean;
+            croppedRenderingEnabled(): boolean;
             /**
              * Sets if croppedRendering is enabled
              *
              * @returns {Plots.Line} The calling Plots.Line
              */
-            croppedRendering(croppedRendering: boolean): Plots.Line<X>;
+            croppedRenderingEnabled(croppedRendering: boolean): Plots.Line<X>;
             protected _createDrawer(dataset: Dataset): Drawer;
             protected _extentsForProperty(property: string): any[];
             protected _getResetYFunction(): (d: any, i: number, dataset: Dataset) => number;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3417,13 +3417,13 @@ declare module Plottable {
              * Thus if only part of the data is in the viewport, then this option will boost of rendering.
              * However if all the data will render, enabling will cause an insignificant overhead.
              */
-            croppedRenderingEnabled(): boolean;
+            croppedRendering(): boolean;
             /**
              * Sets if croppedRendering is enabled
              *
              * @returns {Plots.Line} The calling Plots.Line
              */
-            croppedRenderingEnabled(croppedRendering: boolean): Plots.Line<X>;
+            croppedRendering(croppedRendering: boolean): Plots.Line<X>;
             protected _createDrawer(dataset: Dataset): Drawer;
             protected _extentsForProperty(property: string): any[];
             protected _getResetYFunction(): (d: any, i: number, dataset: Dataset) => number;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3411,16 +3411,17 @@ declare module Plottable {
             interpolator(interpolator: "cardinal-closed"): Line<X>;
             interpolator(interpolator: "monotone"): Line<X>;
             /**
-             * Gets the croppedRendering preformance option state.
+             * Gets if croppedRendering is enabled
              *
-             * When croppedRendering option is enabled, lines that will not be visible in the viewport will not be
-             * drawn anymore (will not have corresponding SVG nodes). If only part of the data is in the viewport,
-             * then this option will boost of rendering. However, if all the data is rendered anyway, having this
-             * option enabled will cause a small overhead that can be noticed in the total render time.
+             * When croppedRendering is enabled, lines that will not be visible in the viewport will not be drawn.
+             * Thus if only part of the data is in the viewport, then this option will boost of rendering.
+             * However if all the data will render, enabling will cause an insignificant overhead.
              */
             croppedRenderingEnabled(): boolean;
             /**
-             * Sets the croppedRendering performance option.
+             * Sets if croppedRendering is enabled
+             *
+             * @returns {Plots.Line} The calling Plots.Line
              */
             croppedRenderingEnabled(croppedRendering: boolean): Plots.Line<X>;
             protected _createDrawer(dataset: Dataset): Drawer;

--- a/plottable.js
+++ b/plottable.js
@@ -630,8 +630,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -1602,8 +1601,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -1840,8 +1838,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -1899,8 +1896,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -2091,8 +2087,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -2206,8 +2201,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -2325,8 +2319,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -2441,8 +2434,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -2778,8 +2770,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -2809,8 +2800,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -2840,8 +2830,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -2863,8 +2852,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -2891,8 +2879,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -2919,8 +2906,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -2943,8 +2929,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -3484,8 +3469,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -3566,8 +3550,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -3665,8 +3648,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -4236,8 +4218,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -4706,8 +4687,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -5044,8 +5024,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -5256,8 +5235,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -5413,8 +5391,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -5686,8 +5663,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -5929,8 +5905,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -6034,8 +6009,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -6399,8 +6373,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -6620,8 +6593,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -6772,8 +6744,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -7238,8 +7209,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -7567,8 +7537,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -7873,8 +7842,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -8228,8 +8196,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -8383,8 +8350,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -9010,8 +8976,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -9347,8 +9312,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -9523,8 +9487,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -9589,8 +9552,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -9756,8 +9718,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -9879,8 +9840,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -10056,8 +10016,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -10261,8 +10220,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -10609,8 +10567,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -10797,8 +10754,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -10962,8 +10918,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -11150,8 +11105,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -11233,8 +11187,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -11347,8 +11300,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -11467,8 +11419,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -11585,8 +11536,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -11910,8 +11860,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -12069,8 +12018,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -12443,8 +12391,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -12505,8 +12452,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {
@@ -12567,8 +12513,7 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Plottable;
 (function (Plottable) {

--- a/plottable.js
+++ b/plottable.js
@@ -630,7 +630,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -1601,7 +1602,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -1838,7 +1840,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -1896,7 +1899,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -2087,7 +2091,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -2201,7 +2206,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -2319,7 +2325,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -2434,7 +2441,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -2770,7 +2778,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -2800,7 +2809,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -2830,7 +2840,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -2852,7 +2863,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -2879,7 +2891,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -2906,7 +2919,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -2929,7 +2943,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -3469,7 +3484,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -3550,7 +3566,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -3648,7 +3665,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -4218,7 +4236,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -4687,7 +4706,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -5024,7 +5044,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -5235,7 +5256,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -5391,7 +5413,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -5663,7 +5686,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -5905,7 +5929,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -6009,7 +6034,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -6373,7 +6399,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -6593,7 +6620,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -6744,7 +6772,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -7209,7 +7238,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -7537,7 +7567,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -7842,7 +7873,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -8196,7 +8228,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -8350,7 +8383,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -8976,7 +9010,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -8993,6 +9028,8 @@ var Plottable;
                 _super.call(this);
                 this._interpolator = "linear";
                 this._autorangeSmooth = false;
+                // Performance options
+                this._croppedRendering = false;
                 this.addClass("line-plot");
                 var animator = new Plottable.Animators.Easing();
                 animator.stepDuration(Plottable.Plot._ANIMATION_MAX_DURATION);
@@ -9056,6 +9093,14 @@ var Plottable;
                     return this._interpolator;
                 }
                 this._interpolator = interpolator;
+                this.render();
+                return this;
+            };
+            Line.prototype.croppedRenderingEnabled = function (croppedRendering) {
+                if (croppedRendering == null) {
+                    return this._croppedRendering;
+                }
+                this._croppedRendering = croppedRendering;
                 this.render();
                 return this;
             };
@@ -9244,9 +9289,53 @@ var Plottable;
                 };
             };
             Line.prototype._getDataToDraw = function () {
+                var _this = this;
                 var dataToDraw = new Plottable.Utils.Map();
-                this.datasets().forEach(function (dataset) { return dataToDraw.set(dataset, [dataset.data()]); });
+                this.datasets().forEach(function (dataset) {
+                    var data = dataset.data();
+                    if (!_this._croppedRendering) {
+                        dataToDraw.set(dataset, [data]);
+                        return;
+                    }
+                    var filteredDataIndices = data.map(function (d, i) { return i; });
+                    if (_this._croppedRendering) {
+                        filteredDataIndices = _this._filterCroppedRendering(dataset, filteredDataIndices);
+                    }
+                    dataToDraw.set(dataset, [filteredDataIndices.map(function (d, i) { return data[d]; })]);
+                });
                 return dataToDraw;
+            };
+            Line.prototype._filterCroppedRendering = function (dataset, indices) {
+                var xScale = this.x().scale;
+                var yScale = this.y().scale;
+                var xAccessor = this.x().accessor;
+                var yAccessor = this.y().accessor;
+                var xDomain = xScale.domain();
+                var yDomain = yScale.domain();
+                var data = dataset.data();
+                var filteredDataIndices = [];
+                for (var i = 0; i < indices.length; i++) {
+                    var currXPoint = xAccessor(data[indices[i]], indices[i], dataset);
+                    var currYPoint = yAccessor(data[indices[i]], indices[i], dataset);
+                    var shouldShow = xDomain[0] <= currXPoint && currXPoint <= xDomain[1] &&
+                        yDomain[0] <= currYPoint && currYPoint <= yDomain[1];
+                    if (!shouldShow && indices[i - 1] != null && data[indices[i - 1]] != null) {
+                        var prevXPoint = xAccessor(data[indices[i - 1]], indices[i - 1], dataset);
+                        var prevYPoint = yAccessor(data[indices[i - 1]], indices[i - 1], dataset);
+                        shouldShow = shouldShow || xDomain[0] <= prevXPoint && prevXPoint <= xDomain[1] &&
+                            yDomain[0] <= prevYPoint && prevYPoint <= yDomain[1];
+                    }
+                    if (!shouldShow && indices[i + 1] != null && data[indices[i + 1]] != null) {
+                        var nextXPoint = xAccessor(data[indices[i + 1]], indices[i + 1], dataset);
+                        var nextYPoint = yAccessor(data[indices[i + 1]], indices[i + 1], dataset);
+                        shouldShow = shouldShow || xDomain[0] <= nextXPoint && nextXPoint <= xDomain[1] &&
+                            yDomain[0] <= nextYPoint && nextYPoint <= yDomain[1];
+                    }
+                    if (shouldShow) {
+                        filteredDataIndices.push(indices[i]);
+                    }
+                }
+                return filteredDataIndices;
             };
             return Line;
         })(Plottable.XYPlot);
@@ -9258,7 +9347,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -9433,7 +9523,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -9498,7 +9589,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -9664,7 +9756,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -9786,7 +9879,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -9962,7 +10056,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -10166,7 +10261,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -10513,7 +10609,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -10700,7 +10797,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -10864,7 +10962,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -11051,7 +11150,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -11133,7 +11233,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -11246,7 +11347,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -11365,7 +11467,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -11482,7 +11585,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -11806,7 +11910,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -11964,7 +12069,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -12337,7 +12443,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -12398,7 +12505,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {
@@ -12459,7 +12567,8 @@ var Plottable;
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    __.prototype = b.prototype;
+    d.prototype = new __();
 };
 var Plottable;
 (function (Plottable) {

--- a/plottable.js
+++ b/plottable.js
@@ -9268,26 +9268,28 @@ var Plottable;
                 return dataToDraw;
             };
             Line.prototype._filterCroppedRendering = function (dataset, indices) {
+                var _this = this;
                 var xProjector = Plottable.Plot._scaledAccessor(this.x());
                 var yProjector = Plottable.Plot._scaledAccessor(this.y());
                 var data = dataset.data();
                 var filteredDataIndices = [];
+                var pointInViewport = function (x, y) {
+                    return Plottable.Utils.Math.inRange(x, 0, _this.width()) &&
+                        Plottable.Utils.Math.inRange(y, 0, _this.height());
+                };
                 for (var i = 0; i < indices.length; i++) {
                     var currXPoint = xProjector(data[indices[i]], indices[i], dataset);
                     var currYPoint = yProjector(data[indices[i]], indices[i], dataset);
-                    var shouldShow = 0 <= currXPoint && currXPoint <= this.width() &&
-                        0 <= currYPoint && currYPoint <= this.height();
+                    var shouldShow = pointInViewport(currXPoint, currYPoint);
                     if (!shouldShow && indices[i - 1] != null && data[indices[i - 1]] != null) {
                         var prevXPoint = xProjector(data[indices[i - 1]], indices[i - 1], dataset);
                         var prevYPoint = yProjector(data[indices[i - 1]], indices[i - 1], dataset);
-                        shouldShow = shouldShow || 0 <= prevXPoint && prevXPoint <= this.width() &&
-                            0 <= prevYPoint && prevYPoint <= this.height();
+                        shouldShow = shouldShow || pointInViewport(prevXPoint, prevYPoint);
                     }
                     if (!shouldShow && indices[i + 1] != null && data[indices[i + 1]] != null) {
                         var nextXPoint = xProjector(data[indices[i + 1]], indices[i + 1], dataset);
                         var nextYPoint = yProjector(data[indices[i + 1]], indices[i + 1], dataset);
-                        shouldShow = shouldShow || 0 <= nextXPoint && nextXPoint <= this.width() &&
-                            0 <= nextYPoint && nextYPoint <= this.height();
+                        shouldShow = shouldShow || pointInViewport(nextXPoint, nextYPoint);
                     }
                     if (shouldShow) {
                         filteredDataIndices.push(indices[i]);

--- a/plottable.js
+++ b/plottable.js
@@ -1,5 +1,5 @@
 /*!
-Plottable 1.12.0 (https://github.com/palantir/plottable)
+Plottable 1.13.0 (https://github.com/palantir/plottable)
 Copyright 2014-2015 Palantir Technologies
 Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
 */
@@ -908,7 +908,7 @@ var Plottable;
 ///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
-    Plottable.version = "1.12.0";
+    Plottable.version = "1.13.0";
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
@@ -8993,7 +8993,6 @@ var Plottable;
                 _super.call(this);
                 this._interpolator = "linear";
                 this._autorangeSmooth = false;
-                // Performance options
                 this._croppedRendering = false;
                 this.addClass("line-plot");
                 var animator = new Plottable.Animators.Easing();
@@ -9263,9 +9262,7 @@ var Plottable;
                         return;
                     }
                     var filteredDataIndices = data.map(function (d, i) { return i; });
-                    if (_this._croppedRendering) {
-                        filteredDataIndices = _this._filterCroppedRendering(dataset, filteredDataIndices);
-                    }
+                    filteredDataIndices = _this._filterCroppedRendering(dataset, filteredDataIndices);
                     dataToDraw.set(dataset, [filteredDataIndices.map(function (d, i) { return data[d]; })]);
                 });
                 return dataToDraw;

--- a/plottable.js
+++ b/plottable.js
@@ -9060,7 +9060,7 @@ var Plottable;
                 this.render();
                 return this;
             };
-            Line.prototype.croppedRendering = function (croppedRendering) {
+            Line.prototype.croppedRenderingEnabled = function (croppedRendering) {
                 if (croppedRendering == null) {
                     return this._croppedRendering;
                 }

--- a/plottable.js
+++ b/plottable.js
@@ -1,5 +1,5 @@
 /*!
-Plottable 1.12.0 (https://github.com/palantir/plottable)
+Plottable 1.13.0 (https://github.com/palantir/plottable)
 Copyright 2014-2015 Palantir Technologies
 Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
 */
@@ -908,7 +908,7 @@ var Plottable;
 ///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
-    Plottable.version = "1.12.0";
+    Plottable.version = "1.13.0";
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />

--- a/plottable.js
+++ b/plottable.js
@@ -1,5 +1,5 @@
 /*!
-Plottable 1.13.0 (https://github.com/palantir/plottable)
+Plottable 1.12.0 (https://github.com/palantir/plottable)
 Copyright 2014-2015 Palantir Technologies
 Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
 */
@@ -908,7 +908,7 @@ var Plottable;
 ///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
-    Plottable.version = "1.13.0";
+    Plottable.version = "1.12.0";
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
@@ -9268,30 +9268,26 @@ var Plottable;
                 return dataToDraw;
             };
             Line.prototype._filterCroppedRendering = function (dataset, indices) {
-                var xScale = this.x().scale;
-                var yScale = this.y().scale;
-                var xAccessor = this.x().accessor;
-                var yAccessor = this.y().accessor;
-                var xDomain = xScale.domain();
-                var yDomain = yScale.domain();
+                var xProjector = Plottable.Plot._scaledAccessor(this.x());
+                var yProjector = Plottable.Plot._scaledAccessor(this.y());
                 var data = dataset.data();
                 var filteredDataIndices = [];
                 for (var i = 0; i < indices.length; i++) {
-                    var currXPoint = xAccessor(data[indices[i]], indices[i], dataset);
-                    var currYPoint = yAccessor(data[indices[i]], indices[i], dataset);
-                    var shouldShow = xDomain[0] <= currXPoint && currXPoint <= xDomain[1] &&
-                        yDomain[0] <= currYPoint && currYPoint <= yDomain[1];
+                    var currXPoint = xProjector(data[indices[i]], indices[i], dataset);
+                    var currYPoint = yProjector(data[indices[i]], indices[i], dataset);
+                    var shouldShow = 0 <= currXPoint && currXPoint <= this.width() &&
+                        0 <= currYPoint && currYPoint <= this.height();
                     if (!shouldShow && indices[i - 1] != null && data[indices[i - 1]] != null) {
-                        var prevXPoint = xAccessor(data[indices[i - 1]], indices[i - 1], dataset);
-                        var prevYPoint = yAccessor(data[indices[i - 1]], indices[i - 1], dataset);
-                        shouldShow = shouldShow || xDomain[0] <= prevXPoint && prevXPoint <= xDomain[1] &&
-                            yDomain[0] <= prevYPoint && prevYPoint <= yDomain[1];
+                        var prevXPoint = xProjector(data[indices[i - 1]], indices[i - 1], dataset);
+                        var prevYPoint = yProjector(data[indices[i - 1]], indices[i - 1], dataset);
+                        shouldShow = shouldShow || 0 <= prevXPoint && prevXPoint <= this.width() &&
+                            0 <= prevYPoint && prevYPoint <= this.height();
                     }
                     if (!shouldShow && indices[i + 1] != null && data[indices[i + 1]] != null) {
-                        var nextXPoint = xAccessor(data[indices[i + 1]], indices[i + 1], dataset);
-                        var nextYPoint = yAccessor(data[indices[i + 1]], indices[i + 1], dataset);
-                        shouldShow = shouldShow || xDomain[0] <= nextXPoint && nextXPoint <= xDomain[1] &&
-                            yDomain[0] <= nextYPoint && nextYPoint <= yDomain[1];
+                        var nextXPoint = xProjector(data[indices[i + 1]], indices[i + 1], dataset);
+                        var nextYPoint = yProjector(data[indices[i + 1]], indices[i + 1], dataset);
+                        shouldShow = shouldShow || 0 <= nextXPoint && nextXPoint <= this.width() &&
+                            0 <= nextYPoint && nextYPoint <= this.height();
                     }
                     if (shouldShow) {
                         filteredDataIndices.push(indices[i]);

--- a/plottable.js
+++ b/plottable.js
@@ -9061,7 +9061,7 @@ var Plottable;
                 this.render();
                 return this;
             };
-            Line.prototype.croppedRenderingEnabled = function (croppedRendering) {
+            Line.prototype.croppedRendering = function (croppedRendering) {
                 if (croppedRendering == null) {
                     return this._croppedRendering;
                 }

--- a/plottable.js
+++ b/plottable.js
@@ -1,5 +1,5 @@
 /*!
-Plottable 1.13.0 (https://github.com/palantir/plottable)
+Plottable 1.12.0 (https://github.com/palantir/plottable)
 Copyright 2014-2015 Palantir Technologies
 Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
 */
@@ -908,7 +908,7 @@ var Plottable;
 ///<reference path="../reference.ts" />
 var Plottable;
 (function (Plottable) {
-    Plottable.version = "1.13.0";
+    Plottable.version = "1.12.0";
 })(Plottable || (Plottable = {}));
 
 ///<reference path="../reference.ts" />
@@ -8993,7 +8993,7 @@ var Plottable;
                 _super.call(this);
                 this._interpolator = "linear";
                 this._autorangeSmooth = false;
-                this._croppedRendering = false;
+                this._croppedRenderingEnabled = false;
                 this.addClass("line-plot");
                 var animator = new Plottable.Animators.Easing();
                 animator.stepDuration(Plottable.Plot._ANIMATION_MAX_DURATION);
@@ -9062,9 +9062,9 @@ var Plottable;
             };
             Line.prototype.croppedRenderingEnabled = function (croppedRendering) {
                 if (croppedRendering == null) {
-                    return this._croppedRendering;
+                    return this._croppedRenderingEnabled;
                 }
-                this._croppedRendering = croppedRendering;
+                this._croppedRenderingEnabled = croppedRendering;
                 this.render();
                 return this;
             };
@@ -9257,7 +9257,7 @@ var Plottable;
                 var dataToDraw = new Plottable.Utils.Map();
                 this.datasets().forEach(function (dataset) {
                     var data = dataset.data();
-                    if (!_this._croppedRendering) {
+                    if (!_this._croppedRenderingEnabled) {
                         dataToDraw.set(dataset, [data]);
                         return;
                     }

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -393,34 +393,30 @@ export module Plots {
     }
 
     private _filterCroppedRendering(dataset: Dataset, indices: number[]) {
-      let xScale = this.x().scale;
-      let yScale = this.y().scale;
-      let xAccessor = this.x().accessor;
-      let yAccessor = this.y().accessor;
-      let xDomain = xScale.domain();
-      let yDomain = yScale.domain();
+      let xProjector = Plot._scaledAccessor(this.x());
+      let yProjector = Plot._scaledAccessor(this.y());
 
       let data = dataset.data();
       let filteredDataIndices: number[] = [];
 
       for (let i = 0; i < indices.length; i++) {
-        let currXPoint = xAccessor(data[indices[i]], indices[i], dataset);
-        let currYPoint = yAccessor(data[indices[i]], indices[i], dataset);
-        let shouldShow = xDomain[0] <= currXPoint && currXPoint <= xDomain[1] &&
-          yDomain[0] <= currYPoint && currYPoint <= yDomain[1];
+        let currXPoint = xProjector(data[indices[i]], indices[i], dataset);
+        let currYPoint = yProjector(data[indices[i]], indices[i], dataset);
+        let shouldShow = 0 <= currXPoint && currXPoint <= this.width() &&
+          0 <= currYPoint && currYPoint <= this.height();
 
         if (!shouldShow && indices[i - 1] != null && data[indices[i - 1]] != null) {
-          let prevXPoint = xAccessor(data[indices[i - 1]], indices[i - 1], dataset);
-          let prevYPoint = yAccessor(data[indices[i - 1]], indices[i - 1], dataset);
-          shouldShow = shouldShow || xDomain[0] <= prevXPoint && prevXPoint <= xDomain[1] &&
-            yDomain[0] <= prevYPoint && prevYPoint <= yDomain[1];
+          let prevXPoint = xProjector(data[indices[i - 1]], indices[i - 1], dataset);
+          let prevYPoint = yProjector(data[indices[i - 1]], indices[i - 1], dataset);
+          shouldShow = shouldShow || 0 <= prevXPoint && prevXPoint <= this.width() &&
+            0 <= prevYPoint && prevYPoint <= this.height();
         }
 
         if (!shouldShow && indices[i + 1] != null && data[indices[i + 1]] != null) {
-          let nextXPoint = xAccessor(data[indices[i + 1]], indices[i + 1], dataset);
-          let nextYPoint = yAccessor(data[indices[i + 1]], indices[i + 1], dataset);
-          shouldShow = shouldShow || xDomain[0] <= nextXPoint && nextXPoint <= xDomain[1] &&
-            yDomain[0] <= nextYPoint && nextYPoint <= yDomain[1];
+          let nextXPoint = xProjector(data[indices[i + 1]], indices[i + 1], dataset);
+          let nextYPoint = yProjector(data[indices[i + 1]], indices[i + 1], dataset);
+          shouldShow = shouldShow || 0 <= nextXPoint && nextXPoint <= this.width() &&
+            0 <= nextYPoint && nextYPoint <= this.height();
         }
 
         if (shouldShow) {

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -148,14 +148,14 @@ export module Plots {
      * Thus if only part of the data is in the viewport, then this option will boost of rendering.
      * However if all the data will render, enabling will cause an insignificant overhead.
      */
-    public croppedRenderingEnabled(): boolean;
+    public croppedRendering(): boolean;
     /**
      * Sets if croppedRendering is enabled
      *
      * @returns {Plots.Line} The calling Plots.Line
      */
-    public croppedRenderingEnabled(croppedRendering: boolean): Plots.Line<X>;
-    public croppedRenderingEnabled(croppedRendering?: boolean): any {
+    public croppedRendering(croppedRendering: boolean): Plots.Line<X>;
+    public croppedRendering(croppedRendering?: boolean): any {
       if (croppedRendering == null) {
         return this._croppedRendering;
       }

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -13,7 +13,7 @@ export module Plots {
     private _interpolator: string | ((points: Array<[number, number]>) => string) = "linear";
 
     private _autorangeSmooth = false;
-    private _croppedRendering = false;
+    private _croppedRenderingEnabled = false;
 
     /**
      * A Line Plot draws line segments starting from the first data point to the next.
@@ -153,9 +153,9 @@ export module Plots {
     public croppedRenderingEnabled(croppedRendering: boolean): Plots.Line<X>;
     public croppedRenderingEnabled(croppedRendering?: boolean): any {
       if (croppedRendering == null) {
-        return this._croppedRendering;
+        return this._croppedRenderingEnabled;
       }
-      this._croppedRendering = croppedRendering;
+      this._croppedRenderingEnabled = croppedRendering;
       this.render();
       return this;
     }
@@ -375,7 +375,7 @@ export module Plots {
       this.datasets().forEach((dataset) => {
         let data = dataset.data();
 
-        if (!this._croppedRendering) {
+        if (!this._croppedRenderingEnabled) {
           dataToDraw.set(dataset, [data]);
           return;
         }

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -143,8 +143,6 @@ export module Plots {
      * Gets if croppedRendering is enabled
      *
      * When croppedRendering is enabled, lines that will not be visible in the viewport will not be drawn.
-     * Thus if only part of the data is in the viewport, then this option will boost of rendering.
-     * However if all the data will render, enabling will cause an insignificant overhead.
      */
     public croppedRenderingEnabled(): boolean;
     /**

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -142,16 +142,17 @@ export module Plots {
     }
 
     /**
-     * Gets the croppedRendering preformance option state.
+     * Gets if croppedRendering is enabled
      *
-     * When croppedRendering option is enabled, lines that will not be visible in the viewport will not be
-     * drawn anymore (will not have corresponding SVG nodes). If only part of the data is in the viewport,
-     * then this option will boost of rendering. However, if all the data is rendered anyway, having this
-     * option enabled will cause a small overhead that can be noticed in the total render time.
+     * When croppedRendering is enabled, lines that will not be visible in the viewport will not be drawn.
+     * Thus if only part of the data is in the viewport, then this option will boost of rendering.
+     * However if all the data will render, enabling will cause an insignificant overhead.
      */
     public croppedRenderingEnabled(): boolean;
     /**
-     * Sets the croppedRendering performance option.
+     * Sets if croppedRendering is enabled
+     *
+     * @returns {Plots.Line} The calling Plots.Line
      */
     public croppedRenderingEnabled(croppedRendering: boolean): Plots.Line<X>;
     public croppedRenderingEnabled(croppedRendering?: boolean): any {

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -398,25 +398,26 @@ export module Plots {
 
       let data = dataset.data();
       let filteredDataIndices: number[] = [];
+      let pointInViewport = (x: number, y: number) => {
+        return Utils.Math.inRange(x, 0, this.width()) &&
+          Utils.Math.inRange(y, 0, this.height());
+      };
 
       for (let i = 0; i < indices.length; i++) {
         let currXPoint = xProjector(data[indices[i]], indices[i], dataset);
         let currYPoint = yProjector(data[indices[i]], indices[i], dataset);
-        let shouldShow = 0 <= currXPoint && currXPoint <= this.width() &&
-          0 <= currYPoint && currYPoint <= this.height();
+        let shouldShow = pointInViewport(currXPoint, currYPoint);
 
         if (!shouldShow && indices[i - 1] != null && data[indices[i - 1]] != null) {
           let prevXPoint = xProjector(data[indices[i - 1]], indices[i - 1], dataset);
           let prevYPoint = yProjector(data[indices[i - 1]], indices[i - 1], dataset);
-          shouldShow = shouldShow || 0 <= prevXPoint && prevXPoint <= this.width() &&
-            0 <= prevYPoint && prevYPoint <= this.height();
+          shouldShow = shouldShow || pointInViewport(prevXPoint, prevYPoint);
         }
 
         if (!shouldShow && indices[i + 1] != null && data[indices[i + 1]] != null) {
           let nextXPoint = xProjector(data[indices[i + 1]], indices[i + 1], dataset);
           let nextYPoint = yProjector(data[indices[i + 1]], indices[i + 1], dataset);
-          shouldShow = shouldShow || 0 <= nextXPoint && nextXPoint <= this.width() &&
-            0 <= nextYPoint && nextYPoint <= this.height();
+          shouldShow = shouldShow || pointInViewport(nextXPoint, nextYPoint);
         }
 
         if (shouldShow) {

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -146,14 +146,14 @@ export module Plots {
      * Thus if only part of the data is in the viewport, then this option will boost of rendering.
      * However if all the data will render, enabling will cause an insignificant overhead.
      */
-    public croppedRendering(): boolean;
+    public croppedRenderingEnabled(): boolean;
     /**
      * Sets if croppedRendering is enabled
      *
      * @returns {Plots.Line} The calling Plots.Line
      */
-    public croppedRendering(croppedRendering: boolean): Plots.Line<X>;
-    public croppedRendering(croppedRendering?: boolean): any {
+    public croppedRenderingEnabled(croppedRendering: boolean): Plots.Line<X>;
+    public croppedRenderingEnabled(croppedRendering?: boolean): any {
       if (croppedRendering == null) {
         return this._croppedRendering;
       }

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -13,8 +13,6 @@ export module Plots {
     private _interpolator: string | ((points: Array<[number, number]>) => string) = "linear";
 
     private _autorangeSmooth = false;
-
-    // Performance options
     private _croppedRendering = false;
 
     /**
@@ -386,9 +384,7 @@ export module Plots {
 
         let filteredDataIndices = data.map((d, i) => i);
 
-        if (this._croppedRendering) {
-          filteredDataIndices = this._filterCroppedRendering(dataset, filteredDataIndices);
-        }
+        filteredDataIndices = this._filterCroppedRendering(dataset, filteredDataIndices);
 
         dataToDraw.set(dataset, [filteredDataIndices.map((d, i) => data[d])]);
       });

--- a/test/plots/linePlotTests.ts
+++ b/test/plots/linePlotTests.ts
@@ -707,13 +707,13 @@ describe("Plots", () => {
       it("can set the croppedRendering option", () => {
         plot.renderTo(svg);
 
-        assert.isFalse(plot.croppedRendering(), "croppedRendering is not enabled by default");
+        assert.isFalse(plot.croppedRenderingEnabled(), "croppedRendering is not enabled by default");
 
-        assert.strictEqual(plot.croppedRendering(true), plot, "enabling the croppedRendering option returns the plot");
-        assert.isTrue(plot.croppedRendering(), "can enable the croppedRendering option");
+        assert.strictEqual(plot.croppedRenderingEnabled(true), plot, "enabling the croppedRendering option returns the plot");
+        assert.isTrue(plot.croppedRenderingEnabled(), "can enable the croppedRendering option");
 
-        plot.croppedRendering(false);
-        assert.isFalse(plot.croppedRendering(), "can disable the croppedRendering option");
+        plot.croppedRenderingEnabled(false);
+        assert.isFalse(plot.croppedRenderingEnabled(), "can disable the croppedRendering option");
 
         svg.remove();
       });
@@ -731,7 +731,7 @@ describe("Plots", () => {
         // Only middle point is in viewport
         xScale.domain([2.5, 3.5]);
 
-        plot.croppedRendering(true);
+        plot.croppedRenderingEnabled(true);
         plot.renderTo(svg);
 
         let path = plot.content().select("path.line").attr("d");
@@ -755,7 +755,7 @@ describe("Plots", () => {
         xScale.domain([2.5, 3.5]);
 
         plot.renderTo(svg);
-        plot.croppedRendering(true);
+        plot.croppedRenderingEnabled(true);
 
         let path = plot.content().select("path.line").attr("d");
         let expectedRenderedData = [1, 2, 3].map((d) => data[d]);
@@ -778,7 +778,7 @@ describe("Plots", () => {
         // Only middle point is in viewport
         yScale.domain([2.5, 3.5]);
 
-        plot.croppedRendering(true);
+        plot.croppedRenderingEnabled(true);
         plot.renderTo(svg);
 
         let path = plot.content().select("path.line").attr("d");
@@ -798,7 +798,7 @@ describe("Plots", () => {
         ];
         plot.addDataset(new Plottable.Dataset(data));
 
-        plot.croppedRendering(true);
+        plot.croppedRenderingEnabled(true);
         plot.renderTo(svg);
 
         let path = plot.content().select("path.line").attr("d");

--- a/test/plots/linePlotTests.ts
+++ b/test/plots/linePlotTests.ts
@@ -817,10 +817,10 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      function checkPathForDataPoints(path: string, data: any[]) {
+      function checkPathForDataPoints(path: string, data: {x: number, y: number}[]) {
         let EPSILON = 0.0001;
 
-        let lineEdges = path.match(/(\-?\d+\.?\d*)(,|\s)(-?\d+\.?\d*)/g);
+        let lineEdges = TestMethods.normalizePath(path).match(/(\-?\d+\.?\d*)(,|\s)(-?\d+\.?\d*)/g);
 
         assert.strictEqual(lineEdges.length, data.length, "correct number of edges drawn");
 

--- a/test/plots/linePlotTests.ts
+++ b/test/plots/linePlotTests.ts
@@ -707,13 +707,13 @@ describe("Plots", () => {
       it("can set the croppedRendering option", () => {
         plot.renderTo(svg);
 
-        assert.isFalse(plot.croppedRenderingEnabled(), "croppedRendering is not enabled by default");
+        assert.isFalse(plot.croppedRendering(), "croppedRendering is not enabled by default");
 
-        assert.strictEqual(plot.croppedRenderingEnabled(true), plot, "enabling the croppedRendering option returns the plot");
-        assert.isTrue(plot.croppedRenderingEnabled(), "can enable the croppedRendering option");
+        assert.strictEqual(plot.croppedRendering(true), plot, "enabling the croppedRendering option returns the plot");
+        assert.isTrue(plot.croppedRendering(), "can enable the croppedRendering option");
 
-        plot.croppedRenderingEnabled(false);
-        assert.isFalse(plot.croppedRenderingEnabled(), "can disable the croppedRendering option");
+        plot.croppedRendering(false);
+        assert.isFalse(plot.croppedRendering(), "can disable the croppedRendering option");
 
         svg.remove();
       });
@@ -731,7 +731,7 @@ describe("Plots", () => {
         // Only middle point is in viewport
         xScale.domain([2.5, 3.5]);
 
-        plot.croppedRenderingEnabled(true);
+        plot.croppedRendering(true);
         plot.renderTo(svg);
 
         let path = plot.content().select("path.line").attr("d");
@@ -755,7 +755,7 @@ describe("Plots", () => {
         xScale.domain([2.5, 3.5]);
 
         plot.renderTo(svg);
-        plot.croppedRenderingEnabled(true);
+        plot.croppedRendering(true);
 
         let path = plot.content().select("path.line").attr("d");
         let expectedRenderedData = [1, 2, 3].map((d) => data[d]);
@@ -778,7 +778,7 @@ describe("Plots", () => {
         // Only middle point is in viewport
         yScale.domain([2.5, 3.5]);
 
-        plot.croppedRenderingEnabled(true);
+        plot.croppedRendering(true);
         plot.renderTo(svg);
 
         let path = plot.content().select("path.line").attr("d");
@@ -798,7 +798,7 @@ describe("Plots", () => {
         ];
         plot.addDataset(new Plottable.Dataset(data));
 
-        plot.croppedRenderingEnabled(true);
+        plot.croppedRendering(true);
         plot.renderTo(svg);
 
         let path = plot.content().select("path.line").attr("d");

--- a/test/plots/linePlotTests.ts
+++ b/test/plots/linePlotTests.ts
@@ -207,7 +207,7 @@ describe("Plots", () => {
       svg.remove();
     });
 
-    describe("selections()", () => {
+    describe("selections", () => {
       it("retrieves all dataset selections with no args", () => {
         let dataset3 = new Plottable.Dataset([
           { foo: 0, bar: 1 },
@@ -681,6 +681,159 @@ describe("Plots", () => {
         assert.deepEqual(xScale.domain(), [-2, -1], "no changes for autoranging smooth with same edge points (smooth)");
       });
 
+    });
+  });
+
+  describe("Line Plot", () => {
+    describe("Cropped Rendering Performance", () => {
+
+      let svg: d3.Selection<void>;
+      let plot: Plottable.Plots.Line<number>;
+
+      let xScale: Plottable.Scales.Linear;
+      let yScale: Plottable.Scales.Linear;
+
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 400;
+
+      beforeEach(() => {
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        xScale = new Plottable.Scales.Linear();
+        yScale = new Plottable.Scales.Linear();
+        plot = new Plottable.Plots.Line<number>();
+        plot.x((d) => d.x, xScale).y((d) => d.y, yScale);
+      });
+
+      it("can set the croppedRendering option", () => {
+        plot.renderTo(svg);
+
+        assert.isFalse(plot.croppedRenderingEnabled(), "croppedRendering is not enabled by default");
+
+        assert.strictEqual(plot.croppedRenderingEnabled(true), plot, "enabling the croppedRendering option returns the plot");
+        assert.isTrue(plot.croppedRenderingEnabled(), "can enable the croppedRendering option");
+
+        plot.croppedRenderingEnabled(false);
+        assert.isFalse(plot.croppedRenderingEnabled(), "can disable the croppedRendering option");
+
+        svg.remove();
+      });
+
+      it("does not render lines that are outside the viewport", () => {
+        let data = [
+          {x: 1, y: 1},
+          {x: 2, y: 2},
+          {x: 3, y: 1},
+          {x: 4, y: 2},
+          {x: 5, y: 1}
+        ];
+        plot.addDataset(new Plottable.Dataset(data));
+
+        // Only middle point is in viewport
+        xScale.domain([2.5, 3.5]);
+
+        plot.croppedRenderingEnabled(true);
+        plot.renderTo(svg);
+
+        let path = plot.content().select("path.line").attr("d");
+        let expectedRenderedData = [1, 2, 3].map((d) => data[d]);
+        checkPathForDataPoints(path, expectedRenderedData);
+
+        svg.remove();
+      });
+
+      it("works when the performance option is set after rendering to svg", () => {
+        let data = [
+          {x: 1, y: 1},
+          {x: 2, y: 2},
+          {x: 3, y: 1},
+          {x: 4, y: 2},
+          {x: 5, y: 1}
+        ];
+        plot.addDataset(new Plottable.Dataset(data));
+
+        // Only middle point is in viewport
+        xScale.domain([2.5, 3.5]);
+
+        plot.renderTo(svg);
+        plot.croppedRenderingEnabled(true);
+
+        let path = plot.content().select("path.line").attr("d");
+        let expectedRenderedData = [1, 2, 3].map((d) => data[d]);
+        checkPathForDataPoints(path, expectedRenderedData);
+
+        svg.remove();
+      });
+
+      it("works for vertical line plots", () => {
+        let data = [
+          {x: 1, y: 1},
+          {x: 2, y: 2},
+          {x: 1, y: 3},
+          {x: 2, y: 4},
+          {x: 1, y: 5}
+        ];
+        plot.addDataset(new Plottable.Dataset(data));
+        xScale.padProportion(0);
+
+        // Only middle point is in viewport
+        yScale.domain([2.5, 3.5]);
+
+        plot.croppedRenderingEnabled(true);
+        plot.renderTo(svg);
+
+        let path = plot.content().select("path.line").attr("d");
+        let expectedRenderedData = [1, 2, 3].map((d) => data[d]);
+        checkPathForDataPoints(path, expectedRenderedData);
+
+        svg.remove();
+      });
+
+      it("adapts to scale changes", () => {
+        let data = [
+          {x: 1, y: 1},
+          {x: 2, y: 2},
+          {x: 3, y: 1},
+          {x: 4, y: 2},
+          {x: 5, y: 1}
+        ];
+        plot.addDataset(new Plottable.Dataset(data));
+
+        plot.croppedRenderingEnabled(true);
+        plot.renderTo(svg);
+
+        let path = plot.content().select("path.line").attr("d");
+        checkPathForDataPoints(path, [0, 1, 2, 3, 4].map((d) => data[d]));
+
+        // Only middle point is in viewport
+        xScale.domain([2.5, 3.5]);
+        path = plot.content().select("path.line").attr("d");
+        checkPathForDataPoints(path, [1, 2, 3].map((d) => data[d]));
+
+        // Only first point is in viewport
+        xScale.domain([-0.5, 1.5]);
+        path = plot.content().select("path.line").attr("d");
+        checkPathForDataPoints(path, [0, 1].map((d) => data[d]));
+
+        svg.remove();
+      });
+
+      function checkPathForDataPoints(path: string, data: any[]) {
+        let EPSILON = 0.0001;
+
+        let lineEdges = path.match(/(\-?\d+\.?\d*)(,|\s)(-?\d+\.?\d*)/g);
+
+        assert.strictEqual(lineEdges.length, data.length, "correct number of edges drawn");
+
+        lineEdges.forEach((edge, i) => {
+          let coordinates = edge.split(/,|\s/);
+
+          assert.strictEqual(coordinates.length, 2, "There is an x coordinate and a y coordinate");
+          assert.closeTo(xScale.invert(+coordinates[0]), data[i].x, EPSILON,
+            `Point ${i} drawn, has correct x coordinate`);
+          assert.closeTo(yScale.invert(+coordinates[1]), data[i].y, EPSILON,
+            `Point ${i} drawn, has correct y coordinate`);
+        });
+      }
     });
   });
 });

--- a/test/plots/linePlotTests.ts
+++ b/test/plots/linePlotTests.ts
@@ -682,9 +682,7 @@ describe("Plots", () => {
       });
 
     });
-  });
 
-  describe("Line Plot", () => {
     describe("Cropped Rendering Performance", () => {
 
       let svg: d3.Selection<void>;
@@ -693,11 +691,8 @@ describe("Plots", () => {
       let xScale: Plottable.Scales.Linear;
       let yScale: Plottable.Scales.Linear;
 
-      let SVG_WIDTH = 400;
-      let SVG_HEIGHT = 400;
-
       beforeEach(() => {
-        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        svg = TestMethods.generateSVG();
         xScale = new Plottable.Scales.Linear();
         yScale = new Plottable.Scales.Linear();
         plot = new Plottable.Plots.Line<number>();


### PR DESCRIPTION
Part of #2523 

Performance request from Contour.

Affects:
- Line Plot
- Area Plot
- Stacked Area Plot

New API points

- `Plots.Line`

```typescript
/**
 * Gets the croppedRendering preformance option state.
 *
 * When croppedRendering option is enabled, lines that will not be visible in the viewport will not be
 * drawn anymore (will not have corresponding SVG nodes). If only part of the data is in the viewport,
 * then this option will boost of rendering. However, if all the data is rendered anyway, having this
 * option enabled will cause a small overhead that can be noticed in the total render time.
 */
public croppedRenderingEnabled(): boolean;

/**
 * Sets the croppedRendering performance option.
 */
public croppedRenderingEnabled(croppedRendering: boolean): Plots.Line<X>;
```

Demo:
- http://jsfiddle.net/yxpq4uuv/4/ - with feature enabled
- http://jsfiddle.net/yxpq4uuv/3/ - without feature enabled

QE Notes:
- Visuals should be exactly the same as before
- Does not behave well when combined with the `Plot.deferredRendering()` (the two perf improvements should be incompatible)
- It should work for both horizontal line plot, vertical line plot and random tangled line plots
- Perf is only for scenarios where we have a small subset of the data in the visual area.
- Should behave very well together with downsample (PR to come)

Extra notes:
- My progress and a "merged" branch can be seen here https://github.com/palantir/plottable/pull/2650