### PR TITLE
[Plots.Line] - croppedRendering by default

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -8993,7 +8993,7 @@ var Plottable;
                 _super.call(this);
                 this._interpolator = "linear";
                 this._autorangeSmooth = false;
-                this._croppedRenderingEnabled = false;
+                this._croppedRenderingEnabled = true;
                 this.addClass("line-plot");
                 var animator = new Plottable.Animators.Easing();
                 animator.stepDuration(Plottable.Plot._ANIMATION_MAX_DURATION);

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -13,7 +13,7 @@ export module Plots {
     private _interpolator: string | ((points: Array<[number, number]>) => string) = "linear";
 
     private _autorangeSmooth = false;
-    private _croppedRenderingEnabled = false;
+    private _croppedRenderingEnabled = true;
 
     /**
      * A Line Plot draws line segments starting from the first data point to the next.

--- a/test/plots/areaPlotTests.ts
+++ b/test/plots/areaPlotTests.ts
@@ -167,24 +167,24 @@ describe("Plots", () => {
       });
 
       it("retrieves correct selections", () => {
-        let twoPointDataset = new Plottable.Dataset([{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }]);
+        let twoPointDataset = new Plottable.Dataset([{ foo: 0, bar: 1 }, { foo: 1, bar: 2 }]);
         areaPlot.addDataset(twoPointDataset);
         let allAreas = areaPlot.selections([twoPointDataset]);
         assert.strictEqual(allAreas.size(), 2, "areas/lines retrieved");
-        let selectionData = allAreas.data();
-        assert.include(selectionData, twoPointDataset.data(), "new dataset data in selection data");
+        let selectionData = allAreas.data()[0];
+        assert.deepEqual(selectionData, twoPointDataset.data(), "new dataset data in selection data");
 
         svg.remove();
       });
 
       it("skips invalid Datasets", () => {
-        let twoPointDataset = new Plottable.Dataset([{ foo: 2, bar: 1 }, { foo: 3, bar: 2 }]);
+        let twoPointDataset = new Plottable.Dataset([{ foo: 0, bar: 1 }, { foo: 1, bar: 2 }]);
         areaPlot.addDataset(twoPointDataset);
         let dummyDataset = new Plottable.Dataset([]);
         let allAreas = areaPlot.selections([twoPointDataset, dummyDataset]);
         assert.strictEqual(allAreas.size(), 2, "areas/lines retrieved");
-        let selectionData = allAreas.data();
-        assert.include(selectionData, twoPointDataset.data(), "new dataset data in selection data");
+        let selectionData = allAreas.data()[0];
+        assert.deepEqual(selectionData, twoPointDataset.data(), "new dataset data in selection data");
 
         svg.remove();
       });

--- a/test/plots/linePlotTests.ts
+++ b/test/plots/linePlotTests.ts
@@ -230,8 +230,8 @@ describe("Plots", () => {
 
         let allLines = linePlot.selections([dataset3]);
         assert.strictEqual(allLines.size(), 1, "all lines retrieved");
-        let selectionData = allLines.data();
-        assert.include(selectionData, dataset3.data(), "third dataset data in selection data");
+        let selectionData = allLines.data()[0];
+        assert.deepEqual(selectionData, dataset3.data(), "third dataset data in selection data");
 
         svg.remove();
       });
@@ -246,8 +246,8 @@ describe("Plots", () => {
 
         let allLines = linePlot.selections([dataset3, dummyDataset]);
         assert.strictEqual(allLines.size(), 1, "all lines retrieved");
-        let selectionData = allLines.data();
-        assert.include(selectionData, dataset3.data(), "third dataset data in selection data");
+        let selectionData = allLines.data()[0];
+        assert.deepEqual(selectionData, dataset3.data(), "third dataset data in selection data");
 
         svg.remove();
       });
@@ -702,7 +702,7 @@ describe("Plots", () => {
       it("can set the croppedRendering option", () => {
         plot.renderTo(svg);
 
-        assert.isFalse(plot.croppedRenderingEnabled(), "croppedRendering is not enabled by default");
+        assert.isTrue(plot.croppedRenderingEnabled(), "croppedRendering is not enabled by default");
 
         assert.strictEqual(plot.croppedRenderingEnabled(true), plot, "enabling the croppedRendering option returns the plot");
         assert.isTrue(plot.croppedRenderingEnabled(), "can enable the croppedRendering option");


### PR DESCRIPTION
Having this be on by default.

Tests change because having an array go through a map does not return the same reference, but `assert.include` uses reference checking I believe -___-