### PR TITLE
tweak test for Windows

### DIFF
--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -97,7 +97,7 @@ describe("NumericAxis", () => {
       let markCenter = (markBB.top + markBB.bottom) / 2;
       labelBB = tickLabels[0][i].getBoundingClientRect();
       let labelCenter = (labelBB.top + labelBB.bottom) / 2;
-      assert.closeTo(labelCenter, markCenter, 1, "tick label is centered on mark");
+      assert.closeTo(labelCenter, markCenter, 1.5, "tick label is centered on mark");
     }
 
     // labels to top


### PR DESCRIPTION
This test is the only test in the current test suite that fails when executed under grunt in Visual Studio 2015. Resolved by changing "closeTo" value from 1 to 1.5
