### PR TITLE
use nested modules

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1,371 +1,337 @@
-declare module Plottable {
-    module Utils {
-        module Math {
-            /**
-             * Checks if x is between a and b.
-             *
-             * @param {number} x The value to test if in range
-             * @param {number} a The beginning of the (inclusive) range
-             * @param {number} b The ending of the (inclusive) range
-             * @return {boolean} Whether x is in [a, b]
-             */
-            function inRange(x: number, a: number, b: number): boolean;
-            /**
-             * Clamps x to the range [min, max].
-             *
-             * @param {number} x The value to be clamped.
-             * @param {number} min The minimum value.
-             * @param {number} max The maximum value.
-             * @return {number} A clamped value in the range [min, max].
-             */
-            function clamp(x: number, min: number, max: number): number;
-            /**
-             * Applies the accessor, if provided, to each element of `array` and returns the maximum value.
-             * If no maximum value can be computed, returns defaultValue.
-             */
-            function max<C>(array: C[], defaultValue: C): C;
-            function max<T, C>(array: T[], accessor: (t?: T, i?: number) => C, defaultValue: C): C;
-            /**
-             * Applies the accessor, if provided, to each element of `array` and returns the minimum value.
-             * If no minimum value can be computed, returns defaultValue.
-             */
-            function min<C>(array: C[], defaultValue: C): C;
-            function min<T, C>(array: T[], accessor: (t?: T, i?: number) => C, defaultValue: C): C;
-            /**
-             * Returns true **only** if x is NaN
-             */
-            function isNaN(n: any): boolean;
-            /**
-             * Returns true if the argument is a number, which is not NaN
-             * Numbers represented as strings do not pass this function
-             */
-            function isValidNumber(n: any): boolean;
-            /**
-             * Generates an array of consecutive, strictly increasing numbers
-             * in the range [start, stop) separeted by step
-             */
-            function range(start: number, stop: number, step?: number): number[];
-            /**
-             * Returns the square of the distance between two points
-             *
-             * @param {Point} p1
-             * @param {Point} p2
-             * @return {number} dist(p1, p2)^2
-             */
-            function distanceSquared(p1: Point, p2: Point): number;
-            function degreesToRadians(degree: number): number;
-        }
+declare module Plottable.Utils.Math {
+    /**
+     * Checks if x is between a and b.
+     *
+     * @param {number} x The value to test if in range
+     * @param {number} a The beginning of the (inclusive) range
+     * @param {number} b The ending of the (inclusive) range
+     * @return {boolean} Whether x is in [a, b]
+     */
+    function inRange(x: number, a: number, b: number): boolean;
+    /**
+     * Clamps x to the range [min, max].
+     *
+     * @param {number} x The value to be clamped.
+     * @param {number} min The minimum value.
+     * @param {number} max The maximum value.
+     * @return {number} A clamped value in the range [min, max].
+     */
+    function clamp(x: number, min: number, max: number): number;
+    /**
+     * Applies the accessor, if provided, to each element of `array` and returns the maximum value.
+     * If no maximum value can be computed, returns defaultValue.
+     */
+    function max<C>(array: C[], defaultValue: C): C;
+    function max<T, C>(array: T[], accessor: (t?: T, i?: number) => C, defaultValue: C): C;
+    /**
+     * Applies the accessor, if provided, to each element of `array` and returns the minimum value.
+     * If no minimum value can be computed, returns defaultValue.
+     */
+    function min<C>(array: C[], defaultValue: C): C;
+    function min<T, C>(array: T[], accessor: (t?: T, i?: number) => C, defaultValue: C): C;
+    /**
+     * Returns true **only** if x is NaN
+     */
+    function isNaN(n: any): boolean;
+    /**
+     * Returns true if the argument is a number, which is not NaN
+     * Numbers represented as strings do not pass this function
+     */
+    function isValidNumber(n: any): boolean;
+    /**
+     * Generates an array of consecutive, strictly increasing numbers
+     * in the range [start, stop) separeted by step
+     */
+    function range(start: number, stop: number, step?: number): number[];
+    /**
+     * Returns the square of the distance between two points
+     *
+     * @param {Point} p1
+     * @param {Point} p2
+     * @return {number} dist(p1, p2)^2
+     */
+    function distanceSquared(p1: Point, p2: Point): number;
+    function degreesToRadians(degree: number): number;
+}
+declare module Plottable.Utils {
+    /**
+     * Shim for ES6 map.
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
+     */
+    class Map<K, V> {
+        private _keyValuePairs;
+        private _es6Map;
+        constructor();
+        set(key: K, value: V): Map<K, V>;
+        get(key: K): V;
+        has(key: K): boolean;
+        forEach(callbackFn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any): void;
+        delete(key: K): boolean;
     }
 }
-declare module Plottable {
-    module Utils {
+declare module Plottable.Utils {
+    /**
+     * Shim for ES6 set.
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
+     */
+    class Set<T> {
+        size: number;
+        private _values;
+        private _es6Set;
+        constructor();
+        add(value: T): Set<T>;
+        delete(value: T): boolean;
+        has(value: T): boolean;
+        forEach(callback: (value: T, value2: T, set: Set<T>) => void, thisArg?: any): void;
+    }
+}
+declare module Plottable.Utils.DOM {
+    /**
+     * Gets the bounding box of an element.
+     * @param {d3.Selection} element
+     * @returns {SVGRed} The bounding box.
+     */
+    function elementBBox(element: d3.Selection<any>): SVGRect;
+    /**
+     * Screen refresh rate which is assumed to be 60fps
+     */
+    var SCREEN_REFRESH_RATE_MILLISECONDS: number;
+    /**
+     * Polyfill for `window.requestAnimationFrame`.
+     * If the function exists, then we use the function directly.
+     * Otherwise, we set a timeout on `SCREEN_REFRESH_RATE_MILLISECONDS` and then perform the function.
+     *
+     * @param {() => void} callback The callback to call in the next animation frame
+     */
+    function requestAnimationFramePolyfill(callback: () => void): void;
+    /**
+     * Calculates the width of the element.
+     * The width includes the padding and the border on the element's left and right sides.
+     *
+     * @param {Element} element The element to query
+     * @returns {number} The width of the element.
+     */
+    function elementWidth(element: Element): number;
+    /**
+     * Calculates the height of the element.
+     * The height includes the padding the and the border on the element's top and bottom sides.
+     *
+     * @param {Element} element The element to query
+     * @returns {number} The height of the element
+     */
+    function elementHeight(element: Element): number;
+    /**
+     * Retrieves the number array representing the translation for the selection
+     *
+     * @param {d3.Selection<any>} selection The selection to query
+     * @returns {[number, number]} The number array representing the translation
+     */
+    function translate(selection: d3.Selection<any>): [number, number];
+    /**
+     * Translates the given selection by the input x / y pixel amounts.
+     *
+     * @param {d3.Selection<any>} selection The selection to translate
+     * @param {number} x The amount to translate in the x direction
+     * @param {number} y The amount to translate in the y direction
+     * @returns {d3.Selection<any>} The input selection
+     */
+    function translate(selection: d3.Selection<any>, x: number, y: number): d3.Selection<any>;
+    /**
+     * Checks if the first ClientRect overlaps the second.
+     *
+     * @param {ClientRect} clientRectA The first ClientRect
+     * @param {ClientRect} clientRectB The second ClientRect
+     * @returns {boolean} If the ClientRects overlap each other.
+     */
+    function clientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect): boolean;
+    /**
+     * Returns true if and only if innerClientRect is inside outerClientRect.
+     *
+     * @param {ClientRect} innerClientRect The first ClientRect
+     * @param {ClientRect} outerClientRect The second ClientRect
+     * @returns {boolean} If and only if the innerClientRect is inside outerClientRect.
+     */
+    function clientRectInside(innerClientRect: ClientRect, outerClientRect: ClientRect): boolean;
+    /**
+     * Retrieves the bounding svg of the input element
+     *
+     * @param {SVGElement} element The element to query
+     * @returns {SVGElement} The bounding svg
+     */
+    function boundingSVG(element: SVGElement): SVGElement;
+    /**
+     * Generates a ClipPath ID that is unique for this instance of Plottable
+     */
+    function generateUniqueClipPathId(): string;
+    /**
+     * Returns true if the supplied coordinates or Ranges intersect or are contained by bbox.
+     *
+     * @param {number | Range} xValOrRange The x coordinate or Range to test
+     * @param {number | Range} yValOrRange The y coordinate or Range to test
+     * @param {SVGRect} bbox The bbox
+     * @param {number} tolerance Amount by which to expand bbox, in each dimension, before
+     * testing intersection
+     *
+     * @returns {boolean} True if the supplied coordinates or Ranges intersect or are
+     * contained by bbox, false otherwise.
+     */
+    function intersectsBBox(xValOrRange: number | Range, yValOrRange: number | Range, bbox: SVGRect, tolerance?: number): boolean;
+}
+declare module Plottable.Utils.Color {
+    /**
+     * Return contrast ratio between two colors
+     * Based on implementation from chroma.js by Gregor Aisch (gka) (licensed under BSD)
+     * chroma.js may be found here: https://github.com/gka/chroma.js
+     * License may be found here: https://github.com/gka/chroma.js/blob/master/LICENSE
+     * see http://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
+     */
+    function contrast(a: string, b: string): number;
+    /**
+     * Returns a brighter copy of this color. Each channel is multiplied by 0.7 ^ -factor.
+     * Channel values are capped at the maximum value of 255, and the minimum value of 30.
+     */
+    function lightenColor(color: string, factor: number): string;
+    /**
+     * Gets the Hex Code of the color resulting by applying the className CSS class to the
+     * colorTester selection. Returns null if the tester is transparent.
+     *
+     * @param {d3.Selection<void>} colorTester The d3 selection to apply the CSS class to
+     * @param {string} className The name of the class to be applied
+     * @return {string} The hex code of the computed color
+     */
+    function colorTest(colorTester: d3.Selection<void>, className: string): string;
+}
+declare module Plottable.Utils.Array {
+    /**
+     * Takes two arrays of numbers and adds them together
+     *
+     * @param {number[]} aList The first array of numbers
+     * @param {number[]} bList The second array of numbers
+     * @return {number[]} An array of numbers where x[i] = aList[i] + bList[i]
+     */
+    function add(aList: number[], bList: number[]): number[];
+    /**
+     * Take an array of values, and return the unique values.
+     * Will work iff ∀ a, b, a.toString() == b.toString() => a == b; will break on Object inputs
+     *
+     * @param {T[]} values The values to find uniqueness for
+     * @return {T[]} The unique values
+     */
+    function uniq<T>(arr: T[]): T[];
+    /**
+     * @param {T[][]} a The 2D array that will have its elements joined together.
+     * @return {T[]} Every array in a, concatenated together in the order they appear.
+     */
+    function flatten<T>(a: T[][]): T[];
+    /**
+     * Creates an array of length `count`, filled with value or (if value is a function), value()
+     *
+     * @param {T | ((index?: number) => T)} value The value to fill the array with or a value generator (called with index as arg)
+     * @param {number} count The length of the array to generate
+     * @return {any[]}
+     */
+    function createFilledArray<T>(value: T | ((index?: number) => T), count: number): T[];
+}
+declare module Plottable.Utils {
+    /**
+     * A set of callbacks which can be all invoked at once.
+     * Each callback exists at most once in the set (based on reference equality).
+     * All callbacks should have the same signature.
+     */
+    class CallbackSet<CB extends Function> extends Set<CB> {
+        callCallbacks(...args: any[]): CallbackSet<CB>;
+    }
+}
+declare module Plottable.Utils.Stacking {
+    type StackedDatum = {
+        value: number;
+        offset: number;
+    };
+    type StackingResult = Utils.Map<Dataset, Utils.Map<string, StackedDatum>>;
+    /**
+     * Computes the StackingResult (value and offset) for each data point in each Dataset.
+     *
+     * @param {Dataset[]} datasets The Datasets to be stacked on top of each other in the order of stacking
+     * @param {Accessor<any>} keyAccessor Accessor for the key of the data
+     * @param {Accessor<number>} valueAccessor Accessor for the value of the data
+     * @return {StackingResult} value and offset for each datapoint in each Dataset
+     */
+    function stack(datasets: Dataset[], keyAccessor: Accessor<any>, valueAccessor: Accessor<number>): StackingResult;
+    /**
+     * Computes the total extent over all data points in all Datasets, taking stacking into consideration.
+     *
+     * @param {StackingResult} stackingResult The value and offset information for each datapoint in each dataset
+     * @oaram {Accessor<any>} keyAccessor Accessor for the key of the data existent in the stackingResult
+     * @param {Accessor<boolean>} filter A filter for data to be considered when computing the total extent
+     * @return {[number, number]} The total extent
+     */
+    function stackedExtent(stackingResult: StackingResult, keyAccessor: Accessor<any>, filter: Accessor<boolean>): number[];
+    /**
+     * Normalizes a key used for stacking
+     *
+     * @param {any} key The key to be normalized
+     * @return {string} The stringified key
+     */
+    function normalizeKey(key: any): string;
+}
+declare module Plottable.Utils.Window {
+    /**
+     * Print a warning message to the console, if it is available.
+     *
+     * @param {string} The warnings to print
+     */
+    function warn(warning: string): void;
+    /**
+     * Is like setTimeout, but activates synchronously if time=0
+     * We special case 0 because of an observed issue where calling setTimeout causes visible flickering.
+     * We believe this is because when requestAnimationFrame calls into the paint function, as soon as that function finishes
+     * evaluating, the results are painted to the screen. As a result, if we want something to occur immediately but call setTimeout
+     * with time=0, then it is pushed to the call stack and rendered in the next frame, so the component that was rendered via
+     * setTimeout appears out-of-sync with the rest of the plot.
+     */
+    function setTimeout(f: Function, time: number, ...args: any[]): number;
+    /**
+     * Sends a deprecation warning to the console. The warning includes the name of the deprecated method,
+     * version number of the deprecation, and an optional message.
+     *
+     * To be used in the first line of a deprecated method.
+     *
+     * @param {string} callingMethod The name of the method being deprecated
+     * @param {string} version The version when the tagged method became obsolete
+     * @param {string?} message Optional message to be shown with the warning
+     */
+    function deprecated(callingMethod: string, version: string, message?: string): void;
+}
+declare module Plottable.Utils {
+    class ClientToSVGTranslator {
+        private static _TRANSLATOR_KEY;
+        private _svg;
+        private _measureRect;
         /**
-         * Shim for ES6 map.
-         * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
+         * Returns the ClientToSVGTranslator for the <svg> containing elem.
+         * If one already exists on that <svg>, it will be returned; otherwise, a new one will be created.
          */
-        class Map<K, V> {
-            private _keyValuePairs;
-            private _es6Map;
-            constructor();
-            set(key: K, value: V): Map<K, V>;
-            get(key: K): V;
-            has(key: K): boolean;
-            forEach(callbackFn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any): void;
-            delete(key: K): boolean;
-        }
-    }
-}
-declare module Plottable {
-    module Utils {
+        static getTranslator(elem: SVGElement): ClientToSVGTranslator;
+        constructor(svg: SVGElement);
         /**
-         * Shim for ES6 set.
-         * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
+         * Computes the position relative to the <svg> in svg-coordinate-space.
          */
-        class Set<T> {
-            size: number;
-            private _values;
-            private _es6Set;
-            constructor();
-            add(value: T): Set<T>;
-            delete(value: T): boolean;
-            has(value: T): boolean;
-            forEach(callback: (value: T, value2: T, set: Set<T>) => void, thisArg?: any): void;
-        }
-    }
-}
-declare module Plottable {
-    module Utils {
-        module DOM {
-            /**
-             * Gets the bounding box of an element.
-             * @param {d3.Selection} element
-             * @returns {SVGRed} The bounding box.
-             */
-            function elementBBox(element: d3.Selection<any>): SVGRect;
-            /**
-             * Screen refresh rate which is assumed to be 60fps
-             */
-            var SCREEN_REFRESH_RATE_MILLISECONDS: number;
-            /**
-             * Polyfill for `window.requestAnimationFrame`.
-             * If the function exists, then we use the function directly.
-             * Otherwise, we set a timeout on `SCREEN_REFRESH_RATE_MILLISECONDS` and then perform the function.
-             *
-             * @param {() => void} callback The callback to call in the next animation frame
-             */
-            function requestAnimationFramePolyfill(callback: () => void): void;
-            /**
-             * Calculates the width of the element.
-             * The width includes the padding and the border on the element's left and right sides.
-             *
-             * @param {Element} element The element to query
-             * @returns {number} The width of the element.
-             */
-            function elementWidth(element: Element): number;
-            /**
-             * Calculates the height of the element.
-             * The height includes the padding the and the border on the element's top and bottom sides.
-             *
-             * @param {Element} element The element to query
-             * @returns {number} The height of the element
-             */
-            function elementHeight(element: Element): number;
-            /**
-             * Retrieves the number array representing the translation for the selection
-             *
-             * @param {d3.Selection<any>} selection The selection to query
-             * @returns {[number, number]} The number array representing the translation
-             */
-            function translate(selection: d3.Selection<any>): [number, number];
-            /**
-             * Translates the given selection by the input x / y pixel amounts.
-             *
-             * @param {d3.Selection<any>} selection The selection to translate
-             * @param {number} x The amount to translate in the x direction
-             * @param {number} y The amount to translate in the y direction
-             * @returns {d3.Selection<any>} The input selection
-             */
-            function translate(selection: d3.Selection<any>, x: number, y: number): d3.Selection<any>;
-            /**
-             * Checks if the first ClientRect overlaps the second.
-             *
-             * @param {ClientRect} clientRectA The first ClientRect
-             * @param {ClientRect} clientRectB The second ClientRect
-             * @returns {boolean} If the ClientRects overlap each other.
-             */
-            function clientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect): boolean;
-            /**
-             * Returns true if and only if innerClientRect is inside outerClientRect.
-             *
-             * @param {ClientRect} innerClientRect The first ClientRect
-             * @param {ClientRect} outerClientRect The second ClientRect
-             * @returns {boolean} If and only if the innerClientRect is inside outerClientRect.
-             */
-            function clientRectInside(innerClientRect: ClientRect, outerClientRect: ClientRect): boolean;
-            /**
-             * Retrieves the bounding svg of the input element
-             *
-             * @param {SVGElement} element The element to query
-             * @returns {SVGElement} The bounding svg
-             */
-            function boundingSVG(element: SVGElement): SVGElement;
-            /**
-             * Generates a ClipPath ID that is unique for this instance of Plottable
-             */
-            function generateUniqueClipPathId(): string;
-            /**
-             * Returns true if the supplied coordinates or Ranges intersect or are contained by bbox.
-             *
-             * @param {number | Range} xValOrRange The x coordinate or Range to test
-             * @param {number | Range} yValOrRange The y coordinate or Range to test
-             * @param {SVGRect} bbox The bbox
-             * @param {number} tolerance Amount by which to expand bbox, in each dimension, before
-             * testing intersection
-             *
-             * @returns {boolean} True if the supplied coordinates or Ranges intersect or are
-             * contained by bbox, false otherwise.
-             */
-            function intersectsBBox(xValOrRange: number | Range, yValOrRange: number | Range, bbox: SVGRect, tolerance?: number): boolean;
-        }
-    }
-}
-declare module Plottable {
-    module Utils {
-        module Color {
-            /**
-             * Return contrast ratio between two colors
-             * Based on implementation from chroma.js by Gregor Aisch (gka) (licensed under BSD)
-             * chroma.js may be found here: https://github.com/gka/chroma.js
-             * License may be found here: https://github.com/gka/chroma.js/blob/master/LICENSE
-             * see http://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
-             */
-            function contrast(a: string, b: string): number;
-            /**
-             * Returns a brighter copy of this color. Each channel is multiplied by 0.7 ^ -factor.
-             * Channel values are capped at the maximum value of 255, and the minimum value of 30.
-             */
-            function lightenColor(color: string, factor: number): string;
-            /**
-             * Gets the Hex Code of the color resulting by applying the className CSS class to the
-             * colorTester selection. Returns null if the tester is transparent.
-             *
-             * @param {d3.Selection<void>} colorTester The d3 selection to apply the CSS class to
-             * @param {string} className The name of the class to be applied
-             * @return {string} The hex code of the computed color
-             */
-            function colorTest(colorTester: d3.Selection<void>, className: string): string;
-        }
-    }
-}
-declare module Plottable {
-    module Utils {
-        module Array {
-            /**
-             * Takes two arrays of numbers and adds them together
-             *
-             * @param {number[]} aList The first array of numbers
-             * @param {number[]} bList The second array of numbers
-             * @return {number[]} An array of numbers where x[i] = aList[i] + bList[i]
-             */
-            function add(aList: number[], bList: number[]): number[];
-            /**
-             * Take an array of values, and return the unique values.
-             * Will work iff ∀ a, b, a.toString() == b.toString() => a == b; will break on Object inputs
-             *
-             * @param {T[]} values The values to find uniqueness for
-             * @return {T[]} The unique values
-             */
-            function uniq<T>(arr: T[]): T[];
-            /**
-             * @param {T[][]} a The 2D array that will have its elements joined together.
-             * @return {T[]} Every array in a, concatenated together in the order they appear.
-             */
-            function flatten<T>(a: T[][]): T[];
-            /**
-             * Creates an array of length `count`, filled with value or (if value is a function), value()
-             *
-             * @param {T | ((index?: number) => T)} value The value to fill the array with or a value generator (called with index as arg)
-             * @param {number} count The length of the array to generate
-             * @return {any[]}
-             */
-            function createFilledArray<T>(value: T | ((index?: number) => T), count: number): T[];
-        }
-    }
-}
-declare module Plottable {
-    module Utils {
+        computePosition(clientX: number, clientY: number): Point;
         /**
-         * A set of callbacks which can be all invoked at once.
-         * Each callback exists at most once in the set (based on reference equality).
-         * All callbacks should have the same signature.
+         * Checks whether event happened inside <svg> element.
          */
-        class CallbackSet<CB extends Function> extends Set<CB> {
-            callCallbacks(...args: any[]): CallbackSet<CB>;
-        }
+        insideSVG(e: Event): boolean;
     }
 }
-declare module Plottable {
-    module Utils {
-        module Stacking {
-            type StackedDatum = {
-                value: number;
-                offset: number;
-            };
-            type StackingResult = Utils.Map<Dataset, Utils.Map<string, StackedDatum>>;
-            /**
-             * Computes the StackingResult (value and offset) for each data point in each Dataset.
-             *
-             * @param {Dataset[]} datasets The Datasets to be stacked on top of each other in the order of stacking
-             * @param {Accessor<any>} keyAccessor Accessor for the key of the data
-             * @param {Accessor<number>} valueAccessor Accessor for the value of the data
-             * @return {StackingResult} value and offset for each datapoint in each Dataset
-             */
-            function stack(datasets: Dataset[], keyAccessor: Accessor<any>, valueAccessor: Accessor<number>): StackingResult;
-            /**
-             * Computes the total extent over all data points in all Datasets, taking stacking into consideration.
-             *
-             * @param {StackingResult} stackingResult The value and offset information for each datapoint in each dataset
-             * @oaram {Accessor<any>} keyAccessor Accessor for the key of the data existent in the stackingResult
-             * @param {Accessor<boolean>} filter A filter for data to be considered when computing the total extent
-             * @return {[number, number]} The total extent
-             */
-            function stackedExtent(stackingResult: StackingResult, keyAccessor: Accessor<any>, filter: Accessor<boolean>): number[];
-            /**
-             * Normalizes a key used for stacking
-             *
-             * @param {any} key The key to be normalized
-             * @return {string} The stringified key
-             */
-            function normalizeKey(key: any): string;
-        }
-    }
-}
-declare module Plottable {
-    module Utils {
-        module Window {
-            /**
-             * Print a warning message to the console, if it is available.
-             *
-             * @param {string} The warnings to print
-             */
-            function warn(warning: string): void;
-            /**
-             * Is like setTimeout, but activates synchronously if time=0
-             * We special case 0 because of an observed issue where calling setTimeout causes visible flickering.
-             * We believe this is because when requestAnimationFrame calls into the paint function, as soon as that function finishes
-             * evaluating, the results are painted to the screen. As a result, if we want something to occur immediately but call setTimeout
-             * with time=0, then it is pushed to the call stack and rendered in the next frame, so the component that was rendered via
-             * setTimeout appears out-of-sync with the rest of the plot.
-             */
-            function setTimeout(f: Function, time: number, ...args: any[]): number;
-            /**
-             * Sends a deprecation warning to the console. The warning includes the name of the deprecated method,
-             * version number of the deprecation, and an optional message.
-             *
-             * To be used in the first line of a deprecated method.
-             *
-             * @param {string} callingMethod The name of the method being deprecated
-             * @param {string} version The version when the tagged method became obsolete
-             * @param {string?} message Optional message to be shown with the warning
-             */
-            function deprecated(callingMethod: string, version: string, message?: string): void;
-        }
-    }
-}
-declare module Plottable {
-    module Utils {
-        class ClientToSVGTranslator {
-            private static _TRANSLATOR_KEY;
-            private _svg;
-            private _measureRect;
-            /**
-             * Returns the ClientToSVGTranslator for the <svg> containing elem.
-             * If one already exists on that <svg>, it will be returned; otherwise, a new one will be created.
-             */
-            static getTranslator(elem: SVGElement): ClientToSVGTranslator;
-            constructor(svg: SVGElement);
-            /**
-             * Computes the position relative to the <svg> in svg-coordinate-space.
-             */
-            computePosition(clientX: number, clientY: number): Point;
-            /**
-             * Checks whether event happened inside <svg> element.
-             */
-            insideSVG(e: Event): boolean;
-        }
-    }
-}
-declare module Plottable {
-    module Configs {
-        /**
-         * Specifies if Plottable should show warnings.
-         */
-        var SHOW_WARNINGS: boolean;
-        /**
-         * Specifies if Plottable should add <title> elements to text.
-         */
-        var ADD_TITLE_ELEMENTS: boolean;
-    }
+declare module Plottable.Configs {
+    /**
+     * Specifies if Plottable should show warnings.
+     */
+    var SHOW_WARNINGS: boolean;
+    /**
+     * Specifies if Plottable should add <title> elements to text.
+     */
+    var ADD_TITLE_ELEMENTS: boolean;
 }
 declare module Plottable {
     var version: string;
@@ -427,84 +393,80 @@ declare module Plottable {
         metadata(metadata: any): Dataset;
     }
 }
-declare module Plottable {
-    module RenderPolicies {
-        /**
-         * A policy for rendering Components.
-         */
-        interface RenderPolicy {
-            render(): any;
-        }
-        /**
-         * Renders Components immediately after they are enqueued.
-         * Useful for debugging, horrible for performance.
-         */
-        class Immediate implements RenderPolicy {
-            render(): void;
-        }
-        /**
-         * The default way to render, which only tries to render every frame
-         * (usually, 1/60th of a second).
-         */
-        class AnimationFrame implements RenderPolicy {
-            render(): void;
-        }
-        /**
-         * Renders with `setTimeout()`.
-         * Generally an inferior way to render compared to `requestAnimationFrame`,
-         * but useful for browsers that don't suppoort `requestAnimationFrame`.
-         */
-        class Timeout implements RenderPolicy {
-            private _timeoutMsec;
-            render(): void;
-        }
+declare module Plottable.RenderPolicies {
+    /**
+     * A policy for rendering Components.
+     */
+    interface RenderPolicy {
+        render(): any;
+    }
+    /**
+     * Renders Components immediately after they are enqueued.
+     * Useful for debugging, horrible for performance.
+     */
+    class Immediate implements RenderPolicy {
+        render(): void;
+    }
+    /**
+     * The default way to render, which only tries to render every frame
+     * (usually, 1/60th of a second).
+     */
+    class AnimationFrame implements RenderPolicy {
+        render(): void;
+    }
+    /**
+     * Renders with `setTimeout()`.
+     * Generally an inferior way to render compared to `requestAnimationFrame`,
+     * but useful for browsers that don't suppoort `requestAnimationFrame`.
+     */
+    class Timeout implements RenderPolicy {
+        private _timeoutMsec;
+        render(): void;
     }
 }
-declare module Plottable {
-    /**
-     * The RenderController is responsible for enqueueing and synchronizing
-     * layout and render calls for Components.
-     *
-     * Layout and render calls occur inside an animation callback
-     * (window.requestAnimationFrame if available).
-     *
-     * RenderController.flush() immediately lays out and renders all Components currently enqueued.
-     *
-     * To always have immediate rendering (useful for debugging), call
-     * ```typescript
-     * Plottable.RenderController.setRenderPolicy(
-     *   new Plottable.RenderPolicies.Immediate()
-     * );
-     * ```
-     */
-    module RenderController {
-        module Policy {
-            var IMMEDIATE: string;
-            var ANIMATION_FRAME: string;
-            var TIMEOUT: string;
-        }
-        function renderPolicy(): RenderPolicies.RenderPolicy;
-        function renderPolicy(renderPolicy: string): void;
-        /**
-         * Enqueues the Component for rendering.
-         *
-         * @param {Component} component
-         */
-        function registerToRender(component: Component): void;
-        /**
-         * Enqueues the Component for layout and rendering.
-         *
-         * @param {Component} component
-         */
-        function registerToComputeLayout(component: Component): void;
-        /**
-         * Renders all Components waiting to be rendered immediately
-         * instead of waiting until the next frame.
-         *
-         * Useful to call when debugging.
-         */
-        function flush(): void;
+/**
+ * The RenderController is responsible for enqueueing and synchronizing
+ * layout and render calls for Components.
+ *
+ * Layout and render calls occur inside an animation callback
+ * (window.requestAnimationFrame if available).
+ *
+ * RenderController.flush() immediately lays out and renders all Components currently enqueued.
+ *
+ * To always have immediate rendering (useful for debugging), call
+ * ```typescript
+ * Plottable.RenderController.setRenderPolicy(
+ *   new Plottable.RenderPolicies.Immediate()
+ * );
+ * ```
+ */
+declare module Plottable.RenderController {
+    module Policy {
+        var IMMEDIATE: string;
+        var ANIMATION_FRAME: string;
+        var TIMEOUT: string;
     }
+    function renderPolicy(): RenderPolicies.RenderPolicy;
+    function renderPolicy(renderPolicy: string): void;
+    /**
+     * Enqueues the Component for rendering.
+     *
+     * @param {Component} component
+     */
+    function registerToRender(component: Component): void;
+    /**
+     * Enqueues the Component for layout and rendering.
+     *
+     * @param {Component} component
+     */
+    function registerToComputeLayout(component: Component): void;
+    /**
+     * Renders all Components waiting to be rendered immediately
+     * instead of waiting until the next frame.
+     *
+     * Useful to call when debugging.
+     */
+    function flush(): void;
 }
 declare module Plottable {
     /**
@@ -589,103 +551,103 @@ declare module Plottable {
      *
      */
     var MILLISECONDS_IN_ONE_DAY: number;
-    module Formatters {
-        /**
-         * Creates a formatter for currency values.
-         *
-         * @param {number} [precision] The number of decimal places to show (default 2).
-         * @param {string} [symbol] The currency symbol to use (default "$").
-         * @param {boolean} [prefix] Whether to prepend or append the currency symbol (default true).
-         *
-         * @returns {Formatter} A formatter for currency values.
-         */
-        function currency(precision?: number, symbol?: string, prefix?: boolean): (d: any) => string;
-        /**
-         * Creates a formatter that displays exactly [precision] decimal places.
-         *
-         * @param {number} [precision] The number of decimal places to show (default 3).
-         *
-         * @returns {Formatter} A formatter that displays exactly [precision] decimal places.
-         */
-        function fixed(precision?: number): (d: any) => string;
-        /**
-         * Creates a formatter that formats numbers to show no more than
-         * [maxNumberOfDecimalPlaces] decimal places. All other values are stringified.
-         *
-         * @param {number} [maxNumberOfDecimalPlaces] The number of decimal places to show (default 3).
-         *
-         * @returns {Formatter} A formatter for general values.
-         */
-        function general(maxNumberOfDecimalPlaces?: number): (d: any) => string;
-        /**
-         * Creates a formatter that stringifies its input.
-         *
-         * @returns {Formatter} A formatter that stringifies its input.
-         */
-        function identity(): (d: any) => string;
-        /**
-         * Creates a formatter for percentage values.
-         * Multiplies the input by 100 and appends "%".
-         *
-         * @param {number} [precision] The number of decimal places to show (default 0).
-         *
-         * @returns {Formatter} A formatter for percentage values.
-         */
-        function percentage(precision?: number): (d: any) => string;
-        /**
-         * Creates a formatter for values that displays [numberOfSignificantFigures] significant figures
-         * and puts SI notation.
-         *
-         * @param {number} [numberOfSignificantFigures] The number of significant figures to show (default 3).
-         *
-         * @returns {Formatter} A formatter for SI values.
-         */
-        function siSuffix(numberOfSignificantFigures?: number): (d: any) => string;
-        /**
-         * Creates a formatter for values that displays abbreviated values
-         * and uses standard short scale suffixes
-         * - K - thousands - 10 ^ 3
-         * - M - millions - 10 ^ 6
-         * - B - billions - 10 ^ 9
-         * - T - trillions - 10 ^ 12
-         * - Q - quadrillions - 10 ^ 15
-         *
-         * Numbers with a magnitude outside of (10 ^ (-precision), 10 ^ 15) are shown using
-         * scientific notation to avoid creating extremely long decimal strings.
-         *
-         * @param {number} [precision] the number of decimal places to show (default 3)
-         * @returns {Formatter} A formatter with short scale formatting
-         */
-        function shortScale(precision?: number): (num: number) => string;
-        /**
-         * Creates a multi time formatter that displays dates.
-         *
-         * @returns {Formatter} A formatter for time/date values.
-         */
-        function multiTime(): (d: any) => string;
-        /**
-         * Creates a time formatter that displays time/date using given specifier.
-         *
-         * List of directives can be found on: https://github.com/mbostock/d3/wiki/Time-Formatting#format
-         *
-         * @param {string} [specifier] The specifier for the formatter.
-         *
-         * @returns {Formatter} A formatter for time/date values.
-         */
-        function time(specifier: string): Formatter;
-        /**
-         * @deprecated As of release v1.3.0, not safe for use with time zones.
-         *
-         * Creates a formatter for relative dates.
-         *
-         * @param {number} baseValue The start date (as epoch time) used in computing relative dates (default 0)
-         * @param {number} increment The unit used in calculating relative date values (default MILLISECONDS_IN_ONE_DAY)
-         * @param {string} label The label to append to the formatted string (default "")
-         *
-         * @returns {Formatter} A formatter for time/date values.
-         */
-        function relativeDate(baseValue?: number, increment?: number, label?: string): (d: any) => string;
-    }
+}
+declare module Plottable.Formatters {
+    /**
+     * Creates a formatter for currency values.
+     *
+     * @param {number} [precision] The number of decimal places to show (default 2).
+     * @param {string} [symbol] The currency symbol to use (default "$").
+     * @param {boolean} [prefix] Whether to prepend or append the currency symbol (default true).
+     *
+     * @returns {Formatter} A formatter for currency values.
+     */
+    function currency(precision?: number, symbol?: string, prefix?: boolean): (d: any) => string;
+    /**
+     * Creates a formatter that displays exactly [precision] decimal places.
+     *
+     * @param {number} [precision] The number of decimal places to show (default 3).
+     *
+     * @returns {Formatter} A formatter that displays exactly [precision] decimal places.
+     */
+    function fixed(precision?: number): (d: any) => string;
+    /**
+     * Creates a formatter that formats numbers to show no more than
+     * [maxNumberOfDecimalPlaces] decimal places. All other values are stringified.
+     *
+     * @param {number} [maxNumberOfDecimalPlaces] The number of decimal places to show (default 3).
+     *
+     * @returns {Formatter} A formatter for general values.
+     */
+    function general(maxNumberOfDecimalPlaces?: number): (d: any) => string;
+    /**
+     * Creates a formatter that stringifies its input.
+     *
+     * @returns {Formatter} A formatter that stringifies its input.
+     */
+    function identity(): (d: any) => string;
+    /**
+     * Creates a formatter for percentage values.
+     * Multiplies the input by 100 and appends "%".
+     *
+     * @param {number} [precision] The number of decimal places to show (default 0).
+     *
+     * @returns {Formatter} A formatter for percentage values.
+     */
+    function percentage(precision?: number): (d: any) => string;
+    /**
+     * Creates a formatter for values that displays [numberOfSignificantFigures] significant figures
+     * and puts SI notation.
+     *
+     * @param {number} [numberOfSignificantFigures] The number of significant figures to show (default 3).
+     *
+     * @returns {Formatter} A formatter for SI values.
+     */
+    function siSuffix(numberOfSignificantFigures?: number): (d: any) => string;
+    /**
+     * Creates a formatter for values that displays abbreviated values
+     * and uses standard short scale suffixes
+     * - K - thousands - 10 ^ 3
+     * - M - millions - 10 ^ 6
+     * - B - billions - 10 ^ 9
+     * - T - trillions - 10 ^ 12
+     * - Q - quadrillions - 10 ^ 15
+     *
+     * Numbers with a magnitude outside of (10 ^ (-precision), 10 ^ 15) are shown using
+     * scientific notation to avoid creating extremely long decimal strings.
+     *
+     * @param {number} [precision] the number of decimal places to show (default 3)
+     * @returns {Formatter} A formatter with short scale formatting
+     */
+    function shortScale(precision?: number): (num: number) => string;
+    /**
+     * Creates a multi time formatter that displays dates.
+     *
+     * @returns {Formatter} A formatter for time/date values.
+     */
+    function multiTime(): (d: any) => string;
+    /**
+     * Creates a time formatter that displays time/date using given specifier.
+     *
+     * List of directives can be found on: https://github.com/mbostock/d3/wiki/Time-Formatting#format
+     *
+     * @param {string} [specifier] The specifier for the formatter.
+     *
+     * @returns {Formatter} A formatter for time/date values.
+     */
+    function time(specifier: string): Formatter;
+    /**
+     * @deprecated As of release v1.3.0, not safe for use with time zones.
+     *
+     * Creates a formatter for relative dates.
+     *
+     * @param {number} baseValue The start date (as epoch time) used in computing relative dates (default 0)
+     * @param {number} increment The unit used in calculating relative date values (default MILLISECONDS_IN_ONE_DAY)
+     * @param {string} label The label to append to the formatted string (default "")
+     *
+     * @returns {Formatter} A formatter for time/date values.
+     */
+    function relativeDate(baseValue?: number, increment?: number, label?: string): (d: any) => string;
 }
 declare module Plottable {
     /**
@@ -693,40 +655,40 @@ declare module Plottable {
      * and returns a string representing the 'd' attribute of the resultant 'path' element
      */
     type SymbolFactory = (symbolSize: number) => string;
-    module SymbolFactories {
-        function circle(): SymbolFactory;
-        function square(): SymbolFactory;
-        function cross(): SymbolFactory;
-        function diamond(): SymbolFactory;
-        function triangleUp(): SymbolFactory;
-        function triangleDown(): SymbolFactory;
+}
+declare module Plottable.SymbolFactories {
+    function circle(): SymbolFactory;
+    function square(): SymbolFactory;
+    function cross(): SymbolFactory;
+    function diamond(): SymbolFactory;
+    function triangleUp(): SymbolFactory;
+    function triangleDown(): SymbolFactory;
+}
+declare module Plottable.Scales {
+    /**
+     * A function that supplies domain values to be included into a Scale.
+     *
+     * @param {Scale} scale
+     * @returns {D[]} An array of values that should be included in the Scale.
+     */
+    interface IncludedValuesProvider<D> {
+        (scale: Scale<D, any>): D[];
+    }
+    /**
+     * A function that supplies padding exception values for the Scale.
+     * If one end of the domain is set to an excepted value as a result of autoDomain()-ing,
+     * that end of the domain will not be padded.
+     *
+     * @param {QuantitativeScale} scale
+     * @returns {D[]} An array of values that should not be padded.
+     */
+    interface PaddingExceptionsProvider<D> {
+        (scale: QuantitativeScale<D>): D[];
     }
 }
 declare module Plottable {
     interface ScaleCallback<S extends Scale<any, any>> {
         (scale: S): any;
-    }
-    module Scales {
-        /**
-         * A function that supplies domain values to be included into a Scale.
-         *
-         * @param {Scale} scale
-         * @returns {D[]} An array of values that should be included in the Scale.
-         */
-        interface IncludedValuesProvider<D> {
-            (scale: Scale<D, any>): D[];
-        }
-        /**
-         * A function that supplies padding exception values for the Scale.
-         * If one end of the domain is set to an excepted value as a result of autoDomain()-ing,
-         * that end of the domain will not be padded.
-         *
-         * @param {QuantitativeScale} scale
-         * @returns {D[]} An array of values that should not be padded.
-         */
-        interface PaddingExceptionsProvider<D> {
-            (scale: QuantitativeScale<D>): D[];
-        }
     }
     class Scale<D, R> {
         private _callbacks;
@@ -946,315 +908,299 @@ declare module Plottable {
         tickGenerator(generator: Scales.TickGenerators.TickGenerator<D>): QuantitativeScale<D>;
     }
 }
-declare module Plottable {
-    module Scales {
-        class Linear extends QuantitativeScale<number> {
-            private _d3Scale;
-            /**
-             * @constructor
-             */
-            constructor();
-            protected _defaultExtent(): number[];
-            protected _expandSingleValueDomain(singleValueDomain: number[]): number[];
-            scale(value: number): number;
-            protected _getDomain(): number[];
-            protected _setBackingScaleDomain(values: number[]): void;
-            protected _getRange(): number[];
-            protected _setRange(values: number[]): void;
-            invert(value: number): number;
-            defaultTicks(): number[];
-            protected _niceDomain(domain: number[], count?: number): number[];
-        }
+declare module Plottable.Scales {
+    class Linear extends QuantitativeScale<number> {
+        private _d3Scale;
+        /**
+         * @constructor
+         */
+        constructor();
+        protected _defaultExtent(): number[];
+        protected _expandSingleValueDomain(singleValueDomain: number[]): number[];
+        scale(value: number): number;
+        protected _getDomain(): number[];
+        protected _setBackingScaleDomain(values: number[]): void;
+        protected _getRange(): number[];
+        protected _setRange(values: number[]): void;
+        invert(value: number): number;
+        defaultTicks(): number[];
+        protected _niceDomain(domain: number[], count?: number): number[];
     }
 }
-declare module Plottable {
-    module Scales {
-        class ModifiedLog extends QuantitativeScale<number> {
-            private _base;
-            private _d3Scale;
-            private _pivot;
-            private _untransformedDomain;
-            /**
-             * A ModifiedLog Scale acts as a regular log scale for large numbers.
-             * As it approaches 0, it gradually becomes linear.
-             * Consequently, a ModifiedLog Scale can process 0 and negative numbers.
-             *
-             * @constructor
-             * @param {number} [base=10]
-             *        The base of the log. Must be > 1.
-             *
-             *        For x <= base, scale(x) = log(x).
-             *
-             *        For 0 < x < base, scale(x) will become more and more
-             *        linear as it approaches 0.
-             *
-             *        At x == 0, scale(x) == 0.
-             *
-             *        For negative values, scale(-x) = -scale(x).
-             */
-            constructor(base?: number);
-            /**
-             * Returns an adjusted log10 value for graphing purposes.  The first
-             * adjustment is that negative values are changed to positive during
-             * the calculations, and then the answer is negated at the end.  The
-             * second is that, for values less than 10, an increasingly large
-             * (0 to 1) scaling factor is added such that at 0 the value is
-             * adjusted to 1, resulting in a returned result of 0.
-             */
-            private _adjustedLog(x);
-            private _invertedAdjustedLog(x);
-            scale(x: number): number;
-            invert(x: number): number;
-            protected _getDomain(): number[];
-            protected _setDomain(values: number[]): void;
-            protected _setBackingScaleDomain(values: number[]): void;
-            ticks(): number[];
-            /**
-             * Return an appropriate number of ticks from lower to upper.
-             *
-             * This will first try to fit as many powers of this.base as it can from
-             * lower to upper.
-             *
-             * If it still has ticks after that, it will generate ticks in "clusters",
-             * e.g. [20, 30, ... 90, 100] would be a cluster, [200, 300, ... 900, 1000]
-             * would be another cluster.
-             *
-             * This function will generate clusters as large as it can while not
-             * drastically exceeding its number of ticks.
-             */
-            private _logTicks(lower, upper);
-            /**
-             * How many ticks does the range [lower, upper] deserve?
-             *
-             * e.g. if your domain was [10, 1000] and I asked _howManyTicks(10, 100),
-             * I would get 1/2 of the ticks. The range 10, 100 takes up 1/2 of the
-             * distance when plotted.
-             */
-            private _howManyTicks(lower, upper);
-            protected _niceDomain(domain: number[], count?: number): number[];
-            protected _defaultExtent(): number[];
-            protected _expandSingleValueDomain(singleValueDomain: number[]): number[];
-            protected _getRange(): number[];
-            protected _setRange(values: number[]): void;
-            defaultTicks(): number[];
-        }
+declare module Plottable.Scales {
+    class ModifiedLog extends QuantitativeScale<number> {
+        private _base;
+        private _d3Scale;
+        private _pivot;
+        private _untransformedDomain;
+        /**
+         * A ModifiedLog Scale acts as a regular log scale for large numbers.
+         * As it approaches 0, it gradually becomes linear.
+         * Consequently, a ModifiedLog Scale can process 0 and negative numbers.
+         *
+         * @constructor
+         * @param {number} [base=10]
+         *        The base of the log. Must be > 1.
+         *
+         *        For x <= base, scale(x) = log(x).
+         *
+         *        For 0 < x < base, scale(x) will become more and more
+         *        linear as it approaches 0.
+         *
+         *        At x == 0, scale(x) == 0.
+         *
+         *        For negative values, scale(-x) = -scale(x).
+         */
+        constructor(base?: number);
+        /**
+         * Returns an adjusted log10 value for graphing purposes.  The first
+         * adjustment is that negative values are changed to positive during
+         * the calculations, and then the answer is negated at the end.  The
+         * second is that, for values less than 10, an increasingly large
+         * (0 to 1) scaling factor is added such that at 0 the value is
+         * adjusted to 1, resulting in a returned result of 0.
+         */
+        private _adjustedLog(x);
+        private _invertedAdjustedLog(x);
+        scale(x: number): number;
+        invert(x: number): number;
+        protected _getDomain(): number[];
+        protected _setDomain(values: number[]): void;
+        protected _setBackingScaleDomain(values: number[]): void;
+        ticks(): number[];
+        /**
+         * Return an appropriate number of ticks from lower to upper.
+         *
+         * This will first try to fit as many powers of this.base as it can from
+         * lower to upper.
+         *
+         * If it still has ticks after that, it will generate ticks in "clusters",
+         * e.g. [20, 30, ... 90, 100] would be a cluster, [200, 300, ... 900, 1000]
+         * would be another cluster.
+         *
+         * This function will generate clusters as large as it can while not
+         * drastically exceeding its number of ticks.
+         */
+        private _logTicks(lower, upper);
+        /**
+         * How many ticks does the range [lower, upper] deserve?
+         *
+         * e.g. if your domain was [10, 1000] and I asked _howManyTicks(10, 100),
+         * I would get 1/2 of the ticks. The range 10, 100 takes up 1/2 of the
+         * distance when plotted.
+         */
+        private _howManyTicks(lower, upper);
+        protected _niceDomain(domain: number[], count?: number): number[];
+        protected _defaultExtent(): number[];
+        protected _expandSingleValueDomain(singleValueDomain: number[]): number[];
+        protected _getRange(): number[];
+        protected _setRange(values: number[]): void;
+        defaultTicks(): number[];
     }
 }
-declare module Plottable {
-    module Scales {
-        class Category extends Scale<string, number> {
-            private _d3Scale;
-            private _range;
-            private _innerPadding;
-            private _outerPadding;
-            /**
-             * A Category Scale maps strings to numbers.
-             *
-             * @constructor
-             */
-            constructor();
-            extentOfValues(values: string[]): string[];
-            protected _getExtent(): string[];
-            domain(): string[];
-            domain(values: string[]): Category;
-            protected _setDomain(values: string[]): void;
-            range(): [number, number];
-            range(values: [number, number]): Category;
-            private static _convertToPlottableInnerPadding(d3InnerPadding);
-            private static _convertToPlottableOuterPadding(d3OuterPadding, d3InnerPadding);
-            /**
-             * Returns the width of the range band.
-             *
-             * @returns {number} The range band width
-             */
-            rangeBand(): number;
-            /**
-             * Returns the step width of the scale.
-             *
-             * The step width is the pixel distance between adjacent values in the domain.
-             *
-             * @returns {number}
-             */
-            stepWidth(): number;
-            /**
-             * Gets the inner padding.
-             *
-             * The inner padding is defined as the padding in between bands on the scale,
-             * expressed as a multiple of the rangeBand().
-             *
-             * @returns {number}
-             */
-            innerPadding(): number;
-            /**
-             * Sets the inner padding.
-             *
-             * The inner padding is defined as the padding in between bands on the scale,
-             * expressed as a multiple of the rangeBand().
-             *
-             * @returns {Category} The calling Category Scale.
-             */
-            innerPadding(innerPadding: number): Category;
-            /**
-             * Gets the outer padding.
-             *
-             * The outer padding is the padding in between the outer bands and the edges of the range,
-             * expressed as a multiple of the rangeBand().
-             *
-             * @returns {number}
-             */
-            outerPadding(): number;
-            /**
-             * Sets the outer padding.
-             *
-             * The outer padding is the padding in between the outer bands and the edges of the range,
-             * expressed as a multiple of the rangeBand().
-             *
-             * @returns {Category} The calling Category Scale.
-             */
-            outerPadding(outerPadding: number): Category;
-            scale(value: string): number;
-            protected _getDomain(): string[];
-            protected _setBackingScaleDomain(values: string[]): void;
-            protected _getRange(): number[];
-            protected _setRange(values: number[]): void;
-        }
+declare module Plottable.Scales {
+    class Category extends Scale<string, number> {
+        private _d3Scale;
+        private _range;
+        private _innerPadding;
+        private _outerPadding;
+        /**
+         * A Category Scale maps strings to numbers.
+         *
+         * @constructor
+         */
+        constructor();
+        extentOfValues(values: string[]): string[];
+        protected _getExtent(): string[];
+        domain(): string[];
+        domain(values: string[]): Category;
+        protected _setDomain(values: string[]): void;
+        range(): [number, number];
+        range(values: [number, number]): Category;
+        private static _convertToPlottableInnerPadding(d3InnerPadding);
+        private static _convertToPlottableOuterPadding(d3OuterPadding, d3InnerPadding);
+        /**
+         * Returns the width of the range band.
+         *
+         * @returns {number} The range band width
+         */
+        rangeBand(): number;
+        /**
+         * Returns the step width of the scale.
+         *
+         * The step width is the pixel distance between adjacent values in the domain.
+         *
+         * @returns {number}
+         */
+        stepWidth(): number;
+        /**
+         * Gets the inner padding.
+         *
+         * The inner padding is defined as the padding in between bands on the scale,
+         * expressed as a multiple of the rangeBand().
+         *
+         * @returns {number}
+         */
+        innerPadding(): number;
+        /**
+         * Sets the inner padding.
+         *
+         * The inner padding is defined as the padding in between bands on the scale,
+         * expressed as a multiple of the rangeBand().
+         *
+         * @returns {Category} The calling Category Scale.
+         */
+        innerPadding(innerPadding: number): Category;
+        /**
+         * Gets the outer padding.
+         *
+         * The outer padding is the padding in between the outer bands and the edges of the range,
+         * expressed as a multiple of the rangeBand().
+         *
+         * @returns {number}
+         */
+        outerPadding(): number;
+        /**
+         * Sets the outer padding.
+         *
+         * The outer padding is the padding in between the outer bands and the edges of the range,
+         * expressed as a multiple of the rangeBand().
+         *
+         * @returns {Category} The calling Category Scale.
+         */
+        outerPadding(outerPadding: number): Category;
+        scale(value: string): number;
+        protected _getDomain(): string[];
+        protected _setBackingScaleDomain(values: string[]): void;
+        protected _getRange(): number[];
+        protected _setRange(values: number[]): void;
     }
 }
-declare module Plottable {
-    module Scales {
-        class Color extends Scale<string, string> {
-            private static _LOOP_LIGHTEN_FACTOR;
-            private static _MAXIMUM_COLORS_FROM_CSS;
-            private static _plottableColorCache;
-            private _d3Scale;
-            /**
-             * A Color Scale maps string values to color hex values expressed as a string.
-             *
-             * @constructor
-             * @param {string} [scaleType] One of "Category10"/"Category20"/"Category20b"/"Category20c".
-             *   (see https://github.com/mbostock/d3/wiki/Ordinal-Scales#categorical-colors)
-             *   If not supplied, reads the colors defined using CSS -- see plottable.css.
-             */
-            constructor(scaleType?: string);
-            extentOfValues(values: string[]): string[];
-            protected _getExtent(): string[];
-            static invalidateColorCache(): void;
-            private static _getPlottableColors();
-            /**
-             * Returns the color-string corresponding to a given string.
-             * If there are not enough colors in the range(), a lightened version of an existing color will be used.
-             *
-             * @param {string} value
-             * @returns {string}
-             */
-            scale(value: string): string;
-            protected _getDomain(): string[];
-            protected _setBackingScaleDomain(values: string[]): void;
-            protected _getRange(): string[];
-            protected _setRange(values: string[]): void;
-        }
+declare module Plottable.Scales {
+    class Color extends Scale<string, string> {
+        private static _LOOP_LIGHTEN_FACTOR;
+        private static _MAXIMUM_COLORS_FROM_CSS;
+        private static _plottableColorCache;
+        private _d3Scale;
+        /**
+         * A Color Scale maps string values to color hex values expressed as a string.
+         *
+         * @constructor
+         * @param {string} [scaleType] One of "Category10"/"Category20"/"Category20b"/"Category20c".
+         *   (see https://github.com/mbostock/d3/wiki/Ordinal-Scales#categorical-colors)
+         *   If not supplied, reads the colors defined using CSS -- see plottable.css.
+         */
+        constructor(scaleType?: string);
+        extentOfValues(values: string[]): string[];
+        protected _getExtent(): string[];
+        static invalidateColorCache(): void;
+        private static _getPlottableColors();
+        /**
+         * Returns the color-string corresponding to a given string.
+         * If there are not enough colors in the range(), a lightened version of an existing color will be used.
+         *
+         * @param {string} value
+         * @returns {string}
+         */
+        scale(value: string): string;
+        protected _getDomain(): string[];
+        protected _setBackingScaleDomain(values: string[]): void;
+        protected _getRange(): string[];
+        protected _setRange(values: string[]): void;
     }
 }
-declare module Plottable {
-    module Scales {
-        class Time extends QuantitativeScale<Date> {
-            private _d3Scale;
-            /**
-             * A Time Scale maps Date objects to numbers.
-             *
-             * @constructor
-             */
-            constructor();
-            /**
-             * Returns an array of ticks values separated by the specified interval.
-             *
-             * @param {string} interval A string specifying the interval unit.
-             * @param {number?} [step] The number of multiples of the interval between consecutive ticks.
-             * @return {Date[]}
-             */
-            tickInterval(interval: string, step?: number): Date[];
-            protected _setDomain(values: Date[]): void;
-            protected _defaultExtent(): Date[];
-            protected _expandSingleValueDomain(singleValueDomain: Date[]): Date[];
-            scale(value: Date): number;
-            protected _getDomain(): Date[];
-            protected _setBackingScaleDomain(values: Date[]): void;
-            protected _getRange(): number[];
-            protected _setRange(values: number[]): void;
-            invert(value: number): Date;
-            defaultTicks(): Date[];
-            protected _niceDomain(domain: Date[]): Date[];
-            /**
-             * Transforms the Plottable TimeInterval string into a d3 time interval equivalent.
-             * If the provided TimeInterval is incorrect, the default is d3.time.year
-             */
-            static timeIntervalToD3Time(timeInterval: string): d3.time.Interval;
-        }
+declare module Plottable.Scales {
+    class Time extends QuantitativeScale<Date> {
+        private _d3Scale;
+        /**
+         * A Time Scale maps Date objects to numbers.
+         *
+         * @constructor
+         */
+        constructor();
+        /**
+         * Returns an array of ticks values separated by the specified interval.
+         *
+         * @param {string} interval A string specifying the interval unit.
+         * @param {number?} [step] The number of multiples of the interval between consecutive ticks.
+         * @return {Date[]}
+         */
+        tickInterval(interval: string, step?: number): Date[];
+        protected _setDomain(values: Date[]): void;
+        protected _defaultExtent(): Date[];
+        protected _expandSingleValueDomain(singleValueDomain: Date[]): Date[];
+        scale(value: Date): number;
+        protected _getDomain(): Date[];
+        protected _setBackingScaleDomain(values: Date[]): void;
+        protected _getRange(): number[];
+        protected _setRange(values: number[]): void;
+        invert(value: number): Date;
+        defaultTicks(): Date[];
+        protected _niceDomain(domain: Date[]): Date[];
+        /**
+         * Transforms the Plottable TimeInterval string into a d3 time interval equivalent.
+         * If the provided TimeInterval is incorrect, the default is d3.time.year
+         */
+        static timeIntervalToD3Time(timeInterval: string): d3.time.Interval;
     }
 }
-declare module Plottable {
-    module Scales {
-        class InterpolatedColor extends Scale<number, string> {
-            static REDS: string[];
-            static BLUES: string[];
-            static POSNEG: string[];
-            private _colorRange;
-            private _colorScale;
-            private _d3Scale;
-            /**
-             * An InterpolatedColor Scale maps numbers to color hex values, expressed as strings.
-             *
-             * @param {string} [scaleType="linear"] One of "linear"/"log"/"sqrt"/"pow".
-             */
-            constructor(scaleType?: string);
-            extentOfValues(values: number[]): number[];
-            /**
-             * Generates the converted QuantitativeScale.
-             */
-            private _d3InterpolatedScale();
-            /**
-             * Generates the d3 interpolator for colors.
-             */
-            private _interpolateColors();
-            private _resetScale();
-            autoDomain(): InterpolatedColor;
-            scale(value: number): string;
-            protected _getDomain(): number[];
-            protected _setBackingScaleDomain(values: number[]): void;
-            protected _getRange(): string[];
-            protected _setRange(range: string[]): void;
-        }
+declare module Plottable.Scales {
+    class InterpolatedColor extends Scale<number, string> {
+        static REDS: string[];
+        static BLUES: string[];
+        static POSNEG: string[];
+        private _colorRange;
+        private _colorScale;
+        private _d3Scale;
+        /**
+         * An InterpolatedColor Scale maps numbers to color hex values, expressed as strings.
+         *
+         * @param {string} [scaleType="linear"] One of "linear"/"log"/"sqrt"/"pow".
+         */
+        constructor(scaleType?: string);
+        extentOfValues(values: number[]): number[];
+        /**
+         * Generates the converted QuantitativeScale.
+         */
+        private _d3InterpolatedScale();
+        /**
+         * Generates the d3 interpolator for colors.
+         */
+        private _interpolateColors();
+        private _resetScale();
+        autoDomain(): InterpolatedColor;
+        scale(value: number): string;
+        protected _getDomain(): number[];
+        protected _setBackingScaleDomain(values: number[]): void;
+        protected _getRange(): string[];
+        protected _setRange(range: string[]): void;
     }
 }
-declare module Plottable {
-    module Scales {
-        module TickGenerators {
-            /**
-             * Generates an array of tick values for the specified scale.
-             *
-             * @param {QuantitativeScale} scale
-             * @returns {D[]}
-             */
-            interface TickGenerator<D> {
-                (scale: Plottable.QuantitativeScale<D>): D[];
-            }
-            /**
-             * Creates a TickGenerator using the specified interval.
-             *
-             * Generates ticks at multiples of the interval while also including the domain boundaries.
-             *
-             * @param {number} interval
-             * @returns {TickGenerator}
-             */
-            function intervalTickGenerator(interval: number): TickGenerator<number>;
-            /**
-             * Creates a TickGenerator returns only integer tick values.
-             *
-             * @returns {TickGenerator}
-             */
-            function integerTickGenerator(): TickGenerator<number>;
-        }
+declare module Plottable.Scales.TickGenerators {
+    /**
+     * Generates an array of tick values for the specified scale.
+     *
+     * @param {QuantitativeScale} scale
+     * @returns {D[]}
+     */
+    interface TickGenerator<D> {
+        (scale: Plottable.QuantitativeScale<D>): D[];
     }
+    /**
+     * Creates a TickGenerator using the specified interval.
+     *
+     * Generates ticks at multiples of the interval while also including the domain boundaries.
+     *
+     * @param {number} interval
+     * @returns {TickGenerator}
+     */
+    function intervalTickGenerator(interval: number): TickGenerator<number>;
+    /**
+     * Creates a TickGenerator returns only integer tick values.
+     *
+     * @returns {TickGenerator}
+     */
+    function integerTickGenerator(): TickGenerator<number>;
 }
 declare module Plottable {
     module Drawers {
@@ -1344,59 +1290,45 @@ declare module Plottable {
         selectionForIndex(index: number): d3.Selection<any>;
     }
 }
-declare module Plottable {
-    module Drawers {
-        class Line extends Drawer {
-            constructor(dataset: Dataset);
-            protected _applyDefaultAttributes(selection: d3.Selection<any>): void;
-            selectionForIndex(index: number): d3.Selection<any>;
-        }
+declare module Plottable.Drawers {
+    class Line extends Drawer {
+        constructor(dataset: Dataset);
+        protected _applyDefaultAttributes(selection: d3.Selection<any>): void;
+        selectionForIndex(index: number): d3.Selection<any>;
     }
 }
-declare module Plottable {
-    module Drawers {
-        class Area extends Drawer {
-            constructor(dataset: Dataset);
-            protected _applyDefaultAttributes(selection: d3.Selection<any>): void;
-            selectionForIndex(index: number): d3.Selection<any>;
-        }
+declare module Plottable.Drawers {
+    class Area extends Drawer {
+        constructor(dataset: Dataset);
+        protected _applyDefaultAttributes(selection: d3.Selection<any>): void;
+        selectionForIndex(index: number): d3.Selection<any>;
     }
 }
-declare module Plottable {
-    module Drawers {
-        class Rectangle extends Drawer {
-            constructor(dataset: Dataset);
-        }
+declare module Plottable.Drawers {
+    class Rectangle extends Drawer {
+        constructor(dataset: Dataset);
     }
 }
-declare module Plottable {
-    module Drawers {
-        class Arc extends Drawer {
-            constructor(dataset: Dataset);
-            protected _applyDefaultAttributes(selection: d3.Selection<any>): void;
-        }
+declare module Plottable.Drawers {
+    class Arc extends Drawer {
+        constructor(dataset: Dataset);
+        protected _applyDefaultAttributes(selection: d3.Selection<any>): void;
     }
 }
-declare module Plottable {
-    module Drawers {
-        class ArcOutline extends Drawer {
-            constructor(dataset: Dataset);
-            protected _applyDefaultAttributes(selection: d3.Selection<any>): void;
-        }
+declare module Plottable.Drawers {
+    class ArcOutline extends Drawer {
+        constructor(dataset: Dataset);
+        protected _applyDefaultAttributes(selection: d3.Selection<any>): void;
     }
 }
-declare module Plottable {
-    module Drawers {
-        class Symbol extends Drawer {
-            constructor(dataset: Dataset);
-        }
+declare module Plottable.Drawers {
+    class Symbol extends Drawer {
+        constructor(dataset: Dataset);
     }
 }
-declare module Plottable {
-    module Drawers {
-        class Segment extends Drawer {
-            constructor(dataset: Dataset);
-        }
+declare module Plottable.Drawers {
+    class Segment extends Drawer {
+        constructor(dataset: Dataset);
     }
 }
 declare module Plottable {
@@ -1687,44 +1619,42 @@ declare module Plottable {
         destroy(): void;
     }
 }
-declare module Plottable {
-    module Components {
-        class Group extends ComponentContainer {
-            private _components;
-            /**
-             * Constructs a Group.
-             *
-             * A Group contains Components that will be rendered on top of each other.
-             * Components added later will be rendered above Components already in the Group.
-             *
-             * @constructor
-             * @param {Component[]} [components=[]] Components to be added to the Group.
-             */
-            constructor(components?: Component[]);
-            protected _forEach(callback: (component: Component) => any): void;
-            /**
-             * Checks whether the specified Component is in the Group.
-             */
-            has(component: Component): boolean;
-            requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
-            computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Group;
-            protected _sizeFromOffer(availableWidth: number, availableHeight: number): {
-                width: number;
-                height: number;
-            };
-            fixedWidth(): boolean;
-            fixedHeight(): boolean;
-            /**
-             * @return {Component[]} The Components in this Group.
-             */
-            components(): Component[];
-            /**
-             * Adds a Component to this Group.
-             * The added Component will be rendered above Components already in the Group.
-             */
-            append(component: Component): Group;
-            protected _remove(component: Component): boolean;
-        }
+declare module Plottable.Components {
+    class Group extends ComponentContainer {
+        private _components;
+        /**
+         * Constructs a Group.
+         *
+         * A Group contains Components that will be rendered on top of each other.
+         * Components added later will be rendered above Components already in the Group.
+         *
+         * @constructor
+         * @param {Component[]} [components=[]] Components to be added to the Group.
+         */
+        constructor(components?: Component[]);
+        protected _forEach(callback: (component: Component) => any): void;
+        /**
+         * Checks whether the specified Component is in the Group.
+         */
+        has(component: Component): boolean;
+        requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
+        computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Group;
+        protected _sizeFromOffer(availableWidth: number, availableHeight: number): {
+            width: number;
+            height: number;
+        };
+        fixedWidth(): boolean;
+        fixedHeight(): boolean;
+        /**
+         * @return {Component[]} The Components in this Group.
+         */
+        components(): Component[];
+        /**
+         * Adds a Component to this Group.
+         * The added Component will be rendered above Components already in the Group.
+         */
+        append(component: Component): Group;
+        protected _remove(component: Component): boolean;
     }
 }
 declare module Plottable {
@@ -1967,886 +1897,868 @@ declare module Plottable {
         var month: string;
         var year: string;
     }
-    module Axes {
+}
+declare module Plottable.Axes {
+    /**
+     * Defines a configuration for a Time Axis tier.
+     * For details on how ticks are generated see: https://github.com/mbostock/d3/wiki/Time-Scales#ticks
+     * interval - A time unit associated with this configuration (seconds, minutes, hours, etc).
+     * step - number of intervals between each tick.
+     * formatter - formatter used to format tick labels.
+     */
+    type TimeAxisTierConfiguration = {
+        interval: string;
+        step: number;
+        formatter: Formatter;
+    };
+    /**
+     * An array of linked TimeAxisTierConfigurations.
+     * Each configuration will be shown on a different tier.
+     * Currently, up to two tiers are supported.
+     */
+    type TimeAxisConfiguration = TimeAxisTierConfiguration[];
+    class Time extends Axis<Date> {
         /**
-         * Defines a configuration for a Time Axis tier.
-         * For details on how ticks are generated see: https://github.com/mbostock/d3/wiki/Time-Scales#ticks
-         * interval - A time unit associated with this configuration (seconds, minutes, hours, etc).
-         * step - number of intervals between each tick.
-         * formatter - formatter used to format tick labels.
+         * The CSS class applied to each Time Axis tier
          */
-        type TimeAxisTierConfiguration = {
-            interval: string;
-            step: number;
-            formatter: Formatter;
+        static TIME_AXIS_TIER_CLASS: string;
+        private static _DEFAULT_TIME_AXIS_CONFIGURATIONS;
+        private _tierLabelContainers;
+        private _tierMarkContainers;
+        private _tierBaselines;
+        private _tierHeights;
+        private _possibleTimeAxisConfigurations;
+        private _numTiers;
+        private _measurer;
+        private _mostPreciseConfigIndex;
+        private _tierLabelPositions;
+        private static _LONG_DATE;
+        /**
+         * Constructs a Time Axis.
+         *
+         * A Time Axis is a visual representation of a Time Scale.
+         *
+         * @constructor
+         * @param {Scales.Time} scale
+         * @param {string} orientation One of "top"/"bottom".
+         */
+        constructor(scale: Scales.Time, orientation: string);
+        /**
+         * Gets the label positions for each tier.
+         */
+        tierLabelPositions(): string[];
+        /**
+         * Sets the label positions for each tier.
+         *
+         * @param {string[]} newPositions The positions for each tier. "bottom" and "center" are the only supported values.
+         * @returns {Axes.Time} The calling Time Axis.
+         */
+        tierLabelPositions(newPositions: string[]): Time;
+        /**
+         * Gets the possible TimeAxisConfigurations.
+         */
+        axisConfigurations(): TimeAxisConfiguration[];
+        /**
+         * Sets the possible TimeAxisConfigurations.
+         * The Time Axis will choose the most precise configuration that will display in the available space.
+         *
+         * @param {TimeAxisConfiguration[]} configurations
+         * @returns {Axes.Time} The calling Time Axis.
+         */
+        axisConfigurations(configurations: TimeAxisConfiguration[]): Time;
+        /**
+         * Gets the index of the most precise TimeAxisConfiguration that will fit in the current width.
+         */
+        private _getMostPreciseConfigurationIndex();
+        orientation(): string;
+        orientation(orientation: string): Time;
+        protected _computeHeight(): number;
+        private _getIntervalLength(config);
+        private _maxWidthForInterval(config);
+        /**
+         * Check if tier configuration fits in the current width.
+         */
+        private _checkTimeAxisTierConfigurationWidth(config);
+        protected _sizeFromOffer(availableWidth: number, availableHeight: number): {
+            width: number;
+            height: number;
+        };
+        protected _setup(): void;
+        private _setupDomElements();
+        private _getTickIntervalValues(config);
+        protected _getTickValues(): any[];
+        private _cleanTiers();
+        private _getTickValuesForConfiguration(config);
+        private _renderTierLabels(container, config, index);
+        private _renderTickMarks(tickValues, index);
+        private _renderLabellessTickMarks(tickValues);
+        private _generateLabellessTicks();
+        renderImmediately(): Time;
+        private _hideOverflowingTiers();
+        private _hideOverlappingAndCutOffLabels(index);
+    }
+}
+declare module Plottable.Axes {
+    class Numeric extends Axis<number> {
+        private _tickLabelPositioning;
+        private _usesTextWidthApproximation;
+        private _measurer;
+        private _wrapper;
+        /**
+         * Constructs a Numeric Axis.
+         *
+         * A Numeric Axis is a visual representation of a QuantitativeScale.
+         *
+         * @constructor
+         * @param {QuantitativeScale} scale
+         * @param {string} orientation One of "top"/"bottom"/"left"/"right".
+         */
+        constructor(scale: QuantitativeScale<number>, orientation: string);
+        protected _setup(): void;
+        protected _computeWidth(): number;
+        private _computeExactTextWidth();
+        private _computeApproximateTextWidth();
+        protected _computeHeight(): number;
+        protected _getTickValues(): number[];
+        protected _rescale(): void;
+        renderImmediately(): Numeric;
+        private _showAllTickMarks();
+        /**
+         * Hides the Tick Marks which have no corresponding Tick Labels
+         */
+        private _hideTickMarksWithoutLabel();
+        /**
+         * Gets the tick label position relative to the tick marks.
+         *
+         * @returns {string} The current tick label position.
+         */
+        tickLabelPosition(): string;
+        /**
+         * Sets the tick label position relative to the tick marks.
+         *
+         * @param {string} position "top"/"center"/"bottom" for a vertical Numeric Axis,
+         *                          "left"/"center"/"right" for a horizontal Numeric Axis.
+         * @returns {Numeric} The calling Numeric Axis.
+         */
+        tickLabelPosition(position: string): Numeric;
+        /**
+         * Gets the approximate text width setting.
+         *
+         * @returns {boolean} The current text width approximation setting.
+         */
+        usesTextWidthApproximation(): boolean;
+        /**
+         * Sets the approximate text width setting. Approximating text width
+         * measurements can drastically speed up plot rendering, but the plot may
+         * have extra white space that would be eliminated by exact measurements.
+         * Additionally, very abnormal fonts may not approximate reasonably.
+         *
+         * @param {boolean} The new text width approximation setting.
+         * @returns {Axes.Numeric} The calling Axes.Numeric.
+         */
+        usesTextWidthApproximation(enable: boolean): Axes.Numeric;
+        private _hideEndTickLabels();
+        private _hideOverflowingTickLabels();
+        private _hideOverlappingTickLabels();
+        /**
+         * The method is responsible for evenly spacing the labels on the axis.
+         * @return test to see if taking every `interval` recrangle from `rects`
+         *         will result in labels not overlapping
+         *
+         * For top, bottom, left, right positioning of the thicks, we want the padding
+         * between the labels to be 3x, such that the label will be  `padding` distance
+         * from the tick and 2 * `padding` distance (or more) from the next tick
+         *
+         */
+        private _hasOverlapWithInterval(interval, rects);
+    }
+}
+declare module Plottable.Axes {
+    class Category extends Axis<string> {
+        private _tickLabelAngle;
+        private _measurer;
+        private _wrapper;
+        private _writer;
+        /**
+         * Constructs a Category Axis.
+         *
+         * A Category Axis is a visual representation of a Category Scale.
+         *
+         * @constructor
+         * @param {Scales.Category} scale
+         * @param {string} [orientation="bottom"] One of "top"/"bottom"/"left"/"right".
+         */
+        constructor(scale: Scales.Category, orientation: string);
+        protected _setup(): void;
+        protected _rescale(): Component;
+        requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
+        protected _coreSize(): number;
+        protected _getTickValues(): string[];
+        /**
+         * Gets the tick label angle in degrees.
+         */
+        tickLabelAngle(): number;
+        /**
+         * Sets the tick label angle in degrees.
+         * Right now only -90/0/90 are supported. 0 is horizontal.
+         *
+         * @param {number} angle
+         * @returns {Category} The calling Category Axis.
+         */
+        tickLabelAngle(angle: number): Category;
+        /**
+         * Measures the size of the ticks while also writing them to the DOM.
+         * @param {d3.Selection} ticks The tick elements to be written to.
+         */
+        private _drawTicks(axisWidth, axisHeight, scale, ticks);
+        /**
+         * Measures the size of the ticks without making any (permanent) DOM
+         * changes.
+         *
+         * @param {string[]} ticks The strings that will be printed on the ticks.
+         */
+        private _measureTicks(axisWidth, axisHeight, scale, ticks);
+        renderImmediately(): Category;
+        computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Category;
+    }
+}
+declare module Plottable.Components {
+    class Label extends Component {
+        private _textContainer;
+        private _text;
+        private _angle;
+        private _measurer;
+        private _wrapper;
+        private _writer;
+        private _padding;
+        /**
+         * A Label is a Component that displays a single line of text.
+         *
+         * @constructor
+         * @param {string} [displayText=""] The text of the Label.
+         * @param {number} [angle=0] The angle of the Label in degrees (-90/0/90). 0 is horizontal.
+         */
+        constructor(displayText?: string, angle?: number);
+        requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
+        protected _setup(): void;
+        /**
+         * Gets the Label's text.
+         */
+        text(): string;
+        /**
+         * Sets the Label's text.
+         *
+         * @param {string} displayText
+         * @returns {Label} The calling Label.
+         */
+        text(displayText: string): Label;
+        /**
+         * Gets the angle of the Label in degrees.
+         */
+        angle(): number;
+        /**
+         * Sets the angle of the Label in degrees.
+         *
+         * @param {number} angle One of -90/0/90. 0 is horizontal.
+         * @returns {Label} The calling Label.
+         */
+        angle(angle: number): Label;
+        /**
+         * Gets the amount of padding around the Label in pixels.
+         */
+        padding(): number;
+        /**
+         * Sets the amount of padding around the Label in pixels.
+         *
+         * @param {number} padAmount
+         * @returns {Label} The calling Label.
+         */
+        padding(padAmount: number): Label;
+        fixedWidth(): boolean;
+        fixedHeight(): boolean;
+        renderImmediately(): Label;
+    }
+    class TitleLabel extends Label {
+        static TITLE_LABEL_CLASS: string;
+        /**
+         * @constructor
+         * @param {string} [text]
+         * @param {number} [angle] One of -90/0/90. 0 is horizontal.
+         */
+        constructor(text?: string, angle?: number);
+    }
+    class AxisLabel extends Label {
+        static AXIS_LABEL_CLASS: string;
+        /**
+         * @constructor
+         * @param {string} [text]
+         * @param {number} [angle] One of -90/0/90. 0 is horizontal.
+         */
+        constructor(text?: string, angle?: number);
+    }
+}
+declare module Plottable.Components {
+    class Legend extends Component {
+        /**
+         * The css class applied to each legend row
+         */
+        static LEGEND_ROW_CLASS: string;
+        /**
+         * The css class applied to each legend entry
+         */
+        static LEGEND_ENTRY_CLASS: string;
+        /**
+         * The css class applied to each legend symbol
+         */
+        static LEGEND_SYMBOL_CLASS: string;
+        private _padding;
+        private _colorScale;
+        private _formatter;
+        private _maxEntriesPerRow;
+        private _comparator;
+        private _measurer;
+        private _wrapper;
+        private _writer;
+        private _symbolFactoryAccessor;
+        private _symbolOpacityAccessor;
+        private _redrawCallback;
+        /**
+         * The Legend consists of a series of entries, each with a color and label taken from the Color Scale.
+         *
+         * @constructor
+         * @param {Scale.Color} scale
+         */
+        constructor(colorScale: Scales.Color);
+        protected _setup(): void;
+        /**
+         * Gets the Formatter for the entry texts.
+         */
+        formatter(): Formatter;
+        /**
+         * Sets the Formatter for the entry texts.
+         *
+         * @param {Formatter} formatter
+         * @returns {Legend} The calling Legend.
+         */
+        formatter(formatter: Formatter): Legend;
+        /**
+         * Gets the maximum number of entries per row.
+         *
+         * @returns {number}
+         */
+        maxEntriesPerRow(): number;
+        /**
+         * Sets the maximum number of entries perrow.
+         *
+         * @param {number} maxEntriesPerRow
+         * @returns {Legend} The calling Legend.
+         */
+        maxEntriesPerRow(maxEntriesPerRow: number): Legend;
+        /**
+         * Gets the current comparator for the Legend's entries.
+         *
+         * @returns {(a: string, b: string) => number}
+         */
+        comparator(): (a: string, b: string) => number;
+        /**
+         * Sets a new comparator for the Legend's entries.
+         * The comparator is used to set the display order of the entries.
+         *
+         * @param {(a: string, b: string) => number} comparator
+         * @returns {Legend} The calling Legend.
+         */
+        comparator(comparator: (a: string, b: string) => number): Legend;
+        /**
+         * Gets the Color Scale.
+         *
+         * @returns {Scales.Color}
+         */
+        colorScale(): Scales.Color;
+        /**
+         * Sets the Color Scale.
+         *
+         * @param {Scales.Color} scale
+         * @returns {Legend} The calling Legend.
+         */
+        colorScale(colorScale: Scales.Color): Legend;
+        destroy(): void;
+        private _calculateLayoutInfo(availableWidth, availableHeight);
+        requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
+        private _packRows(availableWidth, entries, entryLengths);
+        /**
+         * Gets the Entities (representing Legend entries) at a particular point.
+         * Returns an empty array if no Entities are present at that location.
+         *
+         * @param {Point} p
+         * @returns {Entity<Legend>[]}
+         */
+        entitiesAt(p: Point): Entity<Legend>[];
+        renderImmediately(): Legend;
+        /**
+         * Gets the function determining the symbols of the Legend.
+         *
+         * @returns {(datum: any, index: number) => symbolFactory}
+         */
+        symbol(): (datum: any, index: number) => SymbolFactory;
+        /**
+         * Sets the function determining the symbols of the Legend.
+         *
+         * @param {(datum: any, index: number) => SymbolFactory} symbol
+         * @returns {Legend} The calling Legend
+         */
+        symbol(symbol: (datum: any, index: number) => SymbolFactory): Legend;
+        /**
+         * Gets the opacity of the symbols of the Legend.
+         *
+         * @returns {(datum: any, index: number) => number}
+         */
+        symbolOpacity(): (datum: any, index: number) => number;
+        /**
+         * Sets the opacity of the symbols of the Legend.
+         *
+         * @param {number | ((datum: any, index: number) => number)} symbolOpacity
+         * @returns {Legend} The calling Legend
+         */
+        symbolOpacity(symbolOpacity: number | ((datum: any, index: number) => number)): Legend;
+        fixedWidth(): boolean;
+        fixedHeight(): boolean;
+    }
+}
+declare module Plottable.Components {
+    class InterpolatedColorLegend extends Component {
+        private static _DEFAULT_NUM_SWATCHES;
+        private _measurer;
+        private _wrapper;
+        private _writer;
+        private _scale;
+        private _orientation;
+        private _textPadding;
+        private _formatter;
+        private _expands;
+        private _swatchContainer;
+        private _swatchBoundingBox;
+        private _lowerLabel;
+        private _upperLabel;
+        private _redrawCallback;
+        /**
+         * The css class applied to the legend labels.
+         */
+        static LEGEND_LABEL_CLASS: string;
+        /**
+         * Creates an InterpolatedColorLegend.
+         *
+         * The InterpolatedColorLegend consists of a sequence of swatches that show the
+         * associated InterpolatedColor Scale sampled at various points.
+         * Two labels show the maximum and minimum values of the InterpolatedColor Scale.
+         *
+         * @constructor
+         * @param {Scales.InterpolatedColor} interpolatedColorScale
+         */
+        constructor(interpolatedColorScale: Scales.InterpolatedColor);
+        destroy(): void;
+        /**
+         * Gets the Formatter for the labels.
+         */
+        formatter(): Formatter;
+        /**
+         * Sets the Formatter for the labels.
+         *
+         * @param {Formatter} formatter
+         * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
+         */
+        formatter(formatter: Formatter): InterpolatedColorLegend;
+        /**
+         * Gets whether the InterpolatedColorLegend expands to occupy all offered space in the long direction
+         */
+        expands(): boolean;
+        /**
+         * Sets whether the InterpolatedColorLegend expands to occupy all offered space in the long direction
+         *
+         * @param {expands} boolean
+         * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
+         */
+        expands(expands: boolean): InterpolatedColorLegend;
+        private static _ensureOrientation(orientation);
+        /**
+         * Gets the orientation.
+         */
+        orientation(): string;
+        /**
+         * Sets the orientation.
+         *
+         * @param {string} orientation One of "horizontal"/"left"/"right".
+         * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
+         */
+        orientation(orientation: string): InterpolatedColorLegend;
+        fixedWidth(): boolean;
+        fixedHeight(): boolean;
+        private _generateTicks(numSwatches?);
+        protected _setup(): void;
+        requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
+        private _isVertical();
+        renderImmediately(): InterpolatedColorLegend;
+    }
+}
+declare module Plottable.Components {
+    class Gridlines extends Component {
+        private _xScale;
+        private _yScale;
+        private _xLinesContainer;
+        private _yLinesContainer;
+        private _renderCallback;
+        /**
+         * @constructor
+         * @param {QuantitativeScale} xScale The scale to base the x gridlines on. Pass null if no gridlines are desired.
+         * @param {QuantitativeScale} yScale The scale to base the y gridlines on. Pass null if no gridlines are desired.
+         */
+        constructor(xScale: QuantitativeScale<any>, yScale: QuantitativeScale<any>);
+        destroy(): Gridlines;
+        protected _setup(): void;
+        renderImmediately(): Gridlines;
+        computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Gridlines;
+        private _redrawXLines();
+        private _redrawYLines();
+    }
+}
+declare module Plottable.Components {
+    class Table extends ComponentContainer {
+        private _rowPadding;
+        private _columnPadding;
+        private _rows;
+        private _rowWeights;
+        private _columnWeights;
+        private _nRows;
+        private _nCols;
+        private _calculatedLayout;
+        /**
+         * A Table combines Components in the form of a grid. A
+         * common case is combining a y-axis, x-axis, and the plotted data via
+         * ```typescript
+         * new Table([[yAxis, plot],
+         *            [null,  xAxis]]);
+         * ```
+         *
+         * @constructor
+         * @param {Component[][]} [rows=[]] A 2-D array of Components to be added to the Table.
+         *   null can be used if a cell is empty.
+         */
+        constructor(rows?: Component[][]);
+        protected _forEach(callback: (component: Component) => any): void;
+        /**
+         * Checks whether the specified Component is in the Table.
+         */
+        has(component: Component): boolean;
+        /**
+         * Returns the Component at the specified row and column index.
+         *
+         * @param {number} rowIndex
+         * @param {number} columnIndex
+         * @returns {Component} The Component at the specified position, or null if no Component is there.
+         */
+        componentAt(rowIndex: number, columnIndex: number): Component;
+        /**
+         * Adds a Component in the specified row and column position.
+         *
+         * For example, instead of calling `new Table([[a, b], [null, c]])`, you
+         * could call
+         * var table = new Plottable.Components.Table();
+         * table.add(a, 0, 0);
+         * table.add(b, 0, 1);
+         * table.add(c, 1, 1);
+         *
+         * @param {Component} component The Component to be added.
+         * @param {number} row
+         * @param {number} col
+         * @returns {Table} The calling Table.
+         */
+        add(component: Component, row: number, col: number): Table;
+        protected _remove(component: Component): boolean;
+        private _iterateLayout(availableWidth, availableHeight, isFinalOffer?);
+        private _determineGuarantees(offeredWidths, offeredHeights, isFinalOffer?);
+        requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
+        computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Table;
+        /**
+         * Gets the padding above and below each row in pixels.
+         */
+        rowPadding(): number;
+        /**
+         * Sets the padding above and below each row in pixels.
+         *
+         * @param {number} rowPadding
+         * @returns {Table} The calling Table.
+         */
+        rowPadding(rowPadding: number): Table;
+        /**
+         * Gets the padding to the left and right of each column in pixels.
+         */
+        columnPadding(): number;
+        /**
+         * Sets the padding to the left and right of each column in pixels.
+         *
+         * @param {number} columnPadding
+         * @returns {Table} The calling Table.
+         */
+        columnPadding(columnPadding: number): Table;
+        /**
+         * Gets the weight of the specified row.
+         *
+         * @param {number} index
+         */
+        rowWeight(index: number): number;
+        /**
+         * Sets the weight of the specified row.
+         * Space is allocated to rows based on their weight. Rows with higher weights receive proportionally more space.
+         *
+         * A common case would be to have one row take up 2/3rds of the space,
+         * and the other row take up 1/3rd.
+         *
+         * Example:
+         *
+         * ```JavaScript
+         * plot = new Plottable.Component.Table([
+         *  [row1],
+         *  [row2]
+         * ]);
+         *
+         * // assign twice as much space to the first row
+         * plot
+         *  .rowWeight(0, 2)
+         *  .rowWeight(1, 1)
+         * ```
+         *
+         * @param {number} index
+         * @param {number} weight
+         * @returns {Table} The calling Table.
+         */
+        rowWeight(index: number, weight: number): Table;
+        /**
+         * Gets the weight of the specified column.
+         *
+         * @param {number} index
+         */
+        columnWeight(index: number): number;
+        /**
+         * Sets the weight of the specified column.
+         * Space is allocated to columns based on their weight. Columns with higher weights receive proportionally more space.
+         *
+         * Please see `rowWeight` docs for an example.
+         *
+         * @param {number} index
+         * @param {number} weight
+         * @returns {Table} The calling Table.
+         */
+        columnWeight(index: number, weight: number): Table;
+        fixedWidth(): boolean;
+        fixedHeight(): boolean;
+        private _padTableToSize(nRows, nCols);
+        private static _calcComponentWeights(setWeights, componentGroups, fixityAccessor);
+        private static _calcProportionalSpace(weights, freeSpace);
+        private static _fixedSpace(componentGroup, fixityAccessor);
+    }
+}
+declare module Plottable.Components {
+    enum PropertyMode {
+        VALUE = 0,
+        PIXEL = 1,
+    }
+    class SelectionBoxLayer extends Component {
+        protected _box: d3.Selection<void>;
+        private _boxArea;
+        private _boxVisible;
+        private _boxBounds;
+        private _xExtent;
+        private _yExtent;
+        private _xScale;
+        private _yScale;
+        private _adjustBoundsCallback;
+        protected _xBoundsMode: PropertyMode;
+        protected _yBoundsMode: PropertyMode;
+        constructor();
+        protected _setup(): void;
+        protected _sizeFromOffer(availableWidth: number, availableHeight: number): {
+            width: number;
+            height: number;
         };
         /**
-         * An array of linked TimeAxisTierConfigurations.
-         * Each configuration will be shown on a different tier.
-         * Currently, up to two tiers are supported.
+         * Gets the Bounds of the box.
          */
-        type TimeAxisConfiguration = TimeAxisTierConfiguration[];
-        class Time extends Axis<Date> {
-            /**
-             * The CSS class applied to each Time Axis tier
-             */
-            static TIME_AXIS_TIER_CLASS: string;
-            private static _DEFAULT_TIME_AXIS_CONFIGURATIONS;
-            private _tierLabelContainers;
-            private _tierMarkContainers;
-            private _tierBaselines;
-            private _tierHeights;
-            private _possibleTimeAxisConfigurations;
-            private _numTiers;
-            private _measurer;
-            private _mostPreciseConfigIndex;
-            private _tierLabelPositions;
-            private static _LONG_DATE;
-            /**
-             * Constructs a Time Axis.
-             *
-             * A Time Axis is a visual representation of a Time Scale.
-             *
-             * @constructor
-             * @param {Scales.Time} scale
-             * @param {string} orientation One of "top"/"bottom".
-             */
-            constructor(scale: Scales.Time, orientation: string);
-            /**
-             * Gets the label positions for each tier.
-             */
-            tierLabelPositions(): string[];
-            /**
-             * Sets the label positions for each tier.
-             *
-             * @param {string[]} newPositions The positions for each tier. "bottom" and "center" are the only supported values.
-             * @returns {Axes.Time} The calling Time Axis.
-             */
-            tierLabelPositions(newPositions: string[]): Time;
-            /**
-             * Gets the possible TimeAxisConfigurations.
-             */
-            axisConfigurations(): TimeAxisConfiguration[];
-            /**
-             * Sets the possible TimeAxisConfigurations.
-             * The Time Axis will choose the most precise configuration that will display in the available space.
-             *
-             * @param {TimeAxisConfiguration[]} configurations
-             * @returns {Axes.Time} The calling Time Axis.
-             */
-            axisConfigurations(configurations: TimeAxisConfiguration[]): Time;
-            /**
-             * Gets the index of the most precise TimeAxisConfiguration that will fit in the current width.
-             */
-            private _getMostPreciseConfigurationIndex();
-            orientation(): string;
-            orientation(orientation: string): Time;
-            protected _computeHeight(): number;
-            private _getIntervalLength(config);
-            private _maxWidthForInterval(config);
-            /**
-             * Check if tier configuration fits in the current width.
-             */
-            private _checkTimeAxisTierConfigurationWidth(config);
-            protected _sizeFromOffer(availableWidth: number, availableHeight: number): {
-                width: number;
-                height: number;
-            };
-            protected _setup(): void;
-            private _setupDomElements();
-            private _getTickIntervalValues(config);
-            protected _getTickValues(): any[];
-            private _cleanTiers();
-            private _getTickValuesForConfiguration(config);
-            private _renderTierLabels(container, config, index);
-            private _renderTickMarks(tickValues, index);
-            private _renderLabellessTickMarks(tickValues);
-            private _generateLabellessTicks();
-            renderImmediately(): Time;
-            private _hideOverflowingTiers();
-            private _hideOverlappingAndCutOffLabels(index);
-        }
+        bounds(): Bounds;
+        /**
+         * Sets the Bounds of the box.
+         *
+         * @param {Bounds} newBounds
+         * @return {SelectionBoxLayer} The calling SelectionBoxLayer.
+         */
+        bounds(newBounds: Bounds): SelectionBoxLayer;
+        protected _setBounds(newBounds: Bounds): void;
+        private _getBounds();
+        renderImmediately(): SelectionBoxLayer;
+        /**
+         * Gets whether the box is being shown.
+         */
+        boxVisible(): boolean;
+        /**
+         * Shows or hides the selection box.
+         *
+         * @param {boolean} show Whether or not to show the box.
+         * @return {SelectionBoxLayer} The calling SelectionBoxLayer.
+         */
+        boxVisible(show: boolean): SelectionBoxLayer;
+        fixedWidth(): boolean;
+        fixedHeight(): boolean;
+        /**
+         * Gets the x scale for this SelectionBoxLayer.
+         */
+        xScale(): QuantitativeScale<number | {
+            valueOf(): number;
+        }>;
+        /**
+         * Sets the x scale for this SelectionBoxLayer.
+         *
+         * @returns {SelectionBoxLayer} The calling SelectionBoxLayer.
+         */
+        xScale(xScale: QuantitativeScale<number | {
+            valueOf(): number;
+        }>): SelectionBoxLayer;
+        /**
+         * Gets the y scale for this SelectionBoxLayer.
+         */
+        yScale(): QuantitativeScale<number | {
+            valueOf(): number;
+        }>;
+        /**
+         * Sets the y scale for this SelectionBoxLayer.
+         *
+         * @returns {SelectionBoxLayer} The calling SelectionBoxLayer.
+         */
+        yScale(yScale: QuantitativeScale<number | {
+            valueOf(): number;
+        }>): SelectionBoxLayer;
+        /**
+         * Gets the data values backing the left and right edges of the box.
+         *
+         * Returns an undefined array if the edges are not backed by a scale.
+         */
+        xExtent(): (number | {
+            valueOf(): number;
+        })[];
+        /**
+         * Sets the data values backing the left and right edges of the box.
+         */
+        xExtent(xExtent: (number | {
+            valueOf(): number;
+        })[]): SelectionBoxLayer;
+        private _getXExtent();
+        protected _setXExtent(xExtent: (number | {
+            valueOf(): number;
+        })[]): void;
+        /**
+         * Gets the data values backing the top and bottom edges of the box.
+         *
+         * Returns an undefined array if the edges are not backed by a scale.
+         */
+        yExtent(): (number | {
+            valueOf(): number;
+        })[];
+        /**
+         * Sets the data values backing the top and bottom edges of the box.
+         */
+        yExtent(yExtent: (number | {
+            valueOf(): number;
+        })[]): SelectionBoxLayer;
+        private _getYExtent();
+        protected _setYExtent(yExtent: (number | {
+            valueOf(): number;
+        })[]): void;
+        destroy(): void;
+    }
+}
+declare module Plottable.Components {
+    class GuideLineLayer<D> extends Component {
+        static ORIENTATION_VERTICAL: string;
+        static ORIENTATION_HORIZONTAL: string;
+        private _orientation;
+        private _value;
+        private _scale;
+        private _pixelPosition;
+        private _scaleUpdateCallback;
+        private _guideLine;
+        private _mode;
+        constructor(orientation: string);
+        protected _setup(): void;
+        protected _sizeFromOffer(availableWidth: number, availableHeight: number): {
+            width: number;
+            height: number;
+        };
+        protected _isVertical(): boolean;
+        fixedWidth(): boolean;
+        fixedHeight(): boolean;
+        computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): GuideLineLayer<D>;
+        renderImmediately(): GuideLineLayer<D>;
+        private _syncPixelPositionAndValue();
+        protected _setPixelPositionWithoutChangingMode(pixelPosition: number): void;
+        /**
+         * Gets the QuantitativeScale on the GuideLineLayer.
+         *
+         * @return {QuantitativeScale<D>}
+         */
+        scale(): QuantitativeScale<D>;
+        /**
+         * Sets the QuantitativeScale on the GuideLineLayer.
+         * If value() was the last property set, pixelPosition() will be updated according to the new scale.
+         * If pixelPosition() was the last property set, value() will be updated according to the new scale.
+         *
+         * @param {QuantitativeScale<D>} scale
+         * @return {GuideLineLayer<D>} The calling GuideLineLayer.
+         */
+        scale(scale: QuantitativeScale<D>): GuideLineLayer<D>;
+        /**
+         * Gets the value of the guide line in data-space.
+         *
+         * @return {D}
+         */
+        value(): D;
+        /**
+         * Sets the value of the guide line in data-space.
+         * If the GuideLineLayer has a scale, pixelPosition() will be updated now and whenever the scale updates.
+         *
+         * @param {D} value
+         * @return {GuideLineLayer<D>} The calling GuideLineLayer.
+         */
+        value(value: D): GuideLineLayer<D>;
+        /**
+         * Gets the position of the guide line in pixel-space.
+         *
+         * @return {number}
+         */
+        pixelPosition(): number;
+        /**
+         * Sets the position of the guide line in pixel-space.
+         * If the GuideLineLayer has a scale, the value() will be updated now and whenever the scale updates.
+         *
+         * @param {number} pixelPosition
+         * @return {GuideLineLayer<D>} The calling GuideLineLayer.
+         */
+        pixelPosition(pixelPosition: number): GuideLineLayer<D>;
+        destroy(): void;
+    }
+}
+declare module Plottable.Plots {
+    interface PlotEntity extends Entity<Plot> {
+        dataset: Dataset;
+        index: number;
+        component: Plot;
+    }
+    interface AccessorScaleBinding<D, R> {
+        accessor: Accessor<any>;
+        scale?: Scale<D, R>;
+    }
+    module Animator {
+        var MAIN: string;
+        var RESET: string;
     }
 }
 declare module Plottable {
-    module Axes {
-        class Numeric extends Axis<number> {
-            private _tickLabelPositioning;
-            private _usesTextWidthApproximation;
-            private _measurer;
-            private _wrapper;
-            /**
-             * Constructs a Numeric Axis.
-             *
-             * A Numeric Axis is a visual representation of a QuantitativeScale.
-             *
-             * @constructor
-             * @param {QuantitativeScale} scale
-             * @param {string} orientation One of "top"/"bottom"/"left"/"right".
-             */
-            constructor(scale: QuantitativeScale<number>, orientation: string);
-            protected _setup(): void;
-            protected _computeWidth(): number;
-            private _computeExactTextWidth();
-            private _computeApproximateTextWidth();
-            protected _computeHeight(): number;
-            protected _getTickValues(): number[];
-            protected _rescale(): void;
-            renderImmediately(): Numeric;
-            private _showAllTickMarks();
-            /**
-             * Hides the Tick Marks which have no corresponding Tick Labels
-             */
-            private _hideTickMarksWithoutLabel();
-            /**
-             * Gets the tick label position relative to the tick marks.
-             *
-             * @returns {string} The current tick label position.
-             */
-            tickLabelPosition(): string;
-            /**
-             * Sets the tick label position relative to the tick marks.
-             *
-             * @param {string} position "top"/"center"/"bottom" for a vertical Numeric Axis,
-             *                          "left"/"center"/"right" for a horizontal Numeric Axis.
-             * @returns {Numeric} The calling Numeric Axis.
-             */
-            tickLabelPosition(position: string): Numeric;
-            /**
-             * Gets the approximate text width setting.
-             *
-             * @returns {boolean} The current text width approximation setting.
-             */
-            usesTextWidthApproximation(): boolean;
-            /**
-             * Sets the approximate text width setting. Approximating text width
-             * measurements can drastically speed up plot rendering, but the plot may
-             * have extra white space that would be eliminated by exact measurements.
-             * Additionally, very abnormal fonts may not approximate reasonably.
-             *
-             * @param {boolean} The new text width approximation setting.
-             * @returns {Axes.Numeric} The calling Axes.Numeric.
-             */
-            usesTextWidthApproximation(enable: boolean): Axes.Numeric;
-            private _hideEndTickLabels();
-            private _hideOverflowingTickLabels();
-            private _hideOverlappingTickLabels();
-            /**
-             * The method is responsible for evenly spacing the labels on the axis.
-             * @return test to see if taking every `interval` recrangle from `rects`
-             *         will result in labels not overlapping
-             *
-             * For top, bottom, left, right positioning of the thicks, we want the padding
-             * between the labels to be 3x, such that the label will be  `padding` distance
-             * from the tick and 2 * `padding` distance (or more) from the next tick
-             *
-             */
-            private _hasOverlapWithInterval(interval, rects);
-        }
-    }
-}
-declare module Plottable {
-    module Axes {
-        class Category extends Axis<string> {
-            private _tickLabelAngle;
-            private _measurer;
-            private _wrapper;
-            private _writer;
-            /**
-             * Constructs a Category Axis.
-             *
-             * A Category Axis is a visual representation of a Category Scale.
-             *
-             * @constructor
-             * @param {Scales.Category} scale
-             * @param {string} [orientation="bottom"] One of "top"/"bottom"/"left"/"right".
-             */
-            constructor(scale: Scales.Category, orientation: string);
-            protected _setup(): void;
-            protected _rescale(): Component;
-            requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
-            protected _coreSize(): number;
-            protected _getTickValues(): string[];
-            /**
-             * Gets the tick label angle in degrees.
-             */
-            tickLabelAngle(): number;
-            /**
-             * Sets the tick label angle in degrees.
-             * Right now only -90/0/90 are supported. 0 is horizontal.
-             *
-             * @param {number} angle
-             * @returns {Category} The calling Category Axis.
-             */
-            tickLabelAngle(angle: number): Category;
-            /**
-             * Measures the size of the ticks while also writing them to the DOM.
-             * @param {d3.Selection} ticks The tick elements to be written to.
-             */
-            private _drawTicks(axisWidth, axisHeight, scale, ticks);
-            /**
-             * Measures the size of the ticks without making any (permanent) DOM
-             * changes.
-             *
-             * @param {string[]} ticks The strings that will be printed on the ticks.
-             */
-            private _measureTicks(axisWidth, axisHeight, scale, ticks);
-            renderImmediately(): Category;
-            computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Category;
-        }
-    }
-}
-declare module Plottable {
-    module Components {
-        class Label extends Component {
-            private _textContainer;
-            private _text;
-            private _angle;
-            private _measurer;
-            private _wrapper;
-            private _writer;
-            private _padding;
-            /**
-             * A Label is a Component that displays a single line of text.
-             *
-             * @constructor
-             * @param {string} [displayText=""] The text of the Label.
-             * @param {number} [angle=0] The angle of the Label in degrees (-90/0/90). 0 is horizontal.
-             */
-            constructor(displayText?: string, angle?: number);
-            requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
-            protected _setup(): void;
-            /**
-             * Gets the Label's text.
-             */
-            text(): string;
-            /**
-             * Sets the Label's text.
-             *
-             * @param {string} displayText
-             * @returns {Label} The calling Label.
-             */
-            text(displayText: string): Label;
-            /**
-             * Gets the angle of the Label in degrees.
-             */
-            angle(): number;
-            /**
-             * Sets the angle of the Label in degrees.
-             *
-             * @param {number} angle One of -90/0/90. 0 is horizontal.
-             * @returns {Label} The calling Label.
-             */
-            angle(angle: number): Label;
-            /**
-             * Gets the amount of padding around the Label in pixels.
-             */
-            padding(): number;
-            /**
-             * Sets the amount of padding around the Label in pixels.
-             *
-             * @param {number} padAmount
-             * @returns {Label} The calling Label.
-             */
-            padding(padAmount: number): Label;
-            fixedWidth(): boolean;
-            fixedHeight(): boolean;
-            renderImmediately(): Label;
-        }
-        class TitleLabel extends Label {
-            static TITLE_LABEL_CLASS: string;
-            /**
-             * @constructor
-             * @param {string} [text]
-             * @param {number} [angle] One of -90/0/90. 0 is horizontal.
-             */
-            constructor(text?: string, angle?: number);
-        }
-        class AxisLabel extends Label {
-            static AXIS_LABEL_CLASS: string;
-            /**
-             * @constructor
-             * @param {string} [text]
-             * @param {number} [angle] One of -90/0/90. 0 is horizontal.
-             */
-            constructor(text?: string, angle?: number);
-        }
-    }
-}
-declare module Plottable {
-    module Components {
-        class Legend extends Component {
-            /**
-             * The css class applied to each legend row
-             */
-            static LEGEND_ROW_CLASS: string;
-            /**
-             * The css class applied to each legend entry
-             */
-            static LEGEND_ENTRY_CLASS: string;
-            /**
-             * The css class applied to each legend symbol
-             */
-            static LEGEND_SYMBOL_CLASS: string;
-            private _padding;
-            private _colorScale;
-            private _formatter;
-            private _maxEntriesPerRow;
-            private _comparator;
-            private _measurer;
-            private _wrapper;
-            private _writer;
-            private _symbolFactoryAccessor;
-            private _symbolOpacityAccessor;
-            private _redrawCallback;
-            /**
-             * The Legend consists of a series of entries, each with a color and label taken from the Color Scale.
-             *
-             * @constructor
-             * @param {Scale.Color} scale
-             */
-            constructor(colorScale: Scales.Color);
-            protected _setup(): void;
-            /**
-             * Gets the Formatter for the entry texts.
-             */
-            formatter(): Formatter;
-            /**
-             * Sets the Formatter for the entry texts.
-             *
-             * @param {Formatter} formatter
-             * @returns {Legend} The calling Legend.
-             */
-            formatter(formatter: Formatter): Legend;
-            /**
-             * Gets the maximum number of entries per row.
-             *
-             * @returns {number}
-             */
-            maxEntriesPerRow(): number;
-            /**
-             * Sets the maximum number of entries perrow.
-             *
-             * @param {number} maxEntriesPerRow
-             * @returns {Legend} The calling Legend.
-             */
-            maxEntriesPerRow(maxEntriesPerRow: number): Legend;
-            /**
-             * Gets the current comparator for the Legend's entries.
-             *
-             * @returns {(a: string, b: string) => number}
-             */
-            comparator(): (a: string, b: string) => number;
-            /**
-             * Sets a new comparator for the Legend's entries.
-             * The comparator is used to set the display order of the entries.
-             *
-             * @param {(a: string, b: string) => number} comparator
-             * @returns {Legend} The calling Legend.
-             */
-            comparator(comparator: (a: string, b: string) => number): Legend;
-            /**
-             * Gets the Color Scale.
-             *
-             * @returns {Scales.Color}
-             */
-            colorScale(): Scales.Color;
-            /**
-             * Sets the Color Scale.
-             *
-             * @param {Scales.Color} scale
-             * @returns {Legend} The calling Legend.
-             */
-            colorScale(colorScale: Scales.Color): Legend;
-            destroy(): void;
-            private _calculateLayoutInfo(availableWidth, availableHeight);
-            requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
-            private _packRows(availableWidth, entries, entryLengths);
-            /**
-             * Gets the Entities (representing Legend entries) at a particular point.
-             * Returns an empty array if no Entities are present at that location.
-             *
-             * @param {Point} p
-             * @returns {Entity<Legend>[]}
-             */
-            entitiesAt(p: Point): Entity<Legend>[];
-            renderImmediately(): Legend;
-            /**
-             * Gets the function determining the symbols of the Legend.
-             *
-             * @returns {(datum: any, index: number) => symbolFactory}
-             */
-            symbol(): (datum: any, index: number) => SymbolFactory;
-            /**
-             * Sets the function determining the symbols of the Legend.
-             *
-             * @param {(datum: any, index: number) => SymbolFactory} symbol
-             * @returns {Legend} The calling Legend
-             */
-            symbol(symbol: (datum: any, index: number) => SymbolFactory): Legend;
-            /**
-             * Gets the opacity of the symbols of the Legend.
-             *
-             * @returns {(datum: any, index: number) => number}
-             */
-            symbolOpacity(): (datum: any, index: number) => number;
-            /**
-             * Sets the opacity of the symbols of the Legend.
-             *
-             * @param {number | ((datum: any, index: number) => number)} symbolOpacity
-             * @returns {Legend} The calling Legend
-             */
-            symbolOpacity(symbolOpacity: number | ((datum: any, index: number) => number)): Legend;
-            fixedWidth(): boolean;
-            fixedHeight(): boolean;
-        }
-    }
-}
-declare module Plottable {
-    module Components {
-        class InterpolatedColorLegend extends Component {
-            private static _DEFAULT_NUM_SWATCHES;
-            private _measurer;
-            private _wrapper;
-            private _writer;
-            private _scale;
-            private _orientation;
-            private _textPadding;
-            private _formatter;
-            private _expands;
-            private _swatchContainer;
-            private _swatchBoundingBox;
-            private _lowerLabel;
-            private _upperLabel;
-            private _redrawCallback;
-            /**
-             * The css class applied to the legend labels.
-             */
-            static LEGEND_LABEL_CLASS: string;
-            /**
-             * Creates an InterpolatedColorLegend.
-             *
-             * The InterpolatedColorLegend consists of a sequence of swatches that show the
-             * associated InterpolatedColor Scale sampled at various points.
-             * Two labels show the maximum and minimum values of the InterpolatedColor Scale.
-             *
-             * @constructor
-             * @param {Scales.InterpolatedColor} interpolatedColorScale
-             */
-            constructor(interpolatedColorScale: Scales.InterpolatedColor);
-            destroy(): void;
-            /**
-             * Gets the Formatter for the labels.
-             */
-            formatter(): Formatter;
-            /**
-             * Sets the Formatter for the labels.
-             *
-             * @param {Formatter} formatter
-             * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
-             */
-            formatter(formatter: Formatter): InterpolatedColorLegend;
-            /**
-             * Gets whether the InterpolatedColorLegend expands to occupy all offered space in the long direction
-             */
-            expands(): boolean;
-            /**
-             * Sets whether the InterpolatedColorLegend expands to occupy all offered space in the long direction
-             *
-             * @param {expands} boolean
-             * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
-             */
-            expands(expands: boolean): InterpolatedColorLegend;
-            private static _ensureOrientation(orientation);
-            /**
-             * Gets the orientation.
-             */
-            orientation(): string;
-            /**
-             * Sets the orientation.
-             *
-             * @param {string} orientation One of "horizontal"/"left"/"right".
-             * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.
-             */
-            orientation(orientation: string): InterpolatedColorLegend;
-            fixedWidth(): boolean;
-            fixedHeight(): boolean;
-            private _generateTicks(numSwatches?);
-            protected _setup(): void;
-            requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
-            private _isVertical();
-            renderImmediately(): InterpolatedColorLegend;
-        }
-    }
-}
-declare module Plottable {
-    module Components {
-        class Gridlines extends Component {
-            private _xScale;
-            private _yScale;
-            private _xLinesContainer;
-            private _yLinesContainer;
-            private _renderCallback;
-            /**
-             * @constructor
-             * @param {QuantitativeScale} xScale The scale to base the x gridlines on. Pass null if no gridlines are desired.
-             * @param {QuantitativeScale} yScale The scale to base the y gridlines on. Pass null if no gridlines are desired.
-             */
-            constructor(xScale: QuantitativeScale<any>, yScale: QuantitativeScale<any>);
-            destroy(): Gridlines;
-            protected _setup(): void;
-            renderImmediately(): Gridlines;
-            computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Gridlines;
-            private _redrawXLines();
-            private _redrawYLines();
-        }
-    }
-}
-declare module Plottable {
-    module Components {
-        class Table extends ComponentContainer {
-            private _rowPadding;
-            private _columnPadding;
-            private _rows;
-            private _rowWeights;
-            private _columnWeights;
-            private _nRows;
-            private _nCols;
-            private _calculatedLayout;
-            /**
-             * A Table combines Components in the form of a grid. A
-             * common case is combining a y-axis, x-axis, and the plotted data via
-             * ```typescript
-             * new Table([[yAxis, plot],
-             *            [null,  xAxis]]);
-             * ```
-             *
-             * @constructor
-             * @param {Component[][]} [rows=[]] A 2-D array of Components to be added to the Table.
-             *   null can be used if a cell is empty.
-             */
-            constructor(rows?: Component[][]);
-            protected _forEach(callback: (component: Component) => any): void;
-            /**
-             * Checks whether the specified Component is in the Table.
-             */
-            has(component: Component): boolean;
-            /**
-             * Returns the Component at the specified row and column index.
-             *
-             * @param {number} rowIndex
-             * @param {number} columnIndex
-             * @returns {Component} The Component at the specified position, or null if no Component is there.
-             */
-            componentAt(rowIndex: number, columnIndex: number): Component;
-            /**
-             * Adds a Component in the specified row and column position.
-             *
-             * For example, instead of calling `new Table([[a, b], [null, c]])`, you
-             * could call
-             * var table = new Plottable.Components.Table();
-             * table.add(a, 0, 0);
-             * table.add(b, 0, 1);
-             * table.add(c, 1, 1);
-             *
-             * @param {Component} component The Component to be added.
-             * @param {number} row
-             * @param {number} col
-             * @returns {Table} The calling Table.
-             */
-            add(component: Component, row: number, col: number): Table;
-            protected _remove(component: Component): boolean;
-            private _iterateLayout(availableWidth, availableHeight, isFinalOffer?);
-            private _determineGuarantees(offeredWidths, offeredHeights, isFinalOffer?);
-            requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
-            computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Table;
-            /**
-             * Gets the padding above and below each row in pixels.
-             */
-            rowPadding(): number;
-            /**
-             * Sets the padding above and below each row in pixels.
-             *
-             * @param {number} rowPadding
-             * @returns {Table} The calling Table.
-             */
-            rowPadding(rowPadding: number): Table;
-            /**
-             * Gets the padding to the left and right of each column in pixels.
-             */
-            columnPadding(): number;
-            /**
-             * Sets the padding to the left and right of each column in pixels.
-             *
-             * @param {number} columnPadding
-             * @returns {Table} The calling Table.
-             */
-            columnPadding(columnPadding: number): Table;
-            /**
-             * Gets the weight of the specified row.
-             *
-             * @param {number} index
-             */
-            rowWeight(index: number): number;
-            /**
-             * Sets the weight of the specified row.
-             * Space is allocated to rows based on their weight. Rows with higher weights receive proportionally more space.
-             *
-             * A common case would be to have one row take up 2/3rds of the space,
-             * and the other row take up 1/3rd.
-             *
-             * Example:
-             *
-             * ```JavaScript
-             * plot = new Plottable.Component.Table([
-             *  [row1],
-             *  [row2]
-             * ]);
-             *
-             * // assign twice as much space to the first row
-             * plot
-             *  .rowWeight(0, 2)
-             *  .rowWeight(1, 1)
-             * ```
-             *
-             * @param {number} index
-             * @param {number} weight
-             * @returns {Table} The calling Table.
-             */
-            rowWeight(index: number, weight: number): Table;
-            /**
-             * Gets the weight of the specified column.
-             *
-             * @param {number} index
-             */
-            columnWeight(index: number): number;
-            /**
-             * Sets the weight of the specified column.
-             * Space is allocated to columns based on their weight. Columns with higher weights receive proportionally more space.
-             *
-             * Please see `rowWeight` docs for an example.
-             *
-             * @param {number} index
-             * @param {number} weight
-             * @returns {Table} The calling Table.
-             */
-            columnWeight(index: number, weight: number): Table;
-            fixedWidth(): boolean;
-            fixedHeight(): boolean;
-            private _padTableToSize(nRows, nCols);
-            private static _calcComponentWeights(setWeights, componentGroups, fixityAccessor);
-            private static _calcProportionalSpace(weights, freeSpace);
-            private static _fixedSpace(componentGroup, fixityAccessor);
-        }
-    }
-}
-declare module Plottable {
-    module Components {
-        enum PropertyMode {
-            VALUE = 0,
-            PIXEL = 1,
-        }
-        class SelectionBoxLayer extends Component {
-            protected _box: d3.Selection<void>;
-            private _boxArea;
-            private _boxVisible;
-            private _boxBounds;
-            private _xExtent;
-            private _yExtent;
-            private _xScale;
-            private _yScale;
-            private _adjustBoundsCallback;
-            protected _xBoundsMode: PropertyMode;
-            protected _yBoundsMode: PropertyMode;
-            constructor();
-            protected _setup(): void;
-            protected _sizeFromOffer(availableWidth: number, availableHeight: number): {
-                width: number;
-                height: number;
-            };
-            /**
-             * Gets the Bounds of the box.
-             */
-            bounds(): Bounds;
-            /**
-             * Sets the Bounds of the box.
-             *
-             * @param {Bounds} newBounds
-             * @return {SelectionBoxLayer} The calling SelectionBoxLayer.
-             */
-            bounds(newBounds: Bounds): SelectionBoxLayer;
-            protected _setBounds(newBounds: Bounds): void;
-            private _getBounds();
-            renderImmediately(): SelectionBoxLayer;
-            /**
-             * Gets whether the box is being shown.
-             */
-            boxVisible(): boolean;
-            /**
-             * Shows or hides the selection box.
-             *
-             * @param {boolean} show Whether or not to show the box.
-             * @return {SelectionBoxLayer} The calling SelectionBoxLayer.
-             */
-            boxVisible(show: boolean): SelectionBoxLayer;
-            fixedWidth(): boolean;
-            fixedHeight(): boolean;
-            /**
-             * Gets the x scale for this SelectionBoxLayer.
-             */
-            xScale(): QuantitativeScale<number | {
-                valueOf(): number;
-            }>;
-            /**
-             * Sets the x scale for this SelectionBoxLayer.
-             *
-             * @returns {SelectionBoxLayer} The calling SelectionBoxLayer.
-             */
-            xScale(xScale: QuantitativeScale<number | {
-                valueOf(): number;
-            }>): SelectionBoxLayer;
-            /**
-             * Gets the y scale for this SelectionBoxLayer.
-             */
-            yScale(): QuantitativeScale<number | {
-                valueOf(): number;
-            }>;
-            /**
-             * Sets the y scale for this SelectionBoxLayer.
-             *
-             * @returns {SelectionBoxLayer} The calling SelectionBoxLayer.
-             */
-            yScale(yScale: QuantitativeScale<number | {
-                valueOf(): number;
-            }>): SelectionBoxLayer;
-            /**
-             * Gets the data values backing the left and right edges of the box.
-             *
-             * Returns an undefined array if the edges are not backed by a scale.
-             */
-            xExtent(): (number | {
-                valueOf(): number;
-            })[];
-            /**
-             * Sets the data values backing the left and right edges of the box.
-             */
-            xExtent(xExtent: (number | {
-                valueOf(): number;
-            })[]): SelectionBoxLayer;
-            private _getXExtent();
-            protected _setXExtent(xExtent: (number | {
-                valueOf(): number;
-            })[]): void;
-            /**
-             * Gets the data values backing the top and bottom edges of the box.
-             *
-             * Returns an undefined array if the edges are not backed by a scale.
-             */
-            yExtent(): (number | {
-                valueOf(): number;
-            })[];
-            /**
-             * Sets the data values backing the top and bottom edges of the box.
-             */
-            yExtent(yExtent: (number | {
-                valueOf(): number;
-            })[]): SelectionBoxLayer;
-            private _getYExtent();
-            protected _setYExtent(yExtent: (number | {
-                valueOf(): number;
-            })[]): void;
-            destroy(): void;
-        }
-    }
-}
-declare module Plottable {
-    module Components {
-        class GuideLineLayer<D> extends Component {
-            static ORIENTATION_VERTICAL: string;
-            static ORIENTATION_HORIZONTAL: string;
-            private _orientation;
-            private _value;
-            private _scale;
-            private _pixelPosition;
-            private _scaleUpdateCallback;
-            private _guideLine;
-            private _mode;
-            constructor(orientation: string);
-            protected _setup(): void;
-            protected _sizeFromOffer(availableWidth: number, availableHeight: number): {
-                width: number;
-                height: number;
-            };
-            protected _isVertical(): boolean;
-            fixedWidth(): boolean;
-            fixedHeight(): boolean;
-            computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): GuideLineLayer<D>;
-            renderImmediately(): GuideLineLayer<D>;
-            private _syncPixelPositionAndValue();
-            protected _setPixelPositionWithoutChangingMode(pixelPosition: number): void;
-            /**
-             * Gets the QuantitativeScale on the GuideLineLayer.
-             *
-             * @return {QuantitativeScale<D>}
-             */
-            scale(): QuantitativeScale<D>;
-            /**
-             * Sets the QuantitativeScale on the GuideLineLayer.
-             * If value() was the last property set, pixelPosition() will be updated according to the new scale.
-             * If pixelPosition() was the last property set, value() will be updated according to the new scale.
-             *
-             * @param {QuantitativeScale<D>} scale
-             * @return {GuideLineLayer<D>} The calling GuideLineLayer.
-             */
-            scale(scale: QuantitativeScale<D>): GuideLineLayer<D>;
-            /**
-             * Gets the value of the guide line in data-space.
-             *
-             * @return {D}
-             */
-            value(): D;
-            /**
-             * Sets the value of the guide line in data-space.
-             * If the GuideLineLayer has a scale, pixelPosition() will be updated now and whenever the scale updates.
-             *
-             * @param {D} value
-             * @return {GuideLineLayer<D>} The calling GuideLineLayer.
-             */
-            value(value: D): GuideLineLayer<D>;
-            /**
-             * Gets the position of the guide line in pixel-space.
-             *
-             * @return {number}
-             */
-            pixelPosition(): number;
-            /**
-             * Sets the position of the guide line in pixel-space.
-             * If the GuideLineLayer has a scale, the value() will be updated now and whenever the scale updates.
-             *
-             * @param {number} pixelPosition
-             * @return {GuideLineLayer<D>} The calling GuideLineLayer.
-             */
-            pixelPosition(pixelPosition: number): GuideLineLayer<D>;
-            destroy(): void;
-        }
-    }
-}
-declare module Plottable {
-    module Plots {
-        interface PlotEntity extends Entity<Plot> {
-            dataset: Dataset;
-            index: number;
-            component: Plot;
-        }
-        interface AccessorScaleBinding<D, R> {
-            accessor: Accessor<any>;
-            scale?: Scale<D, R>;
-        }
-        module Animator {
-            var MAIN: string;
-            var RESET: string;
-        }
-    }
     class Plot extends Component {
         protected static _ANIMATION_MAX_DURATION: number;
         private _dataChanged;
@@ -3005,130 +2917,128 @@ declare module Plottable {
         protected _animateOnNextRender(): boolean;
     }
 }
-declare module Plottable {
-    module Plots {
-        class Pie extends Plot {
-            private static _INNER_RADIUS_KEY;
-            private static _OUTER_RADIUS_KEY;
-            private static _SECTOR_VALUE_KEY;
-            private _startAngles;
-            private _endAngles;
-            private _labelFormatter;
-            private _labelsEnabled;
-            private _strokeDrawers;
-            /**
-             * @constructor
-             */
-            constructor();
-            protected _setup(): void;
-            computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Pie;
-            addDataset(dataset: Dataset): Pie;
-            protected _addDataset(dataset: Dataset): Pie;
-            removeDataset(dataset: Dataset): Pie;
-            protected _removeDatasetNodes(dataset: Dataset): void;
-            protected _removeDataset(dataset: Dataset): Pie;
-            selections(datasets?: Dataset[]): d3.Selection<any>;
-            protected _onDatasetUpdate(): void;
-            protected _createDrawer(dataset: Dataset): Drawers.Arc;
-            entities(datasets?: Dataset[]): PlotEntity[];
-            /**
-             * Gets the AccessorScaleBinding for the sector value.
-             */
-            sectorValue<S>(): AccessorScaleBinding<S, number>;
-            /**
-             * Sets the sector value to a constant number or the result of an Accessor<number>.
-             *
-             * @param {number|Accessor<number>} sectorValue
-             * @returns {Pie} The calling Pie Plot.
-             */
-            sectorValue(sectorValue: number | Accessor<number>): Plots.Pie;
-            /**
-             * Sets the sector value to a scaled constant value or scaled result of an Accessor.
-             * The provided Scale will account for the values when autoDomain()-ing.
-             *
-             * @param {S|Accessor<S>} sectorValue
-             * @param {Scale<S, number>} scale
-             * @returns {Pie} The calling Pie Plot.
-             */
-            sectorValue<S>(sectorValue: S | Accessor<S>, scale: Scale<S, number>): Plots.Pie;
-            /**
-             * Gets the AccessorScaleBinding for the inner radius.
-             */
-            innerRadius<R>(): AccessorScaleBinding<R, number>;
-            /**
-             * Sets the inner radius to a constant number or the result of an Accessor<number>.
-             *
-             * @param {number|Accessor<number>} innerRadius
-             * @returns {Pie} The calling Pie Plot.
-             */
-            innerRadius(innerRadius: number | Accessor<number>): Plots.Pie;
-            /**
-             * Sets the inner radius to a scaled constant value or scaled result of an Accessor.
-             * The provided Scale will account for the values when autoDomain()-ing.
-             *
-             * @param {R|Accessor<R>} innerRadius
-             * @param {Scale<R, number>} scale
-             * @returns {Pie} The calling Pie Plot.
-             */
-            innerRadius<R>(innerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Pie;
-            /**
-             * Gets the AccessorScaleBinding for the outer radius.
-             */
-            outerRadius<R>(): AccessorScaleBinding<R, number>;
-            /**
-             * Sets the outer radius to a constant number or the result of an Accessor<number>.
-             *
-             * @param {number|Accessor<number>} outerRadius
-             * @returns {Pie} The calling Pie Plot.
-             */
-            outerRadius(outerRadius: number | Accessor<number>): Plots.Pie;
-            /**
-             * Sets the outer radius to a scaled constant value or scaled result of an Accessor.
-             * The provided Scale will account for the values when autoDomain()-ing.
-             *
-             * @param {R|Accessor<R>} outerRadius
-             * @param {Scale<R, number>} scale
-             * @returns {Pie} The calling Pie Plot.
-             */
-            outerRadius<R>(outerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Pie;
-            /**
-             * Get whether slice labels are enabled.
-             *
-             * @returns {boolean} Whether slices should display labels or not.
-             */
-            labelsEnabled(): boolean;
-            /**
-             * Sets whether labels are enabled.
-             *
-             * @param {boolean} labelsEnabled
-             * @returns {Pie} The calling Pie Plot.
-             */
-            labelsEnabled(enabled: boolean): Pie;
-            /**
-             * Gets the Formatter for the labels.
-             */
-            labelFormatter(): Formatter;
-            /**
-             * Sets the Formatter for the labels.
-             *
-             * @param {Formatter} formatter
-             * @returns {Pie} The calling Pie Plot.
-             */
-            labelFormatter(formatter: Formatter): Pie;
-            entitiesAt(queryPoint: Point): PlotEntity[];
-            protected _propertyProjectors(): AttributeToProjector;
-            private _updatePieAngles();
-            protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
-            protected static _isValidData(value: any): boolean;
-            protected _pixelPoint(datum: any, index: number, dataset: Dataset): {
-                x: number;
-                y: number;
-            };
-            protected _additionalPaint(time: number): void;
-            private _generateStrokeDrawSteps();
-            private _sliceIndexForPoint(p);
-            private _drawLabels();
-        }
+declare module Plottable.Plots {
+    class Pie extends Plot {
+        private static _INNER_RADIUS_KEY;
+        private static _OUTER_RADIUS_KEY;
+        private static _SECTOR_VALUE_KEY;
+        private _startAngles;
+        private _endAngles;
+        private _labelFormatter;
+        private _labelsEnabled;
+        private _strokeDrawers;
+        /**
+         * @constructor
+         */
+        constructor();
+        protected _setup(): void;
+        computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Pie;
+        addDataset(dataset: Dataset): Pie;
+        protected _addDataset(dataset: Dataset): Pie;
+        removeDataset(dataset: Dataset): Pie;
+        protected _removeDatasetNodes(dataset: Dataset): void;
+        protected _removeDataset(dataset: Dataset): Pie;
+        selections(datasets?: Dataset[]): d3.Selection<any>;
+        protected _onDatasetUpdate(): void;
+        protected _createDrawer(dataset: Dataset): Drawers.Arc;
+        entities(datasets?: Dataset[]): PlotEntity[];
+        /**
+         * Gets the AccessorScaleBinding for the sector value.
+         */
+        sectorValue<S>(): AccessorScaleBinding<S, number>;
+        /**
+         * Sets the sector value to a constant number or the result of an Accessor<number>.
+         *
+         * @param {number|Accessor<number>} sectorValue
+         * @returns {Pie} The calling Pie Plot.
+         */
+        sectorValue(sectorValue: number | Accessor<number>): Plots.Pie;
+        /**
+         * Sets the sector value to a scaled constant value or scaled result of an Accessor.
+         * The provided Scale will account for the values when autoDomain()-ing.
+         *
+         * @param {S|Accessor<S>} sectorValue
+         * @param {Scale<S, number>} scale
+         * @returns {Pie} The calling Pie Plot.
+         */
+        sectorValue<S>(sectorValue: S | Accessor<S>, scale: Scale<S, number>): Plots.Pie;
+        /**
+         * Gets the AccessorScaleBinding for the inner radius.
+         */
+        innerRadius<R>(): AccessorScaleBinding<R, number>;
+        /**
+         * Sets the inner radius to a constant number or the result of an Accessor<number>.
+         *
+         * @param {number|Accessor<number>} innerRadius
+         * @returns {Pie} The calling Pie Plot.
+         */
+        innerRadius(innerRadius: number | Accessor<number>): Plots.Pie;
+        /**
+         * Sets the inner radius to a scaled constant value or scaled result of an Accessor.
+         * The provided Scale will account for the values when autoDomain()-ing.
+         *
+         * @param {R|Accessor<R>} innerRadius
+         * @param {Scale<R, number>} scale
+         * @returns {Pie} The calling Pie Plot.
+         */
+        innerRadius<R>(innerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Pie;
+        /**
+         * Gets the AccessorScaleBinding for the outer radius.
+         */
+        outerRadius<R>(): AccessorScaleBinding<R, number>;
+        /**
+         * Sets the outer radius to a constant number or the result of an Accessor<number>.
+         *
+         * @param {number|Accessor<number>} outerRadius
+         * @returns {Pie} The calling Pie Plot.
+         */
+        outerRadius(outerRadius: number | Accessor<number>): Plots.Pie;
+        /**
+         * Sets the outer radius to a scaled constant value or scaled result of an Accessor.
+         * The provided Scale will account for the values when autoDomain()-ing.
+         *
+         * @param {R|Accessor<R>} outerRadius
+         * @param {Scale<R, number>} scale
+         * @returns {Pie} The calling Pie Plot.
+         */
+        outerRadius<R>(outerRadius: R | Accessor<R>, scale: Scale<R, number>): Plots.Pie;
+        /**
+         * Get whether slice labels are enabled.
+         *
+         * @returns {boolean} Whether slices should display labels or not.
+         */
+        labelsEnabled(): boolean;
+        /**
+         * Sets whether labels are enabled.
+         *
+         * @param {boolean} labelsEnabled
+         * @returns {Pie} The calling Pie Plot.
+         */
+        labelsEnabled(enabled: boolean): Pie;
+        /**
+         * Gets the Formatter for the labels.
+         */
+        labelFormatter(): Formatter;
+        /**
+         * Sets the Formatter for the labels.
+         *
+         * @param {Formatter} formatter
+         * @returns {Pie} The calling Pie Plot.
+         */
+        labelFormatter(formatter: Formatter): Pie;
+        entitiesAt(queryPoint: Point): PlotEntity[];
+        protected _propertyProjectors(): AttributeToProjector;
+        private _updatePieAngles();
+        protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
+        protected static _isValidData(value: any): boolean;
+        protected _pixelPoint(datum: any, index: number, dataset: Dataset): {
+            x: number;
+            y: number;
+        };
+        protected _additionalPaint(time: number): void;
+        private _generateStrokeDrawSteps();
+        private _sliceIndexForPoint(p);
+        private _drawLabels();
     }
 }
 declare module Plottable {
@@ -3242,894 +3152,872 @@ declare module Plottable {
         protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
     }
 }
-declare module Plottable {
-    module Plots {
-        class Rectangle<X, Y> extends XYPlot<X, Y> {
-            private static _X2_KEY;
-            private static _Y2_KEY;
-            private _labelsEnabled;
-            private _label;
-            /**
-             * A Rectangle Plot displays rectangles based on the data.
-             * The left and right edges of each rectangle can be set with x() and x2().
-             *   If only x() is set the Rectangle Plot will attempt to compute the correct left and right edge positions.
-             * The top and bottom edges of each rectangle can be set with y() and y2().
-             *   If only y() is set the Rectangle Plot will attempt to compute the correct top and bottom edge positions.
-             *
-             * @constructor
-             * @param {Scale.Scale} xScale
-             * @param {Scale.Scale} yScale
-             */
-            constructor();
-            protected _createDrawer(dataset: Dataset): Drawers.Rectangle;
-            protected _generateAttrToProjector(): {
-                [attr: string]: (datum: any, index: number, dataset: Dataset) => any;
-            };
-            protected _generateDrawSteps(): Drawers.DrawStep[];
-            protected _updateExtentsForProperty(property: string): void;
-            protected _filterForProperty(property: string): (datum: any, index: number, dataset: Dataset) => boolean;
-            /**
-             * Gets the AccessorScaleBinding for X.
-             */
-            x(): AccessorScaleBinding<X, number>;
-            /**
-             * Sets X to a constant number or the result of an Accessor<number>.
-             *
-             * @param {number|Accessor<number>} x
-             * @returns {Plots.Rectangle} The calling Rectangle Plot.
-             */
-            x(x: number | Accessor<number>): Plots.Rectangle<X, Y>;
-            /**
-             * Sets X to a scaled constant value or scaled result of an Accessor.
-             * The provided Scale will account for the values when autoDomain()-ing.
-             *
-             * @param {X|Accessor<X>} x
-             * @param {Scale<X, number>} xScale
-             * @returns {Plots.Rectangle} The calling Rectangle Plot.
-             */
-            x(x: X | Accessor<X>, xScale: Scale<X, number>): Plots.Rectangle<X, Y>;
-            /**
-             * Gets the AccessorScaleBinding for X2.
-             */
-            x2(): AccessorScaleBinding<X, number>;
-            /**
-             * Sets X2 to a constant number or the result of an Accessor.
-             * If a Scale has been set for X, it will also be used to scale X2.
-             *
-             * @param {number|Accessor<number>|X|Accessor<X>} x2
-             * @returns {Plots.Rectangle} The calling Rectangle Plot.
-             */
-            x2(x2: number | Accessor<number> | X | Accessor<X>): Plots.Rectangle<X, Y>;
-            /**
-             * Gets the AccessorScaleBinding for Y.
-             */
-            y(): AccessorScaleBinding<Y, number>;
-            /**
-             * Sets Y to a constant number or the result of an Accessor<number>.
-             *
-             * @param {number|Accessor<number>} y
-             * @returns {Plots.Rectangle} The calling Rectangle Plot.
-             */
-            y(y: number | Accessor<number>): Plots.Rectangle<X, Y>;
-            /**
-             * Sets Y to a scaled constant value or scaled result of an Accessor.
-             * The provided Scale will account for the values when autoDomain()-ing.
-             *
-             * @param {Y|Accessor<Y>} y
-             * @param {Scale<Y, number>} yScale
-             * @returns {Plots.Rectangle} The calling Rectangle Plot.
-             */
-            y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): Plots.Rectangle<X, Y>;
-            /**
-             * Gets the AccessorScaleBinding for Y2.
-             */
-            y2(): AccessorScaleBinding<Y, number>;
-            /**
-             * Sets Y2 to a constant number or the result of an Accessor.
-             * If a Scale has been set for Y, it will also be used to scale Y2.
-             *
-             * @param {number|Accessor<number>|Y|Accessor<Y>} y2
-             * @returns {Plots.Rectangle} The calling Rectangle Plot.
-             */
-            y2(y2: number | Accessor<number> | Y | Accessor<Y>): Plots.Rectangle<X, Y>;
-            /**
-             * Gets the PlotEntities at a particular Point.
-             *
-             * @param {Point} point The point to query.
-             * @returns {PlotEntity[]} The PlotEntities at the particular point
-             */
-            entitiesAt(point: Point): PlotEntity[];
-            /**
-             * Gets the Entities that intersect the Bounds.
-             *
-             * @param {Bounds} bounds
-             * @returns {PlotEntity[]}
-             */
-            entitiesIn(bounds: Bounds): PlotEntity[];
-            /**
-             * Gets the Entities that intersect the area defined by the ranges.
-             *
-             * @param {Range} xRange
-             * @param {Range} yRange
-             * @returns {PlotEntity[]}
-             */
-            entitiesIn(xRange: Range, yRange: Range): PlotEntity[];
-            private _entityBBox(datum, index, dataset, attrToProjector);
-            private _entitiesIntersecting(xValOrRange, yValOrRange);
-            /**
-             * Gets the accessor for labels.
-             *
-             * @returns {Accessor<string>}
-             */
-            label(): Accessor<string>;
-            /**
-             * Sets the text of labels to the result of an Accessor.
-             *
-             * @param {Accessor<string>} label
-             * @returns {Plots.Rectangle} The calling Rectangle Plot.
-             */
-            label(label: Accessor<string>): Plots.Rectangle<X, Y>;
-            /**
-             * Gets whether labels are enabled.
-             *
-             * @returns {boolean}
-             */
-            labelsEnabled(): boolean;
-            /**
-             * Sets whether labels are enabled.
-             * Labels too big to be contained in the rectangle, cut off by edges, or blocked by other rectangles will not be shown.
-             *
-             * @param {boolean} labelsEnabled
-             * @returns {Rectangle} The calling Rectangle Plot.
-             */
-            labelsEnabled(enabled: boolean): Plots.Rectangle<X, Y>;
-            protected _propertyProjectors(): AttributeToProjector;
-            protected _pixelPoint(datum: any, index: number, dataset: Dataset): {
-                x: any;
-                y: any;
-            };
-            private _rectangleWidth(scale);
-            protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
-            protected _additionalPaint(time: number): void;
-            private _drawLabels();
-            private _drawLabel(dataToDraw, dataset, datasetIndex);
-            private _overlayLabel(labelXRange, labelYRange, datumIndex, datasetIndex, dataToDraw);
-        }
+declare module Plottable.Plots {
+    class Rectangle<X, Y> extends XYPlot<X, Y> {
+        private static _X2_KEY;
+        private static _Y2_KEY;
+        private _labelsEnabled;
+        private _label;
+        /**
+         * A Rectangle Plot displays rectangles based on the data.
+         * The left and right edges of each rectangle can be set with x() and x2().
+         *   If only x() is set the Rectangle Plot will attempt to compute the correct left and right edge positions.
+         * The top and bottom edges of each rectangle can be set with y() and y2().
+         *   If only y() is set the Rectangle Plot will attempt to compute the correct top and bottom edge positions.
+         *
+         * @constructor
+         * @param {Scale.Scale} xScale
+         * @param {Scale.Scale} yScale
+         */
+        constructor();
+        protected _createDrawer(dataset: Dataset): Drawers.Rectangle;
+        protected _generateAttrToProjector(): {
+            [attr: string]: (datum: any, index: number, dataset: Dataset) => any;
+        };
+        protected _generateDrawSteps(): Drawers.DrawStep[];
+        protected _updateExtentsForProperty(property: string): void;
+        protected _filterForProperty(property: string): (datum: any, index: number, dataset: Dataset) => boolean;
+        /**
+         * Gets the AccessorScaleBinding for X.
+         */
+        x(): AccessorScaleBinding<X, number>;
+        /**
+         * Sets X to a constant number or the result of an Accessor<number>.
+         *
+         * @param {number|Accessor<number>} x
+         * @returns {Plots.Rectangle} The calling Rectangle Plot.
+         */
+        x(x: number | Accessor<number>): Plots.Rectangle<X, Y>;
+        /**
+         * Sets X to a scaled constant value or scaled result of an Accessor.
+         * The provided Scale will account for the values when autoDomain()-ing.
+         *
+         * @param {X|Accessor<X>} x
+         * @param {Scale<X, number>} xScale
+         * @returns {Plots.Rectangle} The calling Rectangle Plot.
+         */
+        x(x: X | Accessor<X>, xScale: Scale<X, number>): Plots.Rectangle<X, Y>;
+        /**
+         * Gets the AccessorScaleBinding for X2.
+         */
+        x2(): AccessorScaleBinding<X, number>;
+        /**
+         * Sets X2 to a constant number or the result of an Accessor.
+         * If a Scale has been set for X, it will also be used to scale X2.
+         *
+         * @param {number|Accessor<number>|X|Accessor<X>} x2
+         * @returns {Plots.Rectangle} The calling Rectangle Plot.
+         */
+        x2(x2: number | Accessor<number> | X | Accessor<X>): Plots.Rectangle<X, Y>;
+        /**
+         * Gets the AccessorScaleBinding for Y.
+         */
+        y(): AccessorScaleBinding<Y, number>;
+        /**
+         * Sets Y to a constant number or the result of an Accessor<number>.
+         *
+         * @param {number|Accessor<number>} y
+         * @returns {Plots.Rectangle} The calling Rectangle Plot.
+         */
+        y(y: number | Accessor<number>): Plots.Rectangle<X, Y>;
+        /**
+         * Sets Y to a scaled constant value or scaled result of an Accessor.
+         * The provided Scale will account for the values when autoDomain()-ing.
+         *
+         * @param {Y|Accessor<Y>} y
+         * @param {Scale<Y, number>} yScale
+         * @returns {Plots.Rectangle} The calling Rectangle Plot.
+         */
+        y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): Plots.Rectangle<X, Y>;
+        /**
+         * Gets the AccessorScaleBinding for Y2.
+         */
+        y2(): AccessorScaleBinding<Y, number>;
+        /**
+         * Sets Y2 to a constant number or the result of an Accessor.
+         * If a Scale has been set for Y, it will also be used to scale Y2.
+         *
+         * @param {number|Accessor<number>|Y|Accessor<Y>} y2
+         * @returns {Plots.Rectangle} The calling Rectangle Plot.
+         */
+        y2(y2: number | Accessor<number> | Y | Accessor<Y>): Plots.Rectangle<X, Y>;
+        /**
+         * Gets the PlotEntities at a particular Point.
+         *
+         * @param {Point} point The point to query.
+         * @returns {PlotEntity[]} The PlotEntities at the particular point
+         */
+        entitiesAt(point: Point): PlotEntity[];
+        /**
+         * Gets the Entities that intersect the Bounds.
+         *
+         * @param {Bounds} bounds
+         * @returns {PlotEntity[]}
+         */
+        entitiesIn(bounds: Bounds): PlotEntity[];
+        /**
+         * Gets the Entities that intersect the area defined by the ranges.
+         *
+         * @param {Range} xRange
+         * @param {Range} yRange
+         * @returns {PlotEntity[]}
+         */
+        entitiesIn(xRange: Range, yRange: Range): PlotEntity[];
+        private _entityBBox(datum, index, dataset, attrToProjector);
+        private _entitiesIntersecting(xValOrRange, yValOrRange);
+        /**
+         * Gets the accessor for labels.
+         *
+         * @returns {Accessor<string>}
+         */
+        label(): Accessor<string>;
+        /**
+         * Sets the text of labels to the result of an Accessor.
+         *
+         * @param {Accessor<string>} label
+         * @returns {Plots.Rectangle} The calling Rectangle Plot.
+         */
+        label(label: Accessor<string>): Plots.Rectangle<X, Y>;
+        /**
+         * Gets whether labels are enabled.
+         *
+         * @returns {boolean}
+         */
+        labelsEnabled(): boolean;
+        /**
+         * Sets whether labels are enabled.
+         * Labels too big to be contained in the rectangle, cut off by edges, or blocked by other rectangles will not be shown.
+         *
+         * @param {boolean} labelsEnabled
+         * @returns {Rectangle} The calling Rectangle Plot.
+         */
+        labelsEnabled(enabled: boolean): Plots.Rectangle<X, Y>;
+        protected _propertyProjectors(): AttributeToProjector;
+        protected _pixelPoint(datum: any, index: number, dataset: Dataset): {
+            x: any;
+            y: any;
+        };
+        private _rectangleWidth(scale);
+        protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
+        protected _additionalPaint(time: number): void;
+        private _drawLabels();
+        private _drawLabel(dataToDraw, dataset, datasetIndex);
+        private _overlayLabel(labelXRange, labelYRange, datumIndex, datasetIndex, dataToDraw);
     }
 }
-declare module Plottable {
-    module Plots {
-        class Scatter<X, Y> extends XYPlot<X, Y> {
-            private static _SIZE_KEY;
-            private static _SYMBOL_KEY;
-            /**
-             * A Scatter Plot draws a symbol at each data point.
-             *
-             * @constructor
-             */
-            constructor();
-            protected _createDrawer(dataset: Dataset): Drawers.Symbol;
-            /**
-             * Gets the AccessorScaleBinding for the size property of the plot.
-             * The size property corresponds to the area of the symbol.
-             */
-            size<S>(): AccessorScaleBinding<S, number>;
-            /**
-             * Sets the size property to a constant number or the result of an Accessor<number>.
-             *
-             * @param {number|Accessor<number>} size
-             * @returns {Plots.Scatter} The calling Scatter Plot.
-             */
-            size(size: number | Accessor<number>): Plots.Scatter<X, Y>;
-            /**
-             * Sets the size property to a scaled constant value or scaled result of an Accessor.
-             * The provided Scale will account for the values when autoDomain()-ing.
-             *
-             * @param {S|Accessor<S>} sectorValue
-             * @param {Scale<S, number>} scale
-             * @returns {Plots.Scatter} The calling Scatter Plot.
-             */
-            size<S>(size: S | Accessor<S>, scale: Scale<S, number>): Plots.Scatter<X, Y>;
-            /**
-             * Gets the AccessorScaleBinding for the symbol property of the plot.
-             * The symbol property corresponds to how the symbol will be drawn.
-             */
-            symbol(): AccessorScaleBinding<any, any>;
-            /**
-             * Sets the symbol property to an Accessor<SymbolFactory>.
-             *
-             * @param {Accessor<SymbolFactory>} symbol
-             * @returns {Plots.Scatter} The calling Scatter Plot.
-             */
-            symbol(symbol: Accessor<SymbolFactory>): Plots.Scatter<X, Y>;
-            protected _generateDrawSteps(): Drawers.DrawStep[];
-            /**
-             * @deprecated As of release v1.1.0, replaced by _entityVisibleOnPlot()
-             */
-            protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
-            protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;
-            protected _propertyProjectors(): AttributeToProjector;
-            /**
-             * Gets the Entities that intersect the Bounds.
-             *
-             * @param {Bounds} bounds
-             * @returns {PlotEntity[]}
-             */
-            entitiesIn(bounds: Bounds): PlotEntity[];
-            /**
-             * Gets the Entities that intersect the area defined by the ranges.
-             *
-             * @param {Range} xRange
-             * @param {Range} yRange
-             * @returns {PlotEntity[]}
-             */
-            entitiesIn(xRange: Range, yRange: Range): PlotEntity[];
-            /**
-             * Gets the Entities at a particular Point.
-             *
-             * @param {Point} p
-             * @returns {PlotEntity[]}
-             */
-            entitiesAt(p: Point): PlotEntity[];
-        }
+declare module Plottable.Plots {
+    class Scatter<X, Y> extends XYPlot<X, Y> {
+        private static _SIZE_KEY;
+        private static _SYMBOL_KEY;
+        /**
+         * A Scatter Plot draws a symbol at each data point.
+         *
+         * @constructor
+         */
+        constructor();
+        protected _createDrawer(dataset: Dataset): Drawers.Symbol;
+        /**
+         * Gets the AccessorScaleBinding for the size property of the plot.
+         * The size property corresponds to the area of the symbol.
+         */
+        size<S>(): AccessorScaleBinding<S, number>;
+        /**
+         * Sets the size property to a constant number or the result of an Accessor<number>.
+         *
+         * @param {number|Accessor<number>} size
+         * @returns {Plots.Scatter} The calling Scatter Plot.
+         */
+        size(size: number | Accessor<number>): Plots.Scatter<X, Y>;
+        /**
+         * Sets the size property to a scaled constant value or scaled result of an Accessor.
+         * The provided Scale will account for the values when autoDomain()-ing.
+         *
+         * @param {S|Accessor<S>} sectorValue
+         * @param {Scale<S, number>} scale
+         * @returns {Plots.Scatter} The calling Scatter Plot.
+         */
+        size<S>(size: S | Accessor<S>, scale: Scale<S, number>): Plots.Scatter<X, Y>;
+        /**
+         * Gets the AccessorScaleBinding for the symbol property of the plot.
+         * The symbol property corresponds to how the symbol will be drawn.
+         */
+        symbol(): AccessorScaleBinding<any, any>;
+        /**
+         * Sets the symbol property to an Accessor<SymbolFactory>.
+         *
+         * @param {Accessor<SymbolFactory>} symbol
+         * @returns {Plots.Scatter} The calling Scatter Plot.
+         */
+        symbol(symbol: Accessor<SymbolFactory>): Plots.Scatter<X, Y>;
+        protected _generateDrawSteps(): Drawers.DrawStep[];
+        /**
+         * @deprecated As of release v1.1.0, replaced by _entityVisibleOnPlot()
+         */
+        protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
+        protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;
+        protected _propertyProjectors(): AttributeToProjector;
+        /**
+         * Gets the Entities that intersect the Bounds.
+         *
+         * @param {Bounds} bounds
+         * @returns {PlotEntity[]}
+         */
+        entitiesIn(bounds: Bounds): PlotEntity[];
+        /**
+         * Gets the Entities that intersect the area defined by the ranges.
+         *
+         * @param {Range} xRange
+         * @param {Range} yRange
+         * @returns {PlotEntity[]}
+         */
+        entitiesIn(xRange: Range, yRange: Range): PlotEntity[];
+        /**
+         * Gets the Entities at a particular Point.
+         *
+         * @param {Point} p
+         * @returns {PlotEntity[]}
+         */
+        entitiesAt(p: Point): PlotEntity[];
     }
 }
-declare module Plottable {
-    module Plots {
-        class Bar<X, Y> extends XYPlot<X, Y> {
-            static ORIENTATION_VERTICAL: string;
-            static ORIENTATION_HORIZONTAL: string;
-            private static _BAR_WIDTH_RATIO;
-            private static _SINGLE_BAR_DIMENSION_RATIO;
-            private static _BAR_AREA_CLASS;
-            private static _LABEL_AREA_CLASS;
-            private static _LABEL_VERTICAL_PADDING;
-            private static _LABEL_HORIZONTAL_PADDING;
-            private _baseline;
-            private _baselineValue;
-            protected _isVertical: boolean;
-            private _labelFormatter;
-            private _labelsEnabled;
-            private _hideBarsIfAnyAreTooWide;
-            private _labelConfig;
-            private _baselineValueProvider;
-            private _barPixelWidth;
-            private _updateBarPixelWidthCallback;
-            /**
-             * A Bar Plot draws bars growing out from a baseline to some value
-             *
-             * @constructor
-             * @param {string} [orientation="vertical"] One of "vertical"/"horizontal".
-             */
-            constructor(orientation?: string);
-            x(): Plots.AccessorScaleBinding<X, number>;
-            x(x: number | Accessor<number>): Bar<X, Y>;
-            x(x: X | Accessor<X>, xScale: Scale<X, number>): Bar<X, Y>;
-            y(): Plots.AccessorScaleBinding<Y, number>;
-            y(y: number | Accessor<number>): Bar<X, Y>;
-            y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): Bar<X, Y>;
-            /**
-             * Gets the orientation of the plot
-             *
-             * @return "vertical" | "horizontal"
-             */
-            orientation(): string;
-            render(): Bar<X, Y>;
-            protected _createDrawer(dataset: Dataset): Drawers.Rectangle;
-            protected _setup(): void;
-            /**
-             * Gets the baseline value.
-             * The baseline is the line that the bars are drawn from.
-             *
-             * @returns {X|Y}
-             */
-            baselineValue(): X | Y;
-            /**
-             * Sets the baseline value.
-             * The baseline is the line that the bars are drawn from.
-             *
-             * @param {X|Y} value
-             * @returns {Bar} The calling Bar Plot.
-             */
-            baselineValue(value: X | Y): Bar<X, Y>;
-            addDataset(dataset: Dataset): Bar<X, Y>;
-            protected _addDataset(dataset: Dataset): Bar<X, Y>;
-            removeDataset(dataset: Dataset): Bar<X, Y>;
-            protected _removeDataset(dataset: Dataset): Bar<X, Y>;
-            datasets(): Dataset[];
-            datasets(datasets: Dataset[]): Plot;
-            /**
-             * Get whether bar labels are enabled.
-             *
-             * @returns {boolean} Whether bars should display labels or not.
-             */
-            labelsEnabled(): boolean;
-            /**
-             * Sets whether labels are enabled.
-             *
-             * @param {boolean} labelsEnabled
-             * @returns {Bar} The calling Bar Plot.
-             */
-            labelsEnabled(enabled: boolean): Bar<X, Y>;
-            /**
-             * Gets the Formatter for the labels.
-             */
-            labelFormatter(): Formatter;
-            /**
-             * Sets the Formatter for the labels.
-             *
-             * @param {Formatter} formatter
-             * @returns {Bar} The calling Bar Plot.
-             */
-            labelFormatter(formatter: Formatter): Bar<X, Y>;
-            protected _createNodesForDataset(dataset: Dataset): Drawer;
-            protected _removeDatasetNodes(dataset: Dataset): void;
-            /**
-             * Returns the PlotEntity nearest to the query point according to the following algorithm:
-             *   - If the query point is inside a bar, returns the PlotEntity for that bar.
-             *   - Otherwise, gets the nearest PlotEntity by the primary direction (X for vertical, Y for horizontal),
-             *     breaking ties with the secondary direction.
-             * Returns undefined if no PlotEntity can be found.
-             *
-             * @param {Point} queryPoint
-             * @returns {PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
-             */
-            entityNearest(queryPoint: Point): PlotEntity;
-            /**
-             * @deprecated As of release v1.1.0, replaced by _entityVisibleOnPlot()
-             */
-            protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
-            protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;
-            /**
-             * Gets the Entities at a particular Point.
-             *
-             * @param {Point} p
-             * @returns {PlotEntity[]}
-             */
-            entitiesAt(p: Point): PlotEntity[];
-            /**
-             * Gets the Entities that intersect the Bounds.
-             *
-             * @param {Bounds} bounds
-             * @returns {PlotEntity[]}
-             */
-            entitiesIn(bounds: Bounds): PlotEntity[];
-            /**
-             * Gets the Entities that intersect the area defined by the ranges.
-             *
-             * @param {Range} xRange
-             * @param {Range} yRange
-             * @returns {PlotEntity[]}
-             */
-            entitiesIn(xRange: Range, yRange: Range): PlotEntity[];
-            private _entitiesIntersecting(xValOrRange, yValOrRange);
-            private _updateValueScale();
-            protected _additionalPaint(time: number): void;
-            /**
-             * Makes sure the extent takes into account the widths of the bars
-             */
-            protected _extentsForProperty(property: string): any[];
-            private _drawLabels();
-            private _drawLabel(data, dataset);
-            protected _generateDrawSteps(): Drawers.DrawStep[];
-            protected _generateAttrToProjector(): {
-                [attr: string]: (datum: any, index: number, dataset: Dataset) => any;
-            };
-            /**
-             * Computes the barPixelWidth of all the bars in the plot.
-             *
-             * If the position scale of the plot is a CategoryScale and in bands mode, then the rangeBands function will be used.
-             * If the position scale of the plot is a QuantitativeScale, then the bar width is equal to the smallest distance between
-             * two adjacent data points, padded for visualisation.
-             */
-            protected _getBarPixelWidth(): number;
-            private _updateBarPixelWidth();
-            entities(datasets?: Dataset[]): PlotEntity[];
-            protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point;
-            protected _uninstallScaleForKey(scale: Scale<any, number>, key: string): void;
-            protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
-        }
+declare module Plottable.Plots {
+    class Bar<X, Y> extends XYPlot<X, Y> {
+        static ORIENTATION_VERTICAL: string;
+        static ORIENTATION_HORIZONTAL: string;
+        private static _BAR_WIDTH_RATIO;
+        private static _SINGLE_BAR_DIMENSION_RATIO;
+        private static _BAR_AREA_CLASS;
+        private static _LABEL_AREA_CLASS;
+        private static _LABEL_VERTICAL_PADDING;
+        private static _LABEL_HORIZONTAL_PADDING;
+        private _baseline;
+        private _baselineValue;
+        protected _isVertical: boolean;
+        private _labelFormatter;
+        private _labelsEnabled;
+        private _hideBarsIfAnyAreTooWide;
+        private _labelConfig;
+        private _baselineValueProvider;
+        private _barPixelWidth;
+        private _updateBarPixelWidthCallback;
+        /**
+         * A Bar Plot draws bars growing out from a baseline to some value
+         *
+         * @constructor
+         * @param {string} [orientation="vertical"] One of "vertical"/"horizontal".
+         */
+        constructor(orientation?: string);
+        x(): Plots.AccessorScaleBinding<X, number>;
+        x(x: number | Accessor<number>): Bar<X, Y>;
+        x(x: X | Accessor<X>, xScale: Scale<X, number>): Bar<X, Y>;
+        y(): Plots.AccessorScaleBinding<Y, number>;
+        y(y: number | Accessor<number>): Bar<X, Y>;
+        y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): Bar<X, Y>;
+        /**
+         * Gets the orientation of the plot
+         *
+         * @return "vertical" | "horizontal"
+         */
+        orientation(): string;
+        render(): Bar<X, Y>;
+        protected _createDrawer(dataset: Dataset): Drawers.Rectangle;
+        protected _setup(): void;
+        /**
+         * Gets the baseline value.
+         * The baseline is the line that the bars are drawn from.
+         *
+         * @returns {X|Y}
+         */
+        baselineValue(): X | Y;
+        /**
+         * Sets the baseline value.
+         * The baseline is the line that the bars are drawn from.
+         *
+         * @param {X|Y} value
+         * @returns {Bar} The calling Bar Plot.
+         */
+        baselineValue(value: X | Y): Bar<X, Y>;
+        addDataset(dataset: Dataset): Bar<X, Y>;
+        protected _addDataset(dataset: Dataset): Bar<X, Y>;
+        removeDataset(dataset: Dataset): Bar<X, Y>;
+        protected _removeDataset(dataset: Dataset): Bar<X, Y>;
+        datasets(): Dataset[];
+        datasets(datasets: Dataset[]): Plot;
+        /**
+         * Get whether bar labels are enabled.
+         *
+         * @returns {boolean} Whether bars should display labels or not.
+         */
+        labelsEnabled(): boolean;
+        /**
+         * Sets whether labels are enabled.
+         *
+         * @param {boolean} labelsEnabled
+         * @returns {Bar} The calling Bar Plot.
+         */
+        labelsEnabled(enabled: boolean): Bar<X, Y>;
+        /**
+         * Gets the Formatter for the labels.
+         */
+        labelFormatter(): Formatter;
+        /**
+         * Sets the Formatter for the labels.
+         *
+         * @param {Formatter} formatter
+         * @returns {Bar} The calling Bar Plot.
+         */
+        labelFormatter(formatter: Formatter): Bar<X, Y>;
+        protected _createNodesForDataset(dataset: Dataset): Drawer;
+        protected _removeDatasetNodes(dataset: Dataset): void;
+        /**
+         * Returns the PlotEntity nearest to the query point according to the following algorithm:
+         *   - If the query point is inside a bar, returns the PlotEntity for that bar.
+         *   - Otherwise, gets the nearest PlotEntity by the primary direction (X for vertical, Y for horizontal),
+         *     breaking ties with the secondary direction.
+         * Returns undefined if no PlotEntity can be found.
+         *
+         * @param {Point} queryPoint
+         * @returns {PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
+         */
+        entityNearest(queryPoint: Point): PlotEntity;
+        /**
+         * @deprecated As of release v1.1.0, replaced by _entityVisibleOnPlot()
+         */
+        protected _visibleOnPlot(datum: any, pixelPoint: Point, selection: d3.Selection<void>): boolean;
+        protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;
+        /**
+         * Gets the Entities at a particular Point.
+         *
+         * @param {Point} p
+         * @returns {PlotEntity[]}
+         */
+        entitiesAt(p: Point): PlotEntity[];
+        /**
+         * Gets the Entities that intersect the Bounds.
+         *
+         * @param {Bounds} bounds
+         * @returns {PlotEntity[]}
+         */
+        entitiesIn(bounds: Bounds): PlotEntity[];
+        /**
+         * Gets the Entities that intersect the area defined by the ranges.
+         *
+         * @param {Range} xRange
+         * @param {Range} yRange
+         * @returns {PlotEntity[]}
+         */
+        entitiesIn(xRange: Range, yRange: Range): PlotEntity[];
+        private _entitiesIntersecting(xValOrRange, yValOrRange);
+        private _updateValueScale();
+        protected _additionalPaint(time: number): void;
+        /**
+         * Makes sure the extent takes into account the widths of the bars
+         */
+        protected _extentsForProperty(property: string): any[];
+        private _drawLabels();
+        private _drawLabel(data, dataset);
+        protected _generateDrawSteps(): Drawers.DrawStep[];
+        protected _generateAttrToProjector(): {
+            [attr: string]: (datum: any, index: number, dataset: Dataset) => any;
+        };
+        /**
+         * Computes the barPixelWidth of all the bars in the plot.
+         *
+         * If the position scale of the plot is a CategoryScale and in bands mode, then the rangeBands function will be used.
+         * If the position scale of the plot is a QuantitativeScale, then the bar width is equal to the smallest distance between
+         * two adjacent data points, padded for visualisation.
+         */
+        protected _getBarPixelWidth(): number;
+        private _updateBarPixelWidth();
+        entities(datasets?: Dataset[]): PlotEntity[];
+        protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point;
+        protected _uninstallScaleForKey(scale: Scale<any, number>, key: string): void;
+        protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
     }
 }
-declare module Plottable {
-    module Plots {
-        class Line<X> extends XYPlot<X, number> {
-            private _interpolator;
-            private _autorangeSmooth;
-            private _croppedRenderingEnabled;
-            private _downsamplingEnabled;
-            /**
-             * A Line Plot draws line segments starting from the first data point to the next.
-             *
-             * @constructor
-             */
-            constructor();
-            x(): Plots.AccessorScaleBinding<X, number>;
-            x(x: number | Accessor<number>): Line<X>;
-            x(x: X | Accessor<X>, xScale: Scale<X, number>): Line<X>;
-            y(): Plots.AccessorScaleBinding<number, number>;
-            y(y: number | Accessor<number>): Line<X>;
-            y(y: number | Accessor<number>, yScale: Scale<number, number>): Line<X>;
-            autorangeMode(): string;
-            autorangeMode(autorangeMode: string): Line<X>;
-            /**
-             * Gets whether or not the autoranging is done smoothly.
-             */
-            autorangeSmooth(): boolean;
-            /**
-             * Sets whether or not the autorange is done smoothly.
-             *
-             * Smooth autoranging is done by making sure lines always exit on the left / right side of the plot
-             * and deactivating the nice domain feature on the scales
-             */
-            autorangeSmooth(autorangeSmooth: boolean): Plots.Line<X>;
-            private _setScaleSnapping();
-            /**
-             * Gets the interpolation function associated with the plot.
-             *
-             * @return {string | (points: Array<[number, number]>) => string)}
-             */
-            interpolator(): string | ((points: Array<[number, number]>) => string);
-            /**
-             * Sets the interpolation function associated with the plot.
-             *
-             * @param {string | points: Array<[number, number]>) => string} interpolator Interpolation function
-             * @return Plots.Line
-             */
-            interpolator(interpolator: string | ((points: Array<[number, number]>) => string)): Plots.Line<X>;
-            interpolator(interpolator: "linear"): Line<X>;
-            interpolator(interpolator: "linear-closed"): Line<X>;
-            interpolator(interpolator: "step"): Line<X>;
-            interpolator(interpolator: "step-before"): Line<X>;
-            interpolator(interpolator: "step-after"): Line<X>;
-            interpolator(interpolator: "basis"): Line<X>;
-            interpolator(interpolator: "basis-open"): Line<X>;
-            interpolator(interpolator: "basis-closed"): Line<X>;
-            interpolator(interpolator: "bundle"): Line<X>;
-            interpolator(interpolator: "cardinal"): Line<X>;
-            interpolator(interpolator: "cardinal-open"): Line<X>;
-            interpolator(interpolator: "cardinal-closed"): Line<X>;
-            interpolator(interpolator: "monotone"): Line<X>;
-            /**
-             * Gets if downsampling is enabled
-             *
-             * When downsampling is enabled, two consecutive lines with the same slope will be merged to one line.
-             */
-            downsamplingEnabled(): boolean;
-            /**
-             * Sets if downsampling is enabled
-             *
-             * @returns {Plots.Line} The calling Plots.Line
-             */
-            downsamplingEnabled(downsampling: boolean): Plots.Line<X>;
-            /**
-             * Gets if croppedRendering is enabled
-             *
-             * When croppedRendering is enabled, lines that will not be visible in the viewport will not be drawn.
-             */
-            croppedRenderingEnabled(): boolean;
-            /**
-             * Sets if croppedRendering is enabled
-             *
-             * @returns {Plots.Line} The calling Plots.Line
-             */
-            croppedRenderingEnabled(croppedRendering: boolean): Plots.Line<X>;
-            protected _createDrawer(dataset: Dataset): Drawer;
-            protected _extentsForProperty(property: string): any[];
-            private _getEdgeIntersectionPoints();
-            protected _getResetYFunction(): (d: any, i: number, dataset: Dataset) => number;
-            protected _generateDrawSteps(): Drawers.DrawStep[];
-            protected _generateAttrToProjector(): {
-                [attr: string]: (datum: any, index: number, dataset: Dataset) => any;
-            };
-            /**
-             * Returns the PlotEntity nearest to the query point by X then by Y, or undefined if no PlotEntity can be found.
-             *
-             * @param {Point} queryPoint
-             * @returns {PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
-             */
-            entityNearest(queryPoint: Point): PlotEntity;
-            protected _propertyProjectors(): AttributeToProjector;
-            protected _constructLineProjector(xProjector: Projector, yProjector: Projector): (datum: any, index: number, dataset: Dataset) => string;
-            protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
-            private _filterCroppedRendering(dataset, indices);
-            private _filterDownsampling(dataset, indices);
-        }
+declare module Plottable.Plots {
+    class Line<X> extends XYPlot<X, number> {
+        private _interpolator;
+        private _autorangeSmooth;
+        private _croppedRenderingEnabled;
+        private _downsamplingEnabled;
+        /**
+         * A Line Plot draws line segments starting from the first data point to the next.
+         *
+         * @constructor
+         */
+        constructor();
+        x(): Plots.AccessorScaleBinding<X, number>;
+        x(x: number | Accessor<number>): Line<X>;
+        x(x: X | Accessor<X>, xScale: Scale<X, number>): Line<X>;
+        y(): Plots.AccessorScaleBinding<number, number>;
+        y(y: number | Accessor<number>): Line<X>;
+        y(y: number | Accessor<number>, yScale: Scale<number, number>): Line<X>;
+        autorangeMode(): string;
+        autorangeMode(autorangeMode: string): Line<X>;
+        /**
+         * Gets whether or not the autoranging is done smoothly.
+         */
+        autorangeSmooth(): boolean;
+        /**
+         * Sets whether or not the autorange is done smoothly.
+         *
+         * Smooth autoranging is done by making sure lines always exit on the left / right side of the plot
+         * and deactivating the nice domain feature on the scales
+         */
+        autorangeSmooth(autorangeSmooth: boolean): Plots.Line<X>;
+        private _setScaleSnapping();
+        /**
+         * Gets the interpolation function associated with the plot.
+         *
+         * @return {string | (points: Array<[number, number]>) => string)}
+         */
+        interpolator(): string | ((points: Array<[number, number]>) => string);
+        /**
+         * Sets the interpolation function associated with the plot.
+         *
+         * @param {string | points: Array<[number, number]>) => string} interpolator Interpolation function
+         * @return Plots.Line
+         */
+        interpolator(interpolator: string | ((points: Array<[number, number]>) => string)): Plots.Line<X>;
+        interpolator(interpolator: "linear"): Line<X>;
+        interpolator(interpolator: "linear-closed"): Line<X>;
+        interpolator(interpolator: "step"): Line<X>;
+        interpolator(interpolator: "step-before"): Line<X>;
+        interpolator(interpolator: "step-after"): Line<X>;
+        interpolator(interpolator: "basis"): Line<X>;
+        interpolator(interpolator: "basis-open"): Line<X>;
+        interpolator(interpolator: "basis-closed"): Line<X>;
+        interpolator(interpolator: "bundle"): Line<X>;
+        interpolator(interpolator: "cardinal"): Line<X>;
+        interpolator(interpolator: "cardinal-open"): Line<X>;
+        interpolator(interpolator: "cardinal-closed"): Line<X>;
+        interpolator(interpolator: "monotone"): Line<X>;
+        /**
+         * Gets if downsampling is enabled
+         *
+         * When downsampling is enabled, two consecutive lines with the same slope will be merged to one line.
+         */
+        downsamplingEnabled(): boolean;
+        /**
+         * Sets if downsampling is enabled
+         *
+         * @returns {Plots.Line} The calling Plots.Line
+         */
+        downsamplingEnabled(downsampling: boolean): Plots.Line<X>;
+        /**
+         * Gets if croppedRendering is enabled
+         *
+         * When croppedRendering is enabled, lines that will not be visible in the viewport will not be drawn.
+         */
+        croppedRenderingEnabled(): boolean;
+        /**
+         * Sets if croppedRendering is enabled
+         *
+         * @returns {Plots.Line} The calling Plots.Line
+         */
+        croppedRenderingEnabled(croppedRendering: boolean): Plots.Line<X>;
+        protected _createDrawer(dataset: Dataset): Drawer;
+        protected _extentsForProperty(property: string): any[];
+        private _getEdgeIntersectionPoints();
+        protected _getResetYFunction(): (d: any, i: number, dataset: Dataset) => number;
+        protected _generateDrawSteps(): Drawers.DrawStep[];
+        protected _generateAttrToProjector(): {
+            [attr: string]: (datum: any, index: number, dataset: Dataset) => any;
+        };
+        /**
+         * Returns the PlotEntity nearest to the query point by X then by Y, or undefined if no PlotEntity can be found.
+         *
+         * @param {Point} queryPoint
+         * @returns {PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
+         */
+        entityNearest(queryPoint: Point): PlotEntity;
+        protected _propertyProjectors(): AttributeToProjector;
+        protected _constructLineProjector(xProjector: Projector, yProjector: Projector): (datum: any, index: number, dataset: Dataset) => string;
+        protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
+        private _filterCroppedRendering(dataset, indices);
+        private _filterDownsampling(dataset, indices);
     }
 }
-declare module Plottable {
-    module Plots {
-        class Area<X> extends Line<X> {
-            private static _Y0_KEY;
-            private _lineDrawers;
-            private _constantBaselineValueProvider;
-            /**
-             * An Area Plot draws a filled region (area) between Y and Y0.
-             *
-             * @constructor
-             */
-            constructor();
-            protected _setup(): void;
-            y(): Plots.AccessorScaleBinding<number, number>;
-            y(y: number | Accessor<number>): Area<X>;
-            y(y: number | Accessor<number>, yScale: QuantitativeScale<number>): Area<X>;
-            /**
-             * Gets the AccessorScaleBinding for Y0.
-             */
-            y0(): Plots.AccessorScaleBinding<number, number>;
-            /**
-             * Sets Y0 to a constant number or the result of an Accessor<number>.
-             * If a Scale has been set for Y, it will also be used to scale Y0.
-             *
-             * @param {number|Accessor<number>} y0
-             * @returns {Area} The calling Area Plot.
-             */
-            y0(y0: number | Accessor<number>): Area<X>;
-            protected _onDatasetUpdate(): void;
-            addDataset(dataset: Dataset): Area<X>;
-            protected _addDataset(dataset: Dataset): Area<X>;
-            protected _removeDatasetNodes(dataset: Dataset): void;
-            protected _additionalPaint(): void;
-            private _generateLineDrawSteps();
-            private _generateLineAttrToProjector();
-            protected _createDrawer(dataset: Dataset): Drawers.Area;
-            protected _generateDrawSteps(): Drawers.DrawStep[];
-            protected _updateYScale(): void;
-            protected _getResetYFunction(): Accessor<any>;
-            protected _propertyProjectors(): AttributeToProjector;
-            selections(datasets?: Dataset[]): d3.Selection<any>;
-            protected _constructAreaProjector(xProjector: Projector, yProjector: Projector, y0Projector: Projector): (datum: any[], index: number, dataset: Dataset) => string;
-        }
+declare module Plottable.Plots {
+    class Area<X> extends Line<X> {
+        private static _Y0_KEY;
+        private _lineDrawers;
+        private _constantBaselineValueProvider;
+        /**
+         * An Area Plot draws a filled region (area) between Y and Y0.
+         *
+         * @constructor
+         */
+        constructor();
+        protected _setup(): void;
+        y(): Plots.AccessorScaleBinding<number, number>;
+        y(y: number | Accessor<number>): Area<X>;
+        y(y: number | Accessor<number>, yScale: QuantitativeScale<number>): Area<X>;
+        /**
+         * Gets the AccessorScaleBinding for Y0.
+         */
+        y0(): Plots.AccessorScaleBinding<number, number>;
+        /**
+         * Sets Y0 to a constant number or the result of an Accessor<number>.
+         * If a Scale has been set for Y, it will also be used to scale Y0.
+         *
+         * @param {number|Accessor<number>} y0
+         * @returns {Area} The calling Area Plot.
+         */
+        y0(y0: number | Accessor<number>): Area<X>;
+        protected _onDatasetUpdate(): void;
+        addDataset(dataset: Dataset): Area<X>;
+        protected _addDataset(dataset: Dataset): Area<X>;
+        protected _removeDatasetNodes(dataset: Dataset): void;
+        protected _additionalPaint(): void;
+        private _generateLineDrawSteps();
+        private _generateLineAttrToProjector();
+        protected _createDrawer(dataset: Dataset): Drawers.Area;
+        protected _generateDrawSteps(): Drawers.DrawStep[];
+        protected _updateYScale(): void;
+        protected _getResetYFunction(): Accessor<any>;
+        protected _propertyProjectors(): AttributeToProjector;
+        selections(datasets?: Dataset[]): d3.Selection<any>;
+        protected _constructAreaProjector(xProjector: Projector, yProjector: Projector, y0Projector: Projector): (datum: any[], index: number, dataset: Dataset) => string;
     }
 }
-declare module Plottable {
-    module Plots {
-        class ClusteredBar<X, Y> extends Bar<X, Y> {
-            private _clusterOffsets;
-            /**
-             * A ClusteredBar Plot groups bars across Datasets based on the primary value of the bars.
-             *   On a vertical ClusteredBar Plot, the bars with the same X value are grouped.
-             *   On a horizontal ClusteredBar Plot, the bars with the same Y value are grouped.
-             *
-             * @constructor
-             * @param {string} [orientation="vertical"] One of "vertical"/"horizontal".
-             */
-            constructor(orientation?: string);
-            protected _generateAttrToProjector(): {
-                [attr: string]: (datum: any, index: number, dataset: Dataset) => any;
-            };
-            private _updateClusterPosition();
-            private _makeInnerScale();
-            protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
-        }
+declare module Plottable.Plots {
+    class ClusteredBar<X, Y> extends Bar<X, Y> {
+        private _clusterOffsets;
+        /**
+         * A ClusteredBar Plot groups bars across Datasets based on the primary value of the bars.
+         *   On a vertical ClusteredBar Plot, the bars with the same X value are grouped.
+         *   On a horizontal ClusteredBar Plot, the bars with the same Y value are grouped.
+         *
+         * @constructor
+         * @param {string} [orientation="vertical"] One of "vertical"/"horizontal".
+         */
+        constructor(orientation?: string);
+        protected _generateAttrToProjector(): {
+            [attr: string]: (datum: any, index: number, dataset: Dataset) => any;
+        };
+        private _updateClusterPosition();
+        private _makeInnerScale();
+        protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
     }
 }
-declare module Plottable {
-    module Plots {
-        class StackedArea<X> extends Area<X> {
-            private _stackingResult;
-            private _stackedExtent;
-            private _baseline;
-            private _baselineValue;
-            private _baselineValueProvider;
-            /**
-             * @constructor
-             */
-            constructor();
-            protected _getAnimator(key: string): Animator;
-            protected _setup(): void;
-            x(): Plots.AccessorScaleBinding<X, number>;
-            x(x: number | Accessor<number>): StackedArea<X>;
-            x(x: X | Accessor<X>, xScale: Scale<X, number>): StackedArea<X>;
-            y(): Plots.AccessorScaleBinding<number, number>;
-            y(y: number | Accessor<number>): StackedArea<X>;
-            y(y: number | Accessor<number>, yScale: QuantitativeScale<number>): StackedArea<X>;
-            /**
-             * Gets if downsampling is enabled
-             *
-             * When downsampling is enabled, two consecutive lines with the same slope will be merged to one line.
-             */
-            downsamplingEnabled(): boolean;
-            /**
-             * Sets if downsampling is enabled
-             *
-             * For now, downsampling is always disabled in stacked area plot
-             * @returns {Plots.StackedArea} The calling Plots.StackedArea
-             */
-            downsamplingEnabled(downsampling: boolean): Plots.Line<X>;
-            protected _additionalPaint(): void;
-            protected _updateYScale(): void;
-            protected _onDatasetUpdate(): StackedArea<X>;
-            protected _updateExtentsForProperty(property: string): void;
-            protected _extentsForProperty(attr: string): any[];
-            private _updateStackExtentsAndOffsets();
-            private _checkSameDomain(datasets, keyAccessor);
-            /**
-             * Given an array of Datasets and the accessor function for the key, computes the
-             * set reunion (no duplicates) of the domain of each Dataset. The keys are stringified
-             * before being returned.
-             *
-             * @param {Dataset[]} datasets The Datasets for which we extract the domain keys
-             * @param {Accessor<any>} keyAccessor The accessor for the key of the data
-             * @return {string[]} An array of stringified keys
-             */
-            private static _domainKeys(datasets, keyAccessor);
-            protected _propertyProjectors(): AttributeToProjector;
-            protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point;
-        }
+declare module Plottable.Plots {
+    class StackedArea<X> extends Area<X> {
+        private _stackingResult;
+        private _stackedExtent;
+        private _baseline;
+        private _baselineValue;
+        private _baselineValueProvider;
+        /**
+         * @constructor
+         */
+        constructor();
+        protected _getAnimator(key: string): Animator;
+        protected _setup(): void;
+        x(): Plots.AccessorScaleBinding<X, number>;
+        x(x: number | Accessor<number>): StackedArea<X>;
+        x(x: X | Accessor<X>, xScale: Scale<X, number>): StackedArea<X>;
+        y(): Plots.AccessorScaleBinding<number, number>;
+        y(y: number | Accessor<number>): StackedArea<X>;
+        y(y: number | Accessor<number>, yScale: QuantitativeScale<number>): StackedArea<X>;
+        /**
+         * Gets if downsampling is enabled
+         *
+         * When downsampling is enabled, two consecutive lines with the same slope will be merged to one line.
+         */
+        downsamplingEnabled(): boolean;
+        /**
+         * Sets if downsampling is enabled
+         *
+         * For now, downsampling is always disabled in stacked area plot
+         * @returns {Plots.StackedArea} The calling Plots.StackedArea
+         */
+        downsamplingEnabled(downsampling: boolean): Plots.Line<X>;
+        protected _additionalPaint(): void;
+        protected _updateYScale(): void;
+        protected _onDatasetUpdate(): StackedArea<X>;
+        protected _updateExtentsForProperty(property: string): void;
+        protected _extentsForProperty(attr: string): any[];
+        private _updateStackExtentsAndOffsets();
+        private _checkSameDomain(datasets, keyAccessor);
+        /**
+         * Given an array of Datasets and the accessor function for the key, computes the
+         * set reunion (no duplicates) of the domain of each Dataset. The keys are stringified
+         * before being returned.
+         *
+         * @param {Dataset[]} datasets The Datasets for which we extract the domain keys
+         * @param {Accessor<any>} keyAccessor The accessor for the key of the data
+         * @return {string[]} An array of stringified keys
+         */
+        private static _domainKeys(datasets, keyAccessor);
+        protected _propertyProjectors(): AttributeToProjector;
+        protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point;
     }
 }
-declare module Plottable {
-    module Plots {
-        class StackedBar<X, Y> extends Bar<X, Y> {
-            private _stackingResult;
-            private _stackedExtent;
-            /**
-             * A StackedBar Plot stacks bars across Datasets based on the primary value of the bars.
-             *   On a vertical StackedBar Plot, the bars with the same X value are stacked.
-             *   On a horizontal StackedBar Plot, the bars with the same Y value are stacked.
-             *
-             * @constructor
-             * @param {Scale} xScale
-             * @param {Scale} yScale
-             * @param {string} [orientation="vertical"] One of "vertical"/"horizontal".
-             */
-            constructor(orientation?: string);
-            x(): Plots.AccessorScaleBinding<X, number>;
-            x(x: number | Accessor<number>): StackedBar<X, Y>;
-            x(x: X | Accessor<X>, xScale: Scale<X, number>): StackedBar<X, Y>;
-            y(): Plots.AccessorScaleBinding<Y, number>;
-            y(y: number | Accessor<number>): StackedBar<X, Y>;
-            y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): StackedBar<X, Y>;
-            protected _generateAttrToProjector(): {
-                [attr: string]: (datum: any, index: number, dataset: Dataset) => any;
-            };
-            protected _onDatasetUpdate(): StackedBar<X, Y>;
-            protected _updateExtentsForProperty(property: string): void;
-            protected _extentsForProperty(attr: string): any[];
-            private _updateStackExtentsAndOffsets();
-        }
+declare module Plottable.Plots {
+    class StackedBar<X, Y> extends Bar<X, Y> {
+        private _stackingResult;
+        private _stackedExtent;
+        /**
+         * A StackedBar Plot stacks bars across Datasets based on the primary value of the bars.
+         *   On a vertical StackedBar Plot, the bars with the same X value are stacked.
+         *   On a horizontal StackedBar Plot, the bars with the same Y value are stacked.
+         *
+         * @constructor
+         * @param {Scale} xScale
+         * @param {Scale} yScale
+         * @param {string} [orientation="vertical"] One of "vertical"/"horizontal".
+         */
+        constructor(orientation?: string);
+        x(): Plots.AccessorScaleBinding<X, number>;
+        x(x: number | Accessor<number>): StackedBar<X, Y>;
+        x(x: X | Accessor<X>, xScale: Scale<X, number>): StackedBar<X, Y>;
+        y(): Plots.AccessorScaleBinding<Y, number>;
+        y(y: number | Accessor<number>): StackedBar<X, Y>;
+        y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): StackedBar<X, Y>;
+        protected _generateAttrToProjector(): {
+            [attr: string]: (datum: any, index: number, dataset: Dataset) => any;
+        };
+        protected _onDatasetUpdate(): StackedBar<X, Y>;
+        protected _updateExtentsForProperty(property: string): void;
+        protected _extentsForProperty(attr: string): any[];
+        private _updateStackExtentsAndOffsets();
     }
 }
-declare module Plottable {
-    module Plots {
-        class Segment<X, Y> extends XYPlot<X, Y> {
-            private static _X2_KEY;
-            private static _Y2_KEY;
-            /**
-             * A Segment Plot displays line segments based on the data.
-             *
-             * @constructor
-             */
-            constructor();
-            protected _createDrawer(dataset: Dataset): Drawers.Segment;
-            protected _generateDrawSteps(): Drawers.DrawStep[];
-            protected _updateExtentsForProperty(property: string): void;
-            protected _filterForProperty(property: string): (datum: any, index: number, dataset: Dataset) => boolean;
-            /**
-             * Gets the AccessorScaleBinding for X
-             */
-            x(): AccessorScaleBinding<X, number>;
-            /**
-             * Sets X to a constant value or the result of an Accessor.
-             *
-             * @param {X|Accessor<X>} x
-             * @returns {Plots.Segment} The calling Segment Plot.
-             */
-            x(x: number | Accessor<number>): Plots.Segment<X, Y>;
-            /**
-             * Sets X to a scaled constant value or scaled result of an Accessor.
-             * The provided Scale will account for the values when autoDomain()-ing.
-             *
-             * @param {X|Accessor<X>} x
-             * @param {Scale<X, number>} xScale
-             * @returns {Plots.Segment} The calling Segment Plot.
-             */
-            x(x: X | Accessor<X>, xScale: Scale<X, number>): Plots.Segment<X, Y>;
-            /**
-             * Gets the AccessorScaleBinding for X2
-             */
-            x2(): AccessorScaleBinding<X, number>;
-            /**
-             * Sets X2 to a constant number or the result of an Accessor.
-             * If a Scale has been set for X, it will also be used to scale X2.
-             *
-             * @param {number|Accessor<number>|Y|Accessor<Y>} y2
-             * @returns {Plots.Segment} The calling Segment Plot
-             */
-            x2(x2: number | Accessor<number> | X | Accessor<X>): Plots.Segment<X, Y>;
-            /**
-             * Gets the AccessorScaleBinding for Y
-             */
-            y(): AccessorScaleBinding<Y, number>;
-            /**
-             * Sets Y to a constant value or the result of an Accessor.
-             *
-             * @param {Y|Accessor<Y>} y
-             * @returns {Plots.Segment} The calling Segment Plot.
-             */
-            y(y: number | Accessor<number>): Plots.Segment<X, Y>;
-            /**
-             * Sets Y to a scaled constant value or scaled result of an Accessor.
-             * The provided Scale will account for the values when autoDomain()-ing.
-             *
-             * @param {Y|Accessor<Y>} y
-             * @param {Scale<Y, number>} yScale
-             * @returns {Plots.Segment} The calling Segment Plot.
-             */
-            y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): Plots.Segment<X, Y>;
-            /**
-             * Gets the AccessorScaleBinding for Y2.
-             */
-            y2(): AccessorScaleBinding<Y, number>;
-            /**
-             * Sets Y2 to a constant number or the result of an Accessor.
-             * If a Scale has been set for Y, it will also be used to scale Y2.
-             *
-             * @param {number|Accessor<number>|Y|Accessor<Y>} y2
-             * @returns {Plots.Segment} The calling Segment Plot.
-             */
-            y2(y2: number | Accessor<number> | Y | Accessor<Y>): Plots.Segment<X, Y>;
-            protected _propertyProjectors(): AttributeToProjector;
-            /**
-             * Gets the Entities that intersect the Bounds.
-             *
-             * @param {Bounds} bounds
-             * @returns {PlotEntity[]}
-             */
-            entitiesIn(bounds: Bounds): PlotEntity[];
-            /**
-             * Gets the Entities that intersect the area defined by the ranges.
-             *
-             * @param {Range} xRange
-             * @param {Range} yRange
-             * @returns {PlotEntity[]}
-             */
-            entitiesIn(xRange: Range, yRange: Range): PlotEntity[];
-            private _entitiesIntersecting(xRange, yRange);
-            private _lineIntersectsBox(entity, xRange, yRange, attrToProjector);
-            private _lineIntersectsSegment(point1, point2, point3, point4);
-        }
+declare module Plottable.Plots {
+    class Segment<X, Y> extends XYPlot<X, Y> {
+        private static _X2_KEY;
+        private static _Y2_KEY;
+        /**
+         * A Segment Plot displays line segments based on the data.
+         *
+         * @constructor
+         */
+        constructor();
+        protected _createDrawer(dataset: Dataset): Drawers.Segment;
+        protected _generateDrawSteps(): Drawers.DrawStep[];
+        protected _updateExtentsForProperty(property: string): void;
+        protected _filterForProperty(property: string): (datum: any, index: number, dataset: Dataset) => boolean;
+        /**
+         * Gets the AccessorScaleBinding for X
+         */
+        x(): AccessorScaleBinding<X, number>;
+        /**
+         * Sets X to a constant value or the result of an Accessor.
+         *
+         * @param {X|Accessor<X>} x
+         * @returns {Plots.Segment} The calling Segment Plot.
+         */
+        x(x: number | Accessor<number>): Plots.Segment<X, Y>;
+        /**
+         * Sets X to a scaled constant value or scaled result of an Accessor.
+         * The provided Scale will account for the values when autoDomain()-ing.
+         *
+         * @param {X|Accessor<X>} x
+         * @param {Scale<X, number>} xScale
+         * @returns {Plots.Segment} The calling Segment Plot.
+         */
+        x(x: X | Accessor<X>, xScale: Scale<X, number>): Plots.Segment<X, Y>;
+        /**
+         * Gets the AccessorScaleBinding for X2
+         */
+        x2(): AccessorScaleBinding<X, number>;
+        /**
+         * Sets X2 to a constant number or the result of an Accessor.
+         * If a Scale has been set for X, it will also be used to scale X2.
+         *
+         * @param {number|Accessor<number>|Y|Accessor<Y>} y2
+         * @returns {Plots.Segment} The calling Segment Plot
+         */
+        x2(x2: number | Accessor<number> | X | Accessor<X>): Plots.Segment<X, Y>;
+        /**
+         * Gets the AccessorScaleBinding for Y
+         */
+        y(): AccessorScaleBinding<Y, number>;
+        /**
+         * Sets Y to a constant value or the result of an Accessor.
+         *
+         * @param {Y|Accessor<Y>} y
+         * @returns {Plots.Segment} The calling Segment Plot.
+         */
+        y(y: number | Accessor<number>): Plots.Segment<X, Y>;
+        /**
+         * Sets Y to a scaled constant value or scaled result of an Accessor.
+         * The provided Scale will account for the values when autoDomain()-ing.
+         *
+         * @param {Y|Accessor<Y>} y
+         * @param {Scale<Y, number>} yScale
+         * @returns {Plots.Segment} The calling Segment Plot.
+         */
+        y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): Plots.Segment<X, Y>;
+        /**
+         * Gets the AccessorScaleBinding for Y2.
+         */
+        y2(): AccessorScaleBinding<Y, number>;
+        /**
+         * Sets Y2 to a constant number or the result of an Accessor.
+         * If a Scale has been set for Y, it will also be used to scale Y2.
+         *
+         * @param {number|Accessor<number>|Y|Accessor<Y>} y2
+         * @returns {Plots.Segment} The calling Segment Plot.
+         */
+        y2(y2: number | Accessor<number> | Y | Accessor<Y>): Plots.Segment<X, Y>;
+        protected _propertyProjectors(): AttributeToProjector;
+        /**
+         * Gets the Entities that intersect the Bounds.
+         *
+         * @param {Bounds} bounds
+         * @returns {PlotEntity[]}
+         */
+        entitiesIn(bounds: Bounds): PlotEntity[];
+        /**
+         * Gets the Entities that intersect the area defined by the ranges.
+         *
+         * @param {Range} xRange
+         * @param {Range} yRange
+         * @returns {PlotEntity[]}
+         */
+        entitiesIn(xRange: Range, yRange: Range): PlotEntity[];
+        private _entitiesIntersecting(xRange, yRange);
+        private _lineIntersectsBox(entity, xRange, yRange, attrToProjector);
+        private _lineIntersectsSegment(point1, point2, point3, point4);
     }
 }
-declare module Plottable {
-    module Plots {
-        class Waterfall<X, Y> extends Bar<X, number> {
-            private static _BAR_DECLINE_CLASS;
-            private static _BAR_GROWTH_CLASS;
-            private static _BAR_TOTAL_CLASS;
-            private static _CONNECTOR_CLASS;
-            private static _CONNECTOR_AREA_CLASS;
-            private static _TOTAL_KEY;
-            private _connectorArea;
-            private _connectorsEnabled;
-            private _extent;
-            private _subtotals;
-            constructor();
-            /**
-             * Gets whether connectors are enabled.
-             *
-             * @returns {boolean} Whether connectors should be shown or not.
-             */
-            connectorsEnabled(): boolean;
-            /**
-             * Sets whether connectors are enabled.
-             *
-             * @param {boolean} enabled
-             * @returns {Plots.Waterfall} The calling Waterfall Plot.
-             */
-            connectorsEnabled(enabled: boolean): Waterfall<X, Y>;
-            /**
-             * Gets the AccessorScaleBinding for whether a bar represents a total or a delta.
-             */
-            total<T>(): Plots.AccessorScaleBinding<T, boolean>;
-            /**
-             * Sets total to a constant number or the result of an Accessor
-             *
-             * @param {Accessor<boolean>}
-             * @returns {Plots.Waterfall} The calling Waterfall Plot.
-             */
-            total(total: Accessor<boolean>): Waterfall<X, Y>;
-            protected _additionalPaint(time: number): void;
-            protected _createNodesForDataset(dataset: Dataset): Drawer;
-            protected _extentsForProperty(attr: string): any[];
-            protected _generateAttrToProjector(): {
-                [attr: string]: (datum: any, index: number, dataset: Dataset) => any;
-            };
-            protected _onDatasetUpdate(): Waterfall<X, Y>;
-            private _calculateSubtotalsAndExtent(dataset);
-            private _drawConnectors();
-            private _updateSubtotals();
-        }
+declare module Plottable.Plots {
+    class Waterfall<X, Y> extends Bar<X, number> {
+        private static _BAR_DECLINE_CLASS;
+        private static _BAR_GROWTH_CLASS;
+        private static _BAR_TOTAL_CLASS;
+        private static _CONNECTOR_CLASS;
+        private static _CONNECTOR_AREA_CLASS;
+        private static _TOTAL_KEY;
+        private _connectorArea;
+        private _connectorsEnabled;
+        private _extent;
+        private _subtotals;
+        constructor();
+        /**
+         * Gets whether connectors are enabled.
+         *
+         * @returns {boolean} Whether connectors should be shown or not.
+         */
+        connectorsEnabled(): boolean;
+        /**
+         * Sets whether connectors are enabled.
+         *
+         * @param {boolean} enabled
+         * @returns {Plots.Waterfall} The calling Waterfall Plot.
+         */
+        connectorsEnabled(enabled: boolean): Waterfall<X, Y>;
+        /**
+         * Gets the AccessorScaleBinding for whether a bar represents a total or a delta.
+         */
+        total<T>(): Plots.AccessorScaleBinding<T, boolean>;
+        /**
+         * Sets total to a constant number or the result of an Accessor
+         *
+         * @param {Accessor<boolean>}
+         * @returns {Plots.Waterfall} The calling Waterfall Plot.
+         */
+        total(total: Accessor<boolean>): Waterfall<X, Y>;
+        protected _additionalPaint(time: number): void;
+        protected _createNodesForDataset(dataset: Dataset): Drawer;
+        protected _extentsForProperty(attr: string): any[];
+        protected _generateAttrToProjector(): {
+            [attr: string]: (datum: any, index: number, dataset: Dataset) => any;
+        };
+        protected _onDatasetUpdate(): Waterfall<X, Y>;
+        private _calculateSubtotalsAndExtent(dataset);
+        private _drawConnectors();
+        private _updateSubtotals();
     }
 }
-declare module Plottable {
-    module Plots {
-        class Wheel<R, T> extends Plot {
-            private static _R_KEY;
-            private static _R2_KEY;
-            private static _T_KEY;
-            private static _T2_KEY;
-            /**
-             * @constructor
-             */
-            constructor();
-            computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Wheel<R, T>;
-            protected _createDrawer(dataset: Dataset): Drawers.Arc;
-            entities(datasets?: Dataset[]): PlotEntity[];
-            protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
-            protected _propertyProjectors(): AttributeToProjector;
-            /**
-             * Gets the AccessorScaleBinding for t in degrees.
-             */
-            t(): AccessorScaleBinding<T, number>;
-            /**
-             * Sets t to a constant number or the result of an Accessor<number> in degrees.
-             *
-             * @param {number|Accessor<number>} t
-             * @returns {Wheel} The calling Wheel Plot.
-             */
-            t(t: number | Accessor<number>): Plots.Wheel<R, T>;
-            /**
-             * Sets t to a scaled constant value or scaled result of an Accessor in degrees.
-             * The supplied Scale will also be used for t2().
-             * The provided Scale will account for the values when autoDomain()-ing.
-             *
-             * @param {T|Accessor<T>} t
-             * @param {QuantitativeScale<T>} scale
-             * @returns {Wheel} The calling Wheel Plot.
-             */
-            t(t: T | Accessor<T>, scale: QuantitativeScale<T>): Plots.Wheel<R, T>;
-            /**
-             * Gets the AccessorScaleBinding for t2 in degrees.
-             */
-            t2(): AccessorScaleBinding<T, number>;
-            /**
-             * Sets t2 to a constant number or the result of an Accessor<number> in degrees.
-             * If a Scale has been set for t, it will also be used to scale t2.
-             *
-             * @param {number|Accessor<number|T|Accessor<T>>} t2
-             * @returns {Wheel} The calling Wheel Plot.
-             */
-            t2(t2: number | Accessor<number> | T | Accessor<T>): Plots.Wheel<R, T>;
-            /**
-             * Gets the AccessorScaleBinding for r.
-             */
-            r(): AccessorScaleBinding<R, number>;
-            /**
-             * Sets r to a constant number or the result of an Accessor<number>.
-             *
-             * @param {number|Accessor<number>} r
-             * @returns {Wheel} The calling Wheel Plot.
-             */
-            r(r: number | Accessor<number>): Plots.Wheel<R, T>;
-            /**
-             * Sets r to a scaled constant value or scaled result of an Accessor.
-             * The supplied Scale will also be used for r2().
-             * The provided Scale will account for the values when autoDomain()-ing.
-             *
-             * @param {R|Accessor<R>} r
-             * @param {QuantitativeScale<R>} scale
-             * @returns {Wheel} The calling Wheel Plot.
-             */
-            r(r: R | Accessor<R>, scale: QuantitativeScale<R>): Plots.Wheel<R, T>;
-            /**
-             * Gets the AccessorScaleBinding for r2.
-             */
-            r2(): AccessorScaleBinding<R, number>;
-            /**
-             * Sets r2 to a constant number or the result of an Accessor<number>.
-             * If a Scale has been set for r, it will also be used to scale r2.
-             *
-             * @param {number|Accessor<number>|R|Accessor<R>} r2
-             * @returns {Wheel} The calling Wheel Plot.
-             */
-            r2(r2: number | Accessor<number> | R | Accessor<R>): Plots.Wheel<R, T>;
-            protected _pixelPoint(datum: any, index: number, dataset: Dataset): {
-                x: number;
-                y: number;
-            };
-        }
+declare module Plottable.Plots {
+    class Wheel<R, T> extends Plot {
+        private static _R_KEY;
+        private static _R2_KEY;
+        private static _T_KEY;
+        private static _T2_KEY;
+        /**
+         * @constructor
+         */
+        constructor();
+        computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): Wheel<R, T>;
+        protected _createDrawer(dataset: Dataset): Drawers.Arc;
+        entities(datasets?: Dataset[]): PlotEntity[];
+        protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
+        protected _propertyProjectors(): AttributeToProjector;
+        /**
+         * Gets the AccessorScaleBinding for t in degrees.
+         */
+        t(): AccessorScaleBinding<T, number>;
+        /**
+         * Sets t to a constant number or the result of an Accessor<number> in degrees.
+         *
+         * @param {number|Accessor<number>} t
+         * @returns {Wheel} The calling Wheel Plot.
+         */
+        t(t: number | Accessor<number>): Plots.Wheel<R, T>;
+        /**
+         * Sets t to a scaled constant value or scaled result of an Accessor in degrees.
+         * The supplied Scale will also be used for t2().
+         * The provided Scale will account for the values when autoDomain()-ing.
+         *
+         * @param {T|Accessor<T>} t
+         * @param {QuantitativeScale<T>} scale
+         * @returns {Wheel} The calling Wheel Plot.
+         */
+        t(t: T | Accessor<T>, scale: QuantitativeScale<T>): Plots.Wheel<R, T>;
+        /**
+         * Gets the AccessorScaleBinding for t2 in degrees.
+         */
+        t2(): AccessorScaleBinding<T, number>;
+        /**
+         * Sets t2 to a constant number or the result of an Accessor<number> in degrees.
+         * If a Scale has been set for t, it will also be used to scale t2.
+         *
+         * @param {number|Accessor<number|T|Accessor<T>>} t2
+         * @returns {Wheel} The calling Wheel Plot.
+         */
+        t2(t2: number | Accessor<number> | T | Accessor<T>): Plots.Wheel<R, T>;
+        /**
+         * Gets the AccessorScaleBinding for r.
+         */
+        r(): AccessorScaleBinding<R, number>;
+        /**
+         * Sets r to a constant number or the result of an Accessor<number>.
+         *
+         * @param {number|Accessor<number>} r
+         * @returns {Wheel} The calling Wheel Plot.
+         */
+        r(r: number | Accessor<number>): Plots.Wheel<R, T>;
+        /**
+         * Sets r to a scaled constant value or scaled result of an Accessor.
+         * The supplied Scale will also be used for r2().
+         * The provided Scale will account for the values when autoDomain()-ing.
+         *
+         * @param {R|Accessor<R>} r
+         * @param {QuantitativeScale<R>} scale
+         * @returns {Wheel} The calling Wheel Plot.
+         */
+        r(r: R | Accessor<R>, scale: QuantitativeScale<R>): Plots.Wheel<R, T>;
+        /**
+         * Gets the AccessorScaleBinding for r2.
+         */
+        r2(): AccessorScaleBinding<R, number>;
+        /**
+         * Sets r2 to a constant number or the result of an Accessor<number>.
+         * If a Scale has been set for r, it will also be used to scale r2.
+         *
+         * @param {number|Accessor<number>|R|Accessor<R>} r2
+         * @returns {Wheel} The calling Wheel Plot.
+         */
+        r2(r2: number | Accessor<number> | R | Accessor<R>): Plots.Wheel<R, T>;
+        protected _pixelPoint(datum: any, index: number, dataset: Dataset): {
+            x: number;
+            y: number;
+        };
     }
 }
 declare module Plottable {
@@ -4154,135 +4042,131 @@ declare module Plottable {
         totalTime(numberOfIterations: number): number;
     }
 }
-declare module Plottable {
-    module Animators {
-        /**
-         * An animator implementation with no animation. The attributes are
-         * immediately set on the selection.
-         */
-        class Null implements Animator {
-            totalTime(selection: any): number;
-            animate(selection: d3.Selection<any>, attrToAppliedProjector: AttributeToAppliedProjector): d3.Selection<any>;
-        }
+declare module Plottable.Animators {
+    /**
+     * An animator implementation with no animation. The attributes are
+     * immediately set on the selection.
+     */
+    class Null implements Animator {
+        totalTime(selection: any): number;
+        animate(selection: d3.Selection<any>, attrToAppliedProjector: AttributeToAppliedProjector): d3.Selection<any>;
     }
 }
-declare module Plottable {
-    module Animators {
+declare module Plottable.Animators {
+    /**
+     * An Animator with easing and configurable durations and delays.
+     */
+    class Easing implements Animator {
         /**
-         * An Animator with easing and configurable durations and delays.
+         * The default starting delay of the animation in milliseconds
          */
-        class Easing implements Animator {
-            /**
-             * The default starting delay of the animation in milliseconds
-             */
-            private static _DEFAULT_START_DELAY_MILLISECONDS;
-            /**
-             * The default duration of one animation step in milliseconds
-             */
-            private static _DEFAULT_STEP_DURATION_MILLISECONDS;
-            /**
-             * The default maximum start delay between each step of an animation
-             */
-            private static _DEFAULT_ITERATIVE_DELAY_MILLISECONDS;
-            /**
-             * The default maximum total animation duration
-             */
-            private static _DEFAULT_MAX_TOTAL_DURATION_MILLISECONDS;
-            /**
-             * The default easing of the animation
-             */
-            private static _DEFAULT_EASING_MODE;
-            private _startDelay;
-            private _stepDuration;
-            private _stepDelay;
-            private _maxTotalDuration;
-            private _easingMode;
-            /**
-             * Constructs the default animator
-             *
-             * @constructor
-             */
-            constructor();
-            totalTime(numberOfSteps: number): number;
-            animate(selection: d3.Selection<any>, attrToAppliedProjector: AttributeToAppliedProjector): d3.Transition<any>;
-            /**
-             * Gets the start delay of the animation in milliseconds.
-             *
-             * @returns {number} The current start delay.
-             */
-            startDelay(): number;
-            /**
-             * Sets the start delay of the animation in milliseconds.
-             *
-             * @param {number} startDelay The start delay in milliseconds.
-             * @returns {Easing} The calling Easing Animator.
-             */
-            startDelay(startDelay: number): Easing;
-            /**
-             * Gets the duration of one animation step in milliseconds.
-             *
-             * @returns {number} The current duration.
-             */
-            stepDuration(): number;
-            /**
-             * Sets the duration of one animation step in milliseconds.
-             *
-             * @param {number} stepDuration The duration in milliseconds.
-             * @returns {Easing} The calling Easing Animator.
-             */
-            stepDuration(stepDuration: number): Easing;
-            /**
-             * Gets the maximum start delay between animation steps in milliseconds.
-             *
-             * @returns {number} The current maximum iterative delay.
-             */
-            stepDelay(): number;
-            /**
-             * Sets the maximum start delay between animation steps in milliseconds.
-             *
-             * @param {number} stepDelay The maximum iterative delay in milliseconds.
-             * @returns {Easing} The calling Easing Animator.
-             */
-            stepDelay(stepDelay: number): Easing;
-            /**
-             * Gets the maximum total animation duration constraint in milliseconds.
-             *
-             * If the animation time would exceed the specified time, the duration of each step
-             * and the delay between each step will be reduced until the animation fits within
-             * the specified time.
-             *
-             * @returns {number} The current maximum total animation duration.
-             */
-            maxTotalDuration(): number;
-            /**
-             * Sets the maximum total animation duration constraint in miliseconds.
-             *
-             * If the animation time would exceed the specified time, the duration of each step
-             * and the delay between each step will be reduced until the animation fits within
-             * the specified time.
-             *
-             * @param {number} maxTotalDuration The maximum total animation duration in milliseconds.
-             * @returns {Easing} The calling Easing Animator.
-             */
-            maxTotalDuration(maxTotalDuration: number): Easing;
-            /**
-             * Gets the current easing mode of the animation.
-             *
-             * @returns {string} the current easing mode.
-             */
-            easingMode(): string;
-            /**
-             * Sets the easing mode of the animation.
-             *
-             * @param {string} easingMode The desired easing mode.
-             * @returns {Easing} The calling Easing Animator.
-             */
-            easingMode(easingMode: string): Easing;
-            /**
-             * Adjust the iterative delay, such that it takes into account the maxTotalDuration constraint
-             */
-            private _getAdjustedIterativeDelay(numberOfSteps);
-        }
+        private static _DEFAULT_START_DELAY_MILLISECONDS;
+        /**
+         * The default duration of one animation step in milliseconds
+         */
+        private static _DEFAULT_STEP_DURATION_MILLISECONDS;
+        /**
+         * The default maximum start delay between each step of an animation
+         */
+        private static _DEFAULT_ITERATIVE_DELAY_MILLISECONDS;
+        /**
+         * The default maximum total animation duration
+         */
+        private static _DEFAULT_MAX_TOTAL_DURATION_MILLISECONDS;
+        /**
+         * The default easing of the animation
+         */
+        private static _DEFAULT_EASING_MODE;
+        private _startDelay;
+        private _stepDuration;
+        private _stepDelay;
+        private _maxTotalDuration;
+        private _easingMode;
+        /**
+         * Constructs the default animator
+         *
+         * @constructor
+         */
+        constructor();
+        totalTime(numberOfSteps: number): number;
+        animate(selection: d3.Selection<any>, attrToAppliedProjector: AttributeToAppliedProjector): d3.Transition<any>;
+        /**
+         * Gets the start delay of the animation in milliseconds.
+         *
+         * @returns {number} The current start delay.
+         */
+        startDelay(): number;
+        /**
+         * Sets the start delay of the animation in milliseconds.
+         *
+         * @param {number} startDelay The start delay in milliseconds.
+         * @returns {Easing} The calling Easing Animator.
+         */
+        startDelay(startDelay: number): Easing;
+        /**
+         * Gets the duration of one animation step in milliseconds.
+         *
+         * @returns {number} The current duration.
+         */
+        stepDuration(): number;
+        /**
+         * Sets the duration of one animation step in milliseconds.
+         *
+         * @param {number} stepDuration The duration in milliseconds.
+         * @returns {Easing} The calling Easing Animator.
+         */
+        stepDuration(stepDuration: number): Easing;
+        /**
+         * Gets the maximum start delay between animation steps in milliseconds.
+         *
+         * @returns {number} The current maximum iterative delay.
+         */
+        stepDelay(): number;
+        /**
+         * Sets the maximum start delay between animation steps in milliseconds.
+         *
+         * @param {number} stepDelay The maximum iterative delay in milliseconds.
+         * @returns {Easing} The calling Easing Animator.
+         */
+        stepDelay(stepDelay: number): Easing;
+        /**
+         * Gets the maximum total animation duration constraint in milliseconds.
+         *
+         * If the animation time would exceed the specified time, the duration of each step
+         * and the delay between each step will be reduced until the animation fits within
+         * the specified time.
+         *
+         * @returns {number} The current maximum total animation duration.
+         */
+        maxTotalDuration(): number;
+        /**
+         * Sets the maximum total animation duration constraint in miliseconds.
+         *
+         * If the animation time would exceed the specified time, the duration of each step
+         * and the delay between each step will be reduced until the animation fits within
+         * the specified time.
+         *
+         * @param {number} maxTotalDuration The maximum total animation duration in milliseconds.
+         * @returns {Easing} The calling Easing Animator.
+         */
+        maxTotalDuration(maxTotalDuration: number): Easing;
+        /**
+         * Gets the current easing mode of the animation.
+         *
+         * @returns {string} the current easing mode.
+         */
+        easingMode(): string;
+        /**
+         * Sets the easing mode of the animation.
+         *
+         * @param {string} easingMode The desired easing mode.
+         * @returns {Easing} The calling Easing Animator.
+         */
+        easingMode(easingMode: string): Easing;
+        /**
+         * Adjust the iterative delay, such that it takes into account the maxTotalDuration constraint
+         */
+        private _getAdjustedIterativeDelay(numberOfSteps);
     }
 }
 declare module Plottable {
@@ -4299,260 +4183,254 @@ declare module Plottable {
         protected _unsetCallback(callbackSet: Utils.CallbackSet<Function>, callback: Function): void;
     }
 }
-declare module Plottable {
-    module Dispatchers {
-        type MouseCallback = (p: Point, event: MouseEvent) => void;
-        class Mouse extends Dispatcher {
-            private static _DISPATCHER_KEY;
-            private _translator;
-            private _lastMousePosition;
-            private _moveCallbacks;
-            private _downCallbacks;
-            private _upCallbacks;
-            private _wheelCallbacks;
-            private _dblClickCallbacks;
-            /**
-             * Get a Mouse Dispatcher for the <svg> containing elem.
-             * If one already exists on that <svg>, it will be returned; otherwise, a new one will be created.
-             *
-             * @param {SVGElement} elem
-             * @return {Dispatchers.Mouse}
-             */
-            static getDispatcher(elem: SVGElement): Dispatchers.Mouse;
-            /**
-             * This constructor not be invoked directly.
-             *
-             * @constructor
-             * @param {SVGElement} svg The root <svg> to attach to.
-             */
-            constructor(svg: SVGElement);
-            /**
-             * Registers a callback to be called when the mouse position changes.
-             *
-             * @param {MouseCallback} callback
-             * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
-             */
-            onMouseMove(callback: MouseCallback): Dispatchers.Mouse;
-            /**
-             * Removes a callback that would be called when the mouse position changes.
-             *
-             * @param {MouseCallback} callback
-             * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
-             */
-            offMouseMove(callback: MouseCallback): Dispatchers.Mouse;
-            /**
-             * Registers a callback to be called when a mousedown occurs.
-             *
-             * @param {MouseCallback} callback
-             * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
-             */
-            onMouseDown(callback: MouseCallback): Dispatchers.Mouse;
-            /**
-             * Removes a callback that would be called when a mousedown occurs.
-             *
-             * @param {MouseCallback} callback
-             * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
-             */
-            offMouseDown(callback: MouseCallback): Dispatchers.Mouse;
-            /**
-             * Registers a callback to be called when a mouseup occurs.
-             *
-             * @param {MouseCallback} callback
-             * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
-             */
-            onMouseUp(callback: MouseCallback): Dispatchers.Mouse;
-            /**
-             * Removes a callback that would be called when a mouseup occurs.
-             *
-             * @param {MouseCallback} callback
-             * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
-             */
-            offMouseUp(callback: MouseCallback): Dispatchers.Mouse;
-            /**
-             * Registers a callback to be called when a wheel event occurs.
-             *
-             * @param {MouseCallback} callback
-             * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
-             */
-            onWheel(callback: MouseCallback): Dispatchers.Mouse;
-            /**
-             * Removes a callback that would be called when a wheel event occurs.
-             *
-             * @param {MouseCallback} callback
-             * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
-             */
-            offWheel(callback: MouseCallback): Dispatchers.Mouse;
-            /**
-             * Registers a callback to be called when a dblClick occurs.
-             *
-             * @param {MouseCallback} callback
-             * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
-             */
-            onDblClick(callback: MouseCallback): Dispatchers.Mouse;
-            /**
-             * Removes a callback that would be called when a dblClick occurs.
-             *
-             * @param {MouseCallback} callback
-             * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
-             */
-            offDblClick(callback: MouseCallback): Dispatchers.Mouse;
-            /**
-             * Computes the mouse position from the given event, and if successful
-             * calls all the callbacks in the provided callbackSet.
-             */
-            private _measureAndDispatch(event, callbackSet, scope?);
-            eventInsideSVG(event: MouseEvent): boolean;
-            /**
-             * Returns the last computed mouse position in <svg> coordinate space.
-             *
-             * @return {Point}
-             */
-            lastMousePosition(): Point;
-        }
+declare module Plottable.Dispatchers {
+    type MouseCallback = (p: Point, event: MouseEvent) => void;
+    class Mouse extends Dispatcher {
+        private static _DISPATCHER_KEY;
+        private _translator;
+        private _lastMousePosition;
+        private _moveCallbacks;
+        private _downCallbacks;
+        private _upCallbacks;
+        private _wheelCallbacks;
+        private _dblClickCallbacks;
+        /**
+         * Get a Mouse Dispatcher for the <svg> containing elem.
+         * If one already exists on that <svg>, it will be returned; otherwise, a new one will be created.
+         *
+         * @param {SVGElement} elem
+         * @return {Dispatchers.Mouse}
+         */
+        static getDispatcher(elem: SVGElement): Dispatchers.Mouse;
+        /**
+         * This constructor not be invoked directly.
+         *
+         * @constructor
+         * @param {SVGElement} svg The root <svg> to attach to.
+         */
+        constructor(svg: SVGElement);
+        /**
+         * Registers a callback to be called when the mouse position changes.
+         *
+         * @param {MouseCallback} callback
+         * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
+         */
+        onMouseMove(callback: MouseCallback): Dispatchers.Mouse;
+        /**
+         * Removes a callback that would be called when the mouse position changes.
+         *
+         * @param {MouseCallback} callback
+         * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
+         */
+        offMouseMove(callback: MouseCallback): Dispatchers.Mouse;
+        /**
+         * Registers a callback to be called when a mousedown occurs.
+         *
+         * @param {MouseCallback} callback
+         * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
+         */
+        onMouseDown(callback: MouseCallback): Dispatchers.Mouse;
+        /**
+         * Removes a callback that would be called when a mousedown occurs.
+         *
+         * @param {MouseCallback} callback
+         * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
+         */
+        offMouseDown(callback: MouseCallback): Dispatchers.Mouse;
+        /**
+         * Registers a callback to be called when a mouseup occurs.
+         *
+         * @param {MouseCallback} callback
+         * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
+         */
+        onMouseUp(callback: MouseCallback): Dispatchers.Mouse;
+        /**
+         * Removes a callback that would be called when a mouseup occurs.
+         *
+         * @param {MouseCallback} callback
+         * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
+         */
+        offMouseUp(callback: MouseCallback): Dispatchers.Mouse;
+        /**
+         * Registers a callback to be called when a wheel event occurs.
+         *
+         * @param {MouseCallback} callback
+         * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
+         */
+        onWheel(callback: MouseCallback): Dispatchers.Mouse;
+        /**
+         * Removes a callback that would be called when a wheel event occurs.
+         *
+         * @param {MouseCallback} callback
+         * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
+         */
+        offWheel(callback: MouseCallback): Dispatchers.Mouse;
+        /**
+         * Registers a callback to be called when a dblClick occurs.
+         *
+         * @param {MouseCallback} callback
+         * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
+         */
+        onDblClick(callback: MouseCallback): Dispatchers.Mouse;
+        /**
+         * Removes a callback that would be called when a dblClick occurs.
+         *
+         * @param {MouseCallback} callback
+         * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
+         */
+        offDblClick(callback: MouseCallback): Dispatchers.Mouse;
+        /**
+         * Computes the mouse position from the given event, and if successful
+         * calls all the callbacks in the provided callbackSet.
+         */
+        private _measureAndDispatch(event, callbackSet, scope?);
+        eventInsideSVG(event: MouseEvent): boolean;
+        /**
+         * Returns the last computed mouse position in <svg> coordinate space.
+         *
+         * @return {Point}
+         */
+        lastMousePosition(): Point;
     }
 }
-declare module Plottable {
-    module Dispatchers {
-        type TouchCallback = (ids: number[], idToPoint: {
-            [id: number]: Point;
-        }, event: TouchEvent) => void;
-        class Touch extends Dispatcher {
-            private static _DISPATCHER_KEY;
-            private _translator;
-            private _startCallbacks;
-            private _moveCallbacks;
-            private _endCallbacks;
-            private _cancelCallbacks;
-            /**
-             * Gets a Touch Dispatcher for the <svg> containing elem.
-             * If one already exists on that <svg>, it will be returned; otherwise, a new one will be created.
-             *
-             * @param {SVGElement} elem
-             * @return {Dispatchers.Touch}
-             */
-            static getDispatcher(elem: SVGElement): Dispatchers.Touch;
-            /**
-             * This constructor should not be invoked directly.
-             *
-             * @constructor
-             * @param {SVGElement} svg The root <svg> to attach to.
-             */
-            constructor(svg: SVGElement);
-            /**
-             * Registers a callback to be called when a touch starts.
-             *
-             * @param {TouchCallback} callback
-             * @return {Dispatchers.Touch} The calling Touch Dispatcher.
-             */
-            onTouchStart(callback: TouchCallback): Dispatchers.Touch;
-            /**
-             * Removes a callback that would be called when a touch starts.
-             *
-             * @param {TouchCallback} callback
-             * @return {Dispatchers.Touch} The calling Touch Dispatcher.
-             */
-            offTouchStart(callback: TouchCallback): Dispatchers.Touch;
-            /**
-             * Registers a callback to be called when the touch position changes.
-             *
-             * @param {TouchCallback} callback
-             * @return {Dispatchers.Touch} The calling Touch Dispatcher.
-             */
-            onTouchMove(callback: TouchCallback): Dispatchers.Touch;
-            /**
-             * Removes a callback that would be called when the touch position changes.
-             *
-             * @param {TouchCallback} callback
-             * @return {Dispatchers.Touch} The calling Touch Dispatcher.
-             */
-            offTouchMove(callback: TouchCallback): Dispatchers.Touch;
-            /**
-             * Registers a callback to be called when a touch ends.
-             *
-             * @param {TouchCallback} callback
-             * @return {Dispatchers.Touch} The calling Touch Dispatcher.
-             */
-            onTouchEnd(callback: TouchCallback): Dispatchers.Touch;
-            /**
-             * Removes a callback that would be called when a touch ends.
-             *
-             * @param {TouchCallback} callback
-             * @return {Dispatchers.Touch} The calling Touch Dispatcher.
-             */
-            offTouchEnd(callback: TouchCallback): Dispatchers.Touch;
-            /**
-             * Registers a callback to be called when a touch is cancelled.
-             *
-             * @param {TouchCallback} callback
-             * @return {Dispatchers.Touch} The calling Touch Dispatcher.
-             */
-            onTouchCancel(callback: TouchCallback): Dispatchers.Touch;
-            /**
-             * Removes a callback that would be called when a touch is cancelled.
-             *
-             * @param {TouchCallback} callback
-             * @return {Dispatchers.Touch} The calling Touch Dispatcher.
-             */
-            offTouchCancel(callback: TouchCallback): Dispatchers.Touch;
-            /**
-             * Computes the Touch position from the given event, and if successful
-             * calls all the callbacks in the provided callbackSet.
-             */
-            private _measureAndDispatch(event, callbackSet, scope?);
-            eventInsideSVG(event: TouchEvent): boolean;
-        }
+declare module Plottable.Dispatchers {
+    type TouchCallback = (ids: number[], idToPoint: {
+        [id: number]: Point;
+    }, event: TouchEvent) => void;
+    class Touch extends Dispatcher {
+        private static _DISPATCHER_KEY;
+        private _translator;
+        private _startCallbacks;
+        private _moveCallbacks;
+        private _endCallbacks;
+        private _cancelCallbacks;
+        /**
+         * Gets a Touch Dispatcher for the <svg> containing elem.
+         * If one already exists on that <svg>, it will be returned; otherwise, a new one will be created.
+         *
+         * @param {SVGElement} elem
+         * @return {Dispatchers.Touch}
+         */
+        static getDispatcher(elem: SVGElement): Dispatchers.Touch;
+        /**
+         * This constructor should not be invoked directly.
+         *
+         * @constructor
+         * @param {SVGElement} svg The root <svg> to attach to.
+         */
+        constructor(svg: SVGElement);
+        /**
+         * Registers a callback to be called when a touch starts.
+         *
+         * @param {TouchCallback} callback
+         * @return {Dispatchers.Touch} The calling Touch Dispatcher.
+         */
+        onTouchStart(callback: TouchCallback): Dispatchers.Touch;
+        /**
+         * Removes a callback that would be called when a touch starts.
+         *
+         * @param {TouchCallback} callback
+         * @return {Dispatchers.Touch} The calling Touch Dispatcher.
+         */
+        offTouchStart(callback: TouchCallback): Dispatchers.Touch;
+        /**
+         * Registers a callback to be called when the touch position changes.
+         *
+         * @param {TouchCallback} callback
+         * @return {Dispatchers.Touch} The calling Touch Dispatcher.
+         */
+        onTouchMove(callback: TouchCallback): Dispatchers.Touch;
+        /**
+         * Removes a callback that would be called when the touch position changes.
+         *
+         * @param {TouchCallback} callback
+         * @return {Dispatchers.Touch} The calling Touch Dispatcher.
+         */
+        offTouchMove(callback: TouchCallback): Dispatchers.Touch;
+        /**
+         * Registers a callback to be called when a touch ends.
+         *
+         * @param {TouchCallback} callback
+         * @return {Dispatchers.Touch} The calling Touch Dispatcher.
+         */
+        onTouchEnd(callback: TouchCallback): Dispatchers.Touch;
+        /**
+         * Removes a callback that would be called when a touch ends.
+         *
+         * @param {TouchCallback} callback
+         * @return {Dispatchers.Touch} The calling Touch Dispatcher.
+         */
+        offTouchEnd(callback: TouchCallback): Dispatchers.Touch;
+        /**
+         * Registers a callback to be called when a touch is cancelled.
+         *
+         * @param {TouchCallback} callback
+         * @return {Dispatchers.Touch} The calling Touch Dispatcher.
+         */
+        onTouchCancel(callback: TouchCallback): Dispatchers.Touch;
+        /**
+         * Removes a callback that would be called when a touch is cancelled.
+         *
+         * @param {TouchCallback} callback
+         * @return {Dispatchers.Touch} The calling Touch Dispatcher.
+         */
+        offTouchCancel(callback: TouchCallback): Dispatchers.Touch;
+        /**
+         * Computes the Touch position from the given event, and if successful
+         * calls all the callbacks in the provided callbackSet.
+         */
+        private _measureAndDispatch(event, callbackSet, scope?);
+        eventInsideSVG(event: TouchEvent): boolean;
     }
 }
-declare module Plottable {
-    module Dispatchers {
-        type KeyCallback = (keyCode: number, event: KeyboardEvent) => void;
-        class Key extends Dispatcher {
-            private static _DISPATCHER_KEY;
-            private _keydownCallbacks;
-            private _keyupCallbacks;
-            /**
-             * Gets a Key Dispatcher. If one already exists it will be returned;
-             * otherwise, a new one will be created.
-             *
-             * @return {Dispatchers.Key}
-             */
-            static getDispatcher(): Dispatchers.Key;
-            /**
-             * This constructor should not be invoked directly.
-             *
-             * @constructor
-             */
-            constructor();
-            /**
-             * Registers a callback to be called whenever a key is pressed.
-             *
-             * @param {KeyCallback} callback
-             * @return {Dispatchers.Key} The calling Key Dispatcher.
-             */
-            onKeyDown(callback: KeyCallback): Key;
-            /**
-             * Removes the callback to be called whenever a key is pressed.
-             *
-             * @param {KeyCallback} callback
-             * @return {Dispatchers.Key} The calling Key Dispatcher.
-             */
-            offKeyDown(callback: KeyCallback): Key;
-            /** Registers a callback to be called whenever a key is released.
-             *
-             * @param {KeyCallback} callback
-             * @return {Dispatchers.Key} The calling Key Dispatcher.
-             */
-            onKeyUp(callback: KeyCallback): Key;
-            /**
-             * Removes the callback to be called whenever a key is released.
-             *
-             * @param {KeyCallback} callback
-             * @return {Dispatchers.Key} The calling Key Dispatcher.
-             */
-            offKeyUp(callback: KeyCallback): Key;
-            private _processKeydown(event);
-            private _processKeyup(event);
-        }
+declare module Plottable.Dispatchers {
+    type KeyCallback = (keyCode: number, event: KeyboardEvent) => void;
+    class Key extends Dispatcher {
+        private static _DISPATCHER_KEY;
+        private _keydownCallbacks;
+        private _keyupCallbacks;
+        /**
+         * Gets a Key Dispatcher. If one already exists it will be returned;
+         * otherwise, a new one will be created.
+         *
+         * @return {Dispatchers.Key}
+         */
+        static getDispatcher(): Dispatchers.Key;
+        /**
+         * This constructor should not be invoked directly.
+         *
+         * @constructor
+         */
+        constructor();
+        /**
+         * Registers a callback to be called whenever a key is pressed.
+         *
+         * @param {KeyCallback} callback
+         * @return {Dispatchers.Key} The calling Key Dispatcher.
+         */
+        onKeyDown(callback: KeyCallback): Key;
+        /**
+         * Removes the callback to be called whenever a key is pressed.
+         *
+         * @param {KeyCallback} callback
+         * @return {Dispatchers.Key} The calling Key Dispatcher.
+         */
+        offKeyDown(callback: KeyCallback): Key;
+        /** Registers a callback to be called whenever a key is released.
+         *
+         * @param {KeyCallback} callback
+         * @return {Dispatchers.Key} The calling Key Dispatcher.
+         */
+        onKeyUp(callback: KeyCallback): Key;
+        /**
+         * Removes the callback to be called whenever a key is released.
+         *
+         * @param {KeyCallback} callback
+         * @return {Dispatchers.Key} The calling Key Dispatcher.
+         */
+        offKeyUp(callback: KeyCallback): Key;
+        private _processKeydown(event);
+        private _processKeyup(event);
     }
 }
 declare module Plottable {
@@ -4610,75 +4488,73 @@ declare module Plottable {
 }
 declare module Plottable {
     type ClickCallback = (point: Point) => void;
-    module Interactions {
-        class Click extends Interaction {
-            private _mouseDispatcher;
-            private _touchDispatcher;
-            private _clickedDown;
-            private _onClickCallbacks;
-            private _mouseDownCallback;
-            private _mouseUpCallback;
-            private _touchStartCallback;
-            private _touchEndCallback;
-            private _touchCancelCallback;
-            protected _anchor(component: Component): void;
-            protected _unanchor(): void;
-            private _handleClickDown(p);
-            private _handleClickUp(p);
-            /**
-             * Adds a callback to be called when the Component is clicked.
-             *
-             * @param {ClickCallback} callback
-             * @return {Interactions.Click} The calling Click Interaction.
-             */
-            onClick(callback: ClickCallback): Click;
-            /**
-             * Removes a callback that would be called when the Component is clicked.
-             *
-             * @param {ClickCallback} callback
-             * @return {Interactions.Click} The calling Click Interaction.
-             */
-            offClick(callback: ClickCallback): Click;
-        }
+}
+declare module Plottable.Interactions {
+    class Click extends Interaction {
+        private _mouseDispatcher;
+        private _touchDispatcher;
+        private _clickedDown;
+        private _onClickCallbacks;
+        private _mouseDownCallback;
+        private _mouseUpCallback;
+        private _touchStartCallback;
+        private _touchEndCallback;
+        private _touchCancelCallback;
+        protected _anchor(component: Component): void;
+        protected _unanchor(): void;
+        private _handleClickDown(p);
+        private _handleClickUp(p);
+        /**
+         * Adds a callback to be called when the Component is clicked.
+         *
+         * @param {ClickCallback} callback
+         * @return {Interactions.Click} The calling Click Interaction.
+         */
+        onClick(callback: ClickCallback): Click;
+        /**
+         * Removes a callback that would be called when the Component is clicked.
+         *
+         * @param {ClickCallback} callback
+         * @return {Interactions.Click} The calling Click Interaction.
+         */
+        offClick(callback: ClickCallback): Click;
     }
 }
-declare module Plottable {
-    module Interactions {
-        class DoubleClick extends Interaction {
-            private _mouseDispatcher;
-            private _touchDispatcher;
-            private _clickState;
-            private _clickedDown;
-            private _clickedPoint;
-            private _onDoubleClickCallbacks;
-            private _mouseDownCallback;
-            private _mouseUpCallback;
-            private _dblClickCallback;
-            private _touchStartCallback;
-            private _touchEndCallback;
-            private _touchCancelCallback;
-            protected _anchor(component: Component): void;
-            protected _unanchor(): void;
-            private _handleClickDown(p);
-            private _handleClickUp(p);
-            private _handleDblClick();
-            private _handleClickCancel();
-            private static _pointsEqual(p1, p2);
-            /**
-             * Adds a callback to be called when the Component is double-clicked.
-             *
-             * @param {ClickCallback} callback
-             * @return {Interactions.DoubleClick} The calling DoubleClick Interaction.
-             */
-            onDoubleClick(callback: ClickCallback): DoubleClick;
-            /**
-             * Removes a callback that would be called when the Component is double-clicked.
-             *
-             * @param {ClickCallback} callback
-             * @return {Interactions.DoubleClick} The calling DoubleClick Interaction.
-             */
-            offDoubleClick(callback: ClickCallback): DoubleClick;
-        }
+declare module Plottable.Interactions {
+    class DoubleClick extends Interaction {
+        private _mouseDispatcher;
+        private _touchDispatcher;
+        private _clickState;
+        private _clickedDown;
+        private _clickedPoint;
+        private _onDoubleClickCallbacks;
+        private _mouseDownCallback;
+        private _mouseUpCallback;
+        private _dblClickCallback;
+        private _touchStartCallback;
+        private _touchEndCallback;
+        private _touchCancelCallback;
+        protected _anchor(component: Component): void;
+        protected _unanchor(): void;
+        private _handleClickDown(p);
+        private _handleClickUp(p);
+        private _handleDblClick();
+        private _handleClickCancel();
+        private static _pointsEqual(p1, p2);
+        /**
+         * Adds a callback to be called when the Component is double-clicked.
+         *
+         * @param {ClickCallback} callback
+         * @return {Interactions.DoubleClick} The calling DoubleClick Interaction.
+         */
+        onDoubleClick(callback: ClickCallback): DoubleClick;
+        /**
+         * Removes a callback that would be called when the Component is double-clicked.
+         *
+         * @param {ClickCallback} callback
+         * @return {Interactions.DoubleClick} The calling DoubleClick Interaction.
+         */
+        offDoubleClick(callback: ClickCallback): DoubleClick;
     }
 }
 declare module Plottable {
@@ -4742,64 +4618,64 @@ declare module Plottable {
 }
 declare module Plottable {
     type PointerCallback = (point: Point) => void;
-    module Interactions {
-        class Pointer extends Interaction {
-            private _mouseDispatcher;
-            private _touchDispatcher;
-            private _insideComponent;
-            private _pointerEnterCallbacks;
-            private _pointerMoveCallbacks;
-            private _pointerExitCallbacks;
-            private _mouseMoveCallback;
-            private _touchStartCallback;
-            protected _anchor(component: Component): void;
-            protected _unanchor(): void;
-            private _handleMouseEvent(p, e);
-            private _handleTouchEvent(p, e);
-            private _handlePointerEvent(p, insideSVG);
-            /**
-             * Adds a callback to be called when the pointer enters the Component.
-             *
-             * @param {PointerCallback} callback
-             * @return {Interactions.Pointer} The calling Pointer Interaction.
-             */
-            onPointerEnter(callback: PointerCallback): Pointer;
-            /**
-             * Removes a callback that would be called when the pointer enters the Component.
-             *
-             * @param {PointerCallback} callback
-             * @return {Interactions.Pointer} The calling Pointer Interaction.
-             */
-            offPointerEnter(callback: PointerCallback): Pointer;
-            /**
-             * Adds a callback to be called when the pointer moves within the Component.
-             *
-             * @param {PointerCallback} callback
-             * @return {Interactions.Pointer} The calling Pointer Interaction.
-             */
-            onPointerMove(callback: PointerCallback): Pointer;
-            /**
-             * Removes a callback that would be called when the pointer moves within the Component.
-             *
-             * @param {PointerCallback} callback
-             * @return {Interactions.Pointer} The calling Pointer Interaction.
-             */
-            offPointerMove(callback: PointerCallback): Pointer;
-            /**
-             * Adds a callback to be called when the pointer exits the Component.
-             *
-             * @param {PointerCallback} callback
-             * @return {Interactions.Pointer} The calling Pointer Interaction.
-             */
-            onPointerExit(callback: PointerCallback): Pointer;
-            /**
-             * Removes a callback that would be called when the pointer exits the Component.
-             *
-             * @param {PointerCallback} callback
-             * @return {Interactions.Pointer} The calling Pointer Interaction.
-             */
-            offPointerExit(callback: PointerCallback): Pointer;
-        }
+}
+declare module Plottable.Interactions {
+    class Pointer extends Interaction {
+        private _mouseDispatcher;
+        private _touchDispatcher;
+        private _insideComponent;
+        private _pointerEnterCallbacks;
+        private _pointerMoveCallbacks;
+        private _pointerExitCallbacks;
+        private _mouseMoveCallback;
+        private _touchStartCallback;
+        protected _anchor(component: Component): void;
+        protected _unanchor(): void;
+        private _handleMouseEvent(p, e);
+        private _handleTouchEvent(p, e);
+        private _handlePointerEvent(p, insideSVG);
+        /**
+         * Adds a callback to be called when the pointer enters the Component.
+         *
+         * @param {PointerCallback} callback
+         * @return {Interactions.Pointer} The calling Pointer Interaction.
+         */
+        onPointerEnter(callback: PointerCallback): Pointer;
+        /**
+         * Removes a callback that would be called when the pointer enters the Component.
+         *
+         * @param {PointerCallback} callback
+         * @return {Interactions.Pointer} The calling Pointer Interaction.
+         */
+        offPointerEnter(callback: PointerCallback): Pointer;
+        /**
+         * Adds a callback to be called when the pointer moves within the Component.
+         *
+         * @param {PointerCallback} callback
+         * @return {Interactions.Pointer} The calling Pointer Interaction.
+         */
+        onPointerMove(callback: PointerCallback): Pointer;
+        /**
+         * Removes a callback that would be called when the pointer moves within the Component.
+         *
+         * @param {PointerCallback} callback
+         * @return {Interactions.Pointer} The calling Pointer Interaction.
+         */
+        offPointerMove(callback: PointerCallback): Pointer;
+        /**
+         * Adds a callback to be called when the pointer exits the Component.
+         *
+         * @param {PointerCallback} callback
+         * @return {Interactions.Pointer} The calling Pointer Interaction.
+         */
+        onPointerExit(callback: PointerCallback): Pointer;
+        /**
+         * Removes a callback that would be called when the pointer exits the Component.
+         *
+         * @param {PointerCallback} callback
+         * @return {Interactions.Pointer} The calling Pointer Interaction.
+         */
+        offPointerExit(callback: PointerCallback): Pointer;
     }
 }
 declare module Plottable {
@@ -4939,368 +4815,364 @@ declare module Plottable {
 }
 declare module Plottable {
     type DragCallback = (start: Point, end: Point) => void;
-    module Interactions {
-        class Drag extends Interaction {
-            private _dragging;
-            private _constrainedToComponent;
-            private _mouseDispatcher;
-            private _touchDispatcher;
-            private _dragOrigin;
-            private _dragStartCallbacks;
-            private _dragCallbacks;
-            private _dragEndCallbacks;
-            private _mouseDownCallback;
-            private _mouseMoveCallback;
-            private _mouseUpCallback;
-            private _touchStartCallback;
-            private _touchMoveCallback;
-            private _touchEndCallback;
-            protected _anchor(component: Component): void;
-            protected _unanchor(): void;
-            private _translateAndConstrain(p);
-            private _startDrag(point, event);
-            private _doDrag(point, event);
-            private _endDrag(point, event);
-            /**
-             * Gets whether the Drag Interaction constrains Points passed to its
-             * callbacks to lie inside its Component.
-             *
-             * If true, when the user drags outside of the Component, the closest Point
-             * inside the Component will be passed to the callback instead of the actual
-             * cursor position.
-             *
-             * @return {boolean}
-             */
-            constrainedToComponent(): boolean;
-            /**
-             * Sets whether the Drag Interaction constrains Points passed to its
-             * callbacks to lie inside its Component.
-             *
-             * If true, when the user drags outside of the Component, the closest Point
-             * inside the Component will be passed to the callback instead of the actual
-             * cursor position.
-             *
-             * @param {boolean}
-             * @return {Interactions.Drag} The calling Drag Interaction.
-             */
-            constrainedToComponent(constrainedToComponent: boolean): Drag;
-            /**
-             * Adds a callback to be called when dragging starts.
-             *
-             * @param {DragCallback} callback
-             * @returns {Drag} The calling Drag Interaction.
-             */
-            onDragStart(callback: DragCallback): Drag;
-            /**
-             * Removes a callback that would be called when dragging starts.
-             *
-             * @param {DragCallback} callback
-             * @returns {Drag} The calling Drag Interaction.
-             */
-            offDragStart(callback: DragCallback): Drag;
-            /**
-             * Adds a callback to be called during dragging.
-             *
-             * @param {DragCallback} callback
-             * @returns {Drag} The calling Drag Interaction.
-             */
-            onDrag(callback: DragCallback): Drag;
-            /**
-             * Removes a callback that would be called during dragging.
-             *
-             * @param {DragCallback} callback
-             * @returns {Drag} The calling Drag Interaction.
-             */
-            offDrag(callback: DragCallback): Drag;
-            /**
-             * Adds a callback to be called when dragging ends.
-             *
-             * @param {DragCallback} callback
-             * @returns {Drag} The calling Drag Interaction.
-             */
-            onDragEnd(callback: DragCallback): Drag;
-            /**
-             * Removes a callback that would be called when dragging ends.
-             *
-             * @param {DragCallback} callback
-             * @returns {Drag} The calling Drag Interaction.
-             */
-            offDragEnd(callback: DragCallback): Drag;
-        }
+}
+declare module Plottable.Interactions {
+    class Drag extends Interaction {
+        private _dragging;
+        private _constrainedToComponent;
+        private _mouseDispatcher;
+        private _touchDispatcher;
+        private _dragOrigin;
+        private _dragStartCallbacks;
+        private _dragCallbacks;
+        private _dragEndCallbacks;
+        private _mouseDownCallback;
+        private _mouseMoveCallback;
+        private _mouseUpCallback;
+        private _touchStartCallback;
+        private _touchMoveCallback;
+        private _touchEndCallback;
+        protected _anchor(component: Component): void;
+        protected _unanchor(): void;
+        private _translateAndConstrain(p);
+        private _startDrag(point, event);
+        private _doDrag(point, event);
+        private _endDrag(point, event);
+        /**
+         * Gets whether the Drag Interaction constrains Points passed to its
+         * callbacks to lie inside its Component.
+         *
+         * If true, when the user drags outside of the Component, the closest Point
+         * inside the Component will be passed to the callback instead of the actual
+         * cursor position.
+         *
+         * @return {boolean}
+         */
+        constrainedToComponent(): boolean;
+        /**
+         * Sets whether the Drag Interaction constrains Points passed to its
+         * callbacks to lie inside its Component.
+         *
+         * If true, when the user drags outside of the Component, the closest Point
+         * inside the Component will be passed to the callback instead of the actual
+         * cursor position.
+         *
+         * @param {boolean}
+         * @return {Interactions.Drag} The calling Drag Interaction.
+         */
+        constrainedToComponent(constrainedToComponent: boolean): Drag;
+        /**
+         * Adds a callback to be called when dragging starts.
+         *
+         * @param {DragCallback} callback
+         * @returns {Drag} The calling Drag Interaction.
+         */
+        onDragStart(callback: DragCallback): Drag;
+        /**
+         * Removes a callback that would be called when dragging starts.
+         *
+         * @param {DragCallback} callback
+         * @returns {Drag} The calling Drag Interaction.
+         */
+        offDragStart(callback: DragCallback): Drag;
+        /**
+         * Adds a callback to be called during dragging.
+         *
+         * @param {DragCallback} callback
+         * @returns {Drag} The calling Drag Interaction.
+         */
+        onDrag(callback: DragCallback): Drag;
+        /**
+         * Removes a callback that would be called during dragging.
+         *
+         * @param {DragCallback} callback
+         * @returns {Drag} The calling Drag Interaction.
+         */
+        offDrag(callback: DragCallback): Drag;
+        /**
+         * Adds a callback to be called when dragging ends.
+         *
+         * @param {DragCallback} callback
+         * @returns {Drag} The calling Drag Interaction.
+         */
+        onDragEnd(callback: DragCallback): Drag;
+        /**
+         * Removes a callback that would be called when dragging ends.
+         *
+         * @param {DragCallback} callback
+         * @returns {Drag} The calling Drag Interaction.
+         */
+        offDragEnd(callback: DragCallback): Drag;
     }
 }
 declare module Plottable {
     type DragBoxCallback = (bounds: Bounds) => void;
-    module Components {
-        class DragBoxLayer extends Components.SelectionBoxLayer {
-            private _dragInteraction;
-            private _detectionEdgeT;
-            private _detectionEdgeB;
-            private _detectionEdgeL;
-            private _detectionEdgeR;
-            private _detectionCornerTL;
-            private _detectionCornerTR;
-            private _detectionCornerBL;
-            private _detectionCornerBR;
-            private _detectionRadius;
-            private _resizable;
-            private _movable;
-            protected _hasCorners: boolean;
-            private _dragStartCallbacks;
-            private _dragCallbacks;
-            private _dragEndCallbacks;
-            private _disconnectInteraction;
-            /**
-             * Constructs a DragBoxLayer.
-             *
-             * A DragBoxLayer is a SelectionBoxLayer with a built-in Drag Interaction.
-             * A drag gesture will set the Bounds of the box.
-             * If resizing is enabled using resizable(true), the edges of box can be repositioned.
-             *
-             * @constructor
-             */
-            constructor();
-            private _setUpCallbacks();
-            protected _setup(): void;
-            private _getResizingEdges(p);
-            renderImmediately(): DragBoxLayer;
-            /**
-             * Gets the detection radius of the drag box in pixels.
-             */
-            detectionRadius(): number;
-            /**
-             * Sets the detection radius of the drag box in pixels.
-             *
-             * @param {number} r
-             * @return {DragBoxLayer} The calling DragBoxLayer.
-             */
-            detectionRadius(r: number): DragBoxLayer;
-            /**
-             * Gets whether or not the drag box is resizable.
-             */
-            resizable(): boolean;
-            /**
-             * Sets whether or not the drag box is resizable.
-             *
-             * @param {boolean} canResize
-             * @return {DragBoxLayer} The calling DragBoxLayer.
-             */
-            resizable(canResize: boolean): DragBoxLayer;
-            protected _setResizableClasses(canResize: boolean): void;
-            /**
-             * Gets whether or not the drag box is movable.
-             */
-            movable(): boolean;
-            /**
-             * Sets whether or not the drag box is movable.
-             *
-             * @param {boolean} movable
-             * @return {DragBoxLayer} The calling DragBoxLayer.
-             */
-            movable(movable: boolean): DragBoxLayer;
-            private _setMovableClass();
-            /**
-             * Sets the callback to be called when dragging starts.
-             *
-             * @param {DragBoxCallback} callback
-             * @returns {DragBoxLayer} The calling DragBoxLayer.
-             */
-            onDragStart(callback: DragBoxCallback): DragBoxLayer;
-            /**
-             * Removes a callback to be called when dragging starts.
-             *
-             * @param {DragBoxCallback} callback
-             * @returns {DragBoxLayer} The calling DragBoxLayer.
-             */
-            offDragStart(callback: DragBoxCallback): DragBoxLayer;
-            /**
-             * Sets a callback to be called during dragging.
-             *
-             * @param {DragBoxCallback} callback
-             * @returns {DragBoxLayer} The calling DragBoxLayer.
-             */
-            onDrag(callback: DragBoxCallback): DragBoxLayer;
-            /**
-             * Removes a callback to be called during dragging.
-             *
-             * @param {DragBoxCallback} callback
-             * @returns {DragBoxLayer} The calling DragBoxLayer.
-             */
-            offDrag(callback: DragBoxCallback): DragBoxLayer;
-            /**
-             * Sets a callback to be called when dragging ends.
-             *
-             * @param {DragBoxCallback} callback
-             * @returns {DragBoxLayer} The calling DragBoxLayer.
-             */
-            onDragEnd(callback: DragBoxCallback): DragBoxLayer;
-            /**
-             * Removes a callback to be called when dragging ends.
-             *
-             * @param {DragBoxCallback} callback
-             * @returns {DragBoxLayer} The calling DragBoxLayer.
-             */
-            offDragEnd(callback: DragBoxCallback): DragBoxLayer;
-            /**
-             * Gets the internal Interactions.Drag of the DragBoxLayer.
-             */
-            dragInteraction(): Interactions.Drag;
-            /**
-             * Enables or disables the interaction and drag box.
-             */
-            enabled(enabled: boolean): DragBoxLayer;
-            /**
-             * Gets the enabled state.
-             */
-            enabled(): boolean;
-            destroy(): void;
-            detach(): Component;
-            anchor(selection: d3.Selection<void>): Component;
-            private _resetState();
-        }
+}
+declare module Plottable.Components {
+    class DragBoxLayer extends Components.SelectionBoxLayer {
+        private _dragInteraction;
+        private _detectionEdgeT;
+        private _detectionEdgeB;
+        private _detectionEdgeL;
+        private _detectionEdgeR;
+        private _detectionCornerTL;
+        private _detectionCornerTR;
+        private _detectionCornerBL;
+        private _detectionCornerBR;
+        private _detectionRadius;
+        private _resizable;
+        private _movable;
+        protected _hasCorners: boolean;
+        private _dragStartCallbacks;
+        private _dragCallbacks;
+        private _dragEndCallbacks;
+        private _disconnectInteraction;
+        /**
+         * Constructs a DragBoxLayer.
+         *
+         * A DragBoxLayer is a SelectionBoxLayer with a built-in Drag Interaction.
+         * A drag gesture will set the Bounds of the box.
+         * If resizing is enabled using resizable(true), the edges of box can be repositioned.
+         *
+         * @constructor
+         */
+        constructor();
+        private _setUpCallbacks();
+        protected _setup(): void;
+        private _getResizingEdges(p);
+        renderImmediately(): DragBoxLayer;
+        /**
+         * Gets the detection radius of the drag box in pixels.
+         */
+        detectionRadius(): number;
+        /**
+         * Sets the detection radius of the drag box in pixels.
+         *
+         * @param {number} r
+         * @return {DragBoxLayer} The calling DragBoxLayer.
+         */
+        detectionRadius(r: number): DragBoxLayer;
+        /**
+         * Gets whether or not the drag box is resizable.
+         */
+        resizable(): boolean;
+        /**
+         * Sets whether or not the drag box is resizable.
+         *
+         * @param {boolean} canResize
+         * @return {DragBoxLayer} The calling DragBoxLayer.
+         */
+        resizable(canResize: boolean): DragBoxLayer;
+        protected _setResizableClasses(canResize: boolean): void;
+        /**
+         * Gets whether or not the drag box is movable.
+         */
+        movable(): boolean;
+        /**
+         * Sets whether or not the drag box is movable.
+         *
+         * @param {boolean} movable
+         * @return {DragBoxLayer} The calling DragBoxLayer.
+         */
+        movable(movable: boolean): DragBoxLayer;
+        private _setMovableClass();
+        /**
+         * Sets the callback to be called when dragging starts.
+         *
+         * @param {DragBoxCallback} callback
+         * @returns {DragBoxLayer} The calling DragBoxLayer.
+         */
+        onDragStart(callback: DragBoxCallback): DragBoxLayer;
+        /**
+         * Removes a callback to be called when dragging starts.
+         *
+         * @param {DragBoxCallback} callback
+         * @returns {DragBoxLayer} The calling DragBoxLayer.
+         */
+        offDragStart(callback: DragBoxCallback): DragBoxLayer;
+        /**
+         * Sets a callback to be called during dragging.
+         *
+         * @param {DragBoxCallback} callback
+         * @returns {DragBoxLayer} The calling DragBoxLayer.
+         */
+        onDrag(callback: DragBoxCallback): DragBoxLayer;
+        /**
+         * Removes a callback to be called during dragging.
+         *
+         * @param {DragBoxCallback} callback
+         * @returns {DragBoxLayer} The calling DragBoxLayer.
+         */
+        offDrag(callback: DragBoxCallback): DragBoxLayer;
+        /**
+         * Sets a callback to be called when dragging ends.
+         *
+         * @param {DragBoxCallback} callback
+         * @returns {DragBoxLayer} The calling DragBoxLayer.
+         */
+        onDragEnd(callback: DragBoxCallback): DragBoxLayer;
+        /**
+         * Removes a callback to be called when dragging ends.
+         *
+         * @param {DragBoxCallback} callback
+         * @returns {DragBoxLayer} The calling DragBoxLayer.
+         */
+        offDragEnd(callback: DragBoxCallback): DragBoxLayer;
+        /**
+         * Gets the internal Interactions.Drag of the DragBoxLayer.
+         */
+        dragInteraction(): Interactions.Drag;
+        /**
+         * Enables or disables the interaction and drag box.
+         */
+        enabled(enabled: boolean): DragBoxLayer;
+        /**
+         * Gets the enabled state.
+         */
+        enabled(): boolean;
+        destroy(): void;
+        detach(): Component;
+        anchor(selection: d3.Selection<void>): Component;
+        private _resetState();
     }
 }
-declare module Plottable {
-    module Components {
-        class XDragBoxLayer extends DragBoxLayer {
-            /**
-             * An XDragBoxLayer is a DragBoxLayer whose size can only be set in the X-direction.
-             * The y-values of the bounds() are always set to 0 and the height() of the XDragBoxLayer.
-             *
-             * @constructor
-             */
-            constructor();
-            computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): XDragBoxLayer;
-            protected _setBounds(newBounds: Bounds): void;
-            protected _setResizableClasses(canResize: boolean): void;
-            yScale<D extends number | {
-                valueOf(): number;
-            }>(): QuantitativeScale<D>;
-            yScale<D extends number | {
-                valueOf(): number;
-            }>(yScale: QuantitativeScale<D>): SelectionBoxLayer;
-            yExtent(): (number | {
-                valueOf(): number;
-            })[];
-            yExtent(yExtent: (number | {
-                valueOf(): number;
-            })[]): SelectionBoxLayer;
-        }
+declare module Plottable.Components {
+    class XDragBoxLayer extends DragBoxLayer {
+        /**
+         * An XDragBoxLayer is a DragBoxLayer whose size can only be set in the X-direction.
+         * The y-values of the bounds() are always set to 0 and the height() of the XDragBoxLayer.
+         *
+         * @constructor
+         */
+        constructor();
+        computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): XDragBoxLayer;
+        protected _setBounds(newBounds: Bounds): void;
+        protected _setResizableClasses(canResize: boolean): void;
+        yScale<D extends number | {
+            valueOf(): number;
+        }>(): QuantitativeScale<D>;
+        yScale<D extends number | {
+            valueOf(): number;
+        }>(yScale: QuantitativeScale<D>): SelectionBoxLayer;
+        yExtent(): (number | {
+            valueOf(): number;
+        })[];
+        yExtent(yExtent: (number | {
+            valueOf(): number;
+        })[]): SelectionBoxLayer;
     }
 }
-declare module Plottable {
-    module Components {
-        class YDragBoxLayer extends DragBoxLayer {
-            /**
-             * A YDragBoxLayer is a DragBoxLayer whose size can only be set in the Y-direction.
-             * The x-values of the bounds() are always set to 0 and the width() of the YDragBoxLayer.
-             *
-             * @constructor
-             */
-            constructor();
-            computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): YDragBoxLayer;
-            protected _setBounds(newBounds: Bounds): void;
-            protected _setResizableClasses(canResize: boolean): void;
-            xScale<D extends number | {
-                valueOf(): number;
-            }>(): QuantitativeScale<D>;
-            xScale<D extends number | {
-                valueOf(): number;
-            }>(xScale: QuantitativeScale<D>): SelectionBoxLayer;
-            xExtent(): (number | {
-                valueOf(): number;
-            })[];
-            xExtent(xExtent: (number | {
-                valueOf(): number;
-            })[]): SelectionBoxLayer;
-        }
+declare module Plottable.Components {
+    class YDragBoxLayer extends DragBoxLayer {
+        /**
+         * A YDragBoxLayer is a DragBoxLayer whose size can only be set in the Y-direction.
+         * The x-values of the bounds() are always set to 0 and the width() of the YDragBoxLayer.
+         *
+         * @constructor
+         */
+        constructor();
+        computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): YDragBoxLayer;
+        protected _setBounds(newBounds: Bounds): void;
+        protected _setResizableClasses(canResize: boolean): void;
+        xScale<D extends number | {
+            valueOf(): number;
+        }>(): QuantitativeScale<D>;
+        xScale<D extends number | {
+            valueOf(): number;
+        }>(xScale: QuantitativeScale<D>): SelectionBoxLayer;
+        xExtent(): (number | {
+            valueOf(): number;
+        })[];
+        xExtent(xExtent: (number | {
+            valueOf(): number;
+        })[]): SelectionBoxLayer;
     }
 }
 declare module Plottable {
     interface DragLineCallback<D> {
         (dragLineLayer: Components.DragLineLayer<D>): void;
     }
-    module Components {
-        class DragLineLayer<D> extends GuideLineLayer<D> {
-            private _dragInteraction;
-            private _detectionRadius;
-            private _detectionEdge;
-            private _enabled;
-            private _dragStartCallbacks;
-            private _dragCallbacks;
-            private _dragEndCallbacks;
-            private _disconnectInteraction;
-            constructor(orientation: string);
-            protected _setup(): void;
-            renderImmediately(): DragLineLayer<D>;
-            /**
-             * Gets the detection radius of the drag line in pixels.
-             */
-            detectionRadius(): number;
-            /**
-             * Sets the detection radius of the drag line in pixels.
-             *
-             * @param {number} detectionRadius
-             * @return {DragLineLayer<D>} The calling DragLineLayer.
-             */
-            detectionRadius(detectionRadius: number): DragLineLayer<D>;
-            /**
-             * Gets whether the DragLineLayer is enabled.
-             */
-            enabled(): boolean;
-            /**
-             * Enables or disables the DragLineLayer.
-             *
-             * @param {boolean} enabled
-             * @return {DragLineLayer<D>} The calling DragLineLayer.
-             */
-            enabled(enabled: boolean): DragLineLayer<D>;
-            /**
-             * Sets the callback to be called when dragging starts.
-             * The callback will be passed the calling DragLineLayer.
-             *
-             * @param {DragLineCallback<D>} callback
-             * @returns {DragLineLayer<D>} The calling DragLineLayer.
-             */
-            onDragStart(callback: DragLineCallback<D>): DragLineLayer<D>;
-            /**
-             * Removes a callback that would be called when dragging starts.
-             *
-             * @param {DragLineCallback<D>} callback
-             * @returns {DragLineLayer<D>} The calling DragLineLayer.
-             */
-            offDragStart(callback: DragLineCallback<D>): DragLineLayer<D>;
-            /**
-             * Sets a callback to be called during dragging.
-             * The callback will be passed the calling DragLineLayer.
-             *
-             * @param {DragLineCallback<D>} callback
-             * @returns {DragLineLayer<D>} The calling DragLineLayer.
-             */
-            onDrag(callback: DragLineCallback<D>): DragLineLayer<D>;
-            /**
-             * Removes a callback that would be called during dragging.
-             *
-             * @param {DragLineCallback<D>} callback
-             * @returns {DragLineLayer<D>} The calling DragLineLayer.
-             */
-            offDrag(callback: DragLineCallback<D>): DragLineLayer<D>;
-            /**
-             * Sets a callback to be called when dragging ends.
-             * The callback will be passed the calling DragLineLayer.
-             *
-             * @param {DragLineCallback<D>} callback
-             * @returns {DragLineLayer<D>} The calling DragLineLayer.
-             */
-            onDragEnd(callback: DragLineCallback<D>): DragLineLayer<D>;
-            /**
-             * Removes a callback that would be called when dragging ends.
-             *
-             * @param {DragLineCallback<D>} callback
-             * @returns {DragLineLayer<D>} The calling DragLineLayer.
-             */
-            offDragEnd(callback: DragLineCallback<D>): DragLineLayer<D>;
-            destroy(): void;
-        }
+}
+declare module Plottable.Components {
+    class DragLineLayer<D> extends GuideLineLayer<D> {
+        private _dragInteraction;
+        private _detectionRadius;
+        private _detectionEdge;
+        private _enabled;
+        private _dragStartCallbacks;
+        private _dragCallbacks;
+        private _dragEndCallbacks;
+        private _disconnectInteraction;
+        constructor(orientation: string);
+        protected _setup(): void;
+        renderImmediately(): DragLineLayer<D>;
+        /**
+         * Gets the detection radius of the drag line in pixels.
+         */
+        detectionRadius(): number;
+        /**
+         * Sets the detection radius of the drag line in pixels.
+         *
+         * @param {number} detectionRadius
+         * @return {DragLineLayer<D>} The calling DragLineLayer.
+         */
+        detectionRadius(detectionRadius: number): DragLineLayer<D>;
+        /**
+         * Gets whether the DragLineLayer is enabled.
+         */
+        enabled(): boolean;
+        /**
+         * Enables or disables the DragLineLayer.
+         *
+         * @param {boolean} enabled
+         * @return {DragLineLayer<D>} The calling DragLineLayer.
+         */
+        enabled(enabled: boolean): DragLineLayer<D>;
+        /**
+         * Sets the callback to be called when dragging starts.
+         * The callback will be passed the calling DragLineLayer.
+         *
+         * @param {DragLineCallback<D>} callback
+         * @returns {DragLineLayer<D>} The calling DragLineLayer.
+         */
+        onDragStart(callback: DragLineCallback<D>): DragLineLayer<D>;
+        /**
+         * Removes a callback that would be called when dragging starts.
+         *
+         * @param {DragLineCallback<D>} callback
+         * @returns {DragLineLayer<D>} The calling DragLineLayer.
+         */
+        offDragStart(callback: DragLineCallback<D>): DragLineLayer<D>;
+        /**
+         * Sets a callback to be called during dragging.
+         * The callback will be passed the calling DragLineLayer.
+         *
+         * @param {DragLineCallback<D>} callback
+         * @returns {DragLineLayer<D>} The calling DragLineLayer.
+         */
+        onDrag(callback: DragLineCallback<D>): DragLineLayer<D>;
+        /**
+         * Removes a callback that would be called during dragging.
+         *
+         * @param {DragLineCallback<D>} callback
+         * @returns {DragLineLayer<D>} The calling DragLineLayer.
+         */
+        offDrag(callback: DragLineCallback<D>): DragLineLayer<D>;
+        /**
+         * Sets a callback to be called when dragging ends.
+         * The callback will be passed the calling DragLineLayer.
+         *
+         * @param {DragLineCallback<D>} callback
+         * @returns {DragLineLayer<D>} The calling DragLineLayer.
+         */
+        onDragEnd(callback: DragLineCallback<D>): DragLineLayer<D>;
+        /**
+         * Removes a callback that would be called when dragging ends.
+         *
+         * @param {DragLineCallback<D>} callback
+         * @returns {DragLineLayer<D>} The calling DragLineLayer.
+         */
+        offDragEnd(callback: DragLineCallback<D>): DragLineLayer<D>;
+        destroy(): void;
     }
 }

--- a/plottable.js
+++ b/plottable.js
@@ -996,24 +996,24 @@ var Plottable;
         RenderPolicies.Timeout = Timeout;
     })(RenderPolicies = Plottable.RenderPolicies || (Plottable.RenderPolicies = {}));
 })(Plottable || (Plottable = {}));
+/**
+ * The RenderController is responsible for enqueueing and synchronizing
+ * layout and render calls for Components.
+ *
+ * Layout and render calls occur inside an animation callback
+ * (window.requestAnimationFrame if available).
+ *
+ * RenderController.flush() immediately lays out and renders all Components currently enqueued.
+ *
+ * To always have immediate rendering (useful for debugging), call
+ * ```typescript
+ * Plottable.RenderController.setRenderPolicy(
+ *   new Plottable.RenderPolicies.Immediate()
+ * );
+ * ```
+ */
 var Plottable;
 (function (Plottable) {
-    /**
-     * The RenderController is responsible for enqueueing and synchronizing
-     * layout and render calls for Components.
-     *
-     * Layout and render calls occur inside an animation callback
-     * (window.requestAnimationFrame if available).
-     *
-     * RenderController.flush() immediately lays out and renders all Components currently enqueued.
-     *
-     * To always have immediate rendering (useful for debugging), call
-     * ```typescript
-     * Plottable.RenderController.setRenderPolicy(
-     *   new Plottable.RenderPolicies.Immediate()
-     * );
-     * ```
-     */
     var RenderController;
     (function (RenderController) {
         var _componentsNeedingRender = new Plottable.Utils.Set();
@@ -1122,6 +1122,9 @@ var Plottable;
      *
      */
     Plottable.MILLISECONDS_IN_ONE_DAY = 24 * 60 * 60 * 1000;
+})(Plottable || (Plottable = {}));
+var Plottable;
+(function (Plottable) {
     var Formatters;
     (function (Formatters) {
         /**
@@ -4051,6 +4054,9 @@ var Plottable;
         TimeInterval.year = "year";
     })(TimeInterval = Plottable.TimeInterval || (Plottable.TimeInterval = {}));
     ;
+})(Plottable || (Plottable = {}));
+var Plottable;
+(function (Plottable) {
     var Axes;
     (function (Axes) {
         var Time = (function (_super) {
@@ -4398,111 +4404,111 @@ var Plottable;
             Time.TIME_AXIS_TIER_CLASS = "time-axis-tier";
             Time._DEFAULT_TIME_AXIS_CONFIGURATIONS = [
                 [
-                    { interval: TimeInterval.second, step: 1, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: Plottable.TimeInterval.second, step: 1, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: Plottable.TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: TimeInterval.second, step: 5, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: Plottable.TimeInterval.second, step: 5, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: Plottable.TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: TimeInterval.second, step: 10, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: Plottable.TimeInterval.second, step: 10, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: Plottable.TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: TimeInterval.second, step: 15, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: Plottable.TimeInterval.second, step: 15, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: Plottable.TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: TimeInterval.second, step: 30, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
-                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: Plottable.TimeInterval.second, step: 30, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
+                    { interval: Plottable.TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: TimeInterval.minute, step: 1, formatter: Plottable.Formatters.time("%I:%M %p") },
-                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: Plottable.TimeInterval.minute, step: 1, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: Plottable.TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: TimeInterval.minute, step: 5, formatter: Plottable.Formatters.time("%I:%M %p") },
-                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: Plottable.TimeInterval.minute, step: 5, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: Plottable.TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: TimeInterval.minute, step: 10, formatter: Plottable.Formatters.time("%I:%M %p") },
-                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: Plottable.TimeInterval.minute, step: 10, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: Plottable.TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: TimeInterval.minute, step: 15, formatter: Plottable.Formatters.time("%I:%M %p") },
-                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: Plottable.TimeInterval.minute, step: 15, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: Plottable.TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: TimeInterval.minute, step: 30, formatter: Plottable.Formatters.time("%I:%M %p") },
-                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: Plottable.TimeInterval.minute, step: 30, formatter: Plottable.Formatters.time("%I:%M %p") },
+                    { interval: Plottable.TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: TimeInterval.hour, step: 1, formatter: Plottable.Formatters.time("%I %p") },
-                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: Plottable.TimeInterval.hour, step: 1, formatter: Plottable.Formatters.time("%I %p") },
+                    { interval: Plottable.TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: TimeInterval.hour, step: 3, formatter: Plottable.Formatters.time("%I %p") },
-                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: Plottable.TimeInterval.hour, step: 3, formatter: Plottable.Formatters.time("%I %p") },
+                    { interval: Plottable.TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: TimeInterval.hour, step: 6, formatter: Plottable.Formatters.time("%I %p") },
-                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: Plottable.TimeInterval.hour, step: 6, formatter: Plottable.Formatters.time("%I %p") },
+                    { interval: Plottable.TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: TimeInterval.hour, step: 12, formatter: Plottable.Formatters.time("%I %p") },
-                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
+                    { interval: Plottable.TimeInterval.hour, step: 12, formatter: Plottable.Formatters.time("%I %p") },
+                    { interval: Plottable.TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%B %e, %Y") }
                 ],
                 [
-                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%a %e") },
-                    { interval: TimeInterval.month, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
+                    { interval: Plottable.TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%a %e") },
+                    { interval: Plottable.TimeInterval.month, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
                 ],
                 [
-                    { interval: TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%e") },
-                    { interval: TimeInterval.month, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
+                    { interval: Plottable.TimeInterval.day, step: 1, formatter: Plottable.Formatters.time("%e") },
+                    { interval: Plottable.TimeInterval.month, step: 1, formatter: Plottable.Formatters.time("%B %Y") }
                 ],
                 [
-                    { interval: TimeInterval.month, step: 1, formatter: Plottable.Formatters.time("%B") },
-                    { interval: TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: Plottable.TimeInterval.month, step: 1, formatter: Plottable.Formatters.time("%B") },
+                    { interval: Plottable.TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: TimeInterval.month, step: 1, formatter: Plottable.Formatters.time("%b") },
-                    { interval: TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: Plottable.TimeInterval.month, step: 1, formatter: Plottable.Formatters.time("%b") },
+                    { interval: Plottable.TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: TimeInterval.month, step: 3, formatter: Plottable.Formatters.time("%b") },
-                    { interval: TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: Plottable.TimeInterval.month, step: 3, formatter: Plottable.Formatters.time("%b") },
+                    { interval: Plottable.TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: TimeInterval.month, step: 6, formatter: Plottable.Formatters.time("%b") },
-                    { interval: TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: Plottable.TimeInterval.month, step: 6, formatter: Plottable.Formatters.time("%b") },
+                    { interval: Plottable.TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: Plottable.TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%y") }
+                    { interval: Plottable.TimeInterval.year, step: 1, formatter: Plottable.Formatters.time("%y") }
                 ],
                 [
-                    { interval: TimeInterval.year, step: 5, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: Plottable.TimeInterval.year, step: 5, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: TimeInterval.year, step: 25, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: Plottable.TimeInterval.year, step: 25, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: TimeInterval.year, step: 50, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: Plottable.TimeInterval.year, step: 50, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: TimeInterval.year, step: 100, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: Plottable.TimeInterval.year, step: 100, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: TimeInterval.year, step: 200, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: Plottable.TimeInterval.year, step: 200, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: TimeInterval.year, step: 500, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: Plottable.TimeInterval.year, step: 500, formatter: Plottable.Formatters.time("%Y") }
                 ],
                 [
-                    { interval: TimeInterval.year, step: 1000, formatter: Plottable.Formatters.time("%Y") }
+                    { interval: Plottable.TimeInterval.year, step: 1000, formatter: Plottable.Formatters.time("%Y") }
                 ]
             ];
             Time._LONG_DATE = new Date(9999, 8, 29, 12, 59, 9999);
@@ -6548,6 +6554,9 @@ var Plottable;
             Animator.RESET = "reset";
         })(Animator = Plots.Animator || (Plots.Animator = {}));
     })(Plots = Plottable.Plots || (Plottable.Plots = {}));
+})(Plottable || (Plottable = {}));
+var Plottable;
+(function (Plottable) {
     var Plot = (function (_super) {
         __extends(Plot, _super);
         /**
@@ -6572,8 +6581,8 @@ var Plottable;
             this._propertyBindings = d3.map();
             this._propertyExtents = d3.map();
             var mainAnimator = new Plottable.Animators.Easing().maxTotalDuration(Plot._ANIMATION_MAX_DURATION);
-            this.animator(Plots.Animator.MAIN, mainAnimator);
-            this.animator(Plots.Animator.RESET, new Plottable.Animators.Null());
+            this.animator(Plottable.Plots.Animator.MAIN, mainAnimator);
+            this.animator(Plottable.Plots.Animator.RESET, new Plottable.Animators.Null());
         }
         Plot.prototype.anchor = function (selection) {
             _super.prototype.anchor.call(this, selection);
@@ -12199,6 +12208,9 @@ var Plottable;
 var Plottable;
 (function (Plottable) {
     ;
+})(Plottable || (Plottable = {}));
+var Plottable;
+(function (Plottable) {
     var Components;
     (function (Components) {
         var DragLineLayer = (function (_super) {

--- a/src/animators/easingAnimator.ts
+++ b/src/animators/easingAnimator.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Animators {
+module Plottable.Animators {
 
   /**
    * An Animator with easing and configurable durations and delays.
@@ -189,5 +188,4 @@ export module Animators {
       return Math.min(this.stepDelay(), maxPossibleIterativeDelay);
     }
   }
-}
 }

--- a/src/animators/nullAnimator.ts
+++ b/src/animators/nullAnimator.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Animators {
+module Plottable.Animators {
 
   /**
    * An animator implementation with no animation. The attributes are
@@ -15,5 +14,4 @@ export module Animators {
     }
   }
 
-}
 }

--- a/src/axes/categoryAxis.ts
+++ b/src/axes/categoryAxis.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Axes {
+module Plottable.Axes {
   export class Category extends Axis<string> {
     private _tickLabelAngle = 0;
     private _measurer: SVGTypewriter.Measurers.CacheCharacterMeasurer;
@@ -237,5 +236,4 @@ export module Axes {
       return this;
     }
   }
-}
 }

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Axes {
+module Plottable.Axes {
   export class Numeric extends Axis<number> {
 
     private _tickLabelPositioning = "center";
@@ -392,5 +391,4 @@ export module Axes {
     }
 
   }
-}
 }

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -10,7 +10,9 @@ export module TimeInterval {
   export var year = "year";
 };
 
-export module Axes {
+}
+
+module Plottable.Axes {
   /**
    * Defines a configuration for a Time Axis tier.
    * For details on how ticks are generated see: https://github.com/mbostock/d3/wiki/Time-Scales#ticks
@@ -568,5 +570,4 @@ export module Axes {
     }
 
   }
-}
 }

--- a/src/components/dragBoxLayer.ts
+++ b/src/components/dragBoxLayer.ts
@@ -1,8 +1,8 @@
 module Plottable {
-
 export type DragBoxCallback = (bounds: Bounds) => void;
+}
 
-export module Components {
+module Plottable.Components {
   type _EdgeIndicator = {
     top: boolean;
     bottom: boolean;
@@ -460,5 +460,4 @@ export module Components {
       });
     }
   }
-}
 }

--- a/src/components/dragLineLayer.ts
+++ b/src/components/dragLineLayer.ts
@@ -1,8 +1,8 @@
 module Plottable {
+  export interface DragLineCallback<D> { (dragLineLayer: Components.DragLineLayer<D>): void; };
+}
 
-export interface DragLineCallback<D> { (dragLineLayer: Components.DragLineLayer<D>): void; };
-
-export module Components {
+module Plottable.Components {
   export class DragLineLayer<D> extends GuideLineLayer<D> {
     private _dragInteraction: Interactions.Drag;
     private _detectionRadius = 3;
@@ -217,5 +217,4 @@ export module Components {
       this._disconnectInteraction();
     }
   }
-}
 }

--- a/src/components/gridlines.ts
+++ b/src/components/gridlines.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Components {
+module Plottable.Components {
   export class Gridlines extends Component {
     private _xScale: QuantitativeScale<any>;
     private _yScale: QuantitativeScale<any>;
@@ -98,5 +97,4 @@ export module Components {
       }
     }
   }
-}
 }

--- a/src/components/group.ts
+++ b/src/components/group.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Components {
+module Plottable.Components {
   export class Group extends ComponentContainer {
     private _components: Component[] = [];
 
@@ -91,5 +90,4 @@ export module Components {
     }
 
   }
-}
 }

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Components {
+module Plottable.Components {
   enum PropertyMode { VALUE, PIXEL };
   export class GuideLineLayer<D> extends Component {
     public static ORIENTATION_VERTICAL = "vertical";
@@ -190,5 +189,4 @@ export module Components {
       }
     }
   }
-}
 }

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Components {
+module Plottable.Components {
   export class InterpolatedColorLegend extends Component {
     private static _DEFAULT_NUM_SWATCHES = 11;
 
@@ -307,5 +306,4 @@ export module Components {
     }
 
   }
-}
 }

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Components {
+module Plottable.Components {
   export class Label extends Component {
     private _textContainer: d3.Selection<void>;
     private _text: string; // text assigned to the Label; may not be the actual text displayed due to truncation
@@ -179,5 +178,4 @@ export module Components {
       this.addClass(AxisLabel.AXIS_LABEL_CLASS);
     }
   }
-}
 }

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Components {
+module Plottable.Components {
   export class Legend extends Component {
     /**
      * The css class applied to each legend row
@@ -379,5 +378,4 @@ export module Components {
       return true;
     }
   }
-}
 }

--- a/src/components/selectionBoxLayer.ts
+++ b/src/components/selectionBoxLayer.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Components {
+module Plottable.Components {
   export enum PropertyMode { VALUE, PIXEL };
   export class SelectionBoxLayer extends Component {
     protected _box: d3.Selection<void>;
@@ -290,5 +289,4 @@ export module Components {
       }
     }
   }
-}
 }

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Components {
+module Plottable.Components {
   type _LayoutAllocation = {
     guaranteedWidths: number[];
     guaranteedHeights: number[];
@@ -489,5 +488,4 @@ export module Components {
       return all(componentGroup.map(groupIsFixed));
     }
   }
-}
 }

--- a/src/components/xDragBoxLayer.ts
+++ b/src/components/xDragBoxLayer.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Components {
+module Plottable.Components {
   export class XDragBoxLayer extends DragBoxLayer {
     /**
      * An XDragBoxLayer is a DragBoxLayer whose size can only be set in the X-direction.
@@ -53,5 +52,4 @@ export module Components {
       throw new Error("XDragBoxLayer has no yExtent");
     }
   }
-}
 }

--- a/src/components/yDragBoxLayer.ts
+++ b/src/components/yDragBoxLayer.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Components {
+module Plottable.Components {
   export class YDragBoxLayer extends DragBoxLayer {
     /**
      * A YDragBoxLayer is a DragBoxLayer whose size can only be set in the Y-direction.
@@ -53,5 +52,4 @@ export module Components {
       throw new Error("YDragBoxLayer has no xExtent");
     }
   }
-}
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Configs {
+module Plottable.Configs {
   /**
    * Specifies if Plottable should show warnings.
    */
@@ -9,5 +8,4 @@ export module Configs {
    * Specifies if Plottable should add <title> elements to text.
    */
   export var ADD_TITLE_ELEMENTS = true;
-}
 }

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -12,8 +12,9 @@ export type Formatter = (d: any) => string;
  *
  */
 export var MILLISECONDS_IN_ONE_DAY = 24 * 60 * 60 * 1000;
+}
 
-export module Formatters {
+module Plottable.Formatters {
 
   interface TimeFilterFormat {
     format: string;
@@ -270,5 +271,4 @@ export module Formatters {
     }
   }
 
-}
 }

--- a/src/core/renderController.ts
+++ b/src/core/renderController.ts
@@ -1,4 +1,3 @@
-module Plottable {
 /**
  * The RenderController is responsible for enqueueing and synchronizing
  * layout and render calls for Components.
@@ -15,7 +14,7 @@ module Plottable {
  * );
  * ```
  */
-export module RenderController {
+module Plottable.RenderController {
   let _componentsNeedingRender = new Utils.Set<Component>();
   let _componentsNeedingComputeLayout = new Utils.Set<Component>();
   let _animationRequested = false;
@@ -111,5 +110,4 @@ export module RenderController {
       _isCurrentlyFlushing = false;
     }
   }
-}
 }

--- a/src/core/renderPolicy.ts
+++ b/src/core/renderPolicy.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module RenderPolicies {
+module Plottable.RenderPolicies {
   /**
    * A policy for rendering Components.
    */
@@ -39,5 +38,4 @@ export module RenderPolicies {
       setTimeout(RenderController.flush, this._timeoutMsec);
     }
   }
-}
 }

--- a/src/core/symbolFactories.ts
+++ b/src/core/symbolFactories.ts
@@ -5,8 +5,9 @@ module Plottable {
  * and returns a string representing the 'd' attribute of the resultant 'path' element
  */
 export type SymbolFactory = (symbolSize: number) => string;
+}
 
-export module SymbolFactories {
+module Plottable.SymbolFactories {
 
   export function circle(): SymbolFactory {
     return (symbolSize: number) => d3.svg.symbol().type("circle").size(Math.PI * Math.pow(symbolSize / 2, 2))(null);
@@ -32,5 +33,4 @@ export module SymbolFactories {
     return (symbolSize: number) => d3.svg.symbol().type("triangle-down").size(Math.sqrt(3) * Math.pow(symbolSize / 2, 2))(null);
   }
 
-}
 }

--- a/src/dispatchers/keyDispatcher.ts
+++ b/src/dispatchers/keyDispatcher.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Dispatchers {
+module Plottable.Dispatchers {
   export type KeyCallback = (keyCode: number, event: KeyboardEvent) => void;
 
   export class Key extends Dispatcher {
@@ -88,5 +87,4 @@ export module Dispatchers {
       this._keyupCallbacks.callCallbacks(event.keyCode, event);
     }
   }
-}
 }

--- a/src/dispatchers/mouseDispatcher.ts
+++ b/src/dispatchers/mouseDispatcher.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Dispatchers {
+module Plottable.Dispatchers {
   export type MouseCallback = (p: Point, event: MouseEvent) => void;
 
   export class Mouse extends Dispatcher {
@@ -202,5 +201,4 @@ export module Dispatchers {
       return this._lastMousePosition;
     }
   }
-}
 }

--- a/src/dispatchers/touchDispatcher.ts
+++ b/src/dispatchers/touchDispatcher.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Dispatchers {
+module Plottable.Dispatchers {
   export type TouchCallback = (ids: number[], idToPoint: { [id: number]: Point; }, event: TouchEvent) => void;
 
   export class Touch extends Dispatcher {
@@ -171,5 +170,4 @@ export module Dispatchers {
       return this._translator.insideSVG(event);
     }
   }
-}
 }

--- a/src/drawers/arcDrawer.ts
+++ b/src/drawers/arcDrawer.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Drawers {
+module Plottable.Drawers {
   export class Arc extends Drawer {
 
     constructor(dataset: Dataset) {
@@ -13,5 +12,4 @@ export module Drawers {
       selection.style("stroke", "none");
     }
   }
-}
 }

--- a/src/drawers/arcOutlineDrawer.ts
+++ b/src/drawers/arcOutlineDrawer.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Drawers {
+module Plottable.Drawers {
 
   export class ArcOutline extends Drawer {
 
@@ -14,5 +13,4 @@ export module Drawers {
       selection.style("fill", "none");
     }
   }
-}
 }

--- a/src/drawers/areaDrawer.ts
+++ b/src/drawers/areaDrawer.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Drawers {
+module Plottable.Drawers {
   export class Area extends Drawer {
 
     constructor(dataset: Dataset) {
@@ -17,5 +16,4 @@ export module Drawers {
       return d3.select(this.selection()[0][0]);
     }
   }
-}
 }

--- a/src/drawers/lineDrawer.ts
+++ b/src/drawers/lineDrawer.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Drawers {
+module Plottable.Drawers {
   export class Line extends Drawer {
 
     constructor(dataset: Dataset) {
@@ -17,5 +16,4 @@ export module Drawers {
       return d3.select(this.selection()[0][0]);
     }
   }
-}
 }

--- a/src/drawers/rectangleDrawer.ts
+++ b/src/drawers/rectangleDrawer.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Drawers {
+module Plottable.Drawers {
   export class Rectangle extends Drawer {
 
     constructor(dataset: Dataset) {
@@ -8,5 +7,4 @@ export module Drawers {
     }
 
   }
-}
 }

--- a/src/drawers/segmentDrawer.ts
+++ b/src/drawers/segmentDrawer.ts
@@ -1,10 +1,8 @@
-module Plottable {
-export module Drawers {
+module Plottable.Drawers {
   export class Segment extends Drawer {
     constructor(dataset: Dataset) {
       super(dataset);
       this._svgElementName = "line";
     }
   }
-}
 }

--- a/src/drawers/symbolDrawer.ts
+++ b/src/drawers/symbolDrawer.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Drawers {
+module Plottable.Drawers {
   export class Symbol extends Drawer {
 
     constructor(dataset: Dataset) {
@@ -9,5 +8,4 @@ export module Drawers {
     }
 
   }
-}
 }

--- a/src/interactions/clickInteraction.ts
+++ b/src/interactions/clickInteraction.ts
@@ -2,7 +2,9 @@ module Plottable {
 
 export type ClickCallback = (point: Point) => void;
 
-export module Interactions {
+}
+
+module Plottable.Interactions {
   export class Click extends Interaction {
 
     private _mouseDispatcher: Plottable.Dispatchers.Mouse;
@@ -79,5 +81,4 @@ export module Interactions {
       return this;
     }
   }
-}
 }

--- a/src/interactions/doubleClickInteraction.ts
+++ b/src/interactions/doubleClickInteraction.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Interactions {
+module Plottable.Interactions {
   enum ClickState {NotClicked, SingleClicked, DoubleClicked};
   export class DoubleClick extends Interaction {
 
@@ -104,5 +103,4 @@ export module Interactions {
       return this;
     }
   }
-}
 }

--- a/src/interactions/dragInteraction.ts
+++ b/src/interactions/dragInteraction.ts
@@ -2,7 +2,9 @@ module Plottable {
 
 export type DragCallback = (start: Point, end: Point) => void;
 
-export module Interactions {
+}
+
+module Plottable.Interactions {
   export class Drag extends Interaction {
     private _dragging = false;
     private _constrainedToComponent = true;
@@ -184,5 +186,4 @@ export module Interactions {
       return this;
     }
   }
-}
 }

--- a/src/interactions/pointerInteraction.ts
+++ b/src/interactions/pointerInteraction.ts
@@ -2,7 +2,9 @@ module Plottable {
 
 export type PointerCallback = (point: Point) => void;
 
-export module Interactions {
+}
+
+module Plottable.Interactions {
   export class Pointer extends Interaction {
     private _mouseDispatcher: Dispatchers.Mouse;
     private _touchDispatcher: Dispatchers.Touch;
@@ -124,5 +126,4 @@ export module Interactions {
       return this;
     }
   }
-}
 }

--- a/src/plots/areaPlot.ts
+++ b/src/plots/areaPlot.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Plots {
+module Plottable.Plots {
   export class Area<X> extends Line<X> {
     private static _Y0_KEY = "y0";
     private _lineDrawers: Utils.Map<Dataset, Drawers.Line>;
@@ -200,5 +199,4 @@ export module Plots {
       };
     }
   }
-}
 }

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -1,12 +1,10 @@
-module Plottable {
+module Plottable.Plots {
+  type LabelConfig = {
+    labelArea: d3.Selection<void>;
+    measurer: SVGTypewriter.Measurers.Measurer;
+    writer: SVGTypewriter.Writers.Writer;
+  };
 
-type LabelConfig = {
-  labelArea: d3.Selection<void>;
-  measurer: SVGTypewriter.Measurers.Measurer;
-  writer: SVGTypewriter.Writers.Writer;
-};
-
-export module Plots {
   export class Bar<X, Y> extends XYPlot<X, Y> {
     public static ORIENTATION_VERTICAL = "vertical";
     public static ORIENTATION_HORIZONTAL = "horizontal";
@@ -735,5 +733,4 @@ export module Plots {
       return dataToDraw;
     }
   }
-}
 }

--- a/src/plots/clusteredBarPlot.ts
+++ b/src/plots/clusteredBarPlot.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Plots {
+module Plottable.Plots {
   export class ClusteredBar<X, Y> extends Bar<X, Y> {
 
     private _clusterOffsets: Utils.Map<Dataset, number>;
@@ -55,5 +54,4 @@ export module Plots {
       return super._getDataToDraw();
     }
   }
-}
 }

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Plots {
+module Plottable.Plots {
   type EdgeIntersections = {
     left: Point[],
     right: Point[],
@@ -140,13 +139,13 @@ export module Plots {
     }
     /**
      * Gets if downsampling is enabled
-     * 
+     *
      * When downsampling is enabled, two consecutive lines with the same slope will be merged to one line.
      */
     public downsamplingEnabled(): boolean;
     /**
      * Sets if downsampling is enabled
-     * 
+     *
      * @returns {Plots.Line} The calling Plots.Line
      */
     public downsamplingEnabled(downsampling: boolean): Plots.Line<X>;
@@ -512,5 +511,4 @@ export module Plots {
       return filteredIndices;
     }
   }
-}
 }

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Plots {
+module Plottable.Plots {
   export class Pie extends Plot {
 
     private static _INNER_RADIUS_KEY = "inner-radius";
@@ -419,5 +418,4 @@ export module Plots {
       });
     }
   }
-}
 }

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -1,6 +1,4 @@
-module Plottable {
-
-export module Plots {
+module Plottable.Plots {
   export interface PlotEntity extends Entity<Plot> {
     dataset: Dataset;
     index: number;
@@ -18,6 +16,7 @@ export module Plots {
   }
 }
 
+module Plottable {
 /**
  * Computing the selection of an entity is an expensive operation. This object aims to
  * reproduce the behavior of the Plots.PlotEntity, excluding the selection, but including

--- a/src/plots/rectanglePlot.ts
+++ b/src/plots/rectanglePlot.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Plots {
+module Plottable.Plots {
   export class Rectangle<X, Y> extends XYPlot<X, Y> {
     private static _X2_KEY = "x2";
     private static _Y2_KEY = "y2";
@@ -481,5 +480,4 @@ export module Plots {
       return false;
     }
   }
-}
 }

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Plots {
+module Plottable.Plots {
   export class Scatter<X, Y> extends XYPlot<X, Y> {
     private static _SIZE_KEY = "size";
     private static _SYMBOL_KEY = "symbol";
@@ -203,5 +202,4 @@ export module Plots {
       });
     }
   }
-}
 }

--- a/src/plots/segmentPlot.ts
+++ b/src/plots/segmentPlot.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Plots {
+module Plottable.Plots {
   export class Segment<X, Y> extends XYPlot<X, Y> {
     private static _X2_KEY = "x2";
     private static _Y2_KEY = "y2";
@@ -248,5 +247,4 @@ export module Plots {
       return calcOrientation(point1, point2, point3) * calcOrientation(point1, point2, point4) < 0;
     }
   }
-}
 }

--- a/src/plots/stackedAreaPlot.ts
+++ b/src/plots/stackedAreaPlot.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Plots {
+module Plottable.Plots {
   export class StackedArea<X> extends Area<X> {
     private _stackingResult: Utils.Stacking.StackingResult;
     private _stackedExtent: number[];
@@ -67,13 +66,13 @@ export module Plots {
 
     /**
      * Gets if downsampling is enabled
-     * 
+     *
      * When downsampling is enabled, two consecutive lines with the same slope will be merged to one line.
      */
     public downsamplingEnabled(): boolean;
     /**
      * Sets if downsampling is enabled
-     * 
+     *
      * For now, downsampling is always disabled in stacked area plot
      * @returns {Plots.StackedArea} The calling Plots.StackedArea
      */
@@ -201,5 +200,4 @@ export module Plots {
     }
 
   }
-}
 }

--- a/src/plots/stackedBarPlot.ts
+++ b/src/plots/stackedBarPlot.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Plots {
+module Plottable.Plots {
   export class StackedBar<X, Y> extends Bar<X, Y> {
     private _stackingResult: Utils.Stacking.StackingResult;
     private _stackedExtent: number[];
@@ -120,5 +119,4 @@ export module Plots {
       this._stackedExtent = Utils.Stacking.stackedExtent(this._stackingResult, keyAccessor, filter);
     }
   }
-}
 }

--- a/src/plots/waterfallPlot.ts
+++ b/src/plots/waterfallPlot.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Plots {
+module Plottable.Plots {
   export class Waterfall<X, Y> extends Bar<X, number> {
     private static _BAR_DECLINE_CLASS = "waterfall-decline";
     private static _BAR_GROWTH_CLASS = "waterfall-growth";
@@ -221,5 +220,4 @@ export module Plots {
       }
     }
   }
-}
 }

--- a/src/plots/wheelPlot.ts
+++ b/src/plots/wheelPlot.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Plots {
+module Plottable.Plots {
   export class Wheel<R, T> extends Plot {
 
     private static _R_KEY = "r";
@@ -228,5 +227,4 @@ export module Plots {
     }
 
   }
-}
 }

--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Scales {
+module Plottable.Scales {
   export class Category extends Scale<string, number> {
     private _d3Scale: d3.scale.Ordinal<string, number>;
     private _range = [0, 1];
@@ -158,5 +157,4 @@ export module Scales {
       this._d3Scale.range(values);
     }
   }
-}
 }

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Scales {
+module Plottable.Scales {
   export class Color extends Scale<string, string> {
 
     private static _LOOP_LIGHTEN_FACTOR = 1.6;
@@ -118,5 +117,4 @@ export module Scales {
       this._d3Scale.range(values);
     }
   }
-}
 }

--- a/src/scales/interpolatedColorScale.ts
+++ b/src/scales/interpolatedColorScale.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Scales {
+module Plottable.Scales {
   type supportedScale = d3.scale.Linear<number, string> | d3.scale.Log<number, string> | d3.scale.Pow<number, string>;
 
   export class InterpolatedColor extends Scale<number, string> {
@@ -152,5 +151,4 @@ export module Scales {
       this._resetScale();
     }
   }
-}
 }

--- a/src/scales/linearScale.ts
+++ b/src/scales/linearScale.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Scales {
+module Plottable.Scales {
   export class Linear extends QuantitativeScale<number> {
     private _d3Scale: d3.scale.Linear<number, number>;
 
@@ -54,5 +53,4 @@ export module Scales {
       return this._d3Scale.copy().domain(domain).nice(count).domain();
     }
   }
-}
 }

--- a/src/scales/modifiedLogScale.ts
+++ b/src/scales/modifiedLogScale.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Scales {
+module Plottable.Scales {
   export class ModifiedLog extends QuantitativeScale<number> {
     private _base: number;
     private _d3Scale: d3.scale.Linear<number, number>;
@@ -201,5 +200,4 @@ export module Scales {
       return this._d3Scale.ticks(Scales.ModifiedLog._DEFAULT_NUM_TICKS);
     }
   }
-}
 }

--- a/src/scales/scale.ts
+++ b/src/scales/scale.ts
@@ -1,9 +1,4 @@
-module Plottable {
-export interface ScaleCallback<S extends Scale<any, any>> {
-  (scale: S): any;
-}
-
-export module Scales {
+module Plottable.Scales {
 
   /**
    * A function that supplies domain values to be included into a Scale.
@@ -26,6 +21,12 @@ export module Scales {
   export interface PaddingExceptionsProvider<D> {
     (scale: QuantitativeScale<D>): D[];
   }
+}
+
+module Plottable {
+
+export interface ScaleCallback<S extends Scale<any, any>> {
+  (scale: S): any;
 }
 
 export class Scale<D, R> {

--- a/src/scales/tickGenerators.ts
+++ b/src/scales/tickGenerators.ts
@@ -1,56 +1,52 @@
-module Plottable {
-export module Scales {
-  export module TickGenerators {
-    // HACKHACK: Generic types in type definition fails compilation
-    // https://github.com/Microsoft/TypeScript/issues/1616
-    /**
-     * Generates an array of tick values for the specified scale.
-     *
-     * @param {QuantitativeScale} scale
-     * @returns {D[]}
-     */
-    export interface TickGenerator<D> {
-      (scale: Plottable.QuantitativeScale<D>): D[];
-    }
-    /**
-     * Creates a TickGenerator using the specified interval.
-     *
-     * Generates ticks at multiples of the interval while also including the domain boundaries.
-     *
-     * @param {number} interval
-     * @returns {TickGenerator}
-     */
-    export function intervalTickGenerator(interval: number): TickGenerator<number> {
-      if (interval <= 0) {
-         throw new Error("interval must be positive number");
-      }
-
-      return function(s: QuantitativeScale<number>) {
-        let domain = s.domain();
-        let low = Math.min(domain[0], domain[1]);
-        let high = Math.max(domain[0], domain[1]);
-        let firstTick = Math.ceil(low / interval) * interval;
-        let numTicks = Math.floor((high - firstTick) / interval) + 1;
-
-        let lowTicks = low % interval === 0 ? [] : [low];
-        let middleTicks = Utils.Math.range(0, numTicks).map(t => firstTick + t * interval);
-        let highTicks = high % interval === 0 ? [] : [high];
-
-        return lowTicks.concat(middleTicks).concat(highTicks);
-      };
-    }
-
-    /**
-     * Creates a TickGenerator returns only integer tick values.
-     *
-     * @returns {TickGenerator}
-     */
-    export function integerTickGenerator(): TickGenerator<number> {
-      return function(s: QuantitativeScale<number>) {
-        let defaultTicks = s.defaultTicks();
-        return defaultTicks.filter((tick, i) => (tick % 1 === 0) || (i === 0) || (i === defaultTicks.length - 1));
-      };
-    }
+module Plottable.Scales.TickGenerators {
+  // HACKHACK: Generic types in type definition fails compilation
+  // https://github.com/Microsoft/TypeScript/issues/1616
+  /**
+   * Generates an array of tick values for the specified scale.
+   *
+   * @param {QuantitativeScale} scale
+   * @returns {D[]}
+   */
+  export interface TickGenerator<D> {
+    (scale: Plottable.QuantitativeScale<D>): D[];
   }
-}
+  /**
+   * Creates a TickGenerator using the specified interval.
+   *
+   * Generates ticks at multiples of the interval while also including the domain boundaries.
+   *
+   * @param {number} interval
+   * @returns {TickGenerator}
+   */
+  export function intervalTickGenerator(interval: number): TickGenerator<number> {
+    if (interval <= 0) {
+        throw new Error("interval must be positive number");
+    }
+
+    return function(s: QuantitativeScale<number>) {
+      let domain = s.domain();
+      let low = Math.min(domain[0], domain[1]);
+      let high = Math.max(domain[0], domain[1]);
+      let firstTick = Math.ceil(low / interval) * interval;
+      let numTicks = Math.floor((high - firstTick) / interval) + 1;
+
+      let lowTicks = low % interval === 0 ? [] : [low];
+      let middleTicks = Utils.Math.range(0, numTicks).map(t => firstTick + t * interval);
+      let highTicks = high % interval === 0 ? [] : [high];
+
+      return lowTicks.concat(middleTicks).concat(highTicks);
+    };
+  }
+
+  /**
+   * Creates a TickGenerator returns only integer tick values.
+   *
+   * @returns {TickGenerator}
+   */
+  export function integerTickGenerator(): TickGenerator<number> {
+    return function(s: QuantitativeScale<number>) {
+      let defaultTicks = s.defaultTicks();
+      return defaultTicks.filter((tick, i) => (tick % 1 === 0) || (i === 0) || (i === defaultTicks.length - 1));
+    };
+  }
 }

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Scales {
+module Plottable.Scales {
   export class Time extends QuantitativeScale<Date> {
     private _d3Scale: d3.time.Scale<number, number>;
     /**
@@ -110,5 +109,4 @@ export module Scales {
       }
     }
   }
-}
 }

--- a/src/utils/arrayUtils.ts
+++ b/src/utils/arrayUtils.ts
@@ -1,64 +1,60 @@
-module Plottable {
-export module Utils {
-  export module Array {
-    let nativeArray = (<any>window).Array;
+module Plottable.Utils.Array {
+  let nativeArray = (<any>window).Array;
 
-    /**
-     * Takes two arrays of numbers and adds them together
-     *
-     * @param {number[]} aList The first array of numbers
-     * @param {number[]} bList The second array of numbers
-     * @return {number[]} An array of numbers where x[i] = aList[i] + bList[i]
-     */
-    export function add(aList: number[], bList: number[]): number[] {
-      if (aList.length !== bList.length) {
-        throw new Error("attempted to add arrays of unequal length");
-      }
-      return aList.map((_: number, i: number) => aList[i] + bList[i]);
+  /**
+   * Takes two arrays of numbers and adds them together
+   *
+   * @param {number[]} aList The first array of numbers
+   * @param {number[]} bList The second array of numbers
+   * @return {number[]} An array of numbers where x[i] = aList[i] + bList[i]
+   */
+  export function add(aList: number[], bList: number[]): number[] {
+    if (aList.length !== bList.length) {
+      throw new Error("attempted to add arrays of unequal length");
     }
-
-    /**
-     * Take an array of values, and return the unique values.
-     * Will work iff ∀ a, b, a.toString() == b.toString() => a == b; will break on Object inputs
-     *
-     * @param {T[]} values The values to find uniqueness for
-     * @return {T[]} The unique values
-     */
-    export function uniq<T>(arr: T[]): T[] {
-      let seen: d3.Set = d3.set();
-      let result: T[] = [];
-      arr.forEach((x) => {
-        if (!seen.has(String(x))) {
-          seen.add(String(x));
-          result.push(x);
-        }
-      });
-      return result;
-    }
-
-    /**
-     * @param {T[][]} a The 2D array that will have its elements joined together.
-     * @return {T[]} Every array in a, concatenated together in the order they appear.
-     */
-    export function flatten<T>(a: T[][]): T[] {
-      return nativeArray.prototype.concat.apply([], a);
-    }
-
-    /**
-     * Creates an array of length `count`, filled with value or (if value is a function), value()
-     *
-     * @param {T | ((index?: number) => T)} value The value to fill the array with or a value generator (called with index as arg)
-     * @param {number} count The length of the array to generate
-     * @return {any[]}
-     */
-    export function createFilledArray<T>(value: T | ((index?: number) => T), count: number) {
-      let out: T[] = [];
-      for (let i = 0; i < count; i++) {
-        out[i] = typeof(value) === "function" ? (<(index?: number) => T> value)(i) : <T> value;
-      }
-      return out;
-    }
-
+    return aList.map((_: number, i: number) => aList[i] + bList[i]);
   }
-}
+
+  /**
+   * Take an array of values, and return the unique values.
+   * Will work iff ∀ a, b, a.toString() == b.toString() => a == b; will break on Object inputs
+   *
+   * @param {T[]} values The values to find uniqueness for
+   * @return {T[]} The unique values
+   */
+  export function uniq<T>(arr: T[]): T[] {
+    let seen: d3.Set = d3.set();
+    let result: T[] = [];
+    arr.forEach((x) => {
+      if (!seen.has(String(x))) {
+        seen.add(String(x));
+        result.push(x);
+      }
+    });
+    return result;
+  }
+
+  /**
+   * @param {T[][]} a The 2D array that will have its elements joined together.
+   * @return {T[]} Every array in a, concatenated together in the order they appear.
+   */
+  export function flatten<T>(a: T[][]): T[] {
+    return nativeArray.prototype.concat.apply([], a);
+  }
+
+  /**
+   * Creates an array of length `count`, filled with value or (if value is a function), value()
+   *
+   * @param {T | ((index?: number) => T)} value The value to fill the array with or a value generator (called with index as arg)
+   * @param {number} count The length of the array to generate
+   * @return {any[]}
+   */
+  export function createFilledArray<T>(value: T | ((index?: number) => T), count: number) {
+    let out: T[] = [];
+    for (let i = 0; i < count; i++) {
+      out[i] = typeof(value) === "function" ? (<(index?: number) => T> value)(i) : <T> value;
+    }
+    return out;
+  }
+
 }

--- a/src/utils/callbackSet.ts
+++ b/src/utils/callbackSet.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Utils {
+module Plottable.Utils {
   /**
    * A set of callbacks which can be all invoked at once.
    * Each callback exists at most once in the set (based on reference equality).
@@ -13,5 +12,4 @@ export module Utils {
       return this;
     }
   }
-}
 }

--- a/src/utils/clientToSVGTranslator.ts
+++ b/src/utils/clientToSVGTranslator.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Utils {
+module Plottable.Utils {
   export class ClientToSVGTranslator {
     private static _TRANSLATOR_KEY = "__Plottable_ClientToSVGTranslator";
     private _svg: SVGElement;
@@ -76,5 +75,4 @@ export module Utils {
       return Utils.DOM.boundingSVG(<SVGElement>e.target) === this._svg;
     }
   }
-}
 }

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -1,78 +1,74 @@
-module Plottable {
-export module Utils {
-  export module Color {
-    let nativeMath: Math = (<any>window).Math;
+module Plottable.Utils.Color {
+  let nativeMath: Math = (<any>window).Math;
 
-    /**
-     * Return contrast ratio between two colors
-     * Based on implementation from chroma.js by Gregor Aisch (gka) (licensed under BSD)
-     * chroma.js may be found here: https://github.com/gka/chroma.js
-     * License may be found here: https://github.com/gka/chroma.js/blob/master/LICENSE
-     * see http://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
-     */
-    export function contrast(a: string, b: string) {
-      let l1 = luminance(a) + 0.05;
-      let l2 = luminance(b) + 0.05;
-      return l1 > l2 ? l1 / l2 : l2 / l1;
-    }
-
-    /**
-     * Returns a brighter copy of this color. Each channel is multiplied by 0.7 ^ -factor.
-     * Channel values are capped at the maximum value of 255, and the minimum value of 30.
-     */
-    export function lightenColor(color: string, factor: number) {
-      let hsl = <d3.Hsl> d3.hsl(color).brighter(factor);
-      return hsl.rgb().toString();
-    }
-
-    /**
-     * Gets the Hex Code of the color resulting by applying the className CSS class to the
-     * colorTester selection. Returns null if the tester is transparent.
-     *
-     * @param {d3.Selection<void>} colorTester The d3 selection to apply the CSS class to
-     * @param {string} className The name of the class to be applied
-     * @return {string} The hex code of the computed color
-     */
-    export function colorTest(colorTester: d3.Selection<void>, className: string) {
-      colorTester.classed(className, true);
-      // Use regex to get the text inside the rgb parentheses
-      let colorStyle = colorTester.style("background-color");
-      if (colorStyle === "transparent") {
-        return null;
-      }
-      let rgb = /\((.+)\)/.exec(colorStyle)[1]
-                          .split(",")
-                          .map((colorValue: string) => {
-                            let colorNumber = +colorValue;
-                            let hexValue = colorNumber.toString(16);
-                            return colorNumber < 16 ? "0" + hexValue : hexValue;
-                          });
-      if (rgb.length === 4 && rgb[3] === "00") {
-        return null;
-      }
-      let hexCode = "#" + rgb.join("");
-      colorTester.classed(className, false);
-      return hexCode;
-    }
-
-    /**
-     * Return relative luminance (defined here: http://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef)
-     * Based on implementation from chroma.js by Gregor Aisch (gka) (licensed under BSD)
-     * chroma.js may be found here: https://github.com/gka/chroma.js
-     * License may be found here: https://github.com/gka/chroma.js/blob/master/LICENSE
-     */
-    function luminance(color: string) {
-      let rgb = d3.rgb(color);
-
-      let lum = (x: number) => {
-        x = x / 255;
-        return x <= 0.03928 ? x / 12.92 : nativeMath.pow((x + 0.055) / 1.055, 2.4);
-      };
-      let r = lum(rgb.r);
-      let g = lum(rgb.g);
-      let b = lum(rgb.b);
-      return 0.2126 * r + 0.7152 * g + 0.0722 * b;
-    }
+  /**
+   * Return contrast ratio between two colors
+   * Based on implementation from chroma.js by Gregor Aisch (gka) (licensed under BSD)
+   * chroma.js may be found here: https://github.com/gka/chroma.js
+   * License may be found here: https://github.com/gka/chroma.js/blob/master/LICENSE
+   * see http://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
+   */
+  export function contrast(a: string, b: string) {
+    let l1 = luminance(a) + 0.05;
+    let l2 = luminance(b) + 0.05;
+    return l1 > l2 ? l1 / l2 : l2 / l1;
   }
-}
+
+  /**
+   * Returns a brighter copy of this color. Each channel is multiplied by 0.7 ^ -factor.
+   * Channel values are capped at the maximum value of 255, and the minimum value of 30.
+   */
+  export function lightenColor(color: string, factor: number) {
+    let hsl = <d3.Hsl> d3.hsl(color).brighter(factor);
+    return hsl.rgb().toString();
+  }
+
+  /**
+   * Gets the Hex Code of the color resulting by applying the className CSS class to the
+   * colorTester selection. Returns null if the tester is transparent.
+   *
+   * @param {d3.Selection<void>} colorTester The d3 selection to apply the CSS class to
+   * @param {string} className The name of the class to be applied
+   * @return {string} The hex code of the computed color
+   */
+  export function colorTest(colorTester: d3.Selection<void>, className: string) {
+    colorTester.classed(className, true);
+    // Use regex to get the text inside the rgb parentheses
+    let colorStyle = colorTester.style("background-color");
+    if (colorStyle === "transparent") {
+      return null;
+    }
+    let rgb = /\((.+)\)/.exec(colorStyle)[1]
+                        .split(",")
+                        .map((colorValue: string) => {
+                          let colorNumber = +colorValue;
+                          let hexValue = colorNumber.toString(16);
+                          return colorNumber < 16 ? "0" + hexValue : hexValue;
+                        });
+    if (rgb.length === 4 && rgb[3] === "00") {
+      return null;
+    }
+    let hexCode = "#" + rgb.join("");
+    colorTester.classed(className, false);
+    return hexCode;
+  }
+
+  /**
+   * Return relative luminance (defined here: http://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef)
+   * Based on implementation from chroma.js by Gregor Aisch (gka) (licensed under BSD)
+   * chroma.js may be found here: https://github.com/gka/chroma.js
+   * License may be found here: https://github.com/gka/chroma.js/blob/master/LICENSE
+   */
+  function luminance(color: string) {
+    let rgb = d3.rgb(color);
+
+    let lum = (x: number) => {
+      x = x / 255;
+      return x <= 0.03928 ? x / 12.92 : nativeMath.pow((x + 0.055) / 1.055, 2.4);
+    };
+    let r = lum(rgb.r);
+    let g = lum(rgb.g);
+    let b = lum(rgb.b);
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  }
 }

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -1,218 +1,214 @@
-module Plottable {
-export module Utils {
-  export module DOM {
-    let nativeMath: Math = (<any>window).Math;
+module Plottable.Utils.DOM {
+  let nativeMath: Math = (<any>window).Math;
 
-    /**
-     * Gets the bounding box of an element.
-     * @param {d3.Selection} element
-     * @returns {SVGRed} The bounding box.
-     */
-    export function elementBBox(element: d3.Selection<any>) {
-      let bbox: SVGRect;
-      // HACKHACK: Firefox won't correctly measure nodes with style "display: none" or their descendents (FF Bug 612118).
-      try {
-        bbox = (<any> element.node()).getBBox();
-      } catch (err) {
-        bbox = { x: 0, y: 0, width: 0, height: 0 };
-      }
-      return bbox;
+  /**
+   * Gets the bounding box of an element.
+   * @param {d3.Selection} element
+   * @returns {SVGRed} The bounding box.
+   */
+  export function elementBBox(element: d3.Selection<any>) {
+    let bbox: SVGRect;
+    // HACKHACK: Firefox won't correctly measure nodes with style "display: none" or their descendents (FF Bug 612118).
+    try {
+      bbox = (<any> element.node()).getBBox();
+    } catch (err) {
+      bbox = { x: 0, y: 0, width: 0, height: 0 };
     }
+    return bbox;
+  }
 
-    /**
-     * Screen refresh rate which is assumed to be 60fps
-     */
-    export var SCREEN_REFRESH_RATE_MILLISECONDS = 1000 / 60;
+  /**
+   * Screen refresh rate which is assumed to be 60fps
+   */
+  export var SCREEN_REFRESH_RATE_MILLISECONDS = 1000 / 60;
 
-    /**
-     * Polyfill for `window.requestAnimationFrame`.
-     * If the function exists, then we use the function directly.
-     * Otherwise, we set a timeout on `SCREEN_REFRESH_RATE_MILLISECONDS` and then perform the function.
-     *
-     * @param {() => void} callback The callback to call in the next animation frame
-     */
-    export function requestAnimationFramePolyfill(callback: () => void) {
-      if (window.requestAnimationFrame != null) {
-        window.requestAnimationFrame(callback);
-      } else {
-        setTimeout(callback, SCREEN_REFRESH_RATE_MILLISECONDS);
-      }
-    }
-
-    /**
-     * Calculates the width of the element.
-     * The width includes the padding and the border on the element's left and right sides.
-     *
-     * @param {Element} element The element to query
-     * @returns {number} The width of the element.
-     */
-    export function elementWidth(element: Element) {
-      let style = window.getComputedStyle(element);
-      return _parseStyleValue(style, "width")
-        + _parseStyleValue(style, "padding-left")
-        + _parseStyleValue(style, "padding-right")
-        + _parseStyleValue(style, "border-left-width")
-        + _parseStyleValue(style, "border-right-width");
-    }
-
-    /**
-     * Calculates the height of the element.
-     * The height includes the padding the and the border on the element's top and bottom sides.
-     *
-     * @param {Element} element The element to query
-     * @returns {number} The height of the element
-     */
-    export function elementHeight(element: Element) {
-      let style = window.getComputedStyle(element);
-      return _parseStyleValue(style, "height")
-        + _parseStyleValue(style, "padding-top")
-        + _parseStyleValue(style, "padding-bottom")
-        + _parseStyleValue(style, "border-top-width")
-        + _parseStyleValue(style, "border-bottom-width");
-    }
-
-    /**
-     * Retrieves the number array representing the translation for the selection
-     *
-     * @param {d3.Selection<any>} selection The selection to query
-     * @returns {[number, number]} The number array representing the translation
-     */
-    export function translate(selection: d3.Selection<any>): [number, number];
-    /**
-     * Translates the given selection by the input x / y pixel amounts.
-     *
-     * @param {d3.Selection<any>} selection The selection to translate
-     * @param {number} x The amount to translate in the x direction
-     * @param {number} y The amount to translate in the y direction
-     * @returns {d3.Selection<any>} The input selection
-     */
-    export function translate(selection: d3.Selection<any>, x: number, y: number): d3.Selection<any>;
-    export function translate(selection: d3.Selection<any>, x?: number, y?: number): any {
-      let transformMatrix = d3.transform(selection.attr("transform"));
-
-      if (x == null) {
-        return transformMatrix.translate;
-      }
-
-      y = (y == null) ? 0 : y;
-      transformMatrix.translate[0] = x;
-      transformMatrix.translate[1] = y;
-      selection.attr("transform", transformMatrix.toString());
-      return selection;
-    }
-
-    /**
-     * Checks if the first ClientRect overlaps the second.
-     *
-     * @param {ClientRect} clientRectA The first ClientRect
-     * @param {ClientRect} clientRectB The second ClientRect
-     * @returns {boolean} If the ClientRects overlap each other.
-     */
-    export function clientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect) {
-      if (nativeMath.floor(clientRectA.right) <= nativeMath.ceil(clientRectB.left)) { return false; }
-      if (nativeMath.ceil(clientRectA.left) >= nativeMath.floor(clientRectB.right)) { return false; }
-      if (nativeMath.floor(clientRectA.bottom) <= nativeMath.ceil(clientRectB.top)) { return false; }
-      if (nativeMath.ceil(clientRectA.top) >= nativeMath.floor(clientRectB.bottom)) { return false; }
-      return true;
-    }
-
-    /**
-     * Returns true if and only if innerClientRect is inside outerClientRect.
-     *
-     * @param {ClientRect} innerClientRect The first ClientRect
-     * @param {ClientRect} outerClientRect The second ClientRect
-     * @returns {boolean} If and only if the innerClientRect is inside outerClientRect.
-     */
-    export function clientRectInside(innerClientRect: ClientRect, outerClientRect: ClientRect) {
-      return (
-        nativeMath.floor(outerClientRect.left) <= nativeMath.ceil(innerClientRect.left) &&
-        nativeMath.floor(outerClientRect.top) <= nativeMath.ceil(innerClientRect.top) &&
-        nativeMath.floor(innerClientRect.right) <= nativeMath.ceil(outerClientRect.right) &&
-        nativeMath.floor(innerClientRect.bottom) <= nativeMath.ceil(outerClientRect.bottom)
-      );
-    }
-
-    /**
-     * Retrieves the bounding svg of the input element
-     *
-     * @param {SVGElement} element The element to query
-     * @returns {SVGElement} The bounding svg
-     */
-    export function boundingSVG(element: SVGElement): SVGElement {
-      let ownerSVG = element.ownerSVGElement;
-      if (ownerSVG != null) {
-        return ownerSVG;
-      }
-      if (element.nodeName.toLowerCase() === "svg") { // elem itself is an SVG
-        return element;
-      }
-      return null; // not in the DOM
-    }
-
-    let _latestClipPathId = 0;
-    /**
-     * Generates a ClipPath ID that is unique for this instance of Plottable
-     */
-    export function generateUniqueClipPathId() {
-      return "plottableClipPath" + ++_latestClipPathId;
-    }
-
-    /**
-     * Returns true if the supplied coordinates or Ranges intersect or are contained by bbox.
-     *
-     * @param {number | Range} xValOrRange The x coordinate or Range to test
-     * @param {number | Range} yValOrRange The y coordinate or Range to test
-     * @param {SVGRect} bbox The bbox
-     * @param {number} tolerance Amount by which to expand bbox, in each dimension, before
-     * testing intersection
-     *
-     * @returns {boolean} True if the supplied coordinates or Ranges intersect or are
-     * contained by bbox, false otherwise.
-     */
-    export function intersectsBBox(
-        xValOrRange: number | Range,
-        yValOrRange: number | Range,
-        bbox: SVGRect,
-        tolerance = 0.5) {
-      let xRange = _parseRange(xValOrRange);
-      let yRange = _parseRange(yValOrRange);
-
-      // SVGRects are positioned with sub-pixel accuracy (the default unit
-      // for the x, y, height & width attributes), but user selections (e.g. via
-      // mouse events) usually have pixel accuracy. A tolerance of half-a-pixel
-      // seems appropriate.
-      return bbox.x + bbox.width >= xRange.min - tolerance &&
-        bbox.x <= xRange.max + tolerance &&
-        bbox.y + bbox.height >= yRange.min - tolerance &&
-        bbox.y <= yRange.max + tolerance;
-    }
-
-    /**
-     * Create a Range from a number or an object with "min" and "max" defined.
-     *
-     * @param {any} input The object to parse
-     *
-     * @returns {Range} The generated Range
-     */
-    function _parseRange(input: number | Range): Range {
-      if (typeof (input) === "number") {
-        let value = <number>input;
-        return { min: value, max: value };
-      }
-
-      let range = <Range>input;
-      if (range instanceof Object && "min" in range && "max" in range) {
-        return range;
-      }
-
-      throw new Error("input '" + input + "' can't be parsed as an Range");
-    }
-
-    function _parseStyleValue(style: CSSStyleDeclaration, property: string): number {
-      let value = style.getPropertyValue(property);
-      let parsedValue = parseFloat(value);
-      return parsedValue || 0;
+  /**
+   * Polyfill for `window.requestAnimationFrame`.
+   * If the function exists, then we use the function directly.
+   * Otherwise, we set a timeout on `SCREEN_REFRESH_RATE_MILLISECONDS` and then perform the function.
+   *
+   * @param {() => void} callback The callback to call in the next animation frame
+   */
+  export function requestAnimationFramePolyfill(callback: () => void) {
+    if (window.requestAnimationFrame != null) {
+      window.requestAnimationFrame(callback);
+    } else {
+      setTimeout(callback, SCREEN_REFRESH_RATE_MILLISECONDS);
     }
   }
-}
+
+  /**
+   * Calculates the width of the element.
+   * The width includes the padding and the border on the element's left and right sides.
+   *
+   * @param {Element} element The element to query
+   * @returns {number} The width of the element.
+   */
+  export function elementWidth(element: Element) {
+    let style = window.getComputedStyle(element);
+    return _parseStyleValue(style, "width")
+      + _parseStyleValue(style, "padding-left")
+      + _parseStyleValue(style, "padding-right")
+      + _parseStyleValue(style, "border-left-width")
+      + _parseStyleValue(style, "border-right-width");
+  }
+
+  /**
+   * Calculates the height of the element.
+   * The height includes the padding the and the border on the element's top and bottom sides.
+   *
+   * @param {Element} element The element to query
+   * @returns {number} The height of the element
+   */
+  export function elementHeight(element: Element) {
+    let style = window.getComputedStyle(element);
+    return _parseStyleValue(style, "height")
+      + _parseStyleValue(style, "padding-top")
+      + _parseStyleValue(style, "padding-bottom")
+      + _parseStyleValue(style, "border-top-width")
+      + _parseStyleValue(style, "border-bottom-width");
+  }
+
+  /**
+   * Retrieves the number array representing the translation for the selection
+   *
+   * @param {d3.Selection<any>} selection The selection to query
+   * @returns {[number, number]} The number array representing the translation
+   */
+  export function translate(selection: d3.Selection<any>): [number, number];
+  /**
+   * Translates the given selection by the input x / y pixel amounts.
+   *
+   * @param {d3.Selection<any>} selection The selection to translate
+   * @param {number} x The amount to translate in the x direction
+   * @param {number} y The amount to translate in the y direction
+   * @returns {d3.Selection<any>} The input selection
+   */
+  export function translate(selection: d3.Selection<any>, x: number, y: number): d3.Selection<any>;
+  export function translate(selection: d3.Selection<any>, x?: number, y?: number): any {
+    let transformMatrix = d3.transform(selection.attr("transform"));
+
+    if (x == null) {
+      return transformMatrix.translate;
+    }
+
+    y = (y == null) ? 0 : y;
+    transformMatrix.translate[0] = x;
+    transformMatrix.translate[1] = y;
+    selection.attr("transform", transformMatrix.toString());
+    return selection;
+  }
+
+  /**
+   * Checks if the first ClientRect overlaps the second.
+   *
+   * @param {ClientRect} clientRectA The first ClientRect
+   * @param {ClientRect} clientRectB The second ClientRect
+   * @returns {boolean} If the ClientRects overlap each other.
+   */
+  export function clientRectsOverlap(clientRectA: ClientRect, clientRectB: ClientRect) {
+    if (nativeMath.floor(clientRectA.right) <= nativeMath.ceil(clientRectB.left)) { return false; }
+    if (nativeMath.ceil(clientRectA.left) >= nativeMath.floor(clientRectB.right)) { return false; }
+    if (nativeMath.floor(clientRectA.bottom) <= nativeMath.ceil(clientRectB.top)) { return false; }
+    if (nativeMath.ceil(clientRectA.top) >= nativeMath.floor(clientRectB.bottom)) { return false; }
+    return true;
+  }
+
+  /**
+   * Returns true if and only if innerClientRect is inside outerClientRect.
+   *
+   * @param {ClientRect} innerClientRect The first ClientRect
+   * @param {ClientRect} outerClientRect The second ClientRect
+   * @returns {boolean} If and only if the innerClientRect is inside outerClientRect.
+   */
+  export function clientRectInside(innerClientRect: ClientRect, outerClientRect: ClientRect) {
+    return (
+      nativeMath.floor(outerClientRect.left) <= nativeMath.ceil(innerClientRect.left) &&
+      nativeMath.floor(outerClientRect.top) <= nativeMath.ceil(innerClientRect.top) &&
+      nativeMath.floor(innerClientRect.right) <= nativeMath.ceil(outerClientRect.right) &&
+      nativeMath.floor(innerClientRect.bottom) <= nativeMath.ceil(outerClientRect.bottom)
+    );
+  }
+
+  /**
+   * Retrieves the bounding svg of the input element
+   *
+   * @param {SVGElement} element The element to query
+   * @returns {SVGElement} The bounding svg
+   */
+  export function boundingSVG(element: SVGElement): SVGElement {
+    let ownerSVG = element.ownerSVGElement;
+    if (ownerSVG != null) {
+      return ownerSVG;
+    }
+    if (element.nodeName.toLowerCase() === "svg") { // elem itself is an SVG
+      return element;
+    }
+    return null; // not in the DOM
+  }
+
+  let _latestClipPathId = 0;
+  /**
+   * Generates a ClipPath ID that is unique for this instance of Plottable
+   */
+  export function generateUniqueClipPathId() {
+    return "plottableClipPath" + ++_latestClipPathId;
+  }
+
+  /**
+   * Returns true if the supplied coordinates or Ranges intersect or are contained by bbox.
+   *
+   * @param {number | Range} xValOrRange The x coordinate or Range to test
+   * @param {number | Range} yValOrRange The y coordinate or Range to test
+   * @param {SVGRect} bbox The bbox
+   * @param {number} tolerance Amount by which to expand bbox, in each dimension, before
+   * testing intersection
+   *
+   * @returns {boolean} True if the supplied coordinates or Ranges intersect or are
+   * contained by bbox, false otherwise.
+   */
+  export function intersectsBBox(
+      xValOrRange: number | Range,
+      yValOrRange: number | Range,
+      bbox: SVGRect,
+      tolerance = 0.5) {
+    let xRange = _parseRange(xValOrRange);
+    let yRange = _parseRange(yValOrRange);
+
+    // SVGRects are positioned with sub-pixel accuracy (the default unit
+    // for the x, y, height & width attributes), but user selections (e.g. via
+    // mouse events) usually have pixel accuracy. A tolerance of half-a-pixel
+    // seems appropriate.
+    return bbox.x + bbox.width >= xRange.min - tolerance &&
+      bbox.x <= xRange.max + tolerance &&
+      bbox.y + bbox.height >= yRange.min - tolerance &&
+      bbox.y <= yRange.max + tolerance;
+  }
+
+  /**
+   * Create a Range from a number or an object with "min" and "max" defined.
+   *
+   * @param {any} input The object to parse
+   *
+   * @returns {Range} The generated Range
+   */
+  function _parseRange(input: number | Range): Range {
+    if (typeof (input) === "number") {
+      let value = <number>input;
+      return { min: value, max: value };
+    }
+
+    let range = <Range>input;
+    if (range instanceof Object && "min" in range && "max" in range) {
+      return range;
+    }
+
+    throw new Error("input '" + input + "' can't be parsed as an Range");
+  }
+
+  function _parseStyleValue(style: CSSStyleDeclaration, property: string): number {
+    let value = style.getPropertyValue(property);
+    let parsedValue = parseFloat(value);
+    return parsedValue || 0;
+  }
 }

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Utils {
+module Plottable.Utils {
   /**
    * Shim for ES6 map.
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
@@ -88,5 +87,4 @@ export module Utils {
       return false;
     }
   }
-}
 }

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -1,110 +1,106 @@
-module Plottable {
-export module Utils {
-  export module Math {
+module Plottable.Utils.Math {
 
-    let nativeMath: Math = (<any>window).Math;
+  let nativeMath: Math = (<any>window).Math;
 
-    /**
-     * Checks if x is between a and b.
-     *
-     * @param {number} x The value to test if in range
-     * @param {number} a The beginning of the (inclusive) range
-     * @param {number} b The ending of the (inclusive) range
-     * @return {boolean} Whether x is in [a, b]
-     */
-    export function inRange(x: number, a: number, b: number) {
-      return (nativeMath.min(a, b) <= x && x <= nativeMath.max(a, b));
-    }
-
-    /**
-     * Clamps x to the range [min, max].
-     *
-     * @param {number} x The value to be clamped.
-     * @param {number} min The minimum value.
-     * @param {number} max The maximum value.
-     * @return {number} A clamped value in the range [min, max].
-     */
-    export function clamp(x: number, min: number, max: number) {
-      return nativeMath.min(nativeMath.max(min, x), max);
-    }
-
-    /**
-     * Applies the accessor, if provided, to each element of `array` and returns the maximum value.
-     * If no maximum value can be computed, returns defaultValue.
-     */
-    export function max<C>(array: C[], defaultValue: C): C;
-    export function max<T, C>(array: T[], accessor: (t?: T, i?: number) => C, defaultValue: C): C;
-    export function max(array: any[], firstArg: any, secondArg?: any): any {
-      let accessor = typeof(firstArg) === "function" ? firstArg : null;
-      let defaultValue = accessor == null ? firstArg : secondArg;
-      /* tslint:disable:ban */
-      let maxValue = accessor == null ? d3.max(array) : d3.max(array, accessor);
-      /* tslint:enable:ban */
-      return maxValue !== undefined ? maxValue : defaultValue;
-    }
-
-    /**
-     * Applies the accessor, if provided, to each element of `array` and returns the minimum value.
-     * If no minimum value can be computed, returns defaultValue.
-     */
-    export function min<C>(array: C[], defaultValue: C): C;
-    export function min<T, C>(array: T[], accessor: (t?: T, i?: number) => C, defaultValue: C): C;
-    export function min(array: any[], firstArg: any, secondArg?: any): any {
-      let accessor = typeof(firstArg) === "function" ? firstArg : null;
-      let defaultValue = accessor == null ? firstArg : secondArg;
-      /* tslint:disable:ban */
-      let minValue = accessor == null ? d3.min(array) : d3.min(array, accessor);
-      /* tslint:enable:ban */
-      return minValue !== undefined ? minValue : defaultValue;
-    }
-
-    /**
-     * Returns true **only** if x is NaN
-     */
-    export function isNaN(n: any) {
-      return n !== n;
-    }
-
-    /**
-     * Returns true if the argument is a number, which is not NaN
-     * Numbers represented as strings do not pass this function
-     */
-    export function isValidNumber(n: any) {
-      return typeof n === "number" && !Plottable.Utils.Math.isNaN(n) && isFinite(n);
-    }
-
-    /**
-     * Generates an array of consecutive, strictly increasing numbers
-     * in the range [start, stop) separeted by step
-     */
-    export function range(start: number, stop: number, step = 1): number[] {
-      if (step === 0) {
-        throw new Error("step cannot be 0");
-      }
-      let length = nativeMath.max(nativeMath.ceil((stop - start) / step), 0);
-      let range: number[] = [];
-
-      for (let i = 0; i < length; ++i) {
-        range[i] = start + step * i;
-      }
-
-      return range;
-    }
-
-    /**
-     * Returns the square of the distance between two points
-     *
-     * @param {Point} p1
-     * @param {Point} p2
-     * @return {number} dist(p1, p2)^2
-     */
-    export function distanceSquared(p1: Point, p2: Point) {
-      return nativeMath.pow(p2.y - p1.y, 2) + nativeMath.pow(p2.x - p1.x, 2);
-    }
-
-    export function degreesToRadians(degree: number) {
-      return degree / 360 * nativeMath.PI * 2;
-    }
+  /**
+   * Checks if x is between a and b.
+   *
+   * @param {number} x The value to test if in range
+   * @param {number} a The beginning of the (inclusive) range
+   * @param {number} b The ending of the (inclusive) range
+   * @return {boolean} Whether x is in [a, b]
+   */
+  export function inRange(x: number, a: number, b: number) {
+    return (nativeMath.min(a, b) <= x && x <= nativeMath.max(a, b));
   }
-}
+
+  /**
+   * Clamps x to the range [min, max].
+   *
+   * @param {number} x The value to be clamped.
+   * @param {number} min The minimum value.
+   * @param {number} max The maximum value.
+   * @return {number} A clamped value in the range [min, max].
+   */
+  export function clamp(x: number, min: number, max: number) {
+    return nativeMath.min(nativeMath.max(min, x), max);
+  }
+
+  /**
+   * Applies the accessor, if provided, to each element of `array` and returns the maximum value.
+   * If no maximum value can be computed, returns defaultValue.
+   */
+  export function max<C>(array: C[], defaultValue: C): C;
+  export function max<T, C>(array: T[], accessor: (t?: T, i?: number) => C, defaultValue: C): C;
+  export function max(array: any[], firstArg: any, secondArg?: any): any {
+    let accessor = typeof(firstArg) === "function" ? firstArg : null;
+    let defaultValue = accessor == null ? firstArg : secondArg;
+    /* tslint:disable:ban */
+    let maxValue = accessor == null ? d3.max(array) : d3.max(array, accessor);
+    /* tslint:enable:ban */
+    return maxValue !== undefined ? maxValue : defaultValue;
+  }
+
+  /**
+   * Applies the accessor, if provided, to each element of `array` and returns the minimum value.
+   * If no minimum value can be computed, returns defaultValue.
+   */
+  export function min<C>(array: C[], defaultValue: C): C;
+  export function min<T, C>(array: T[], accessor: (t?: T, i?: number) => C, defaultValue: C): C;
+  export function min(array: any[], firstArg: any, secondArg?: any): any {
+    let accessor = typeof(firstArg) === "function" ? firstArg : null;
+    let defaultValue = accessor == null ? firstArg : secondArg;
+    /* tslint:disable:ban */
+    let minValue = accessor == null ? d3.min(array) : d3.min(array, accessor);
+    /* tslint:enable:ban */
+    return minValue !== undefined ? minValue : defaultValue;
+  }
+
+  /**
+   * Returns true **only** if x is NaN
+   */
+  export function isNaN(n: any) {
+    return n !== n;
+  }
+
+  /**
+   * Returns true if the argument is a number, which is not NaN
+   * Numbers represented as strings do not pass this function
+   */
+  export function isValidNumber(n: any) {
+    return typeof n === "number" && !Plottable.Utils.Math.isNaN(n) && isFinite(n);
+  }
+
+  /**
+   * Generates an array of consecutive, strictly increasing numbers
+   * in the range [start, stop) separeted by step
+   */
+  export function range(start: number, stop: number, step = 1): number[] {
+    if (step === 0) {
+      throw new Error("step cannot be 0");
+    }
+    let length = nativeMath.max(nativeMath.ceil((stop - start) / step), 0);
+    let range: number[] = [];
+
+    for (let i = 0; i < length; ++i) {
+      range[i] = start + step * i;
+    }
+
+    return range;
+  }
+
+  /**
+   * Returns the square of the distance between two points
+   *
+   * @param {Point} p1
+   * @param {Point} p2
+   * @return {number} dist(p1, p2)^2
+   */
+  export function distanceSquared(p1: Point, p2: Point) {
+    return nativeMath.pow(p2.y - p1.y, 2) + nativeMath.pow(p2.x - p1.x, 2);
+  }
+
+  export function degreesToRadians(degree: number) {
+    return degree / 360 * nativeMath.PI * 2;
+  }
 }

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -1,5 +1,4 @@
-module Plottable {
-export module Utils {
+module Plottable.Utils {
   /**
    * Shim for ES6 set.
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
@@ -70,5 +69,4 @@ export module Utils {
     }
 
   }
-}
 }

--- a/src/utils/stackingUtils.ts
+++ b/src/utils/stackingUtils.ts
@@ -1,88 +1,84 @@
-module Plottable {
-export module Utils {
-  export module Stacking {
+module Plottable.Utils.Stacking {
 
-    export type StackedDatum = {
-      value: number;
-      offset: number;
-    };
+  export type StackedDatum = {
+    value: number;
+    offset: number;
+  };
 
-    export type StackingResult = Utils.Map<Dataset, Utils.Map<string, StackedDatum>>;
+  export type StackingResult = Utils.Map<Dataset, Utils.Map<string, StackedDatum>>;
 
-    let nativeMath: Math = (<any>window).Math;
+  let nativeMath: Math = (<any>window).Math;
 
-    /**
-     * Computes the StackingResult (value and offset) for each data point in each Dataset.
-     *
-     * @param {Dataset[]} datasets The Datasets to be stacked on top of each other in the order of stacking
-     * @param {Accessor<any>} keyAccessor Accessor for the key of the data
-     * @param {Accessor<number>} valueAccessor Accessor for the value of the data
-     * @return {StackingResult} value and offset for each datapoint in each Dataset
-     */
-    export function stack(datasets: Dataset[], keyAccessor: Accessor<any>, valueAccessor: Accessor<number>): StackingResult {
-      let positiveOffsets = d3.map<number>();
-      let negativeOffsets = d3.map<number>();
-      let datasetToKeyToStackedDatum = new Utils.Map<Dataset, Utils.Map<string, StackedDatum>>();
+  /**
+   * Computes the StackingResult (value and offset) for each data point in each Dataset.
+   *
+   * @param {Dataset[]} datasets The Datasets to be stacked on top of each other in the order of stacking
+   * @param {Accessor<any>} keyAccessor Accessor for the key of the data
+   * @param {Accessor<number>} valueAccessor Accessor for the value of the data
+   * @return {StackingResult} value and offset for each datapoint in each Dataset
+   */
+  export function stack(datasets: Dataset[], keyAccessor: Accessor<any>, valueAccessor: Accessor<number>): StackingResult {
+    let positiveOffsets = d3.map<number>();
+    let negativeOffsets = d3.map<number>();
+    let datasetToKeyToStackedDatum = new Utils.Map<Dataset, Utils.Map<string, StackedDatum>>();
 
-      datasets.forEach((dataset) => {
-        let keyToStackedDatum = new Utils.Map<string, StackedDatum>();
-        dataset.data().forEach((datum, index) => {
-          let key = normalizeKey(keyAccessor(datum, index, dataset));
-          let value = +valueAccessor(datum, index, dataset);
-          let offset: number;
-          let offsetMap = (value >= 0) ? positiveOffsets : negativeOffsets;
-          if (offsetMap.has(key)) {
-            offset = offsetMap.get(key);
-            offsetMap.set(key, offset + value);
-          } else {
-            offset = 0;
-            offsetMap.set(key, value);
-          }
-          keyToStackedDatum.set(key, {
-            value: value,
-            offset: offset
-          });
-        });
-        datasetToKeyToStackedDatum.set(dataset, keyToStackedDatum);
-      });
-      return datasetToKeyToStackedDatum;
-    }
-
-    /**
-     * Computes the total extent over all data points in all Datasets, taking stacking into consideration.
-     *
-     * @param {StackingResult} stackingResult The value and offset information for each datapoint in each dataset
-     * @oaram {Accessor<any>} keyAccessor Accessor for the key of the data existent in the stackingResult
-     * @param {Accessor<boolean>} filter A filter for data to be considered when computing the total extent
-     * @return {[number, number]} The total extent
-     */
-    export function stackedExtent(stackingResult: StackingResult, keyAccessor: Accessor<any>, filter: Accessor<boolean>) {
-      let extents: number[] = [];
-      stackingResult.forEach((stackedDatumMap: Utils.Map<string, StackedDatum>, dataset: Dataset) => {
-        dataset.data().forEach((datum, index) => {
-          if (filter != null && !filter(datum, index, dataset)) {
-            return;
-          }
-          let stackedDatum = stackedDatumMap.get(normalizeKey(keyAccessor(datum, index, dataset)));
-          extents.push(stackedDatum.value + stackedDatum.offset);
+    datasets.forEach((dataset) => {
+      let keyToStackedDatum = new Utils.Map<string, StackedDatum>();
+      dataset.data().forEach((datum, index) => {
+        let key = normalizeKey(keyAccessor(datum, index, dataset));
+        let value = +valueAccessor(datum, index, dataset);
+        let offset: number;
+        let offsetMap = (value >= 0) ? positiveOffsets : negativeOffsets;
+        if (offsetMap.has(key)) {
+          offset = offsetMap.get(key);
+          offsetMap.set(key, offset + value);
+        } else {
+          offset = 0;
+          offsetMap.set(key, value);
+        }
+        keyToStackedDatum.set(key, {
+          value: value,
+          offset: offset
         });
       });
-      let maxStackExtent = Utils.Math.max(extents, 0);
-      let minStackExtent = Utils.Math.min(extents, 0);
-
-      return [nativeMath.min(minStackExtent, 0), nativeMath.max(0, maxStackExtent)];
-    }
-
-    /**
-     * Normalizes a key used for stacking
-     *
-     * @param {any} key The key to be normalized
-     * @return {string} The stringified key
-     */
-    export function normalizeKey(key: any) {
-      return String(key);
-    }
-
+      datasetToKeyToStackedDatum.set(dataset, keyToStackedDatum);
+    });
+    return datasetToKeyToStackedDatum;
   }
-}
+
+  /**
+   * Computes the total extent over all data points in all Datasets, taking stacking into consideration.
+   *
+   * @param {StackingResult} stackingResult The value and offset information for each datapoint in each dataset
+   * @oaram {Accessor<any>} keyAccessor Accessor for the key of the data existent in the stackingResult
+   * @param {Accessor<boolean>} filter A filter for data to be considered when computing the total extent
+   * @return {[number, number]} The total extent
+   */
+  export function stackedExtent(stackingResult: StackingResult, keyAccessor: Accessor<any>, filter: Accessor<boolean>) {
+    let extents: number[] = [];
+    stackingResult.forEach((stackedDatumMap: Utils.Map<string, StackedDatum>, dataset: Dataset) => {
+      dataset.data().forEach((datum, index) => {
+        if (filter != null && !filter(datum, index, dataset)) {
+          return;
+        }
+        let stackedDatum = stackedDatumMap.get(normalizeKey(keyAccessor(datum, index, dataset)));
+        extents.push(stackedDatum.value + stackedDatum.offset);
+      });
+    });
+    let maxStackExtent = Utils.Math.max(extents, 0);
+    let minStackExtent = Utils.Math.min(extents, 0);
+
+    return [nativeMath.min(minStackExtent, 0), nativeMath.max(0, maxStackExtent)];
+  }
+
+  /**
+   * Normalizes a key used for stacking
+   *
+   * @param {any} key The key to be normalized
+   * @return {string} The stringified key
+   */
+  export function normalizeKey(key: any) {
+    return String(key);
+  }
+
 }

--- a/src/utils/windowUtils.ts
+++ b/src/utils/windowUtils.ts
@@ -1,59 +1,55 @@
-module Plottable {
-export module Utils {
-  export module Window {
+module Plottable.Utils.Window {
 
-    /**
-     * Print a warning message to the console, if it is available.
-     *
-     * @param {string} The warnings to print
-     */
-    export function warn(warning: string) {
-      if (!Configs.SHOW_WARNINGS) {
-        return;
-      }
-      /* tslint:disable:no-console */
-      if ((<any> window).console != null) {
-        if ((<any> window).console.warn != null) {
-          console.warn(warning);
-        } else if ((<any> window).console.log != null) {
-          console.log(warning);
-        }
-      }
-      /* tslint:enable:no-console */
+  /**
+   * Print a warning message to the console, if it is available.
+   *
+   * @param {string} The warnings to print
+   */
+  export function warn(warning: string) {
+    if (!Configs.SHOW_WARNINGS) {
+      return;
     }
-
-    /**
-     * Is like setTimeout, but activates synchronously if time=0
-     * We special case 0 because of an observed issue where calling setTimeout causes visible flickering.
-     * We believe this is because when requestAnimationFrame calls into the paint function, as soon as that function finishes
-     * evaluating, the results are painted to the screen. As a result, if we want something to occur immediately but call setTimeout
-     * with time=0, then it is pushed to the call stack and rendered in the next frame, so the component that was rendered via
-     * setTimeout appears out-of-sync with the rest of the plot.
-     */
-    export function setTimeout(f: Function, time: number, ...args: any[]) {
-      if (time === 0) {
-        f(args);
-        return -1;
-      } else {
-        return window.setTimeout(f, time, args);
+    /* tslint:disable:no-console */
+    if ((<any> window).console != null) {
+      if ((<any> window).console.warn != null) {
+        console.warn(warning);
+      } else if ((<any> window).console.log != null) {
+        console.log(warning);
       }
     }
-
-    /**
-     * Sends a deprecation warning to the console. The warning includes the name of the deprecated method,
-     * version number of the deprecation, and an optional message.
-     *
-     * To be used in the first line of a deprecated method.
-     *
-     * @param {string} callingMethod The name of the method being deprecated
-     * @param {string} version The version when the tagged method became obsolete
-     * @param {string?} message Optional message to be shown with the warning
-     */
-    export function deprecated(callingMethod: string, version: string, message = "") {
-      Utils.Window.warn("Method " + callingMethod + " has been deprecated in version " + version +
-        ". Please refer to the release notes. " + message);
-    }
-
+    /* tslint:enable:no-console */
   }
-}
+
+  /**
+   * Is like setTimeout, but activates synchronously if time=0
+   * We special case 0 because of an observed issue where calling setTimeout causes visible flickering.
+   * We believe this is because when requestAnimationFrame calls into the paint function, as soon as that function finishes
+   * evaluating, the results are painted to the screen. As a result, if we want something to occur immediately but call setTimeout
+   * with time=0, then it is pushed to the call stack and rendered in the next frame, so the component that was rendered via
+   * setTimeout appears out-of-sync with the rest of the plot.
+   */
+  export function setTimeout(f: Function, time: number, ...args: any[]) {
+    if (time === 0) {
+      f(args);
+      return -1;
+    } else {
+      return window.setTimeout(f, time, args);
+    }
+  }
+
+  /**
+   * Sends a deprecation warning to the console. The warning includes the name of the deprecated method,
+   * version number of the deprecation, and an optional message.
+   *
+   * To be used in the first line of a deprecated method.
+   *
+   * @param {string} callingMethod The name of the method being deprecated
+   * @param {string} version The version when the tagged method became obsolete
+   * @param {string?} message Optional message to be shown with the warning
+   */
+  export function deprecated(callingMethod: string, version: string, message = "") {
+    Utils.Window.warn("Method " + callingMethod + " has been deprecated in version " + version +
+      ". Please refer to the release notes. " + message);
+  }
+
 }


### PR DESCRIPTION
Based on the last answer here https://stackoverflow.com/questions/12737942/does-typescript-support-namespace , we can nest our modules such that

```typescript
module A {
  export module B {
  }
}
```

can be rewritten as

```typescript
module A.B {
}
```

This is somewhat exactly what we have been looking for in our files to prevent the annoying indentation.

It also exposes a few awkward pieces of organization when placing exported types and interfaces.

QE: This should not affect anything from a user perspective, mainly taking advantage of one aspect of Typescript.  Regression pass please