### PR TITLE
change the default comparator of legend

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -5419,8 +5419,7 @@ var Plottable;
                 this._formatter = Plottable.Formatters.identity();
                 this.xAlignment("right").yAlignment("top");
                 this.comparator(function (a, b) {
-                    var _this = this;
-                    var formattedText = this._colorScale.domain().slice().map(function (d) { return _this._formatter(d); });
+                    var formattedText = _this._colorScale.domain().slice().map(function (d) { return _this._formatter(d); });
                     return formattedText.indexOf(a) - formattedText.indexOf(b);
                 });
                 this._symbolFactoryAccessor = function () { return Plottable.SymbolFactories.circle(); };

--- a/plottable.js
+++ b/plottable.js
@@ -5418,7 +5418,11 @@ var Plottable;
                 this._colorScale.onUpdate(this._redrawCallback);
                 this._formatter = Plottable.Formatters.identity();
                 this.xAlignment("right").yAlignment("top");
-                this.comparator(function (a, b) { return 0; });
+                this.comparator(function (a, b) {
+                    var _this = this;
+                    var formattedText = this._colorScale.domain().slice().map(function (d) { return _this._formatter(d); });
+                    return formattedText.indexOf(a) - formattedText.indexOf(b);
+                });
                 this._symbolFactoryAccessor = function () { return Plottable.SymbolFactories.circle(); };
                 this._symbolOpacityAccessor = function () { return 1; };
             }

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -48,7 +48,10 @@ export module Components {
       this._colorScale.onUpdate(this._redrawCallback);
       this._formatter = Formatters.identity();
       this.xAlignment("right").yAlignment("top");
-      this.comparator((a: string, b: string) => 0);
+      this.comparator(function(a: string, b: string) {
+        let formattedText = this._colorScale.domain().slice().map((d: string) => this._formatter(d));
+        return formattedText.indexOf(a) - formattedText.indexOf(b);
+      });
       this._symbolFactoryAccessor = () => SymbolFactories.circle();
       this._symbolOpacityAccessor = () => 1;
     }

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -48,7 +48,7 @@ export module Components {
       this._colorScale.onUpdate(this._redrawCallback);
       this._formatter = Formatters.identity();
       this.xAlignment("right").yAlignment("top");
-      this.comparator(function(a: string, b: string) {
+      this.comparator((a: string, b: string) => {
         let formattedText = this._colorScale.domain().slice().map((d: string) => this._formatter(d));
         return formattedText.indexOf(a) - formattedText.indexOf(b);
       });

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -291,6 +291,15 @@ describe("Legend", () => {
     svg.remove();
   });
 
+  it("do not change the order of legend entries when using default comparator", () => {
+    let colorDomain = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"];
+    color.domain(colorDomain);
+    legend.renderTo(svg);
+    let entryTexts = svg.selectAll(entrySelector)[0].map((node: Element) => d3.select(node).select("text").text());
+    assert.deepEqual(colorDomain, entryTexts, "displayed texts should have the same order as the legend domain");
+    svg.remove();
+  });
+
   describe("entitiesAt()", () => {
     function computeExpectedSymbolPosition(legend: Plottable.Components.Legend, rowIndex: number, entryIndexWithinRow: number) {
       let row = d3.select(legend.content().selectAll(rowSelector)[0][rowIndex]);

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -295,7 +295,7 @@ describe("Legend", () => {
     let colorDomain = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"];
     color.domain(colorDomain);
     legend.renderTo(svg);
-    let entryTexts = svg.selectAll(entrySelector)[0].map((node: Element) => d3.select(node).select("text").text());
+    let entryTexts = legend.content().selectAll(entrySelector).data();
     assert.deepEqual(colorDomain, entryTexts, "displayed texts should have the same order as the legend domain");
     svg.remove();
   });

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -291,7 +291,7 @@ describe("Legend", () => {
     svg.remove();
   });
 
-  it("do not change the order of legend entries when using default comparator", () => {
+  it("does not change the order of legend entries when using default comparator", () => {
     let colorDomain = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"];
     color.domain(colorDomain);
     legend.renderTo(svg);


### PR DESCRIPTION
**Issue**: the order of entries in a Legend are different from its order in domains.
**Fix**: The previous comparator assumes all elements are equal, which cause problems when using different sorting methods. The new default comparator sorts the  formatted texts based on their corresponding indexes of domain names.

Before:https://jsfiddle.net/5pzsk1nv/
After:https://jsfiddle.net/yunhaolucky/5pzsk1nv/2/

This fix might not work if several entries have the same formatted text.

close #2839