### PR TITLE
[NumericAxis Tests] - rework

### DIFF
--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -16,6 +16,13 @@ describe("NumericAxis", () => {
     assert.operator(inner.bottom, "<", outer.bottom + epsilon, message + " (box inside (bottom))");
   }
 
+  function applyVisibleFilter(selection: d3.Selection<any>) {
+    return selection.filter(function() {
+      let visibilityAttr =  d3.select(this).style("visibility");
+      return visibilityAttr === "visible" || visibilityAttr === "inherit";
+    });
+  }
+
   describe("setting the position of the tick labels when bottom oriented", () => {
 
     let axis: Plottable.Axes.Numeric;
@@ -156,11 +163,8 @@ describe("NumericAxis", () => {
       let numericAxis = new Plottable.Axes.Numeric(scale, "bottom");
       numericAxis.renderTo(svg);
 
-      let visibleTickLabels = numericAxis.content()
-        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
-        .filter(function() {
-          return d3.select(this).style("visibility") === "visible";
-        });
+      let visibleTickLabels = applyVisibleFilter(numericAxis.content()
+        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
 
       visibleTickLabels.each(function(d, i) {
         let labelRect = this.getBoundingClientRect();
@@ -194,11 +198,7 @@ describe("NumericAxis", () => {
       let axis = new Plottable.Axes.Numeric(scale, "bottom");
       axis.renderTo(svg);
 
-      let visibleTickLabels = axis.content().selectAll(".tick-label")
-        .filter(function(d: any, i: number) {
-          let visibility = d3.select(this).style("visibility");
-          return (visibility === "visible") || (visibility === "inherit");
-        });
+      let visibleTickLabels = applyVisibleFilter(axis.content().selectAll(".tick-label"));
 
       let visibleTickLabelRects = visibleTickLabels[0].map((label: Element) => label.getBoundingClientRect());
 
@@ -222,11 +222,7 @@ describe("NumericAxis", () => {
       let axis = new Plottable.Axes.Numeric(scale, "bottom");
       axis.renderTo(svg);
 
-      let tickLabels = axis.content().selectAll(".tick-label")
-          .filter(function(d: any, i: number) {
-            let visibility = d3.select(this).style("visibility");
-            return (visibility === "visible") || (visibility === "inherit");
-          });
+      let tickLabels = applyVisibleFilter(axis.content().selectAll(".tick-label"));
       assert.operator(tickLabels.size(), ">", 1, "more than one tick label is shown");
 
       let tickLabelElementPairs = d3.pairs(tickLabels[0]);
@@ -274,17 +270,9 @@ describe("NumericAxis", () => {
                                     .innerTickLength(50);
       axis.renderTo(svg);
 
-      let tickLabels = axis.content().selectAll("." + Plottable.Axis.TICK_LABEL_CLASS)
-          .filter(function(d: any, i: number) {
-            let visibility = d3.select(this).style("visibility");
-            return (visibility === "visible") || (visibility === "inherit");
-          });
+      let tickLabels = applyVisibleFilter(axis.content().selectAll("." + Plottable.Axis.TICK_LABEL_CLASS));
 
-      let tickMarks = axis.content().selectAll("." + Plottable.Axis.TICK_MARK_CLASS)
-          .filter(function(d: any, i: number) {
-            let visibility = d3.select(this).style("visibility");
-            return (visibility === "visible") || (visibility === "inherit");
-          });
+      let tickMarks = applyVisibleFilter(axis.content().selectAll("." + Plottable.Axis.TICK_MARK_CLASS));
 
       tickLabels.each(function(d, i) {
         let tickLabelRect = this.getBoundingClientRect();
@@ -332,11 +320,8 @@ describe("NumericAxis", () => {
       axis.formatter(formatter);
       axis.renderTo(svg);
 
-      let visibleTickLabels = axis.content()
-        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
-        .filter(function() {
-          return d3.select(this).style("visibility") === "visible";
-        });
+      let visibleTickLabels = applyVisibleFilter(axis.content()
+        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
       let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
       visibleTickLabels.each(function(d, i) {
         let visibleTickLabelRect = this.getBoundingClientRect();
@@ -356,11 +341,8 @@ describe("NumericAxis", () => {
       axis.formatter(formatter);
       axis.renderTo(svg);
 
-      let visibleTickLabels = axis.content()
-        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
-        .filter(function() {
-          return d3.select(this).style("visibility") === "visible";
-        });
+      let visibleTickLabels = applyVisibleFilter(axis.content()
+        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
       let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
       visibleTickLabels.each(function(d, i) {
         let visibleTickLabelRect = this.getBoundingClientRect();
@@ -379,11 +361,8 @@ describe("NumericAxis", () => {
       let axis = new Plottable.Axes.Numeric(scale, "bottom");
       axis.renderTo(svg);
 
-      let visibleTickLabels = axis.content()
-        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
-        .filter(function() {
-          return d3.select(this).style("visibility") === "visible";
-        });
+      let visibleTickLabels = applyVisibleFilter(axis.content()
+        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
       let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
       visibleTickLabels.each(function(d, i) {
         let visibleTickLabelRect = this.getBoundingClientRect();

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -76,8 +76,8 @@ describe("Axes", () => {
       });
     });
 
-    horizontalOrientations.forEach((orientation) => {
-      it(`does not overlap tick labels in a constrained space for horizontal orientation ${orientation}`, () => {
+    orientations.forEach((orientation) => {
+      it(`does not overlap tick labels in a constrained space for orientation ${orientation}`, () => {
         let svg = TestMethods.generateSVG();
         let constrainedWidth = 50;
         let constrainedHeight = 50;
@@ -102,8 +102,8 @@ describe("Axes", () => {
       });
     });
 
-    horizontalOrientations.forEach((orientation) => {
-      it("separates tick labels with the same spacing", () => {
+    orientations.forEach((orientation) => {
+      it(`separates tick labels with the same spacing for orientation ${orientation}`, () => {
         let svg = TestMethods.generateSVG();
         let scale = new Plottable.Scales.Linear();
         scale.domain([-2500000, 2500000]);
@@ -116,7 +116,7 @@ describe("Axes", () => {
         let visibleTickLabelRects = visibleTickLabels[0].map((label: Element) => label.getBoundingClientRect());
 
         function getClientRectCenter(rect: ClientRect) {
-          return rect.left + rect.width / 2;
+          return isHorizontalOrientation(orientation) ? rect.left + rect.width / 2 : rect.top + rect.height / 2;
         }
 
         let interval = getClientRectCenter(visibleTickLabelRects[1]) - getClientRectCenter(visibleTickLabelRects[0]);
@@ -129,8 +129,8 @@ describe("Axes", () => {
       });
     });
 
-    horizontalOrientations.forEach((orientation) => {
-      it("renders numbers in order with a reversed domain", () => {
+    orientations.forEach((orientation) => {
+      it(`renders numbers in order with a reversed domain for orientation ${orientation}`, () => {
         let svg = TestMethods.generateSVG();
         let scale = new Plottable.Scales.Linear();
         scale.domain([3, 0]);
@@ -237,8 +237,7 @@ describe("Axes", () => {
         let tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
         tickLabels.each(function(d, i) {
           let labelText = d3.select(this).text();
-          let formattedValue = formatter(d);
-          assert.strictEqual(labelText, formattedValue, `formatter used to format tick label ${i}`);
+          assert.strictEqual(labelText, formatter(d), `formatter used to format tick label ${i}`);
         });
 
         svg.remove();

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -250,10 +250,7 @@ describe("Axes", () => {
         let scale = new Plottable.Scales.Linear();
         scale.domain([5, -5]);
 
-        let formatter = (d: any) => (d === 0) ? "ZERO" : String(d);
-
         let axis = new Plottable.Axes.Numeric(scale, orientation);
-        axis.formatter(formatter);
         axis.renderTo(svg);
 
         let visibleTickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
@@ -273,10 +270,7 @@ describe("Axes", () => {
         let scale = new Plottable.Scales.Linear();
         scale.domain([50000000000, -50000000000]);
 
-        let formatter = (d: any) => (d === 0) ? "ZERO" : String(d);
-
         let axis = new Plottable.Axes.Numeric(scale, verticalOrientation);
-        axis.formatter(formatter);
         axis.renderTo(svg);
 
         let visibleTickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -210,7 +210,7 @@ describe("NumericAxis", () => {
       let interval = getClientRectCenter(visibleTickLabelRects[1]) - getClientRectCenter(visibleTickLabelRects[0]);
       d3.pairs(visibleTickLabelRects).forEach((rects, i) => {
         assert.closeTo(getClientRectCenter(rects[1]) - getClientRectCenter(rects[0]),
-          interval, 0.5, `tick label pair ${i} is spaced the same as the first pair`);
+          interval, window.Pixel_CloseTo_Requirement, `tick label pair ${i} is spaced the same as the first pair`);
       });
 
       svg.remove();

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -1,350 +1,350 @@
 ///<reference path="../testReference.ts" />
 
-describe("NumericAxis", () => {
-  function boxIsInside(inner: ClientRect, outer: ClientRect, epsilon = 0) {
-    if (inner.left < outer.left - epsilon) { return false; }
-    if (inner.right > outer.right + epsilon) { return false; }
-    if (inner.top < outer.top - epsilon) { return false; }
-    if (inner.bottom > outer.bottom + epsilon) { return false; }
-    return true;
-  }
+describe("Axes", () => {
+  describe("NumericAxis", () => {
+    function boxIsInside(inner: ClientRect, outer: ClientRect, epsilon = 0) {
+      if (inner.left < outer.left - epsilon) { return false; }
+      if (inner.right > outer.right + epsilon) { return false; }
+      if (inner.top < outer.top - epsilon) { return false; }
+      if (inner.bottom > outer.bottom + epsilon) { return false; }
+      return true;
+    }
 
-  function assertBoxInside(inner: ClientRect, outer: ClientRect, epsilon = 0, message = "") {
-    assert.operator(inner.left, ">", outer.left - epsilon, message + " (box inside (left))");
-    assert.operator(inner.right, "<", outer.right + epsilon, message + " (box inside (right))");
-    assert.operator(inner.top, ">", outer.top - epsilon, message + " (box inside (top))");
-    assert.operator(inner.bottom, "<", outer.bottom + epsilon, message + " (box inside (bottom))");
-  }
+    function assertBoxInside(inner: ClientRect, outer: ClientRect, epsilon = 0, message = "") {
+      assert.operator(inner.left, ">", outer.left - epsilon, message + " (box inside (left))");
+      assert.operator(inner.right, "<", outer.right + epsilon, message + " (box inside (right))");
+      assert.operator(inner.top, ">", outer.top - epsilon, message + " (box inside (top))");
+      assert.operator(inner.bottom, "<", outer.bottom + epsilon, message + " (box inside (bottom))");
+    }
 
-  function applyVisibleFilter(selection: d3.Selection<any>) {
-    return selection.filter(function() {
-      let visibilityAttr =  d3.select(this).style("visibility");
-      return visibilityAttr === "visible" || visibilityAttr === "inherit";
-    });
-  }
-
-  const horizontalOrientations = ["bottom", "top"];
-  const verticalOrientations = ["left", "right"];
-  const orientations = horizontalOrientations.concat(verticalOrientations);
-
-  const isHorizontalOrientation = (orientation: string) => horizontalOrientations.indexOf(orientation) >= 0;
-
-  horizontalOrientations.forEach((orientation) => {
-    const verticalTickLabelPositions = ["top", "bottom"];
-    it(`throws an error when setting an invalid position on orientation ${orientation}`, () => {
-      const scale = new Plottable.Scales.Linear();
-      const axis = new Plottable.Axes.Numeric(scale, orientation);
-      verticalTickLabelPositions.forEach((position) => {
-        (<any> assert).throws(() => axis.tickLabelPosition(position), "horizontal", "cannot set position");
+    function applyVisibleFilter(selection: d3.Selection<any>) {
+      return selection.filter(function() {
+        let visibilityAttr =  d3.select(this).style("visibility");
+        return visibilityAttr === "visible" || visibilityAttr === "inherit";
       });
-    });
-  });
+    }
 
-  verticalOrientations.forEach((orientation) => {
-    const horizontalTickLabelPositions = ["left", "right"];
-    it(`throws an error when setting an invalid position on orientation ${orientation}`, () => {
-      const scale = new Plottable.Scales.Linear();
-      const axis = new Plottable.Axes.Numeric(scale, orientation);
-      horizontalTickLabelPositions.forEach((position) => {
-        (<any> assert).throws(() => axis.tickLabelPosition(position), "vertical", "cannot set position");
-      });
-    });
-  });
+    const horizontalOrientations = ["bottom", "top"];
+    const verticalOrientations = ["left", "right"];
+    const orientations = horizontalOrientations.concat(verticalOrientations);
 
-  orientations.forEach((orientation) => {
+    const isHorizontalOrientation = (orientation: string) => horizontalOrientations.indexOf(orientation) >= 0;
+
     const verticalTickLabelPositions = ["top", "bottom"];
     const horizontalTickLabelPositions = ["left", "right"];
 
-    const labelPositions = isHorizontalOrientation(orientation) ? horizontalTickLabelPositions : verticalTickLabelPositions;
-    labelPositions.forEach((labelPosition) => {
-      it(`draws tick labels ${labelPosition} of the corresponding mark if specified for orientation ${orientation}`, () => {
+    horizontalOrientations.forEach((orientation) => {
+      it(`throws an error when setting an invalid position on orientation ${orientation}`, () => {
         const scale = new Plottable.Scales.Linear();
         const axis = new Plottable.Axes.Numeric(scale, orientation);
-        const svg = TestMethods.generateSVG();
-        axis.tickLabelPosition(labelPosition);
+        verticalTickLabelPositions.forEach((position) => {
+          (<any> assert).throws(() => axis.tickLabelPosition(position), "horizontal", `cannot set position to ${position}`);
+        });
+      });
+    });
+
+    verticalOrientations.forEach((orientation) => {
+      it(`throws an error when setting an invalid position on orientation ${orientation}`, () => {
+        const scale = new Plottable.Scales.Linear();
+        const axis = new Plottable.Axes.Numeric(scale, orientation);
+        horizontalTickLabelPositions.forEach((position) => {
+          (<any> assert).throws(() => axis.tickLabelPosition(position), "vertical", `cannot set position to ${position}`);
+        });
+      });
+    });
+
+    orientations.forEach((orientation) => {
+      const labelPositions = isHorizontalOrientation(orientation) ? horizontalTickLabelPositions : verticalTickLabelPositions;
+      labelPositions.forEach((labelPosition) => {
+        it(`draws tick labels ${labelPosition} of the corresponding mark if specified for orientation ${orientation}`, () => {
+          const scale = new Plottable.Scales.Linear();
+          const axis = new Plottable.Axes.Numeric(scale, orientation);
+          const svg = TestMethods.generateSVG();
+          axis.tickLabelPosition(labelPosition);
+          axis.renderTo(svg);
+
+          const tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
+          const tickMarks = axis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
+          assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
+          assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
+
+          tickLabels.each(function(d, i) {
+            TestMethods.assertBBoxNonIntersection(d3.select(this), d3.select(tickMarks[0][i]));
+          });
+          svg.remove();
+        });
+      });
+    });
+
+    describe("drawing tick labels when bottom oriented", () => {
+
+      let svg: d3.Selection<void>;
+
+      beforeEach(() => {
+        svg = TestMethods.generateSVG();
+      });
+
+      it("does not overlap tick labels in a constrained space", () => {
+        let constrainedWidth = 50;
+        let constrainedHeight = 50;
+        svg.attr("width", constrainedWidth);
+        svg.attr("height", constrainedHeight);
+        let scale = new Plottable.Scales.Linear();
+        let axis = new Plottable.Axes.Numeric(scale, "bottom");
         axis.renderTo(svg);
 
-        const tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
-        const tickMarks = axis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
+        let visibleTickLabels = applyVisibleFilter(axis.content()
+          .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+
+        visibleTickLabels.each(function(d, i) {
+          let labelRect = this.getBoundingClientRect();
+          visibleTickLabels[0].slice(i + 1).forEach(function(otherVisibleTickLabel, i2) {
+            let labelRect2 = (<Element> otherVisibleTickLabel).getBoundingClientRect();
+            let rectOverlap = Plottable.Utils.DOM.clientRectsOverlap(labelRect, labelRect2);
+            assert.isFalse(rectOverlap, `tick label ${i} does not overlap with tick label ${i2}`);
+          });
+        });
+
+        svg.remove();
+      });
+
+      it("ensures that long labels are contained", () => {
+        let scale = new Plottable.Scales.Linear().domain([400000000, 500000000]);
+        let axis = new Plottable.Axes.Numeric(scale, "left");
+
+        axis.renderTo(svg);
+
+        let tickLabelContainerClass = "tick-label-container";
+        let labelContainer = axis.content().select(`.${tickLabelContainerClass}`);
+        axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`).each(function() {
+          TestMethods.assertBBoxInclusion(labelContainer, d3.select(this));
+        });
+        svg.remove();
+      });
+
+      it("separates tick labels with the same spacing", () => {
+        let scale = new Plottable.Scales.Linear();
+        scale.domain([-2500000, 2500000]);
+
+        let axis = new Plottable.Axes.Numeric(scale, "bottom");
+        axis.renderTo(svg);
+
+        let visibleTickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+
+        let visibleTickLabelRects = visibleTickLabels[0].map((label: Element) => label.getBoundingClientRect());
+
+        function getClientRectCenter(rect: ClientRect) {
+          return rect.left + rect.width / 2;
+        }
+
+        let interval = getClientRectCenter(visibleTickLabelRects[1]) - getClientRectCenter(visibleTickLabelRects[0]);
+        d3.pairs(visibleTickLabelRects).forEach((rects, i) => {
+          assert.closeTo(getClientRectCenter(rects[1]) - getClientRectCenter(rects[0]),
+            interval, window.Pixel_CloseTo_Requirement, `tick label pair ${i} is spaced the same as the first pair`);
+        });
+
+        svg.remove();
+      });
+
+      it("renders numbers in order with a reversed domain", () => {
+        let scale = new Plottable.Scales.Linear();
+        scale.domain([3, 0]);
+
+        let axis = new Plottable.Axes.Numeric(scale, "bottom");
+        axis.renderTo(svg);
+
+        let tickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+        assert.operator(tickLabels.size(), ">", 1, "more than one tick label is shown");
+
+        let tickLabelElementPairs = d3.pairs(tickLabels[0]);
+        tickLabelElementPairs.forEach(function(tickLabelElementPair, i) {
+          let label1 = d3.select(tickLabelElementPair[0]);
+          let label2 = d3.select(tickLabelElementPair[1]);
+          let labelNumber1 = parseFloat(label1.text());
+          let labelNumber2 = parseFloat(label2.text());
+          assert.operator(labelNumber1, ">", labelNumber2, `pair ${i} arranged in descending order from left to right`);
+        });
+
+        svg.remove();
+      });
+    });
+
+    orientations.forEach((orientation) => {
+      it(`draws ticks labels centered with the corresponding tick mark for orientation ${orientation}`, () => {
+        let svg = TestMethods.generateSVG();
+        let scale = new Plottable.Scales.Linear();
+        let axis = new Plottable.Axes.Numeric(scale, orientation);
+        axis.renderTo(svg);
+
+        let tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
         assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
+        let tickMarks = axis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
         assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
 
         tickLabels.each(function(d, i) {
-          TestMethods.assertBBoxNonIntersection(d3.select(this), d3.select(tickMarks[0][i]));
+          let tickLabelClientRect = this.getBoundingClientRect();
+          let tickMarkClientRect = (<Element> tickMarks[0][i]).getBoundingClientRect();
+          let labelCenter = isHorizontalOrientation(orientation) ?
+            (tickLabelClientRect.left + tickLabelClientRect.right) / 2 :
+            (tickLabelClientRect.top + tickLabelClientRect.bottom) / 2;
+          let markCenter = isHorizontalOrientation(orientation) ?
+            (tickMarkClientRect.left + tickMarkClientRect.right) / 2 :
+            (tickMarkClientRect.top + tickMarkClientRect.bottom) / 2;
+          assert.closeTo(labelCenter, markCenter, 1.5, `tick label ${i} is centered on mark`);
+        });
+
+        svg.remove();
+      });
+    });
+
+    it("does not overlap tick marks with tick labels", () => {
+      let svg = TestMethods.generateSVG();
+
+      let scale = new Plottable.Scales.Linear();
+      scale.domain([175, 185]);
+      let axis = new Plottable.Axes.Numeric(scale, "left")
+                                    .innerTickLength(50);
+      axis.renderTo(svg);
+
+      let tickLabels = applyVisibleFilter(axis.content().selectAll("." + Plottable.Axis.TICK_LABEL_CLASS));
+
+      let tickMarks = applyVisibleFilter(axis.content().selectAll("." + Plottable.Axis.TICK_MARK_CLASS));
+
+      tickLabels.each(function(d, i) {
+        let tickLabelRect = this.getBoundingClientRect();
+        tickMarks.each(function(d2, i2) {
+          let tickMarkRect = this.getBoundingClientRect();
+            assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(tickLabelRect, tickMarkRect),
+              `tickMark ${i} and tickLabel ${i2} should not overlap`);
+        });
+      });
+      svg.remove();
+    });
+
+    describe("formatting the labels", () => {
+      it("formats to the specified formatter", () => {
+        let svg = TestMethods.generateSVG();
+        let scale = new Plottable.Scales.Linear();
+
+        let formatter = Plottable.Formatters.fixed(2);
+
+        let axis = new Plottable.Axes.Numeric(scale, "left");
+        axis.formatter(formatter);
+        axis.renderTo(svg);
+
+        let tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
+        tickLabels.each(function(d, i) {
+          let labelText = d3.select(this).text();
+          let formattedValue = formatter(d);
+          assert.strictEqual(labelText, formattedValue, `formatter used to format tick label ${i}`);
+        });
+
+        svg.remove();
+      });
+    });
+
+    orientations.forEach((orientation) => {
+      it(`allocates enough height to show all tick labels for orientation ${orientation}`, () => {
+        let svg = TestMethods.generateSVG();
+        let scale = new Plottable.Scales.Linear();
+        scale.domain([5, -5]);
+
+        let formatter = (d: any) => (d === 0) ? "ZERO" : String(d);
+
+        let axis = new Plottable.Axes.Numeric(scale, orientation);
+        axis.formatter(formatter);
+        axis.renderTo(svg);
+
+        let visibleTickLabels = applyVisibleFilter(axis.content()
+          .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+        let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
+        visibleTickLabels.each(function(d, i) {
+          let visibleTickLabelRect = this.getBoundingClientRect();
+          assert.isTrue(boxIsInside(visibleTickLabelRect, boundingBox, 0.5), `tick label ${i} is inside the bounding box`);
+        });
+
+        svg.remove();
+      });
+    });
+
+    verticalOrientations.forEach((verticalOrientation) => {
+      it(`allocates enough width to show long tick labels for orientation ${verticalOrientation}`, () => {
+        let svg = TestMethods.generateSVG();
+        let scale = new Plottable.Scales.Linear();
+        scale.domain([50000000000, -50000000000]);
+
+        let formatter = (d: any) => (d === 0) ? "ZERO" : String(d);
+
+        let axis = new Plottable.Axes.Numeric(scale, verticalOrientation);
+        axis.formatter(formatter);
+        axis.renderTo(svg);
+
+        let visibleTickLabels = applyVisibleFilter(axis.content()
+          .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+        let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
+        visibleTickLabels.each(function(d, i) {
+          let visibleTickLabelRect = this.getBoundingClientRect();
+          assertBoxInside(visibleTickLabelRect, boundingBox, 0, `long tick label ${i} is inside the bounding box`);
         });
         svg.remove();
       });
     });
-  });
 
-  describe("drawing tick labels when bottom oriented", () => {
-
-    let svg: d3.Selection<void>;
-
-    beforeEach(() => {
-      svg = TestMethods.generateSVG();
-    });
-
-    it("does not overlap tick labels in a constrained space", () => {
-      let constrainedWidth = 50;
-      let constrainedHeight = 50;
-      svg.attr("width", constrainedWidth);
-      svg.attr("height", constrainedHeight);
-      let scale = new Plottable.Scales.Linear();
-      let numericAxis = new Plottable.Axes.Numeric(scale, "bottom");
-      numericAxis.renderTo(svg);
-
-      let visibleTickLabels = applyVisibleFilter(numericAxis.content()
-        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
-
-      visibleTickLabels.each(function(d, i) {
-        let labelRect = this.getBoundingClientRect();
-        visibleTickLabels[0].slice(i + 1).forEach(function(otherVisibleTickLabel, i2) {
-          let labelRect2 = (<Element> otherVisibleTickLabel).getBoundingClientRect();
-          let rectOverlap = Plottable.Utils.DOM.clientRectsOverlap(labelRect, labelRect2);
-          assert.isFalse(rectOverlap, `tick label ${i} does not overlap with tick label ${i2}`);
-        });
-      });
-
-      svg.remove();
-    });
-
-    it("ensures that long labels are contained", () => {
-      let scale = new Plottable.Scales.Linear().domain([400000000, 500000000]);
-      let axis = new Plottable.Axes.Numeric(scale, "left");
-
-      axis.renderTo(svg);
-
-      let tickLabelContainerClass = "tick-label-container";
-      let labelContainer = axis.content().select(`.${tickLabelContainerClass}`);
-      axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`).each(function() {
-        TestMethods.assertBBoxInclusion(labelContainer, d3.select(this));
-      });
-      svg.remove();
-    });
-
-    it("separates tick labels with the same spacing", () => {
-      let scale = new Plottable.Scales.Linear();
-      scale.domain([-2500000, 2500000]);
-
-      let axis = new Plottable.Axes.Numeric(scale, "bottom");
-      axis.renderTo(svg);
-
-      let visibleTickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
-
-      let visibleTickLabelRects = visibleTickLabels[0].map((label: Element) => label.getBoundingClientRect());
-
-      function getClientRectCenter(rect: ClientRect) {
-        return rect.left + rect.width / 2;
-      }
-
-      let interval = getClientRectCenter(visibleTickLabelRects[1]) - getClientRectCenter(visibleTickLabelRects[0]);
-      d3.pairs(visibleTickLabelRects).forEach((rects, i) => {
-        assert.closeTo(getClientRectCenter(rects[1]) - getClientRectCenter(rects[0]),
-          interval, window.Pixel_CloseTo_Requirement, `tick label pair ${i} is spaced the same as the first pair`);
-      });
-
-      svg.remove();
-    });
-
-    it("renders numbers in order with a reversed domain", () => {
-      let scale = new Plottable.Scales.Linear();
-      scale.domain([3, 0]);
-
-      let axis = new Plottable.Axes.Numeric(scale, "bottom");
-      axis.renderTo(svg);
-
-      let tickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
-      assert.operator(tickLabels.size(), ">", 1, "more than one tick label is shown");
-
-      let tickLabelElementPairs = d3.pairs(tickLabels[0]);
-      tickLabelElementPairs.forEach(function(tickLabelElementPair, i) {
-        let label1 = d3.select(tickLabelElementPair[0]);
-        let label2 = d3.select(tickLabelElementPair[1]);
-        let labelNumber1 = parseFloat(label1.text());
-        let labelNumber2 = parseFloat(label2.text());
-        assert.operator(labelNumber1, ">", labelNumber2, `pair ${i} arranged in descending order from left to right`);
-      });
-
-      svg.remove();
-    });
-  });
-
-  orientations.forEach((orientation) => {
-    it(`draws ticks labels centered with the corresponding tick mark for orientation ${orientation}`, () => {
-      let svg = TestMethods.generateSVG();
-      let scale = new Plottable.Scales.Linear();
-      let numericAxis = new Plottable.Axes.Numeric(scale, orientation);
-      numericAxis.renderTo(svg);
-
-      let tickLabels = numericAxis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
-      assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
-      let tickMarks = numericAxis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
-      assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
-
-      tickLabels.each(function(d, i) {
-        let tickLabelClientRect = this.getBoundingClientRect();
-        let tickMarkClientRect = (<Element> tickMarks[0][i]).getBoundingClientRect();
-        let labelCenter = isHorizontalOrientation(orientation) ?
-          (tickLabelClientRect.left + tickLabelClientRect.right) / 2 :
-          (tickLabelClientRect.top + tickLabelClientRect.bottom) / 2;
-        let markCenter = isHorizontalOrientation(orientation) ?
-          (tickMarkClientRect.left + tickMarkClientRect.right) / 2 :
-          (tickMarkClientRect.top + tickMarkClientRect.bottom) / 2;
-        assert.closeTo(labelCenter, markCenter, 1.5, `tick label ${i} is centered on mark`);
-      });
-
-      svg.remove();
-    });
-  });
-
-  it("does not overlap tick marks with tick labels", () => {
-    let svg = TestMethods.generateSVG();
-
-    let scale = new Plottable.Scales.Linear();
-    scale.domain([175, 185]);
-    let axis = new Plottable.Axes.Numeric(scale, "left")
-                                  .innerTickLength(50);
-    axis.renderTo(svg);
-
-    let tickLabels = applyVisibleFilter(axis.content().selectAll("." + Plottable.Axis.TICK_LABEL_CLASS));
-
-    let tickMarks = applyVisibleFilter(axis.content().selectAll("." + Plottable.Axis.TICK_MARK_CLASS));
-
-    tickLabels.each(function(d, i) {
-      let tickLabelRect = this.getBoundingClientRect();
-      tickMarks.each(function(d2, i2) {
-        let tickMarkRect = this.getBoundingClientRect();
-          assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(tickLabelRect, tickMarkRect),
-            `tickMark ${i} and tickLabel ${i2} should not overlap`);
-      });
-    });
-    svg.remove();
-  });
-
-  describe("formatting the labels", () => {
-    it("formats to the specified formatter", () => {
-      let svg = TestMethods.generateSVG();
-      let scale = new Plottable.Scales.Linear();
-
-      let formatter = Plottable.Formatters.fixed(2);
-
-      let numericAxis = new Plottable.Axes.Numeric(scale, "left");
-      numericAxis.formatter(formatter);
-      numericAxis.renderTo(svg);
-
-      let tickLabels = numericAxis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
-      tickLabels.each(function(d, i) {
-        let labelText = d3.select(this).text();
-        let formattedValue = formatter(d);
-        assert.strictEqual(labelText, formattedValue, `formatter used to format tick label ${i}`);
-      });
-
-      svg.remove();
-    });
-  });
-
-  orientations.forEach((orientation) => {
-    it(`allocates enough height to show all tick labels for orientation ${orientation}`, () => {
-      let svg = TestMethods.generateSVG();
-      let scale = new Plottable.Scales.Linear();
-      scale.domain([5, -5]);
-
-      let formatter = (d: any) => (d === 0) ? "ZERO" : String(d);
-
-      let axis = new Plottable.Axes.Numeric(scale, orientation);
-      axis.formatter(formatter);
-      axis.renderTo(svg);
-
-      let visibleTickLabels = applyVisibleFilter(axis.content()
-        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
-      let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
-      visibleTickLabels.each(function(d, i) {
-        let visibleTickLabelRect = this.getBoundingClientRect();
-        assert.isTrue(boxIsInside(visibleTickLabelRect, boundingBox, 0.5), `tick label ${i} is inside the bounding box`);
-      });
-
-      svg.remove();
-    });
-  });
-
-  verticalOrientations.forEach((verticalOrientation) => {
-    it(`allocates enough width to show long tick labels for orientation ${verticalOrientation}`, () => {
-      let svg = TestMethods.generateSVG();
-      let scale = new Plottable.Scales.Linear();
-      scale.domain([50000000000, -50000000000]);
-
-      let formatter = (d: any) => (d === 0) ? "ZERO" : String(d);
-
-      let axis = new Plottable.Axes.Numeric(scale, verticalOrientation);
-      axis.formatter(formatter);
-      axis.renderTo(svg);
-
-      let visibleTickLabels = applyVisibleFilter(axis.content()
-        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
-      let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
-      visibleTickLabels.each(function(d, i) {
-        let visibleTickLabelRect = this.getBoundingClientRect();
-        assertBoxInside(visibleTickLabelRect, boundingBox, 0, `long tick label ${i} is inside the bounding box`);
-      });
-      svg.remove();
-    });
-  });
-
-  describe("drawing tick marks", () => {
-    it("does not draw ticks marks outside of the svg", () => {
-      let svg = TestMethods.generateSVG();
-      let scale = new Plottable.Scales.Linear();
-      let domainMin = 0;
-      let domainMax = 3;
-      scale.domain([domainMin, domainMax]);
-      scale.tickGenerator(function() {
-        return Plottable.Utils.Math.range(domainMin, domainMax + 4);
-      });
-      let axis = new Plottable.Axes.Numeric(scale, "bottom");
-      axis.renderTo(svg);
-      let tickMarks = axis.content().selectAll(".tick-mark");
-      tickMarks.each(function(d, i) {
-        let tickMark = d3.select(this);
-        let tickMarkPosition = TestMethods.numAttr(tickMark, "x1");
-        assert.operator(tickMarkPosition, ">=", 0, `tick mark ${i} drawn right of left edge`);
-        assert.operator(tickMarkPosition, "<=", axis.width(), `tick mark ${i} drawn left of right edge`);
-      });
-      svg.remove();
-    });
-  });
-
-  describe("using width approximation", () => {
-    it("reasonably approximates tick label sizes with approximate measuring", () => {
-      let svg = TestMethods.generateSVG();
-
-      let testDomains = [[-1, 1],
-                      [0, 10],
-                      [0, 999999999]];
-
-      let maxErrorFactor = 1.4;
-
-      testDomains.forEach((testDomain) => {
+    describe("drawing tick marks", () => {
+      it("does not draw ticks marks outside of the svg", () => {
+        let svg = TestMethods.generateSVG();
         let scale = new Plottable.Scales.Linear();
-        scale.domain(testDomain);
-        let numericAxis = new Plottable.Axes.Numeric(scale, "left");
-
-        numericAxis.usesTextWidthApproximation(true);
-        numericAxis.renderTo(svg);
-        let widthApprox = numericAxis.width();
-
-        numericAxis.usesTextWidthApproximation(false);
-        numericAxis.redraw();
-        let widthExact = numericAxis.width();
-
-        assert.operator(widthApprox, "<", (widthExact * maxErrorFactor),
-          `approximate domain of [${testDomain[0]},${testDomain[1]}] less than ${maxErrorFactor} times larger than exact scale`);
-        assert.operator(widthApprox, ">=", widthExact,
-          `approximate domain of [${testDomain[0]},${testDomain[1]}] greater than an exact scale`);
-        numericAxis.destroy();
+        let domainMin = 0;
+        let domainMax = 3;
+        scale.domain([domainMin, domainMax]);
+        scale.tickGenerator(function() {
+          return Plottable.Utils.Math.range(domainMin, domainMax + 4);
+        });
+        let axis = new Plottable.Axes.Numeric(scale, "bottom");
+        axis.renderTo(svg);
+        let tickMarks = axis.content().selectAll(".tick-mark");
+        tickMarks.each(function(d, i) {
+          let tickMark = d3.select(this);
+          let tickMarkPosition = TestMethods.numAttr(tickMark, "x1");
+          assert.operator(tickMarkPosition, ">=", 0, `tick mark ${i} drawn right of left edge`);
+          assert.operator(tickMarkPosition, "<=", axis.width(), `tick mark ${i} drawn left of right edge`);
+        });
+        svg.remove();
       });
+    });
 
-      svg.remove();
+    describe("using width approximation", () => {
+      it("reasonably approximates tick label sizes with approximate measuring", () => {
+        let svg = TestMethods.generateSVG();
+
+        let testDomains = [[-1, 1],
+                        [0, 10],
+                        [0, 999999999]];
+
+        let maxErrorFactor = 1.4;
+
+        testDomains.forEach((testDomain) => {
+          let scale = new Plottable.Scales.Linear();
+          scale.domain(testDomain);
+          let axis = new Plottable.Axes.Numeric(scale, "left");
+
+          axis.usesTextWidthApproximation(true);
+          axis.renderTo(svg);
+          let widthApprox = axis.width();
+
+          axis.usesTextWidthApproximation(false);
+          axis.redraw();
+          let widthExact = axis.width();
+
+          assert.operator(widthApprox, "<", (widthExact * maxErrorFactor),
+            `approximate domain of [${testDomain[0]},${testDomain[1]}] less than ${maxErrorFactor} times larger than exact scale`);
+          assert.operator(widthApprox, ">=", widthExact,
+            `approximate domain of [${testDomain[0]},${testDomain[1]}] greater than an exact scale`);
+          axis.destroy();
+        });
+
+        svg.remove();
+      });
     });
   });
 });

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -76,25 +76,18 @@ describe("Axes", () => {
       });
     });
 
-    describe("drawing tick labels when bottom oriented", () => {
-
-      let svg: d3.Selection<void>;
-
-      beforeEach(() => {
-        svg = TestMethods.generateSVG();
-      });
-
-      it("does not overlap tick labels in a constrained space", () => {
+    horizontalOrientations.forEach((orientation) => {
+      it(`does not overlap tick labels in a constrained space for horizontal orientation ${orientation}`, () => {
+        let svg = TestMethods.generateSVG();
         let constrainedWidth = 50;
         let constrainedHeight = 50;
         svg.attr("width", constrainedWidth);
         svg.attr("height", constrainedHeight);
         let scale = new Plottable.Scales.Linear();
-        let axis = new Plottable.Axes.Numeric(scale, "bottom");
+        let axis = new Plottable.Axes.Numeric(scale, orientation);
         axis.renderTo(svg);
 
-        let visibleTickLabels = applyVisibleFilter(axis.content()
-          .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+        let visibleTickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
 
         visibleTickLabels.each(function(d, i) {
           let labelRect = this.getBoundingClientRect();
@@ -107,26 +100,15 @@ describe("Axes", () => {
 
         svg.remove();
       });
+    });
 
-      it("ensures that long labels are contained", () => {
-        let scale = new Plottable.Scales.Linear().domain([400000000, 500000000]);
-        let axis = new Plottable.Axes.Numeric(scale, "left");
-
-        axis.renderTo(svg);
-
-        let tickLabelContainerClass = "tick-label-container";
-        let labelContainer = axis.content().select(`.${tickLabelContainerClass}`);
-        axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`).each(function() {
-          TestMethods.assertBBoxInclusion(labelContainer, d3.select(this));
-        });
-        svg.remove();
-      });
-
+    horizontalOrientations.forEach((orientation) => {
       it("separates tick labels with the same spacing", () => {
+        let svg = TestMethods.generateSVG();
         let scale = new Plottable.Scales.Linear();
         scale.domain([-2500000, 2500000]);
 
-        let axis = new Plottable.Axes.Numeric(scale, "bottom");
+        let axis = new Plottable.Axes.Numeric(scale, orientation);
         axis.renderTo(svg);
 
         let visibleTickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
@@ -145,12 +127,15 @@ describe("Axes", () => {
 
         svg.remove();
       });
+    });
 
+    horizontalOrientations.forEach((orientation) => {
       it("renders numbers in order with a reversed domain", () => {
+        let svg = TestMethods.generateSVG();
         let scale = new Plottable.Scales.Linear();
         scale.domain([3, 0]);
 
-        let axis = new Plottable.Axes.Numeric(scale, "bottom");
+        let axis = new Plottable.Axes.Numeric(scale, orientation);
         axis.renderTo(svg);
 
         let tickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
@@ -168,6 +153,23 @@ describe("Axes", () => {
         svg.remove();
       });
     });
+
+    verticalOrientations.forEach((orientation) => {
+        it(`ensures that long labels are contained for vertical orientation ${orientation}`, () => {
+          let scale = new Plottable.Scales.Linear().domain([400000000, 500000000]);
+          let axis = new Plottable.Axes.Numeric(scale, orientation);
+
+          let svg = TestMethods.generateSVG();
+          axis.renderTo(svg);
+
+          let tickLabelContainerClass = "tick-label-container";
+          let labelContainer = axis.content().select(`.${tickLabelContainerClass}`);
+          axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`).each(function() {
+            TestMethods.assertBBoxInclusion(labelContainer, d3.select(this));
+          });
+          svg.remove();
+        });
+      });
 
     orientations.forEach((orientation) => {
       it(`draws ticks labels centered with the corresponding tick mark for orientation ${orientation}`, () => {
@@ -255,8 +257,7 @@ describe("Axes", () => {
         axis.formatter(formatter);
         axis.renderTo(svg);
 
-        let visibleTickLabels = applyVisibleFilter(axis.content()
-          .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+        let visibleTickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
         let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
         visibleTickLabels.each(function(d, i) {
           let visibleTickLabelRect = this.getBoundingClientRect();
@@ -279,8 +280,7 @@ describe("Axes", () => {
         axis.formatter(formatter);
         axis.renderTo(svg);
 
-        let visibleTickLabels = applyVisibleFilter(axis.content()
-          .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+        let visibleTickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
         let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
         visibleTickLabels.each(function(d, i) {
           let visibleTickLabelRect = this.getBoundingClientRect();

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -261,57 +261,16 @@ describe("NumericAxis", () => {
     });
   });
 
-  describe("allocating space when left oriented", () => {
-    it("allocates enough width to show short tick labels when vertical", () => {
+  orientations.forEach((orientation) => {
+    it(`allocates enough height to show all tick labels for orientation ${orientation}`, () => {
       let svg = TestMethods.generateSVG();
       let scale = new Plottable.Scales.Linear();
       scale.domain([5, -5]);
 
       let formatter = (d: any) => (d === 0) ? "ZERO" : String(d);
 
-      let axis = new Plottable.Axes.Numeric(scale, "left");
+      let axis = new Plottable.Axes.Numeric(scale, orientation);
       axis.formatter(formatter);
-      axis.renderTo(svg);
-
-      let visibleTickLabels = applyVisibleFilter(axis.content()
-        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
-      let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
-      visibleTickLabels.each(function(d, i) {
-        let visibleTickLabelRect = this.getBoundingClientRect();
-        assert.isTrue(boxIsInside(visibleTickLabelRect, boundingBox), `tick label ${i} is inside the bounding box`);
-      });
-      svg.remove();
-    });
-
-    it("allocates enough width to show long tick labels when vertical", () => {
-      let svg = TestMethods.generateSVG();
-      let scale = new Plottable.Scales.Linear();
-      scale.domain([50000000000, -50000000000]);
-
-      let formatter = (d: any) => (d === 0) ? "ZERO" : String(d);
-
-      let axis = new Plottable.Axes.Numeric(scale, "left");
-      axis.formatter(formatter);
-      axis.renderTo(svg);
-
-      let visibleTickLabels = applyVisibleFilter(axis.content()
-        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
-      let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
-      visibleTickLabels.each(function(d, i) {
-        let visibleTickLabelRect = this.getBoundingClientRect();
-        assertBoxInside(visibleTickLabelRect, boundingBox, 0, `long tick label ${i} is inside the bounding box`);
-      });
-      svg.remove();
-    });
-  });
-
-  describe("allocating space when bottom oriented", () => {
-    it("allocates enough height to show all tick labels when horizontal", () => {
-      let svg = TestMethods.generateSVG();
-      let scale = new Plottable.Scales.Linear();
-      scale.domain([5, -5]);
-
-      let axis = new Plottable.Axes.Numeric(scale, "bottom");
       axis.renderTo(svg);
 
       let visibleTickLabels = applyVisibleFilter(axis.content()
@@ -322,6 +281,29 @@ describe("NumericAxis", () => {
         assert.isTrue(boxIsInside(visibleTickLabelRect, boundingBox, 0.5), `tick label ${i} is inside the bounding box`);
       });
 
+      svg.remove();
+    });
+  });
+
+  verticalOrientations.forEach((verticalOrientation) => {
+    it(`allocates enough width to show long tick labels for orientation ${verticalOrientation}`, () => {
+      let svg = TestMethods.generateSVG();
+      let scale = new Plottable.Scales.Linear();
+      scale.domain([50000000000, -50000000000]);
+
+      let formatter = (d: any) => (d === 0) ? "ZERO" : String(d);
+
+      let axis = new Plottable.Axes.Numeric(scale, verticalOrientation);
+      axis.formatter(formatter);
+      axis.renderTo(svg);
+
+      let visibleTickLabels = applyVisibleFilter(axis.content()
+        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+      let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
+      visibleTickLabels.each(function(d, i) {
+        let visibleTickLabelRect = this.getBoundingClientRect();
+        assertBoxInside(visibleTickLabelRect, boundingBox, 0, `long tick label ${i} is inside the bounding box`);
+      });
       svg.remove();
     });
   });

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -11,7 +11,7 @@ describe("Axes", () => {
 
     function applyVisibleFilter(selection: d3.Selection<any>) {
       return selection.filter(function() {
-        let visibilityAttr =  d3.select(this).style("visibility");
+        const visibilityAttr =  d3.select(this).style("visibility");
         return visibilityAttr === "visible" || visibilityAttr === "inherit";
       });
     }
@@ -22,140 +22,141 @@ describe("Axes", () => {
 
     const isHorizontalOrientation = (orientation: string) => horizontalOrientations.indexOf(orientation) >= 0;
 
-    const verticalTickLabelPositions = ["top", "bottom"];
-    const horizontalTickLabelPositions = ["left", "right"];
+    describe("managing tick labels", () => {
+      const verticalTickLabelPositions = ["top", "bottom"];
+      const horizontalTickLabelPositions = ["left", "right"];
 
-    horizontalOrientations.forEach((orientation) => {
-      it(`throws an error when setting an invalid position on orientation ${orientation}`, () => {
-        const scale = new Plottable.Scales.Linear();
-        const axis = new Plottable.Axes.Numeric(scale, orientation);
-        verticalTickLabelPositions.forEach((position) => {
-          (<any> assert).throws(() => axis.tickLabelPosition(position), "horizontal", `cannot set position to ${position}`);
-        });
-      });
-    });
-
-    verticalOrientations.forEach((orientation) => {
-      it(`throws an error when setting an invalid position on orientation ${orientation}`, () => {
-        const scale = new Plottable.Scales.Linear();
-        const axis = new Plottable.Axes.Numeric(scale, orientation);
-        horizontalTickLabelPositions.forEach((position) => {
-          (<any> assert).throws(() => axis.tickLabelPosition(position), "vertical", `cannot set position to ${position}`);
-        });
-      });
-    });
-
-    orientations.forEach((orientation) => {
-      const labelPositions = isHorizontalOrientation(orientation) ? horizontalTickLabelPositions : verticalTickLabelPositions;
-      labelPositions.forEach((labelPosition) => {
-        it(`draws tick labels ${labelPosition} of the corresponding mark if specified for orientation ${orientation}`, () => {
+      horizontalOrientations.forEach((orientation) => {
+        it(`throws an error when setting an invalid position on orientation ${orientation}`, () => {
           const scale = new Plottable.Scales.Linear();
           const axis = new Plottable.Axes.Numeric(scale, orientation);
+          verticalTickLabelPositions.forEach((position) => {
+            (<any> assert).throws(() => axis.tickLabelPosition(position), "horizontal", `cannot set position to ${position}`);
+          });
+        });
+      });
+
+      verticalOrientations.forEach((orientation) => {
+        it(`throws an error when setting an invalid position on orientation ${orientation}`, () => {
+          const scale = new Plottable.Scales.Linear();
+          const axis = new Plottable.Axes.Numeric(scale, orientation);
+          horizontalTickLabelPositions.forEach((position) => {
+            (<any> assert).throws(() => axis.tickLabelPosition(position), "vertical", `cannot set position to ${position}`);
+          });
+        });
+      });
+
+      orientations.forEach((orientation) => {
+        const labelPositions = isHorizontalOrientation(orientation) ? horizontalTickLabelPositions : verticalTickLabelPositions;
+        labelPositions.forEach((labelPosition) => {
+          it(`draws tick labels ${labelPosition} of the corresponding mark if specified for orientation ${orientation}`, () => {
+            const scale = new Plottable.Scales.Linear();
+            const axis = new Plottable.Axes.Numeric(scale, orientation);
+            const svg = TestMethods.generateSVG();
+            axis.tickLabelPosition(labelPosition);
+            axis.renderTo(svg);
+
+            const tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
+            const tickMarks = axis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
+            assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
+            assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
+
+            tickLabels.each(function(d, i) {
+              TestMethods.assertBBoxNonIntersection(d3.select(this), d3.select(tickMarks[0][i]));
+            });
+            svg.remove();
+          });
+        });
+      });
+
+      orientations.forEach((orientation) => {
+        it(`does not overlap tick labels in a constrained space for orientation ${orientation}`, () => {
           const svg = TestMethods.generateSVG();
-          axis.tickLabelPosition(labelPosition);
+          const constrainedWidth = 50;
+          const constrainedHeight = 50;
+          svg.attr("width", constrainedWidth);
+          svg.attr("height", constrainedHeight);
+          const scale = new Plottable.Scales.Linear();
+          const axis = new Plottable.Axes.Numeric(scale, orientation);
           axis.renderTo(svg);
 
-          const tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
-          const tickMarks = axis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
-          assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
-          assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
+          const visibconstickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
 
-          tickLabels.each(function(d, i) {
-            TestMethods.assertBBoxNonIntersection(d3.select(this), d3.select(tickMarks[0][i]));
+          visibconstickLabels.each(function(d, i) {
+            const labelRect = this.getBoundingClientRect();
+            visibconstickLabels[0].slice(i + 1).forEach(function(otherVisibconstickLabel, i2) {
+              const labelRect2 = (<Element> otherVisibconstickLabel).getBoundingClientRect();
+              const rectOverlap = Plottable.Utils.DOM.clientRectsOverlap(labelRect, labelRect2);
+              assert.isFalse(rectOverlap, `tick label ${i} does not overlap with tick label ${i2}`);
+            });
           });
+
           svg.remove();
         });
       });
-    });
 
-    orientations.forEach((orientation) => {
-      it(`does not overlap tick labels in a constrained space for orientation ${orientation}`, () => {
-        let svg = TestMethods.generateSVG();
-        let constrainedWidth = 50;
-        let constrainedHeight = 50;
-        svg.attr("width", constrainedWidth);
-        svg.attr("height", constrainedHeight);
-        let scale = new Plottable.Scales.Linear();
-        let axis = new Plottable.Axes.Numeric(scale, orientation);
-        axis.renderTo(svg);
+      orientations.forEach((orientation) => {
+        it(`separates tick labels with the same spacing for orientation ${orientation}`, () => {
+          const svg = TestMethods.generateSVG();
+          const scale = new Plottable.Scales.Linear();
+          scale.domain([-2500000, 2500000]);
 
-        let visibleTickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
-
-        visibleTickLabels.each(function(d, i) {
-          let labelRect = this.getBoundingClientRect();
-          visibleTickLabels[0].slice(i + 1).forEach(function(otherVisibleTickLabel, i2) {
-            let labelRect2 = (<Element> otherVisibleTickLabel).getBoundingClientRect();
-            let rectOverlap = Plottable.Utils.DOM.clientRectsOverlap(labelRect, labelRect2);
-            assert.isFalse(rectOverlap, `tick label ${i} does not overlap with tick label ${i2}`);
-          });
-        });
-
-        svg.remove();
-      });
-    });
-
-    orientations.forEach((orientation) => {
-      it(`separates tick labels with the same spacing for orientation ${orientation}`, () => {
-        let svg = TestMethods.generateSVG();
-        let scale = new Plottable.Scales.Linear();
-        scale.domain([-2500000, 2500000]);
-
-        let axis = new Plottable.Axes.Numeric(scale, orientation);
-        axis.renderTo(svg);
-
-        let visibleTickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
-
-        let visibleTickLabelRects = visibleTickLabels[0].map((label: Element) => label.getBoundingClientRect());
-
-        function getClientRectCenter(rect: ClientRect) {
-          return isHorizontalOrientation(orientation) ? rect.left + rect.width / 2 : rect.top + rect.height / 2;
-        }
-
-        let interval = getClientRectCenter(visibleTickLabelRects[1]) - getClientRectCenter(visibleTickLabelRects[0]);
-        d3.pairs(visibleTickLabelRects).forEach((rects, i) => {
-          assert.closeTo(getClientRectCenter(rects[1]) - getClientRectCenter(rects[0]),
-            interval, window.Pixel_CloseTo_Requirement, `tick label pair ${i} is spaced the same as the first pair`);
-        });
-
-        svg.remove();
-      });
-    });
-
-    orientations.forEach((orientation) => {
-      it(`renders numbers in order with a reversed domain for orientation ${orientation}`, () => {
-        let svg = TestMethods.generateSVG();
-        let scale = new Plottable.Scales.Linear();
-        scale.domain([3, 0]);
-
-        let axis = new Plottable.Axes.Numeric(scale, orientation);
-        axis.renderTo(svg);
-
-        let tickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
-        assert.operator(tickLabels.size(), ">", 1, "more than one tick label is shown");
-
-        let tickLabelElementPairs = d3.pairs(tickLabels[0]);
-        tickLabelElementPairs.forEach(function(tickLabelElementPair, i) {
-          let label1 = d3.select(tickLabelElementPair[0]);
-          let label2 = d3.select(tickLabelElementPair[1]);
-          let labelNumber1 = parseFloat(label1.text());
-          let labelNumber2 = parseFloat(label2.text());
-          assert.operator(labelNumber1, ">", labelNumber2, `pair ${i} arranged in descending order from left to right`);
-        });
-
-        svg.remove();
-      });
-    });
-
-    verticalOrientations.forEach((orientation) => {
-        it(`ensures that long labels are contained for vertical orientation ${orientation}`, () => {
-          let scale = new Plottable.Scales.Linear().domain([400000000, 500000000]);
-          let axis = new Plottable.Axes.Numeric(scale, orientation);
-
-          let svg = TestMethods.generateSVG();
+          const axis = new Plottable.Axes.Numeric(scale, orientation);
           axis.renderTo(svg);
 
-          let tickLabelContainerClass = "tick-label-container";
-          let labelContainer = axis.content().select(`.${tickLabelContainerClass}`);
+          const visibconstickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+
+          const visibconstickLabelRects = visibconstickLabels[0].map((label: Element) => label.getBoundingClientRect());
+
+          function getClientRectCenter(rect: ClientRect) {
+            return isHorizontalOrientation(orientation) ? rect.left + rect.width / 2 : rect.top + rect.height / 2;
+          }
+
+          const interval = getClientRectCenter(visibconstickLabelRects[1]) - getClientRectCenter(visibconstickLabelRects[0]);
+          d3.pairs(visibconstickLabelRects).forEach((rects, i) => {
+            assert.closeTo(getClientRectCenter(rects[1]) - getClientRectCenter(rects[0]),
+              interval, window.Pixel_CloseTo_Requirement, `tick label pair ${i} is spaced the same as the first pair`);
+          });
+
+          svg.remove();
+        });
+      });
+
+      orientations.forEach((orientation) => {
+        it(`renders numbers in order with a reversed domain for orientation ${orientation}`, () => {
+          const svg = TestMethods.generateSVG();
+          const scale = new Plottable.Scales.Linear();
+          scale.domain([3, 0]);
+
+          const axis = new Plottable.Axes.Numeric(scale, orientation);
+          axis.renderTo(svg);
+
+          const tickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+          assert.operator(tickLabels.size(), ">", 1, "more than one tick label is shown");
+
+          const tickLabelElementPairs = d3.pairs(tickLabels[0]);
+          tickLabelElementPairs.forEach(function(tickLabelElementPair, i) {
+            const label1 = d3.select(tickLabelElementPair[0]);
+            const label2 = d3.select(tickLabelElementPair[1]);
+            const labelNumber1 = parseFloat(label1.text());
+            const labelNumber2 = parseFloat(label2.text());
+            assert.operator(labelNumber1, ">", labelNumber2, `pair ${i} arranged in descending order from left to right`);
+          });
+
+          svg.remove();
+        });
+      });
+
+      verticalOrientations.forEach((orientation) => {
+        it(`ensures that long labels are contained for vertical orientation ${orientation}`, () => {
+          const scale = new Plottable.Scales.Linear().domain([400000000, 500000000]);
+          const axis = new Plottable.Axes.Numeric(scale, orientation);
+
+          const svg = TestMethods.generateSVG();
+          axis.renderTo(svg);
+
+          const tickLabelContainerClass = "tick-label-container";
+          const labelContainer = axis.content().select(`.${tickLabelContainerClass}`);
           axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`).each(function() {
             TestMethods.assertBBoxInclusion(labelContainer, d3.select(this));
           });
@@ -163,72 +164,73 @@ describe("Axes", () => {
         });
       });
 
-    orientations.forEach((orientation) => {
-      it(`draws ticks labels centered with the corresponding tick mark for orientation ${orientation}`, () => {
-        let svg = TestMethods.generateSVG();
-        let scale = new Plottable.Scales.Linear();
-        let axis = new Plottable.Axes.Numeric(scale, orientation);
+      orientations.forEach((orientation) => {
+        it(`draws ticks labels centered with the corresponding tick mark for orientation ${orientation}`, () => {
+          const svg = TestMethods.generateSVG();
+          const scale = new Plottable.Scales.Linear();
+          const axis = new Plottable.Axes.Numeric(scale, orientation);
+          axis.renderTo(svg);
+
+          const tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
+          assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
+          const tickMarks = axis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
+          assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
+
+          tickLabels.each(function(d, i) {
+            const tickLabelClientRect = this.getBoundingClientRect();
+            const tickMarkClientRect = (<Element> tickMarks[0][i]).getBoundingClientRect();
+            const labelCenter = isHorizontalOrientation(orientation) ?
+              (tickLabelClientRect.left + tickLabelClientRect.right) / 2 :
+              (tickLabelClientRect.top + tickLabelClientRect.bottom) / 2;
+            const markCenter = isHorizontalOrientation(orientation) ?
+              (tickMarkClientRect.left + tickMarkClientRect.right) / 2 :
+              (tickMarkClientRect.top + tickMarkClientRect.bottom) / 2;
+            assert.closeTo(labelCenter, markCenter, 1.5, `tick label ${i} is centered on mark`);
+          });
+
+          svg.remove();
+        });
+      });
+
+      it("does not overlap tick marks with tick labels", () => {
+        const svg = TestMethods.generateSVG();
+
+        const scale = new Plottable.Scales.Linear();
+        scale.domain([175, 185]);
+        const axis = new Plottable.Axes.Numeric(scale, "left")
+                                      .innerTickLength(50);
         axis.renderTo(svg);
 
-        let tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
-        assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
-        let tickMarks = axis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
-        assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
+        const tickLabels = applyVisibleFilter(axis.content().selectAll("." + Plottable.Axis.TICK_LABEL_CLASS));
+
+        const tickMarks = applyVisibleFilter(axis.content().selectAll("." + Plottable.Axis.TICK_MARK_CLASS));
 
         tickLabels.each(function(d, i) {
-          let tickLabelClientRect = this.getBoundingClientRect();
-          let tickMarkClientRect = (<Element> tickMarks[0][i]).getBoundingClientRect();
-          let labelCenter = isHorizontalOrientation(orientation) ?
-            (tickLabelClientRect.left + tickLabelClientRect.right) / 2 :
-            (tickLabelClientRect.top + tickLabelClientRect.bottom) / 2;
-          let markCenter = isHorizontalOrientation(orientation) ?
-            (tickMarkClientRect.left + tickMarkClientRect.right) / 2 :
-            (tickMarkClientRect.top + tickMarkClientRect.bottom) / 2;
-          assert.closeTo(labelCenter, markCenter, 1.5, `tick label ${i} is centered on mark`);
+          const tickLabelRect = this.getBoundingClientRect();
+          tickMarks.each(function(d2, i2) {
+            const tickMarkRect = this.getBoundingClientRect();
+              assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(tickLabelRect, tickMarkRect),
+                `tickMark ${i} and tickLabel ${i2} should not overlap`);
+          });
         });
-
         svg.remove();
       });
     });
 
-    it("does not overlap tick marks with tick labels", () => {
-      let svg = TestMethods.generateSVG();
-
-      let scale = new Plottable.Scales.Linear();
-      scale.domain([175, 185]);
-      let axis = new Plottable.Axes.Numeric(scale, "left")
-                                    .innerTickLength(50);
-      axis.renderTo(svg);
-
-      let tickLabels = applyVisibleFilter(axis.content().selectAll("." + Plottable.Axis.TICK_LABEL_CLASS));
-
-      let tickMarks = applyVisibleFilter(axis.content().selectAll("." + Plottable.Axis.TICK_MARK_CLASS));
-
-      tickLabels.each(function(d, i) {
-        let tickLabelRect = this.getBoundingClientRect();
-        tickMarks.each(function(d2, i2) {
-          let tickMarkRect = this.getBoundingClientRect();
-            assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(tickLabelRect, tickMarkRect),
-              `tickMark ${i} and tickLabel ${i2} should not overlap`);
-        });
-      });
-      svg.remove();
-    });
-
     describe("formatting the labels", () => {
       it("formats to the specified formatter", () => {
-        let svg = TestMethods.generateSVG();
-        let scale = new Plottable.Scales.Linear();
+        const svg = TestMethods.generateSVG();
+        const scale = new Plottable.Scales.Linear();
 
-        let formatter = Plottable.Formatters.fixed(2);
+        const formatter = Plottable.Formatters.fixed(2);
 
-        let axis = new Plottable.Axes.Numeric(scale, "left");
+        const axis = new Plottable.Axes.Numeric(scale, "left");
         axis.formatter(formatter);
         axis.renderTo(svg);
 
-        let tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
+        const tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
         tickLabels.each(function(d, i) {
-          let labelText = d3.select(this).text();
+          const labelText = d3.select(this).text();
           assert.strictEqual(labelText, formatter(d), `formatter used to format tick label ${i}`);
         });
 
@@ -236,61 +238,70 @@ describe("Axes", () => {
       });
     });
 
-    orientations.forEach((orientation) => {
-      it(`allocates enough height to show all tick labels for orientation ${orientation}`, () => {
-        let svg = TestMethods.generateSVG();
-        let scale = new Plottable.Scales.Linear();
-        scale.domain([5, -5]);
+    describe("allocating space", () => {
+      let svg: d3.Selection<void>;
 
-        let axis = new Plottable.Axes.Numeric(scale, orientation);
-        axis.renderTo(svg);
-
-        let visibleTickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
-        let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
-        visibleTickLabels.each(function(d, i) {
-          let visibleTickLabelRect = this.getBoundingClientRect();
-          assertBoxInside(visibleTickLabelRect, boundingBox, 0.5, `tick label ${i} is inside the bounding box`);
-        });
-
-        svg.remove();
+      beforeEach(() => {
+        svg = TestMethods.generateSVG();
       });
-    });
 
-    verticalOrientations.forEach((verticalOrientation) => {
-      it(`allocates enough width to show long tick labels for orientation ${verticalOrientation}`, () => {
-        let svg = TestMethods.generateSVG();
-        let scale = new Plottable.Scales.Linear();
-        scale.domain([50000000000, -50000000000]);
+      afterEach(function() {
+        if (this.currentTest.state === "passed") {
+          svg.remove();
+        }
+      });
 
-        let axis = new Plottable.Axes.Numeric(scale, verticalOrientation);
-        axis.renderTo(svg);
+      orientations.forEach((orientation) => {
+        it(`allocates enough height to show all tick labels for orientation ${orientation}`, () => {
+          const scale = new Plottable.Scales.Linear();
+          scale.domain([5, -5]);
 
-        let visibleTickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
-        let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
-        visibleTickLabels.each(function(d, i) {
-          let visibleTickLabelRect = this.getBoundingClientRect();
-          assertBoxInside(visibleTickLabelRect, boundingBox, 0, `long tick label ${i} is inside the bounding box`);
+          const axis = new Plottable.Axes.Numeric(scale, orientation);
+          axis.renderTo(svg);
+
+          const visibconstickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+          const boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
+          visibconstickLabels.each(function(d, i) {
+            const visibconstickLabelRect = this.getBoundingClientRect();
+            assertBoxInside(visibconstickLabelRect, boundingBox, 0.5, `tick label ${i} is inside the bounding box`);
+          });
         });
-        svg.remove();
+      });
+
+      verticalOrientations.forEach((verticalOrientation) => {
+        it(`allocates enough width to show long tick labels for orientation ${verticalOrientation}`, () => {
+          const scale = new Plottable.Scales.Linear();
+          scale.domain([50000000000, -50000000000]);
+
+          const axis = new Plottable.Axes.Numeric(scale, verticalOrientation);
+          axis.renderTo(svg);
+
+          const visibconstickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+          const boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
+          visibconstickLabels.each(function(d, i) {
+            const visibconstickLabelRect = this.getBoundingClientRect();
+            assertBoxInside(visibconstickLabelRect, boundingBox, 0, `long tick label ${i} is inside the bounding box`);
+          });
+        });
       });
     });
 
     describe("drawing tick marks", () => {
       it("does not draw ticks marks outside of the svg", () => {
-        let svg = TestMethods.generateSVG();
-        let scale = new Plottable.Scales.Linear();
-        let domainMin = 0;
-        let domainMax = 3;
+        const svg = TestMethods.generateSVG();
+        const scale = new Plottable.Scales.Linear();
+        const domainMin = 0;
+        const domainMax = 3;
         scale.domain([domainMin, domainMax]);
         scale.tickGenerator(function() {
           return Plottable.Utils.Math.range(domainMin, domainMax + 4);
         });
-        let axis = new Plottable.Axes.Numeric(scale, "bottom");
+        const axis = new Plottable.Axes.Numeric(scale, "bottom");
         axis.renderTo(svg);
-        let tickMarks = axis.content().selectAll(".tick-mark");
+        const tickMarks = axis.content().selectAll(".tick-mark");
         tickMarks.each(function(d, i) {
-          let tickMark = d3.select(this);
-          let tickMarkPosition = TestMethods.numAttr(tickMark, "x1");
+          const tickMark = d3.select(this);
+          const tickMarkPosition = TestMethods.numAttr(tickMark, "x1");
           assert.operator(tickMarkPosition, ">=", 0, `tick mark ${i} drawn right of left edge`);
           assert.operator(tickMarkPosition, "<=", axis.width(), `tick mark ${i} drawn left of right edge`);
         });
@@ -300,26 +311,26 @@ describe("Axes", () => {
 
     describe("using width approximation", () => {
       it("reasonably approximates tick label sizes with approximate measuring", () => {
-        let svg = TestMethods.generateSVG();
+        const svg = TestMethods.generateSVG();
 
-        let testDomains = [[-1, 1],
+        const testDomains = [[-1, 1],
                         [0, 10],
                         [0, 999999999]];
 
-        let maxErrorFactor = 1.4;
+        const maxErrorFactor = 1.4;
 
         testDomains.forEach((testDomain) => {
-          let scale = new Plottable.Scales.Linear();
+          const scale = new Plottable.Scales.Linear();
           scale.domain(testDomain);
-          let axis = new Plottable.Axes.Numeric(scale, "left");
+          const axis = new Plottable.Axes.Numeric(scale, "left");
 
           axis.usesTextWidthApproximation(true);
           axis.renderTo(svg);
-          let widthApprox = axis.width();
+          const widthApprox = axis.width();
 
           axis.usesTextWidthApproximation(false);
           axis.redraw();
-          let widthExact = axis.width();
+          const widthExact = axis.width();
 
           assert.operator(widthApprox, "<", (widthExact * maxErrorFactor),
             `approximate domain of [${testDomain[0]},${testDomain[1]}] less than ${maxErrorFactor} times larger than exact scale`);

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -23,105 +23,57 @@ describe("NumericAxis", () => {
     });
   }
 
-  describe("setting the position of the tick labels when bottom oriented", () => {
+  const horizontalOrientations = ["bottom", "top"];
+  const verticalOrientations = ["left", "right"];
+  const orientations = horizontalOrientations.concat(verticalOrientations);
 
-    let axis: Plottable.Axes.Numeric;
+  const isHorizontalOrientation = (orientation: string) => horizontalOrientations.indexOf(orientation) >= 0;
 
-    beforeEach(() => {
-      let scale = new Plottable.Scales.Linear();
-      axis = new Plottable.Axes.Numeric(scale, "bottom");
-    });
-
-    it("throws an error when setting an invalid position", () => {
-      assert.throws(() => axis.tickLabelPosition("top"), "horizontal");
-      assert.throws(() => axis.tickLabelPosition("bottom"), "horizontal");
-    });
-
-    it("draws tick labels left of the corresponding mark if specified", () => {
-      let svg = TestMethods.generateSVG();
-      axis.tickLabelPosition("left");
-      axis.renderTo(svg);
-
-      let tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
-      let tickMarks = axis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
-      assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
-      assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
-
-      tickLabels.each(function(d, i) {
-        let tickLabelClientRect = this.getBoundingClientRect();
-        let tickMarkClientRect = (<Element> tickMarks[0][i]).getBoundingClientRect();
-        assert.operator(tickLabelClientRect.left, "<=", tickMarkClientRect.right, `tick label ${i} is to left of mark`);
+  horizontalOrientations.forEach((orientation) => {
+    const verticalTickLabelPositions = ["top", "bottom"];
+    it(`throws an error when setting an invalid position on orientation ${orientation}`, () => {
+      const scale = new Plottable.Scales.Linear();
+      const axis = new Plottable.Axes.Numeric(scale, orientation);
+      verticalTickLabelPositions.forEach((position) => {
+        (<any> assert).throws(() => axis.tickLabelPosition(position), "horizontal", "cannot set position");
       });
-      svg.remove();
-    });
-
-    it("draws tick labels right of the corresponding mark if specified", () => {
-      let svg = TestMethods.generateSVG();
-      axis.tickLabelPosition("right");
-      axis.renderTo(svg);
-
-      let tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
-      let tickMarks = axis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
-      assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
-      assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
-
-      tickLabels.each(function(d, i) {
-        let tickLabelClientRect = this.getBoundingClientRect();
-        let tickMarkClientRect = (<Element> tickMarks[0][i]).getBoundingClientRect();
-        assert.operator(tickMarkClientRect.right, "<=", tickLabelClientRect.left, `tick label ${i} is to right of mark`);
-      });
-      svg.remove();
     });
   });
 
-  describe("setting the position of the tick labels when left oriented", () => {
-
-    let axis: Plottable.Axes.Numeric;
-
-    beforeEach(() => {
-      let scale = new Plottable.Scales.Linear();
-      axis = new Plottable.Axes.Numeric(scale, "left");
-    });
-
-    it("throws an error when setting an invalid position", () => {
-      assert.throws(() => axis.tickLabelPosition("left"), "vertical");
-      assert.throws(() => axis.tickLabelPosition("right"), "vertical");
-    });
-
-    it("draws tick labels top of the corresponding mark if specified", () => {
-      let svg = TestMethods.generateSVG();
-      axis.tickLabelPosition("top");
-      axis.renderTo(svg);
-
-      let tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
-      let tickMarks = axis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
-      assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
-      assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
-
-      tickLabels.each(function(d, i) {
-        let tickLabelClientRect = this.getBoundingClientRect();
-        let tickMarkClientRect = (<Element> tickMarks[0][i]).getBoundingClientRect();
-        assert.operator(tickLabelClientRect.bottom, "<=", tickMarkClientRect.top, `tick label ${i} is above mark`);
+  verticalOrientations.forEach((orientation) => {
+    const horizontalTickLabelPositions = ["left", "right"];
+    it(`throws an error when setting an invalid position on orientation ${orientation}`, () => {
+      const scale = new Plottable.Scales.Linear();
+      const axis = new Plottable.Axes.Numeric(scale, orientation);
+      horizontalTickLabelPositions.forEach((position) => {
+        (<any> assert).throws(() => axis.tickLabelPosition(position), "vertical", "cannot set position");
       });
-      svg.remove();
     });
+  });
 
-    it("draws tick labels bottom of the corresponding mark if specified", () => {
-      let svg = TestMethods.generateSVG();
-      axis.tickLabelPosition("bottom");
-      axis.renderTo(svg);
+  orientations.forEach((orientation) => {
+    const verticalTickLabelPositions = ["top", "bottom"];
+    const horizontalTickLabelPositions = ["left", "right"];
 
-      let tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
-      let tickMarks = axis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
-      assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
-      assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
+    const labelPositions = isHorizontalOrientation(orientation) ? horizontalTickLabelPositions : verticalTickLabelPositions;
+    labelPositions.forEach((labelPosition) => {
+      it(`draws tick labels ${labelPosition} of the corresponding mark if specified for orientation ${orientation}`, () => {
+        const scale = new Plottable.Scales.Linear();
+        const axis = new Plottable.Axes.Numeric(scale, orientation);
+        const svg = TestMethods.generateSVG();
+        axis.tickLabelPosition(labelPosition);
+        axis.renderTo(svg);
 
-      tickLabels.each(function(d, i) {
-        let tickLabelClientRect = this.getBoundingClientRect();
-        let tickMarkClientRect = (<Element> tickMarks[0][i]).getBoundingClientRect();
-        assert.operator(tickMarkClientRect.bottom, "<=", tickLabelClientRect.top, `tick label ${i} is below mark`);
+        const tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
+        const tickMarks = axis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
+        assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
+        assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
+
+        tickLabels.each(function(d, i) {
+          TestMethods.assertBBoxNonIntersection(d3.select(this), d3.select(tickMarks[0][i]));
+        });
+        svg.remove();
       });
-      svg.remove();
     });
   });
 

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -16,453 +16,438 @@ describe("NumericAxis", () => {
     assert.operator(inner.bottom, "<", outer.bottom + epsilon, message + " (box inside (bottom))");
   }
 
-  it("tickLabelPosition() input validation", () => {
-    let scale = new Plottable.Scales.Linear();
-    let horizontalAxis = new Plottable.Axes.Numeric(scale, "bottom");
-    assert.throws(() => horizontalAxis.tickLabelPosition("top"), "horizontal");
-    assert.throws(() => horizontalAxis.tickLabelPosition("bottom"), "horizontal");
+  describe("setting the position of the tick labels when bottom oriented", () => {
 
-    let verticalAxis = new Plottable.Axes.Numeric(scale, "left");
-    assert.throws(() => verticalAxis.tickLabelPosition("left"), "vertical");
-    assert.throws(() => verticalAxis.tickLabelPosition("right"), "vertical");
-  });
+    let axis: Plottable.Axes.Numeric;
 
-  it("draws tick labels correctly (horizontal)", () => {
-    let SVG_WIDTH = 500;
-    let SVG_HEIGHT = 100;
-    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-    let scale = new Plottable.Scales.Linear();
-    scale.range([0, SVG_WIDTH]);
-    let numericAxis = new Plottable.Axes.Numeric(scale, "bottom");
-    numericAxis.renderTo(svg);
-
-    let tickLabels = (<any> numericAxis)._element.selectAll("." + Plottable.Axis.TICK_LABEL_CLASS);
-    assert.operator(tickLabels[0].length, ">=", 2, "at least two tick labels were drawn");
-    let tickMarks = (<any> numericAxis)._element.selectAll("." + Plottable.Axis.TICK_MARK_CLASS);
-    assert.strictEqual( tickLabels[0].length, tickMarks[0].length, "there is one label per mark");
-
-    let i: number;
-    let markBB: ClientRect;
-    let labelBB: ClientRect;
-    for (i = 0; i < tickLabels[0].length; i++) {
-      markBB = tickMarks[0][i].getBoundingClientRect();
-      let markCenter = (markBB.left + markBB.right) / 2;
-      labelBB = tickLabels[0][i].getBoundingClientRect();
-      let labelCenter = (labelBB.left + labelBB.right) / 2;
-      assert.closeTo(labelCenter, markCenter, 1, "tick label is centered on mark");
-    }
-
-    // labels to left
-    numericAxis.tickLabelPosition("left");
-    tickLabels = (<any> numericAxis)._element.selectAll("." + Plottable.Axis.TICK_LABEL_CLASS);
-    tickMarks = (<any> numericAxis)._element.selectAll("." + Plottable.Axis.TICK_MARK_CLASS);
-    for (i = 0; i < tickLabels[0].length; i++) {
-      markBB = tickMarks[0][i].getBoundingClientRect();
-      labelBB = tickLabels[0][i].getBoundingClientRect();
-      assert.operator(labelBB.left, "<=", markBB.right, "tick label is to left of mark");
-    }
-
-    // labels to right
-    numericAxis.tickLabelPosition("right");
-    tickLabels = (<any> numericAxis)._element.selectAll("." + Plottable.Axis.TICK_LABEL_CLASS);
-    tickMarks = (<any> numericAxis)._element.selectAll("." + Plottable.Axis.TICK_MARK_CLASS);
-    for (i = 0; i < tickLabels[0].length; i++) {
-      markBB = tickMarks[0][i].getBoundingClientRect();
-      labelBB = tickLabels[0][i].getBoundingClientRect();
-      assert.operator(markBB.right, "<=", labelBB.left, "tick label is to right of mark");
-    }
-
-    svg.remove();
-  });
-
-  it("draws ticks correctly (vertical)", () => {
-    let SVG_WIDTH = 100;
-    let SVG_HEIGHT = 500;
-    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-    let scale = new Plottable.Scales.Linear();
-    scale.range([0, SVG_HEIGHT]);
-    let numericAxis = new Plottable.Axes.Numeric(scale, "left");
-    numericAxis.renderTo(svg);
-
-    let tickLabels = (<any> numericAxis)._element.selectAll("." + Plottable.Axis.TICK_LABEL_CLASS);
-    assert.operator(tickLabels[0].length, ">=", 2, "at least two tick labels were drawn");
-    let tickMarks = (<any> numericAxis)._element.selectAll("." + Plottable.Axis.TICK_MARK_CLASS);
-    assert.strictEqual(tickLabels[0].length, tickMarks[0].length, "there is one label per mark");
-
-    let i: number;
-    let markBB: ClientRect;
-    let labelBB: ClientRect;
-    for (i = 0; i < tickLabels[0].length; i++) {
-      markBB = tickMarks[0][i].getBoundingClientRect();
-      let markCenter = (markBB.top + markBB.bottom) / 2;
-      labelBB = tickLabels[0][i].getBoundingClientRect();
-      let labelCenter = (labelBB.top + labelBB.bottom) / 2;
-      assert.closeTo(labelCenter, markCenter, 1.5, "tick label is centered on mark");
-    }
-
-    // labels to top
-    numericAxis.tickLabelPosition("top");
-    tickLabels = (<any> numericAxis)._element.selectAll("." + Plottable.Axis.TICK_LABEL_CLASS);
-    tickMarks = (<any> numericAxis)._element.selectAll("." + Plottable.Axis.TICK_MARK_CLASS);
-    for (i = 0; i < tickLabels[0].length; i++) {
-      markBB = tickMarks[0][i].getBoundingClientRect();
-      labelBB = tickLabels[0][i].getBoundingClientRect();
-      assert.operator(labelBB.bottom, "<=", markBB.top, "tick label is above mark");
-    }
-
-    // labels to bottom
-    numericAxis.tickLabelPosition("bottom");
-    tickLabels = (<any> numericAxis)._element.selectAll("." + Plottable.Axis.TICK_LABEL_CLASS);
-    tickMarks = (<any> numericAxis)._element.selectAll("." + Plottable.Axis.TICK_MARK_CLASS);
-    for (i = 0; i < tickLabels[0].length; i++) {
-      markBB = tickMarks[0][i].getBoundingClientRect();
-      labelBB = tickLabels[0][i].getBoundingClientRect();
-      assert.operator(markBB.bottom, "<=", labelBB.top, "tick label is below mark");
-    }
-
-    svg.remove();
-  });
-
-  it("uses the supplied Formatter", () => {
-    let SVG_WIDTH = 100;
-    let SVG_HEIGHT = 500;
-    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-    let scale = new Plottable.Scales.Linear();
-    scale.range([0, SVG_HEIGHT]);
-
-    let formatter = Plottable.Formatters.fixed(2);
-
-    let numericAxis = new Plottable.Axes.Numeric(scale, "left");
-    numericAxis.formatter(formatter);
-    numericAxis.renderTo(svg);
-
-    let tickLabels = (<any> numericAxis)._element.selectAll("." + Plottable.Axis.TICK_LABEL_CLASS);
-    tickLabels.each(function(d: any, i: number) {
-      let labelText = d3.select(this).text();
-      let formattedValue = formatter(d);
-      assert.strictEqual(labelText, formattedValue, "The supplied Formatter was used to format the tick label");
-    });
-
-    svg.remove();
-  });
-
-  it("tick labels don't overlap in a constrained space", () => {
-    let SVG_WIDTH = 100;
-    let SVG_HEIGHT = 100;
-    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-    let scale = new Plottable.Scales.Linear();
-    scale.range([0, SVG_WIDTH]);
-    let numericAxis = new Plottable.Axes.Numeric(scale, "bottom");
-    numericAxis.renderTo(svg);
-
-    let visibleTickLabels = (<any> numericAxis)._element
-                              .selectAll("." + Plottable.Axis.TICK_LABEL_CLASS)
-                              .filter(function(d: any, i: number) {
-                                return d3.select(this).style("visibility") === "visible";
-                              });
-    let numLabels = visibleTickLabels[0].length;
-    let clientRect1: ClientRect;
-    let clientRect2: ClientRect;
-    for (let i = 0; i < numLabels; i++) {
-      for (let j = i + 1; j < numLabels; j++) {
-        clientRect1 = visibleTickLabels[0][i].getBoundingClientRect();
-        clientRect2 = visibleTickLabels[0][j].getBoundingClientRect();
-
-        assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(clientRect1, clientRect2), "tick labels don't overlap");
-      }
-    }
-
-    numericAxis.orientation("bottom");
-    visibleTickLabels = (<any> numericAxis)._element
-                          .selectAll("." + Plottable.Axis.TICK_LABEL_CLASS)
-                          .filter(function(d: any, i: number) {
-                            return d3.select(this).style("visibility") === "visible";
-                          });
-    numLabels = visibleTickLabels[0].length;
-    for (let i = 0; i < numLabels; i++) {
-      for (let j = i + 1; j < numLabels; j++) {
-        clientRect1 = visibleTickLabels[0][i].getBoundingClientRect();
-        clientRect2 = visibleTickLabels[0][j].getBoundingClientRect();
-
-        assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(clientRect1, clientRect2), "tick labels don't overlap");
-      }
-    }
-
-    svg.remove();
-  });
-
-  it("allocates enough width to show all tick labels when vertical", () => {
-    let SVG_WIDTH = 150;
-    let SVG_HEIGHT = 500;
-    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-    let scale = new Plottable.Scales.Linear();
-    scale.domain([5, -5]);
-    scale.range([0, SVG_HEIGHT]);
-
-    let formatter = (d: any) => {
-      if (d === 0) {
-        return "ZERO";
-      }
-      return String(d);
-    };
-
-    let numericAxis = new Plottable.Axes.Numeric(scale, "left");
-    numericAxis.formatter(formatter);
-    numericAxis.renderTo(svg);
-
-    let visibleTickLabels = (<any> numericAxis)._element
-                          .selectAll("." + Plottable.Axis.TICK_LABEL_CLASS)
-                          .filter(function(d: any, i: number) {
-                            return d3.select(this).style("visibility") === "visible";
-                          });
-    let boundingBox: ClientRect = (<any> numericAxis)._element.select(".bounding-box").node().getBoundingClientRect();
-    let labelBox: ClientRect;
-    visibleTickLabels[0].forEach((label: Element) => {
-      labelBox = label.getBoundingClientRect();
-      assert.isTrue(boxIsInside(labelBox, boundingBox), "tick labels don't extend outside the bounding box");
-    });
-
-    scale.domain([50000000000, -50000000000]);
-    visibleTickLabels = (<any> numericAxis)._element
-                          .selectAll("." + Plottable.Axis.TICK_LABEL_CLASS)
-                          .filter(function(d: any, i: number) {
-                            return d3.select(this).style("visibility") === "visible";
-                          });
-    boundingBox = (<any> numericAxis)._element.select(".bounding-box").node().getBoundingClientRect();
-    visibleTickLabels[0].forEach((label: Element) => {
-      labelBox = label.getBoundingClientRect();
-      assertBoxInside(labelBox, boundingBox, 0, "long tick " + label.textContent + " is inside the bounding box");
-    });
-
-    svg.remove();
-  });
-
-  it("allocates enough height to show all tick labels when horizontal", () => {
-    let SVG_WIDTH = 500;
-    let SVG_HEIGHT = 100;
-    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-    let scale = new Plottable.Scales.Linear();
-    scale.domain([5, -5]);
-    scale.range([0, SVG_WIDTH]);
-
-    let formatter = Plottable.Formatters.fixed(2);
-
-    let numericAxis = new Plottable.Axes.Numeric(scale, "bottom");
-    numericAxis.formatter(formatter);
-    numericAxis.renderTo(svg);
-
-    let visibleTickLabels = (<any> numericAxis)._element
-                          .selectAll("." + Plottable.Axis.TICK_LABEL_CLASS)
-                          .filter(function(d: any, i: number) {
-                            return d3.select(this).style("visibility") === "visible";
-                          });
-    let boundingBox: ClientRect = (<any> numericAxis)._element.select(".bounding-box").node().getBoundingClientRect();
-    let labelBox: ClientRect;
-    visibleTickLabels[0].forEach((label: Element) => {
-      labelBox = label.getBoundingClientRect();
-      assert.isTrue(boxIsInside(labelBox, boundingBox, 0.5), "tick labels don't extend outside the bounding box");
-    });
-
-    svg.remove();
-  });
-
-  it("truncates long labels", () => {
-    let dataset = new Plottable.Dataset([
-      { x: "A", y: 500000000 },
-      { x: "B", y: 400000000 }
-    ]);
-    let SVG_WIDTH = 120;
-    let SVG_HEIGHT = 300;
-    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-
-    let xScale = new Plottable.Scales.Category();
-    let yScale = new Plottable.Scales.Linear();
-    let yAxis = new Plottable.Axes.Numeric(yScale, "left");
-
-    let yLabel = new Plottable.Components.AxisLabel("LABEL");
-    yLabel.angle(-90);
-    let barPlot = new Plottable.Plots.Bar();
-    barPlot.x((d: any) => d.x, xScale);
-    barPlot.y((d: any) => d.y, yScale);
-    barPlot.addDataset(dataset);
-
-    let chart = new Plottable.Components.Table([
-        [ yLabel, yAxis, barPlot ]
-    ]);
-    chart.renderTo(svg);
-
-    let labelContainer = d3.select(".tick-label-container");
-    d3.selectAll(".tick-label").each(function() {
-      TestMethods.assertBBoxInclusion(labelContainer, d3.select(this));
-    });
-    svg.remove();
-  });
-
-  it("confines labels to the bounding box for the axis", () => {
-    let SVG_WIDTH = 500;
-    let SVG_HEIGHT = 100;
-    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-    let scale = new Plottable.Scales.Linear();
-    let axis = new Plottable.Axes.Numeric(scale, "bottom");
-    axis.formatter((d: any) => "longstringsareverylong");
-    axis.renderTo(svg);
-    let boundingBox = d3.select(".x-axis .bounding-box");
-    d3.selectAll(".x-axis .tick-label").each(function() {
-      let tickLabel = d3.select(this);
-      if (tickLabel.style("visibility") === "inherit") {
-        TestMethods.assertBBoxInclusion(boundingBox, tickLabel);
-      }
-    });
-    svg.remove();
-  });
-
-  function getClientRectCenter(rect: ClientRect) {
-    return rect.left + rect.width / 2;
-  }
-
-  it("tick labels follow a sensible interval", () => {
-    let SVG_WIDTH = 500;
-    let SVG_HEIGHT = 100;
-    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-
-    let scale = new Plottable.Scales.Linear();
-    scale.domain([-2500000, 2500000]);
-
-    let baseAxis = new Plottable.Axes.Numeric(scale, "bottom");
-    baseAxis.renderTo(svg);
-
-    let visibleTickLabels = (<any> baseAxis)._element.selectAll(".tick-label")
-      .filter(function(d: any, i: number) {
-        let visibility = d3.select(this).style("visibility");
-        return (visibility === "visible") || (visibility === "inherit");
-      });
-
-    let visibleTickLabelRects = visibleTickLabels[0].map((label: HTMLScriptElement) => label.getBoundingClientRect());
-    let interval = getClientRectCenter(visibleTickLabelRects[1]) - getClientRectCenter(visibleTickLabelRects[0]);
-    for (let i = 0; i < visibleTickLabelRects.length - 1; i++) {
-      assert.closeTo(getClientRectCenter(visibleTickLabelRects[i + 1]) - getClientRectCenter(visibleTickLabelRects[i]),
-        interval, 0.5, "intervals are all spaced the same");
-    }
-
-    svg.remove();
-  });
-
-  it("does not draw ticks marks outside of the svg", () => {
-    let SVG_WIDTH = 300;
-    let SVG_HEIGHT = 100;
-    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-    let scale = new Plottable.Scales.Linear();
-    scale.domain([0, 3]);
-    scale.tickGenerator(function(s) {
-      return [0, 1, 2, 3, 4];
-    });
-    let baseAxis = new Plottable.Axes.Numeric(scale, "bottom");
-    baseAxis.renderTo(svg);
-    let tickMarks = (<any> baseAxis)._element.selectAll(".tick-mark");
-    tickMarks.each(function() {
-      let tickMark = d3.select(this);
-      let tickMarkPosition = Number(tickMark.attr("x"));
-      assert.isTrue(tickMarkPosition >= 0 && tickMarkPosition <= SVG_WIDTH, "tick marks are located within the bounding SVG");
-    });
-    svg.remove();
-  });
-
-  it("renders tick labels properly when the domain is reversed", () => {
-    let SVG_WIDTH = 300;
-    let SVG_HEIGHT = 100;
-    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-
-    let scale = new Plottable.Scales.Linear();
-    scale.domain([3, 0]);
-
-    let baseAxis = new Plottable.Axes.Numeric(scale, "bottom");
-    baseAxis.renderTo(svg);
-
-    let tickLabels = (<any> baseAxis)._element.selectAll(".tick-label")
-        .filter(function(d: any, i: number) {
-          let visibility = d3.select(this).style("visibility");
-          return (visibility === "visible") || (visibility === "inherit");
-        });
-    assert.isTrue(tickLabels[0].length > 1, "more than one tick label is shown");
-
-    for (let i = 0; i < tickLabels[0].length - 1; i++) {
-      let currLabel = d3.select(tickLabels[0][i]);
-      let nextLabel = d3.select(tickLabels[0][i + 1]);
-      assert.isTrue(Number(currLabel.text()) > Number(nextLabel.text()), "numbers are arranged in descending order from left to right");
-    }
-
-    svg.remove();
-  });
-
-  it("constrained tick labels do not overlap tick marks", () => {
-    let svg = TestMethods.generateSVG(100, 50);
-
-    let yScale = new Plottable.Scales.Linear();
-    yScale.domain([175, 185]);
-    let yAxis = new Plottable.Axes.Numeric(yScale, "left")
-                                  .tickLabelPosition("top")
-                                  .innerTickLength(50);
-    yAxis.renderTo(svg);
-
-    let tickLabels = (<any> yAxis)._element.selectAll("." + Plottable.Axis.TICK_LABEL_CLASS)
-        .filter(function(d: any, i: number) {
-          let visibility = d3.select(this).style("visibility");
-          return (visibility === "visible") || (visibility === "inherit");
-        });
-
-    let tickMarks = (<any> yAxis)._element.selectAll("." + Plottable.Axis.TICK_MARK_CLASS)
-        .filter(function(d: any, i: number) {
-          let visibility = d3.select(this).style("visibility");
-          return (visibility === "visible") || (visibility === "inherit");
-        });
-
-    tickLabels.each(function() {
-      let tickLabelRect = this.getBoundingClientRect();
-
-      tickMarks.each(function() {
-        let tickMarkRect = this.getBoundingClientRect();
-          assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(tickLabelRect, tickMarkRect),
-            "tickMarks and tickLabels should not overlap when top/bottom/left/right position is used for the tickLabel");
-      });
-    });
-
-    svg.remove();
-  });
-
-  it("reasonably approximates tick label sizes with approximate measuring", () => {
-    let SVG_WIDTH = 500;
-    let SVG_HEIGHT = 100;
-
-    let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-
-    let testCases = [[-1, 1],
-                     [0, 10],
-                     [0, 999999999]];
-
-    let maxErrorFactor = 1.4;
-
-    testCases.forEach((domainBounds) => {
+    beforeEach(() => {
       let scale = new Plottable.Scales.Linear();
-      scale.domain(domainBounds);
-      let numericAxis = new Plottable.Axes.Numeric(scale, "left");
-
-      numericAxis.usesTextWidthApproximation(true);
-      numericAxis.renderTo(svg);
-      let widthApprox = numericAxis.width();
-
-      numericAxis.usesTextWidthApproximation(false);
-      numericAxis.redraw();
-      let widthExact = numericAxis.width();
-
-      assert.operator(widthApprox, "<", (widthExact * maxErrorFactor),
-        "an approximate scale of [" + domainBounds[0] + "," + domainBounds[1] + "] is less than "
-        + maxErrorFactor + "x larger than an exact scale");
-      assert.operator(widthApprox, ">=", widthExact,
-        "an approximate scale of [" + domainBounds[0] + "," + domainBounds[1] + "] is smaller than an exact scale");
-
-      numericAxis.destroy();
+      axis = new Plottable.Axes.Numeric(scale, "bottom");
     });
 
-    svg.remove();
+    it("throws an error when setting an invalid position", () => {
+      assert.throws(() => axis.tickLabelPosition("top"), "horizontal");
+      assert.throws(() => axis.tickLabelPosition("bottom"), "horizontal");
+    });
+
+    it("draws tick labels left of the corresponding mark if specified", () => {
+      let svg = TestMethods.generateSVG();
+      axis.tickLabelPosition("left");
+      axis.renderTo(svg);
+
+      let tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
+      let tickMarks = axis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
+      assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
+      assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
+
+      tickLabels.each(function(d, i) {
+        let tickLabelClientRect = this.getBoundingClientRect();
+        let tickMarkClientRect = (<Element> tickMarks[0][i]).getBoundingClientRect();
+        assert.operator(tickLabelClientRect.left, "<=", tickMarkClientRect.right, `tick label ${i} is to left of mark`);
+      });
+      svg.remove();
+    });
+
+    it("draws tick labels right of the corresponding mark if specified", () => {
+      let svg = TestMethods.generateSVG();
+      axis.tickLabelPosition("right");
+      axis.renderTo(svg);
+
+      let tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
+      let tickMarks = axis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
+      assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
+      assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
+
+      tickLabels.each(function(d, i) {
+        let tickLabelClientRect = this.getBoundingClientRect();
+        let tickMarkClientRect = (<Element> tickMarks[0][i]).getBoundingClientRect();
+        assert.operator(tickMarkClientRect.right, "<=", tickLabelClientRect.left, `tick label ${i} is to right of mark`);
+      });
+      svg.remove();
+    });
+  });
+
+  describe("setting the position of the tick labels when left oriented", () => {
+
+    let axis: Plottable.Axes.Numeric;
+
+    beforeEach(() => {
+      let scale = new Plottable.Scales.Linear();
+      axis = new Plottable.Axes.Numeric(scale, "left");
+    });
+
+    it("throws an error when setting an invalid position", () => {
+      assert.throws(() => axis.tickLabelPosition("left"), "vertical");
+      assert.throws(() => axis.tickLabelPosition("right"), "vertical");
+    });
+
+    it("draws tick labels top of the corresponding mark if specified", () => {
+      let svg = TestMethods.generateSVG();
+      axis.tickLabelPosition("top");
+      axis.renderTo(svg);
+
+      let tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
+      let tickMarks = axis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
+      assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
+      assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
+
+      tickLabels.each(function(d, i) {
+        let tickLabelClientRect = this.getBoundingClientRect();
+        let tickMarkClientRect = (<Element> tickMarks[0][i]).getBoundingClientRect();
+        assert.operator(tickLabelClientRect.bottom, "<=", tickMarkClientRect.top, `tick label ${i} is above mark`);
+      });
+      svg.remove();
+    });
+
+    it("draws tick labels bottom of the corresponding mark if specified", () => {
+      let svg = TestMethods.generateSVG();
+      axis.tickLabelPosition("bottom");
+      axis.renderTo(svg);
+
+      let tickLabels = axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
+      let tickMarks = axis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
+      assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
+      assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
+
+      tickLabels.each(function(d, i) {
+        let tickLabelClientRect = this.getBoundingClientRect();
+        let tickMarkClientRect = (<Element> tickMarks[0][i]).getBoundingClientRect();
+        assert.operator(tickMarkClientRect.bottom, "<=", tickLabelClientRect.top, `tick label ${i} is below mark`);
+      });
+      svg.remove();
+    });
+  });
+
+  describe("drawing tick labels when bottom oriented", () => {
+
+    let svg: d3.Selection<void>;
+
+    beforeEach(() => {
+      svg = TestMethods.generateSVG();
+    });
+
+    it("draws ticks labels centered with the corresponding tick mark", () => {
+      let scale = new Plottable.Scales.Linear();
+      let numericAxis = new Plottable.Axes.Numeric(scale, "bottom");
+      numericAxis.renderTo(svg);
+
+      let tickLabels = numericAxis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
+      assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
+      let tickMarks = numericAxis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
+      assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
+
+      tickLabels.each(function(d, i) {
+        let tickLabelClientRect = this.getBoundingClientRect();
+        let tickMarkClientRect = (<Element> tickMarks[0][i]).getBoundingClientRect();
+        let labelCenter = (tickLabelClientRect.left + tickLabelClientRect.right) / 2;
+        let markCenter = (tickMarkClientRect.left + tickMarkClientRect.right) / 2;
+        assert.closeTo(labelCenter, markCenter, window.Pixel_CloseTo_Requirement, `tick label ${i} is centered on mark`);
+      });
+
+      svg.remove();
+    });
+
+    it("does not overlap tick labels in a constrained space", () => {
+      let constrainedWidth = 50;
+      let constrainedHeight = 50;
+      svg.attr("width", constrainedWidth);
+      svg.attr("height", constrainedHeight);
+      let scale = new Plottable.Scales.Linear();
+      let numericAxis = new Plottable.Axes.Numeric(scale, "bottom");
+      numericAxis.renderTo(svg);
+
+      let visibleTickLabels = numericAxis.content()
+        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
+        .filter(function() {
+          return d3.select(this).style("visibility") === "visible";
+        });
+
+      visibleTickLabels.each(function(d, i) {
+        let labelRect = this.getBoundingClientRect();
+        visibleTickLabels[0].slice(i + 1).forEach(function(otherVisibleTickLabel, i2) {
+          let labelRect2 = (<Element> otherVisibleTickLabel).getBoundingClientRect();
+          let rectOverlap = Plottable.Utils.DOM.clientRectsOverlap(labelRect, labelRect2);
+          assert.isFalse(rectOverlap, `tick label ${i} does not overlap with tick label ${i2}`);
+        });
+      });
+
+      svg.remove();
+    });
+
+    it("ensures that long labels are contained", () => {
+      let scale = new Plottable.Scales.Linear().domain([400000000, 500000000]);
+      let axis = new Plottable.Axes.Numeric(scale, "left");
+
+      axis.renderTo(svg);
+
+      let labelContainer = axis.content().select(".tick-label-container");
+      axis.content().selectAll(".tick-label").each(function() {
+        TestMethods.assertBBoxInclusion(labelContainer, d3.select(this));
+      });
+      svg.remove();
+    });
+
+    it("separates tick labels with the same spacing", () => {
+      let scale = new Plottable.Scales.Linear();
+      scale.domain([-2500000, 2500000]);
+
+      let axis = new Plottable.Axes.Numeric(scale, "bottom");
+      axis.renderTo(svg);
+
+      let visibleTickLabels = axis.content().selectAll(".tick-label")
+        .filter(function(d: any, i: number) {
+          let visibility = d3.select(this).style("visibility");
+          return (visibility === "visible") || (visibility === "inherit");
+        });
+
+      let visibleTickLabelRects = visibleTickLabels[0].map((label: Element) => label.getBoundingClientRect());
+
+      function getClientRectCenter(rect: ClientRect) {
+        return rect.left + rect.width / 2;
+      }
+
+      let interval = getClientRectCenter(visibleTickLabelRects[1]) - getClientRectCenter(visibleTickLabelRects[0]);
+      d3.pairs(visibleTickLabelRects).forEach((rects, i) => {
+        assert.closeTo(getClientRectCenter(rects[1]) - getClientRectCenter(rects[0]),
+          interval, 0.5, `tick label pair ${i} is spaced the same as the first pair`);
+      });
+
+      svg.remove();
+    });
+
+    it("renders numbers in order with a reversed domain", () => {
+      let scale = new Plottable.Scales.Linear();
+      scale.domain([3, 0]);
+
+      let axis = new Plottable.Axes.Numeric(scale, "bottom");
+      axis.renderTo(svg);
+
+      let tickLabels = axis.content().selectAll(".tick-label")
+          .filter(function(d: any, i: number) {
+            let visibility = d3.select(this).style("visibility");
+            return (visibility === "visible") || (visibility === "inherit");
+          });
+      assert.operator(tickLabels.size(), ">", 1, "more than one tick label is shown");
+
+      let tickLabelElementPairs = d3.pairs(tickLabels[0]);
+      tickLabelElementPairs.forEach(function(tickLabelElementPair, i) {
+        let label1 = d3.select(tickLabelElementPair[0]);
+        let label2 = d3.select(tickLabelElementPair[1]);
+        let labelNumber1 = parseFloat(label1.text());
+        let labelNumber2 = parseFloat(label2.text());
+        assert.operator(labelNumber1, ">", labelNumber2, `pair ${i} arranged in descending order from left to right`);
+      });
+
+      svg.remove();
+    });
+  });
+
+  describe("drawing tick labels when left oriented", () => {
+    it("draws ticks labels centered with the corresponding tick mark", () => {
+      let svg = TestMethods.generateSVG();
+      let scale = new Plottable.Scales.Linear();
+      let numericAxis = new Plottable.Axes.Numeric(scale, "left");
+      numericAxis.renderTo(svg);
+
+      let tickLabels = numericAxis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
+      assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
+      let tickMarks = numericAxis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
+      assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
+
+      tickLabels.each(function(d, i) {
+        let tickLabelClientRect = this.getBoundingClientRect();
+        let tickMarkClientRect = (<Element> tickMarks[0][i]).getBoundingClientRect();
+        let labelCenter = (tickLabelClientRect.top + tickLabelClientRect.bottom) / 2;
+        let markCenter = (tickMarkClientRect.top + tickMarkClientRect.bottom) / 2;
+        assert.closeTo(labelCenter, markCenter, 1.5, `tick label ${i} is centered on mark`);
+      });
+
+      svg.remove();
+    });
+
+    it("does not overlap tick marks with tick labels", () => {
+      let svg = TestMethods.generateSVG();
+
+      let scale = new Plottable.Scales.Linear();
+      scale.domain([175, 185]);
+      let axis = new Plottable.Axes.Numeric(scale, "left")
+                                    .innerTickLength(50);
+      axis.renderTo(svg);
+
+      let tickLabels = axis.content().selectAll("." + Plottable.Axis.TICK_LABEL_CLASS)
+          .filter(function(d: any, i: number) {
+            let visibility = d3.select(this).style("visibility");
+            return (visibility === "visible") || (visibility === "inherit");
+          });
+
+      let tickMarks = axis.content().selectAll("." + Plottable.Axis.TICK_MARK_CLASS)
+          .filter(function(d: any, i: number) {
+            let visibility = d3.select(this).style("visibility");
+            return (visibility === "visible") || (visibility === "inherit");
+          });
+
+      tickLabels.each(function(d, i) {
+        let tickLabelRect = this.getBoundingClientRect();
+        tickMarks.each(function(d2, i2) {
+          let tickMarkRect = this.getBoundingClientRect();
+            assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(tickLabelRect, tickMarkRect),
+              `tickMark ${i} and tickLabel ${i2} should not overlap`);
+        });
+      });
+      svg.remove();
+    });
+  });
+
+  describe("formatting the labels", () => {
+    it("formats to the specified formatter", () => {
+      let svg = TestMethods.generateSVG();
+      let scale = new Plottable.Scales.Linear();
+
+      let formatter = Plottable.Formatters.fixed(2);
+
+      let numericAxis = new Plottable.Axes.Numeric(scale, "left");
+      numericAxis.formatter(formatter);
+      numericAxis.renderTo(svg);
+
+      let tickLabels = numericAxis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
+      tickLabels.each(function(d, i) {
+        let labelText = d3.select(this).text();
+        let formattedValue = formatter(d);
+        assert.strictEqual(labelText, formattedValue, `formatter used to format tick label ${i}`);
+      });
+
+      svg.remove();
+    });
+  });
+
+  describe("allocating space when left oriented", () => {
+    it("allocates enough width to show short tick labels when vertical", () => {
+      let svg = TestMethods.generateSVG();
+      let scale = new Plottable.Scales.Linear();
+      scale.domain([5, -5]);
+
+      let formatter = (d: any) => (d === 0) ? "ZERO" : String(d);
+
+      let axis = new Plottable.Axes.Numeric(scale, "left");
+      axis.formatter(formatter);
+      axis.renderTo(svg);
+
+      let visibleTickLabels = axis.content()
+        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
+        .filter(function() {
+          return d3.select(this).style("visibility") === "visible";
+        });
+      let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
+      visibleTickLabels.each(function(d, i) {
+        let visibleTickLabelRect = this.getBoundingClientRect();
+        assert.isTrue(boxIsInside(visibleTickLabelRect, boundingBox), `tick label ${i} is inside the bounding box`);
+      });
+      svg.remove();
+    });
+
+    it("allocates enough width to show long tick labels when vertical", () => {
+      let svg = TestMethods.generateSVG();
+      let scale = new Plottable.Scales.Linear();
+      scale.domain([50000000000, -50000000000]);
+
+      let formatter = (d: any) => (d === 0) ? "ZERO" : String(d);
+
+      let axis = new Plottable.Axes.Numeric(scale, "left");
+      axis.formatter(formatter);
+      axis.renderTo(svg);
+
+      let visibleTickLabels = axis.content()
+        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
+        .filter(function() {
+          return d3.select(this).style("visibility") === "visible";
+        });
+      let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
+      visibleTickLabels.each(function(d, i) {
+        let visibleTickLabelRect = this.getBoundingClientRect();
+        assertBoxInside(visibleTickLabelRect, boundingBox, 0, `long tick label ${i} is inside the bounding box`);
+      });
+      svg.remove();
+    });
+  });
+
+  describe("allocating space when bottom oriented", () => {
+    it("allocates enough height to show all tick labels when horizontal", () => {
+      let svg = TestMethods.generateSVG();
+      let scale = new Plottable.Scales.Linear();
+      scale.domain([5, -5]);
+
+      let axis = new Plottable.Axes.Numeric(scale, "bottom");
+      axis.renderTo(svg);
+
+      let visibleTickLabels = axis.content()
+        .selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`)
+        .filter(function() {
+          return d3.select(this).style("visibility") === "visible";
+        });
+      let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
+      visibleTickLabels.each(function(d, i) {
+        let visibleTickLabelRect = this.getBoundingClientRect();
+        assert.isTrue(boxIsInside(visibleTickLabelRect, boundingBox, 0.5), `tick label ${i} is inside the bounding box`);
+      });
+
+      svg.remove();
+    });
+  });
+
+  describe("drawing tick marks", () => {
+    it("does not draw ticks marks outside of the svg", () => {
+      let svg = TestMethods.generateSVG();
+      let scale = new Plottable.Scales.Linear();
+      let domainMin = 0;
+      let domainMax = 3;
+      scale.domain([domainMin, domainMax]);
+      scale.tickGenerator(function() {
+        return Plottable.Utils.Math.range(domainMin, domainMax + 4);
+      });
+      let axis = new Plottable.Axes.Numeric(scale, "bottom");
+      axis.renderTo(svg);
+      let tickMarks = axis.content().selectAll(".tick-mark");
+      tickMarks.each(function(d, i) {
+        let tickMark = d3.select(this);
+        let tickMarkPosition = TestMethods.numAttr(tickMark, "x1");
+        assert.operator(tickMarkPosition, ">=", 0, `tick mark ${i} drawn right of left edge`);
+        assert.operator(tickMarkPosition, "<=", axis.width(), `tick mark ${i} drawn left of right edge`);
+      });
+      svg.remove();
+    });
+  });
+
+  describe("using width approximation", () => {
+    it("reasonably approximates tick label sizes with approximate measuring", () => {
+      let svg = TestMethods.generateSVG();
+
+      let testDomains = [[-1, 1],
+                      [0, 10],
+                      [0, 999999999]];
+
+      let maxErrorFactor = 1.4;
+
+      testDomains.forEach((testDomain) => {
+        let scale = new Plottable.Scales.Linear();
+        scale.domain(testDomain);
+        let numericAxis = new Plottable.Axes.Numeric(scale, "left");
+
+        numericAxis.usesTextWidthApproximation(true);
+        numericAxis.renderTo(svg);
+        let widthApprox = numericAxis.width();
+
+        numericAxis.usesTextWidthApproximation(false);
+        numericAxis.redraw();
+        let widthExact = numericAxis.width();
+
+        assert.operator(widthApprox, "<", (widthExact * maxErrorFactor),
+          `approximate domain of [${testDomain[0]},${testDomain[1]}] less than ${maxErrorFactor} times larger than exact scale`);
+        assert.operator(widthApprox, ">=", widthExact,
+          `approximate domain of [${testDomain[0]},${testDomain[1]}] greater than an exact scale`);
+        numericAxis.destroy();
+      });
+
+      svg.remove();
+    });
   });
 });

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -85,27 +85,6 @@ describe("NumericAxis", () => {
       svg = TestMethods.generateSVG();
     });
 
-    it("draws ticks labels centered with the corresponding tick mark", () => {
-      let scale = new Plottable.Scales.Linear();
-      let numericAxis = new Plottable.Axes.Numeric(scale, "bottom");
-      numericAxis.renderTo(svg);
-
-      let tickLabels = numericAxis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
-      assert.operator(tickLabels.size(), ">=", 2, "at least two tick labels were drawn");
-      let tickMarks = numericAxis.content().selectAll(`.${Plottable.Axis.TICK_MARK_CLASS}`);
-      assert.strictEqual(tickLabels.size(), tickMarks.size(), "there is one label per mark");
-
-      tickLabels.each(function(d, i) {
-        let tickLabelClientRect = this.getBoundingClientRect();
-        let tickMarkClientRect = (<Element> tickMarks[0][i]).getBoundingClientRect();
-        let labelCenter = (tickLabelClientRect.left + tickLabelClientRect.right) / 2;
-        let markCenter = (tickMarkClientRect.left + tickMarkClientRect.right) / 2;
-        assert.closeTo(labelCenter, markCenter, window.Pixel_CloseTo_Requirement, `tick label ${i} is centered on mark`);
-      });
-
-      svg.remove();
-    });
-
     it("does not overlap tick labels in a constrained space", () => {
       let constrainedWidth = 50;
       let constrainedHeight = 50;
@@ -191,11 +170,11 @@ describe("NumericAxis", () => {
     });
   });
 
-  describe("drawing tick labels when left oriented", () => {
-    it("draws ticks labels centered with the corresponding tick mark", () => {
+  orientations.forEach((orientation) => {
+    it(`draws ticks labels centered with the corresponding tick mark for orientation ${orientation}`, () => {
       let svg = TestMethods.generateSVG();
       let scale = new Plottable.Scales.Linear();
-      let numericAxis = new Plottable.Axes.Numeric(scale, "left");
+      let numericAxis = new Plottable.Axes.Numeric(scale, orientation);
       numericAxis.renderTo(svg);
 
       let tickLabels = numericAxis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`);
@@ -206,37 +185,41 @@ describe("NumericAxis", () => {
       tickLabels.each(function(d, i) {
         let tickLabelClientRect = this.getBoundingClientRect();
         let tickMarkClientRect = (<Element> tickMarks[0][i]).getBoundingClientRect();
-        let labelCenter = (tickLabelClientRect.top + tickLabelClientRect.bottom) / 2;
-        let markCenter = (tickMarkClientRect.top + tickMarkClientRect.bottom) / 2;
+        let labelCenter = isHorizontalOrientation(orientation) ?
+          (tickLabelClientRect.left + tickLabelClientRect.right) / 2 :
+          (tickLabelClientRect.top + tickLabelClientRect.bottom) / 2;
+        let markCenter = isHorizontalOrientation(orientation) ?
+          (tickMarkClientRect.left + tickMarkClientRect.right) / 2 :
+          (tickMarkClientRect.top + tickMarkClientRect.bottom) / 2;
         assert.closeTo(labelCenter, markCenter, 1.5, `tick label ${i} is centered on mark`);
       });
 
       svg.remove();
     });
+  });
 
-    it("does not overlap tick marks with tick labels", () => {
-      let svg = TestMethods.generateSVG();
+  it("does not overlap tick marks with tick labels", () => {
+    let svg = TestMethods.generateSVG();
 
-      let scale = new Plottable.Scales.Linear();
-      scale.domain([175, 185]);
-      let axis = new Plottable.Axes.Numeric(scale, "left")
-                                    .innerTickLength(50);
-      axis.renderTo(svg);
+    let scale = new Plottable.Scales.Linear();
+    scale.domain([175, 185]);
+    let axis = new Plottable.Axes.Numeric(scale, "left")
+                                  .innerTickLength(50);
+    axis.renderTo(svg);
 
-      let tickLabels = applyVisibleFilter(axis.content().selectAll("." + Plottable.Axis.TICK_LABEL_CLASS));
+    let tickLabels = applyVisibleFilter(axis.content().selectAll("." + Plottable.Axis.TICK_LABEL_CLASS));
 
-      let tickMarks = applyVisibleFilter(axis.content().selectAll("." + Plottable.Axis.TICK_MARK_CLASS));
+    let tickMarks = applyVisibleFilter(axis.content().selectAll("." + Plottable.Axis.TICK_MARK_CLASS));
 
-      tickLabels.each(function(d, i) {
-        let tickLabelRect = this.getBoundingClientRect();
-        tickMarks.each(function(d2, i2) {
-          let tickMarkRect = this.getBoundingClientRect();
-            assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(tickLabelRect, tickMarkRect),
-              `tickMark ${i} and tickLabel ${i2} should not overlap`);
-        });
+    tickLabels.each(function(d, i) {
+      let tickLabelRect = this.getBoundingClientRect();
+      tickMarks.each(function(d2, i2) {
+        let tickMarkRect = this.getBoundingClientRect();
+          assert.isFalse(Plottable.Utils.DOM.clientRectsOverlap(tickLabelRect, tickMarkRect),
+            `tickMark ${i} and tickLabel ${i2} should not overlap`);
       });
-      svg.remove();
     });
+    svg.remove();
   });
 
   describe("formatting the labels", () => {

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -2,14 +2,6 @@
 
 describe("Axes", () => {
   describe("NumericAxis", () => {
-    function boxIsInside(inner: ClientRect, outer: ClientRect, epsilon = 0) {
-      if (inner.left < outer.left - epsilon) { return false; }
-      if (inner.right > outer.right + epsilon) { return false; }
-      if (inner.top < outer.top - epsilon) { return false; }
-      if (inner.bottom > outer.bottom + epsilon) { return false; }
-      return true;
-    }
-
     function assertBoxInside(inner: ClientRect, outer: ClientRect, epsilon = 0, message = "") {
       assert.operator(inner.left, ">", outer.left - epsilon, message + " (box inside (left))");
       assert.operator(inner.right, "<", outer.right + epsilon, message + " (box inside (right))");
@@ -257,7 +249,7 @@ describe("Axes", () => {
         let boundingBox = (<Element> svg.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
         visibleTickLabels.each(function(d, i) {
           let visibleTickLabelRect = this.getBoundingClientRect();
-          assert.isTrue(boxIsInside(visibleTickLabelRect, boundingBox, 0.5), `tick label ${i} is inside the bounding box`);
+          assertBoxInside(visibleTickLabelRect, boundingBox, 0.5, `tick label ${i} is inside the bounding box`);
         });
 
         svg.remove();

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -184,8 +184,9 @@ describe("NumericAxis", () => {
 
       axis.renderTo(svg);
 
-      let labelContainer = axis.content().select(".tick-label-container");
-      axis.content().selectAll(".tick-label").each(function() {
+      let tickLabelContainerClass = "tick-label-container";
+      let labelContainer = axis.content().select(`.${tickLabelContainerClass}`);
+      axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`).each(function() {
         TestMethods.assertBBoxInclusion(labelContainer, d3.select(this));
       });
       svg.remove();
@@ -198,7 +199,7 @@ describe("NumericAxis", () => {
       let axis = new Plottable.Axes.Numeric(scale, "bottom");
       axis.renderTo(svg);
 
-      let visibleTickLabels = applyVisibleFilter(axis.content().selectAll(".tick-label"));
+      let visibleTickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
 
       let visibleTickLabelRects = visibleTickLabels[0].map((label: Element) => label.getBoundingClientRect());
 
@@ -222,7 +223,7 @@ describe("NumericAxis", () => {
       let axis = new Plottable.Axes.Numeric(scale, "bottom");
       axis.renderTo(svg);
 
-      let tickLabels = applyVisibleFilter(axis.content().selectAll(".tick-label"));
+      let tickLabels = applyVisibleFilter(axis.content().selectAll(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
       assert.operator(tickLabels.size(), ">", 1, "more than one tick label is shown");
 
       let tickLabelElementPairs = d3.pairs(tickLabels[0]);


### PR DESCRIPTION
Completely reworked to adhere to current guidelines (using `.size()` instead of `[0].length`).  Also making use of `it`s inside of `forEach`'s to test against multiple orientations easily.

Test screenshot:
![screen shot 2015-10-26 at 2 34 28 pm](https://cloud.githubusercontent.com/assets/1448299/10743180/b1c9cf18-7bee-11e5-9d8a-0c7dbf8349fa.png)
