### PR TITLE
[Scales.Time] Change default extent to be wider and consistent.

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -2335,6 +2335,7 @@ var Plottable;
             function Time() {
                 _super.call(this);
                 this._d3Scale = d3.time.scale();
+                this.autoDomain();
             }
             /**
              * Returns an array of ticks values separated by the specified interval.
@@ -2358,11 +2359,7 @@ var Plottable;
                 return _super.prototype._setDomain.call(this, values);
             };
             Time.prototype._defaultExtent = function () {
-                var now = new Date();
-                var endTimeValue = now.valueOf();
-                now.setDate(now.getDate() - 1);
-                var startTimeValue = now.valueOf();
-                return [new Date(startTimeValue), new Date(endTimeValue)];
+                return [new Date("1970-01-01"), new Date("1970-01-02")];
             };
             Time.prototype._expandSingleValueDomain = function (singleValueDomain) {
                 var startTime = singleValueDomain[0].getTime();

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -12,6 +12,7 @@ export module Scales {
     constructor() {
       super();
       this._d3Scale = d3.time.scale();
+      this.autoDomain();
     }
 
     /**
@@ -38,11 +39,7 @@ export module Scales {
     }
 
     protected _defaultExtent(): Date[] {
-      let now = new Date();
-      let endTimeValue = now.valueOf();
-      now.setDate(now.getDate() - 1);
-      let startTimeValue = now.valueOf();
-      return [new Date(startTimeValue), new Date(endTimeValue)];
+      return [new Date("1970-01-01"), new Date("1970-01-02")];
     }
 
     protected _expandSingleValueDomain(singleValueDomain: Date[]): Date[] {

--- a/test/scales/timeScaleTests.ts
+++ b/test/scales/timeScaleTests.ts
@@ -49,6 +49,14 @@ describe("Scales", () => {
         assert.operator(scale.domain()[1].getTime(), ">", unpaddedDomain[1].getTime(), "right side of domain was padded");
       });
 
+      it("has a consistent default domain", () => {
+        let scale2 = new Plottable.Scales.Time();
+        assert.strictEqual(scale.domain()[0].getTime(), scale2.domain()[0].getTime(),
+          "both scales have the same default left side of domain");
+        assert.strictEqual(scale.domain()[1].getTime(), scale2.domain()[1].getTime(),
+          "both scales have the same default right side of domain");
+      });
+
       it("respects padding exceptions", () => {
         let minValue = new Date(2000, 5, 4);
         let maxValue = new Date(2000, 5, 6);


### PR DESCRIPTION
Previously, the default extent was supposed to be based on the current day, but wound up defaulting instead to `[Unix epoch, + 1 second]`. The default extent has now been changed to be `[Unix epoch, + 1 day]`.

Close #2740.