### PR TITLE
testing new configuration options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -196,7 +196,7 @@ module.exports = function(grunt) {
         testname: "Plottable Sauce Unit Tests",
         pollInterval: 5000,
         statusCheckAttempts: 60,
-        maxRetries: 5,
+        maxRetries: 1,
         browsers: [{
           browserName: "firefox",
           platform: "linux"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -196,6 +196,7 @@ module.exports = function(grunt) {
         testname: "Plottable Sauce Unit Tests",
         pollInterval: 5000,
         statusCheckAttempts: 60,
+        maxRetries: 5,
         browsers: [{
           browserName: "firefox",
           platform: "linux"
@@ -212,9 +213,7 @@ module.exports = function(grunt) {
           version: "8.0",
           deviceName: "iPad Simulator",
           deviceOrientation: "portrait"
-        }],
-        build: process.env.TRAVIS_JOB_ID,
-        "tunnel-identifier": process.env.TRAVIS_JOB_NUMBER
+        }]
       }
     }
   };


### PR DESCRIPTION
Looking at our tool's [configuration options](https://github.com/axemclion/grunt-saucelabs#usage), it seems that we can update a few of the options to deal with the flakiness that has been happening lately.

2 of the options have been removed since they did not seem to do anything.

1 option has been added ("maxRetries") which should hopefully decrease our chances of SauceLabs flaking out on us.  "maxRetries" sets how many times a test will run if the test reaches a timeout error, which sounds like an option that is designed for flaky builds.  This setting will be set to 5.  I do admit that this is mostly a bandaid, but if the flakiness is due to forces outside our control, then I think this is the best solution