### PR TITLE
entity nearest returns undefined instead of breaking, when no data in view

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -6968,6 +6968,9 @@ var Plottable;
                     closestPointEntity = entity;
                 }
             });
+            if (closestPointEntity === undefined) {
+                return undefined;
+            }
             return this._lightweightPlotEntityToPlotEntity(closestPointEntity);
         };
         /**

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -543,6 +543,9 @@ export class Plot extends Component {
         closestPointEntity = entity;
       }
     });
+    if (closestPointEntity === undefined) {
+      return undefined;
+    }
 
     return this._lightweightPlotEntityToPlotEntity(closestPointEntity);
   }

--- a/test/plots/piePlotTests.ts
+++ b/test/plots/piePlotTests.ts
@@ -464,6 +464,17 @@ describe("Plots", () => {
         assert.lengthOf(entitiesOutsideOuterRadius, 0, "no entities returned when clicking outside outerRadius()");
         svg.remove();
       });
+
+      it("returns undefined for entitiesNearest when no entities rendered", () => {
+        piePlot.datasets([new Plottable.Dataset([])]);
+        piePlot.renderTo(svg);
+        let closest = piePlot.entityNearest({
+          x: 1,
+          y: 1
+        });
+        assert.strictEqual(closest, undefined, "no datum has been retrieved");
+        svg.remove();
+      });
     });
 
     describe("Fail safe tests", () => {

--- a/test/plots/piePlotTests.ts
+++ b/test/plots/piePlotTests.ts
@@ -469,8 +469,8 @@ describe("Plots", () => {
         piePlot.datasets([new Plottable.Dataset([])]);
         piePlot.renderTo(svg);
         let closest = piePlot.entityNearest({
-          x: 1,
-          y: 1
+          x: piePlot.width() / 2,
+          y: piePlot.height() / 2
         });
         assert.strictEqual(closest, undefined, "no datum has been retrieved");
         svg.remove();

--- a/test/plots/piePlotTests.ts
+++ b/test/plots/piePlotTests.ts
@@ -465,7 +465,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("returns undefined for entitiesNearest when no entities rendered", () => {
+      it("retrieves undefined for entitiesNearest when no entities rendered", () => {
         piePlot.datasets([new Plottable.Dataset([])]);
         piePlot.renderTo(svg);
         let closest = piePlot.entityNearest({

--- a/test/plots/rectanglePlotTests.ts
+++ b/test/plots/rectanglePlotTests.ts
@@ -147,8 +147,8 @@ describe("Plots", () => {
         plot.addDataset(new Plottable.Dataset([]));
         plot.renderTo(svg);
         let closest = plot.entityNearest({
-          x: xScale.scale(1),
-          y: xScale.scale(1)
+          x: plot.width()/2,
+          y: plot.height()/2
         });
         assert.strictEqual(closest, undefined, "no datum has been retrieved");
         svg.remove();

--- a/test/plots/rectanglePlotTests.ts
+++ b/test/plots/rectanglePlotTests.ts
@@ -142,6 +142,17 @@ describe("Plots", () => {
         assert.strictEqual(entities[1].index, 2, "the entity of index 2 is retrieved");
         svg.remove();
       });
+
+      it("retrieves undefined from entityNearest() when no entities are rendered", () => {
+        plot.addDataset(new Plottable.Dataset([]));
+        plot.renderTo(svg);
+        let closest = plot.entityNearest({
+          x: xScale.scale(1),
+          y: xScale.scale(1)
+        });
+        assert.strictEqual(closest, undefined, "no datum has been retrieved");
+        svg.remove();
+      });
     });
 
     describe("autoranging the x and y scales", () => {

--- a/test/plots/rectanglePlotTests.ts
+++ b/test/plots/rectanglePlotTests.ts
@@ -143,7 +143,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("retrieves undefined from entityNearest() when no entities are rendered", () => {
+      it("retrieves undefined from entityNearest when no entities are rendered", () => {
         plot.addDataset(new Plottable.Dataset([]));
         plot.renderTo(svg);
         let closest = plot.entityNearest({

--- a/test/plots/rectanglePlotTests.ts
+++ b/test/plots/rectanglePlotTests.ts
@@ -147,8 +147,8 @@ describe("Plots", () => {
         plot.addDataset(new Plottable.Dataset([]));
         plot.renderTo(svg);
         let closest = plot.entityNearest({
-          x: plot.width()/2,
-          y: plot.height()/2
+          x: plot.width() / 2,
+          y: plot.height() / 2
         });
         assert.strictEqual(closest, undefined, "no datum has been retrieved");
         svg.remove();

--- a/test/plots/scatterPlotTests.ts
+++ b/test/plots/scatterPlotTests.ts
@@ -281,8 +281,8 @@ describe("Plots", () => {
         plot.renderTo(svg);
 
         let closest = plot.entityNearest({
-          x: plot.width()/2,
-          y: plot.height()/2
+          x: plot.width() / 2,
+          y: plot.height() / 2
         });
         assert.strictEqual(closest, undefined, "no datum has been retrieved");
         svg.remove();

--- a/test/plots/scatterPlotTests.ts
+++ b/test/plots/scatterPlotTests.ts
@@ -275,6 +275,19 @@ describe("Plots", () => {
         svg.remove();
       });
 
+      it("returns undefined from nearestEntity when no scatter points are in view", () => {
+        yScale.domain([-2, -1]);
+        xScale.domain([-2, -1]);
+        plot.renderTo(svg);
+
+        let closest = plot.entityNearest({
+          x: xScale.scale(1),
+          y: xScale.scale(2)
+        });
+        assert.strictEqual(closest, undefined, "no datum has been retrieved");
+        svg.remove();
+      });
+
       it("can retrieve Entities in a certain range", () => {
         plot.renderTo(svg);
 

--- a/test/plots/scatterPlotTests.ts
+++ b/test/plots/scatterPlotTests.ts
@@ -275,7 +275,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("retrieves undefined from nearestEntity when no scatter points are in view", () => {
+      it("retrieves undefined from entityNearest when no scatter points are in view", () => {
         yScale.domain([-2, -1]);
         xScale.domain([-2, -1]);
         plot.renderTo(svg);

--- a/test/plots/scatterPlotTests.ts
+++ b/test/plots/scatterPlotTests.ts
@@ -281,8 +281,8 @@ describe("Plots", () => {
         plot.renderTo(svg);
 
         let closest = plot.entityNearest({
-          x: xScale.scale(1),
-          y: xScale.scale(2)
+          x: plot.width()/2,
+          y: plot.height()/2
         });
         assert.strictEqual(closest, undefined, "no datum has been retrieved");
         svg.remove();

--- a/test/plots/scatterPlotTests.ts
+++ b/test/plots/scatterPlotTests.ts
@@ -275,7 +275,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("returns undefined from nearestEntity when no scatter points are in view", () => {
+      it("retrieves undefined from nearestEntity when no scatter points are in view", () => {
         yScale.domain([-2, -1]);
         xScale.domain([-2, -1]);
         plot.renderTo(svg);

--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -237,6 +237,17 @@ describe("Plots", () => {
         svg.remove();
       });
 
+      it("retrieves undefined from entityNearest when no entities are rendered", () => {
+        plot.datasets([new Plottable.Dataset([])]);
+        plot.renderTo(svg);
+        let closest = plot.entityNearest({
+          x: xScale.scale(1),
+          y: xScale.scale(1)
+        });
+        assert.strictEqual(closest, undefined, "no datum has been retrieved");
+        svg.remove();
+      });
+
       function checkEntitiesInRange(plot: Plottable.Plots.Segment<any, any>, index: number,
                                     x1: number, x2: number, y1: number, y2: number) {
         const entities = plot.entitiesIn(

--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -241,8 +241,8 @@ describe("Plots", () => {
         plot.datasets([new Plottable.Dataset([])]);
         plot.renderTo(svg);
         let closest = plot.entityNearest({
-          x: xScale.scale(1),
-          y: xScale.scale(1)
+          x: plot.width()/2,
+          y: plot.height()/2
         });
         assert.strictEqual(closest, undefined, "no datum has been retrieved");
         svg.remove();

--- a/test/plots/segmentPlotTests.ts
+++ b/test/plots/segmentPlotTests.ts
@@ -241,8 +241,8 @@ describe("Plots", () => {
         plot.datasets([new Plottable.Dataset([])]);
         plot.renderTo(svg);
         let closest = plot.entityNearest({
-          x: plot.width()/2,
-          y: plot.height()/2
+          x: plot.width() / 2,
+          y: plot.height() / 2
         });
         assert.strictEqual(closest, undefined, "no datum has been retrieved");
         svg.remove();


### PR DESCRIPTION
line & bar have own implementations and shouldn't be affected
line http://jsfiddle.net/6kjx5810/3/
area http://jsfiddle.net/6kjx5810/5/
bar http://jsfiddle.net/6kjx5810/4/

pie http://jsfiddle.net/6kjx5810/6/
rectangle http://jsfiddle.net/6kjx5810/2/
segment http://jsfiddle.net/6kjx5810/1/
scatter http://jsfiddle.net/6kjx5810/

Nan, Infinity, clicking outside svg bounds http://jsfiddle.net/6kjx5810/7/