### PR TITLE
[PlotTests] - Rework

### DIFF
--- a/test/plots/plotTests.ts
+++ b/test/plots/plotTests.ts
@@ -249,12 +249,28 @@ describe("Plots", () => {
         });
       });
 
+      it("passes the correct index to the Accessor", () => {
+        const data = ["A", "B", "C"];
+        const dataset = new Plottable.Dataset(data);
+        plot.addDataset(dataset);
+        const indexCheckAccessor = (datum: any, index: number) => {
+          assert.strictEqual(index, data.indexOf(datum), "was passed correct index");
+          return datum;
+        };
+        const scale = new Plottable.Scales.Category();
+        plot.attr("foo", indexCheckAccessor, scale);
+
+        const svg = TestMethods.generateSVG();
+        plot.anchor(svg);
+        svg.remove();
+      });
+
       it("can apply a scale to the returned values", () => {
         const data = [1, 2, 3, 4, 5];
         const dataset = new Plottable.Dataset(data);
         plot.addDataset(dataset);
 
-        const numberAccessor = (d: any, i: number) => d + i * 10;
+        const numberAccessor = (d: any, i: number) => d;
         const linearScale = new Plottable.Scales.Linear();
         assert.strictEqual(plot.attr("foo", numberAccessor, linearScale), plot, "setting the attribute returns the calling plot");
 
@@ -267,7 +283,7 @@ describe("Plots", () => {
           });
         });
 
-        const stringAccessor = (d: any, i: number) => `${d + i * 10} foo`;
+        const stringAccessor = (d: any, i: number) => `${d} foo`;
         const categoryScale = new Plottable.Scales.Category();
         categoryScale.domain(data.map(stringAccessor));
         assert.strictEqual(plot.attr("foo", stringAccessor, categoryScale), plot, "setting the attribute returns the calling plot");

--- a/test/plots/plotTests.ts
+++ b/test/plots/plotTests.ts
@@ -178,7 +178,7 @@ describe("Plots", () => {
       });
 
       // not supported on IE9 (http://caniuse.com/#feat=history)
-      if (window.history == null || window.history.replaceState == null) {
+      if (window.history != null && window.history.replaceState != null) {
         it("updates the clipPath reference when rendered", () => {
           const svg = TestMethods.generateSVG();
           const plot = new Plottable.Plot();

--- a/test/plots/plotTests.ts
+++ b/test/plots/plotTests.ts
@@ -149,7 +149,7 @@ describe("Plots", () => {
       svg.remove();
     });
 
-    it("disconnects the data extents from the scales when destroyed", () => {
+    it("disconnects the data extents from the scales when detached", () => {
       const plot = new Plottable.Plot();
       const scale = new Plottable.Scales.Linear();
       plot.attr("attr", (d) => d, scale);
@@ -204,7 +204,7 @@ describe("Plots", () => {
       }
     });
 
-    describe("setting the attribute of plot elements", () => {
+    describe("setting attributes with attr()", () => {
       let plot: Plottable.Plot;
 
       beforeEach(() => {
@@ -249,7 +249,7 @@ describe("Plots", () => {
         });
       });
 
-      it("can set the attribute based on the scaled input data", () => {
+      it("can apply a scale to the returned values", () => {
         const data = [1, 2, 3, 4, 5];
         const dataset = new Plottable.Dataset(data);
         plot.addDataset(dataset);
@@ -282,7 +282,7 @@ describe("Plots", () => {
         });
       });
 
-      it("updates the scales extents when an attribute is set", () => {
+      it("updates the scales extents associated with an attribute when that attribute is set", () => {
         const scale = new Plottable.Scales.Linear();
 
         const data = [5, -5, 10];


### PR DESCRIPTION
Test screenshot:
![screen shot 2015-10-26 at 2 25 24 pm](https://cloud.githubusercontent.com/assets/1448299/10742981/76f435fa-7bed-11e5-8334-813851966d45.png)

`Plot` is incredibly odd in that it cannot render on its own.  Thus, situations that directly deal with a rendered product are not tested.  However, other cases regarding anchoring, dataset mangement, etc have been reworked to follow the new guidellines.

Part of #2630 