### PR TITLE
[Plots.Bar] - extents updated when barpixelwidth is updated

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -8440,8 +8440,9 @@ var Plottable;
                 return this._isVertical ? Bar.ORIENTATION_VERTICAL : Bar.ORIENTATION_HORIZONTAL;
             };
             Bar.prototype.render = function () {
-                _super.prototype.render.call(this);
                 this._updateBarPixelWidth();
+                this._updateExtents();
+                _super.prototype.render.call(this);
                 return this;
             };
             Bar.prototype._createDrawer = function (dataset) {

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -99,8 +99,9 @@ export module Plots {
     }
 
     public render() {
-      super.render();
       this._updateBarPixelWidth();
+      this._updateExtents();
+      super.render();
       return this;
     }
 

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -1214,12 +1214,12 @@ describe("Plots", () => {
       svg.remove();
     });
 
-    it("plot auto domain works when there is one bar", () => {
+    it("updates the scale extent correctly when there is one bar", () => {
       let svg = TestMethods.generateSVG();
 
       let xScale = new Plottable.Scales.Linear();
       let yScale = new Plottable.Scales.Linear();
-      let xPoint = (xScale.domain()[0] + xScale.domain()[1]) / 2 + 10;
+      let xPoint = Math.max(xScale.domain()[0], xScale.domain()[1]) + 10;
       let data = [{x: xPoint, y: 10}];
       let dataset = new Plottable.Dataset(data);
 

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -1213,5 +1213,26 @@ describe("Plots", () => {
       assert.deepEqual(yScale.domain(), [-2.5, 2.5], "domain has been adjusted to visible points");
       svg.remove();
     });
+
+    it("plot auto domain works when there is one bar", () => {
+      let svg = TestMethods.generateSVG();
+
+      let xScale = new Plottable.Scales.Linear();
+      let yScale = new Plottable.Scales.Linear();
+      let xPoint = (xScale.domain()[0] + xScale.domain()[1]) / 2 + 10;
+      let data = [{x: xPoint, y: 10}];
+      let dataset = new Plottable.Dataset(data);
+
+      let barPlot = new Plottable.Plots.Bar();
+      barPlot.datasets([dataset]);
+      barPlot.x(function(d) { return d.x; }, xScale);
+      barPlot.y(function(d) { return d.y; }, yScale);
+
+      barPlot.renderTo(svg);
+      let xScaleDomain = xScale.domain();
+      assert.operator(xPoint, ">=", xScaleDomain[0], "x value greater than new domain min");
+      assert.operator(xPoint, "<=", xScaleDomain[1], "x value less than new domain max");
+      svg.remove();
+    });
   });
 });

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -1214,7 +1214,7 @@ describe("Plots", () => {
       svg.remove();
     });
 
-    it("updates the scale extent correctly when there is one bar", () => {
+    it("updates the scale extent correctly when there is one bar (vertical)", () => {
       let svg = TestMethods.generateSVG();
 
       let xScale = new Plottable.Scales.Linear();
@@ -1232,6 +1232,27 @@ describe("Plots", () => {
       let xScaleDomain = xScale.domain();
       assert.operator(xPoint, ">=", xScaleDomain[0], "x value greater than new domain min");
       assert.operator(xPoint, "<=", xScaleDomain[1], "x value less than new domain max");
+      svg.remove();
+    });
+
+    it("updates the scale extent correctly when there is one bar (horizontal)", () => {
+      let svg = TestMethods.generateSVG();
+
+      let xScale = new Plottable.Scales.Linear();
+      let yScale = new Plottable.Scales.Linear();
+      let yPoint = Math.max(xScale.domain()[0], xScale.domain()[1]) + 10;
+      let data = [{x: 10, y: yPoint}];
+      let dataset = new Plottable.Dataset(data);
+
+      let barPlot = new Plottable.Plots.Bar(Plottable.Plots.Bar.ORIENTATION_HORIZONTAL);
+      barPlot.datasets([dataset]);
+      barPlot.x(function(d) { return d.x; }, xScale);
+      barPlot.y(function(d) { return d.y; }, yScale);
+
+      barPlot.renderTo(svg);
+      let yScaleDomain = yScale.domain();
+      assert.operator(yPoint, ">=", yScaleDomain[0], "x value greater than new domain min");
+      assert.operator(yPoint, "<=", yScaleDomain[1], "x value less than new domain max");
       svg.remove();
     });
   });

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -1240,7 +1240,7 @@ describe("Plots", () => {
 
       let xScale = new Plottable.Scales.Linear();
       let yScale = new Plottable.Scales.Linear();
-      let yPoint = Math.max(xScale.domain()[0], xScale.domain()[1]) + 10;
+      let yPoint = Math.max(yScale.domain()[0], yScale.domain()[1]) + 10;
       let data = [{x: 10, y: yPoint}];
       let dataset = new Plottable.Dataset(data);
 
@@ -1251,8 +1251,8 @@ describe("Plots", () => {
 
       barPlot.renderTo(svg);
       let yScaleDomain = yScale.domain();
-      assert.operator(yPoint, ">=", yScaleDomain[0], "x value greater than new domain min");
-      assert.operator(yPoint, "<=", yScaleDomain[1], "x value less than new domain max");
+      assert.operator(yPoint, ">=", yScaleDomain[0], "y value greater than new domain min");
+      assert.operator(yPoint, "<=", yScaleDomain[1], "y value less than new domain max");
       svg.remove();
     });
   });


### PR DESCRIPTION
The extents on a bar plot are based on the width of the bars.  As a result, if the barPixelWidth were to update, the extents have to update as well