### PR TITLE
correct end tick marks length when tier label positions are set to "center"

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -4443,13 +4443,15 @@ var Plottable;
                 tickMarks.attr(attr);
                 if (this.orientation() === "bottom") {
                     attr["y1"] = offset;
-                    attr["y2"] = offset + this._tierHeights[index];
+                    attr["y2"] = offset + (this._tierLabelPositions[index] === "center" ? this.endTickLength() : this._tierHeights[index]);
                 }
                 else {
                     attr["y1"] = this.height() - offset;
-                    attr["y2"] = this.height() - (offset + this._tierHeights[index]);
+                    attr["y2"] = this.height() - (offset + (this._tierLabelPositions[index] === "center" ?
+                        this.endTickLength() : this._tierHeights[index]));
                 }
                 d3.select(tickMarks[0][0]).attr(attr);
+                d3.select(tickMarks[0][tickMarks.size() - 1]).attr(attr);
                 // Add end-tick classes to first and last tick for CSS customization purposes
                 d3.select(tickMarks[0][0]).classed(Plottable.Axis.END_TICK_MARK_CLASS, true);
                 d3.select(tickMarks[0][tickMarks.size() - 1]).classed(Plottable.Axis.END_TICK_MARK_CLASS, true);

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -422,12 +422,14 @@ export module Axes {
       tickMarks.attr(attr);
       if (this.orientation() === "bottom") {
         attr["y1"] = offset;
-        attr["y2"] = offset + this._tierHeights[index];
+        attr["y2"] = offset + (this._tierLabelPositions[index] === "center" ? this.endTickLength() : this._tierHeights[index]);
       } else {
         attr["y1"] = this.height() - offset;
-        attr["y2"] = this.height() - (offset + this._tierHeights[index]);
+        attr["y2"] = this.height() - (offset + (this._tierLabelPositions[index] === "center" ?
+                                                  this.endTickLength() : this._tierHeights[index]));
       }
       d3.select(tickMarks[0][0]).attr(attr);
+      d3.select(tickMarks[0][tickMarks.size() - 1]).attr(attr);
 
       // Add end-tick classes to first and last tick for CSS customization purposes
       d3.select(tickMarks[0][0]).classed(Axis.END_TICK_MARK_CLASS, true);

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -130,6 +130,21 @@ describe("TimeAxis", () => {
     svg.remove();
   });
 
+  it("end ticks' lengths equal to endTickLength() when tierLabelPosition is set to center", () => {
+    let width = 500;
+    let svg = TestMethods.generateSVG(width, 100);
+    axis.tierLabelPositions(["center", "center"]);
+    scale.domain([new Date("2010-01-01"), new Date("2014-01-01")]);
+    axis.renderTo(svg);
+    let endTicks = axis.content().selectAll(`.${Plottable.Axis.END_TICK_MARK_CLASS}`);
+    assert.operator(endTicks.size(), ">=", 1, "At least one end tick mark is selected in the test");
+    endTicks.each(function(d, i){
+      let tickLength = Math.abs(+this.getAttribute("y1") - +this.getAttribute("y2"));
+      assert.strictEqual(tickLength, axis.endTickLength(), "end tick marks's length should equal to endTickLength()");
+    });
+    svg.remove();
+  });
+
   it("tick labels do not overlap with tick marks", () => {
     let svg = TestMethods.generateSVG(400, 100);
     scale = new Plottable.Scales.Time();

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -138,8 +138,10 @@ describe("TimeAxis", () => {
     let endTicks = axis.content().selectAll(`.${Plottable.Axis.END_TICK_MARK_CLASS}`);
     assert.operator(endTicks.size(), ">=", 1, "At least one end tick mark is selected in the test");
     endTicks.each(function(d, i){
-      let tickLength = Math.abs(+this.getAttribute("y1") - +this.getAttribute("y2"));
-      assert.strictEqual(tickLength, axis.endTickLength(), "end tick marks's length should equal to endTickLength()");
+      let endTick = d3.select(this);
+      let tickLength = Math.abs(TestMethods.numAttr(endTick, "y1") - TestMethods.numAttr(endTick, "y2"));
+      assert.closeTo(tickLength, axis.endTickLength(), window.Pixel_CloseTo_Requirement,
+        "end tick marks's length should equal to endTickLength()");
     });
     svg.remove();
   });

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -131,8 +131,7 @@ describe("TimeAxis", () => {
   });
 
   it("end ticks' lengths equal to endTickLength() when tierLabelPosition is set to center", () => {
-    let width = 500;
-    let svg = TestMethods.generateSVG(width, 100);
+    let svg = TestMethods.generateSVG(400, 100);
     axis.tierLabelPositions(["center", "center"]);
     scale.domain([new Date("2010-01-01"), new Date("2014-01-01")]);
     axis.renderTo(svg);


### PR DESCRIPTION
**Issue**
Previously in a TimeAxis, when its `tierLabelPosition` is set to "center", the end tick marks on two sides have different lengths. The first end tick mark's length is the height of the tier.

**Fix**
Now the lengths of the end tick marks are `axis.endTickLength()`, whose default value is 5.

**JSFiddle**
Before:http://jsfiddle.net/yunhaolucky/o87wsq9h/5/
After:http://jsfiddle.net/yunhaolucky/o87wsq9h/6/
close #2800