### PR TITLE
refactor DragLineLayerTests

### DIFF
--- a/test/components/dragLineLayerTests.ts
+++ b/test/components/dragLineLayerTests.ts
@@ -106,7 +106,7 @@ describe("GuideLineLayer", () => {
           return {
             x: orientation === "vertical" ? value : halfPoint.x,
             y: orientation === "vertical" ? halfPoint.y : value
-          }
+          };
         };
 
         function getRelventAttrFromPoint(point: Plottable.Point) {
@@ -137,7 +137,8 @@ describe("GuideLineLayer", () => {
             getDragPoint(startPosition),
             getDragPoint(endPosition)
           );
-          TestMethods.assertLineAttrs(dll.content().select(GUIDE_LINE_CSSCLASS), getExpectedAttr(endPosition), "line was dragged to the final location");
+          TestMethods.assertLineAttrs(dll.content().select(GUIDE_LINE_CSSCLASS), getExpectedAttr(endPosition),
+            "line was dragged to the final location");
           assert.strictEqual(dll.pixelPosition(), endPosition, "pixelPosition was updated correctly");
           svg.remove();
         });
@@ -152,7 +153,8 @@ describe("GuideLineLayer", () => {
             getDragPoint(startPosition + dll.detectionRadius()),
             getDragPoint(endPosition)
           );
-          TestMethods.assertLineAttrs(dll.content().select(GUIDE_LINE_CSSCLASS), getExpectedAttr(endPosition), "line was dragged to the final location");
+          TestMethods.assertLineAttrs(dll.content().select(GUIDE_LINE_CSSCLASS), getExpectedAttr(endPosition),
+            "line was dragged to the final location");
           assert.strictEqual(dll.pixelPosition(), endPosition, "pixelPosition was updated correctly");
           svg.remove();
         });
@@ -258,7 +260,8 @@ describe("GuideLineLayer", () => {
         svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         dll.pixelPosition(startPosition);
         dll.renderTo(svg);
-      })
+      });
+
       it("calls callback onDragStart", () => {
         assert.strictEqual(dll.onDragStart(callback), dll, "onDragStart() returns the calling DragLineLayer");
         dll.renderTo(svg);

--- a/test/components/dragLineLayerTests.ts
+++ b/test/components/dragLineLayerTests.ts
@@ -1,531 +1,347 @@
 ///<reference path="../testReference.ts" />
 
-describe("Interactive Components", () => {
+describe("GuideLineLayer", () => {
   describe("DragLineLayer", () => {
-    it("get/set detectionRadius()", () => {
-      let dll = new Plottable.Components.DragLineLayer<void>("vertical");
-      assert.strictEqual(dll.detectionRadius(), 3, "defaults to 3");
-      let setRadius = 6;
-      assert.strictEqual(dll.detectionRadius(setRadius), dll, "returns the calling DragLineLayer");
-      assert.strictEqual(dll.detectionRadius(), 6, "getter returns the set value");
-      // HACKHACK #2614: chai-assert.d.ts has the wrong signature
-      (<any> assert).throws(() => dll.detectionRadius(-1), Error, "", "rejects negative values");
-    });
+    describe("Basic Usage", () => {
+      let dll: Plottable.Components.DragLineLayer<void>;
+      let svg: d3.Selection<void>;
 
-    it("get/set enabled()", () => {
-      let dll = new Plottable.Components.DragLineLayer<void>("vertical");
-      assert.isTrue(dll.enabled(), "defaults to true");
-      assert.strictEqual(dll.enabled(false), dll, "setter mode returns the calling DragLineLayer");
-      assert.isFalse(dll.enabled(), "successfully set to false");
-    });
+      beforeEach(() => {
+        svg = TestMethods.generateSVG();
+        dll = new Plottable.Components.DragLineLayer<void>("vertical");
+      });
 
-    it("shows the correct cursor (vertical)", () => {
-      let dll = new Plottable.Components.DragLineLayer<void>("vertical");
-      let svg = TestMethods.generateSVG(400, 300);
-      dll.renderTo(svg);
-      let dragEdge = dll.content().select(".drag-edge");
-      let computedStyles = window.getComputedStyle(<Element> dragEdge.node());
-      assert.notStrictEqual(computedStyles.stroke, "none", "drag-edge has a non-\"none\" stroke");
-      assert.strictEqual(computedStyles.cursor, "ew-resize", "shows the resize cursor if enabled");
-      dll.enabled(false);
-      computedStyles = window.getComputedStyle(<Element> dragEdge.node());
-      assert.strictEqual(computedStyles.cursor, "auto", "cursor set to \"auto\" if not enabled");
-      svg.remove();
-    });
-
-    it("shows the correct cursor (horizontal)", () => {
-      let dll = new Plottable.Components.DragLineLayer<void>("horizontal");
-      let svg = TestMethods.generateSVG(300, 400);
-      dll.renderTo(svg);
-      let dragEdge = dll.content().select(".drag-edge");
-      let computedStyles = window.getComputedStyle(<Element> dragEdge.node());
-      assert.notStrictEqual(computedStyles.stroke, "none", "drag-edge has a non-\"none\" stroke");
-      assert.strictEqual(computedStyles.cursor, "ns-resize", "shows the resize cursor if enabled");
-      dll.enabled(false);
-      computedStyles = window.getComputedStyle(<Element> dragEdge.node());
-      assert.strictEqual(computedStyles.cursor, "auto", "cursor set to \"auto\" if not enabled");
-      svg.remove();
-    });
-
-    describe("Dragging (vertical)", () => {
-      let SVG_WIDTH = 400;
-      let SVG_HEIGHT = 300;
-
-      it("line can be dragged", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        let dll = new Plottable.Components.DragLineLayer<void>("vertical");
-        let startX = SVG_WIDTH / 2;
-        dll.pixelPosition(startX);
+      it("can get and set detectionRadius property", () => {
+        assert.strictEqual(dll.detectionRadius(), 3, "defaults to 3");
+        assert.doesNotThrow(() => dll.detectionRadius(4), Error, "can set detection radius before anchoring");
         dll.renderTo(svg);
-        let endX = SVG_WIDTH / 4;
-        TestMethods.triggerFakeDragSequence(
-          dll.background(),
-          { x: startX, y: SVG_HEIGHT / 2 },
-          { x: endX, y: SVG_HEIGHT / 2 }
-        );
-        TestMethods.assertLineAttrs(
-          dll.content().select(".guide-line"),
-          {
-            x1: endX,
-            y1: 0,
-            x2: endX,
-            y2: SVG_HEIGHT
-          },
-          "line was dragged to the final location"
-        );
-        assert.strictEqual(dll.pixelPosition(), endX, "pixelPosition was updated correctly");
+
+        assert.strictEqual(dll.detectionRadius(), 4, "detection radius did not change upon rendering");
+        assert.strictEqual(dll.detectionRadius(6), dll, "returns the calling DragLineLayer");
+        assert.strictEqual(dll.detectionRadius(), 6, "getter returns the set value");
+
+        // HACKHACK #2661: Cannot assert errors being thrown with description
+        (<any> assert).throws(() => dll.detectionRadius(-1), Error, "detection radius cannot be negative.", "rejects negative values");
+
         svg.remove();
       });
 
-      it("line can be dragged if drag starts within detectionRadius()", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        let dll = new Plottable.Components.DragLineLayer<void>("vertical");
-        let linePosition = SVG_WIDTH / 2;
-        dll.pixelPosition(linePosition);
-        dll.renderTo(svg);
-        let endX = SVG_WIDTH / 4;
-        TestMethods.triggerFakeDragSequence(
-          dll.background(),
-          { x: linePosition + dll.detectionRadius(), y: SVG_HEIGHT / 2 },
-          { x: endX, y: SVG_HEIGHT / 2 }
-        );
-        TestMethods.assertLineAttrs(
-          dll.content().select(".guide-line"),
-          {
-            x1: endX,
-            y1: 0,
-            x2: endX,
-            y2: SVG_HEIGHT
-          },
-          "line was dragged to the final location"
-        );
-        assert.strictEqual(dll.pixelPosition(), endX, "pixelPosition was updated correctly");
+      it("can get and set enabled property", () => {
+        assert.isTrue(dll.enabled(), "defaults to true");
+        assert.strictEqual(dll.enabled(false), dll, "setter mode returns the calling DragLineLayer");
+        assert.isFalse(dll.enabled(), "successfully set to false");
+        assert.strictEqual(dll.enabled(true), dll, "setter mode returns the calling DragLineLayer");
+        assert.isTrue(dll.enabled(), "successfully set back to true");
+
         svg.remove();
       });
 
-      it("starting a drag outside the detection radius does nothing", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        let dll = new Plottable.Components.DragLineLayer<void>("vertical");
-        let linePosition = SVG_WIDTH / 2;
-        dll.pixelPosition(linePosition);
-        dll.renderTo(svg);
-        let endX = SVG_WIDTH / 4;
-        TestMethods.triggerFakeDragSequence(
-          dll.background(),
-          { x: linePosition + 2 * dll.detectionRadius(), y: SVG_HEIGHT / 2 },
-          { x: endX, y: SVG_HEIGHT / 2 }
-        );
-        TestMethods.assertLineAttrs(
-          dll.content().select(".guide-line"),
-          {
-            x1: linePosition,
-            y1: 0,
-            x2: linePosition,
-            y2: SVG_HEIGHT
-          },
-          "line did not move"
-        );
+      it("removes all callbacks on the DragLineLayer on destroy", () => {
+        let callback = () => "foo";
+        dll.onDragStart(callback);
+        dll.onDrag(callback);
+        dll.onDragEnd(callback);
+
+        dll.destroy();
+
+        let dragStartCallbacks = <Plottable.Utils.CallbackSet<Plottable.DragLineCallback<void>>> (<any> dll)._dragStartCallbacks;
+        let dragCallbacks = <Plottable.Utils.CallbackSet<Plottable.DragLineCallback<void>>> (<any> dll)._dragCallbacks;
+        let dragEndCallbacks = <Plottable.Utils.CallbackSet<Plottable.DragLineCallback<void>>> (<any> dll)._dragEndCallbacks;
+        assert.strictEqual(dragStartCallbacks.size, 0, "dragStart callbacks removed on destroy()");
+        assert.strictEqual(dragCallbacks.size, 0, "drag callbacks removed on destroy()");
+        assert.strictEqual(dragEndCallbacks.size, 0, "drag end callbacks removed on destroy()");
         svg.remove();
       });
 
-      it("can't be dragged if not enabled", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        let dll = new Plottable.Components.DragLineLayer<void>("vertical");
-        dll.enabled(false);
-        let startX = SVG_WIDTH / 2;
-        dll.pixelPosition(startX);
-        dll.renderTo(svg);
-        let endX = SVG_WIDTH / 4;
-        TestMethods.triggerFakeDragSequence(
-          dll.background(),
-          { x: startX, y: SVG_HEIGHT / 2 },
-          { x: endX, y: SVG_HEIGHT / 2 }
-        );
-        TestMethods.assertLineAttrs(
-          dll.content().select(".guide-line"),
-          {
-            x1: startX,
-            y1: 0,
-            x2: startX,
-            y2: SVG_HEIGHT
-          },
-          "line did not move"
-        );
-        svg.remove();
-      });
+      it("correctly disconnects from the internal Drag Interaction on destroy", () => {
+        let dragInteraction = (<any> dll)._dragInteraction;
 
-      it("dragging does not affect the mode (value mode)", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        let dll = new Plottable.Components.DragLineLayer<number>("vertical");
-        let scale = new Plottable.Scales.Linear();
-        scale.domain([0, 1]);
-        dll.scale(scale);
+        dll.destroy();
 
-        let startValue = 0.5;
-        dll.value(startValue);
-        dll.renderTo(svg);
-
-        let startX = scale.scale(startValue);
-        let endX = SVG_WIDTH / 4;
-        TestMethods.triggerFakeDragSequence(
-          dll.background(),
-          { x: startX, y: SVG_HEIGHT / 2 },
-          { x: endX, y: SVG_HEIGHT / 2 }
-        );
-        let endValue = scale.invert(endX);
-        assert.strictEqual(dll.value(), endValue, "value was updated correctly");
-
-        scale.domain([0, 2]);
-        assert.strictEqual(dll.value(), endValue, "remained in \"value\" mode: value did not change when scale updated");
-        svg.remove();
-      });
-
-      it("dragging does not affect the mode (pixel mode)", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        let dll = new Plottable.Components.DragLineLayer<number>("vertical");
-        let scale = new Plottable.Scales.Linear();
-        scale.domain([0, 1]);
-        dll.scale(scale);
-
-        let startX = SVG_WIDTH / 2;
-        dll.pixelPosition(startX);
-        dll.renderTo(svg);
-
-        let endX = SVG_WIDTH / 4;
-        TestMethods.triggerFakeDragSequence(
-          dll.background(),
-          { x: startX, y: SVG_HEIGHT / 2 },
-          { x: endX, y: SVG_HEIGHT / 2 }
-        );
-        let endValue = scale.invert(endX);
-        assert.strictEqual(dll.value(), endValue, "value was updated correctly");
-
-        scale.domain([0, 2]);
-        assert.strictEqual(dll.pixelPosition(), endX, "remained in \"position\" mode: position did not change when scale updated");
+        let interactionStartCallbacks = <Plottable.Utils.CallbackSet<Plottable.DragCallback>> dragInteraction._dragStartCallbacks;
+        let interactionCallbacks = <Plottable.Utils.CallbackSet<Plottable.DragCallback>> dragInteraction._dragCallbacks;
+        let interactionEndCallbacks = <Plottable.Utils.CallbackSet<Plottable.DragCallback>> dragInteraction._dragEndCallbacks;
+        assert.strictEqual(interactionStartCallbacks.size, 0, "Interaction dragStart callbacks removed on destroy()");
+        assert.strictEqual(interactionCallbacks.size, 0, "Interaction drag callbacks removed on destroy()");
+        assert.strictEqual(interactionEndCallbacks.size, 0, "Interaction drag end callbacks removed on destroy()");
+        assert.notStrictEqual((<any> dragInteraction)._componentAttachedTo, dll, "Interaction was detached");
         svg.remove();
       });
     });
 
-    describe("Dragging (horizontal)", () => {
-      let SVG_WIDTH = 300;
-      let SVG_HEIGHT = 400;
+    ["vertical", "horizontal"].forEach((orientation: string) => {
+      describe(`Dragging orientation for ${orientation} DragLineLayer`, () => {
+        const SVG_WIDTH = orientation === "vertical" ? 400 : 300;
+        const SVG_HEIGHT = orientation === "vertical" ? 300 : 400;
+        const DRAG_EDGE_CSSCLASS = ".drag-edge";
+        const GUIDE_LINE_CSSCLASS = ".guide-line";
 
-      it("line can be dragged", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        let dll = new Plottable.Components.DragLineLayer<void>("horizontal");
-        let startY = SVG_HEIGHT / 2;
-        dll.pixelPosition(startY);
-        dll.renderTo(svg);
-        let endY = SVG_HEIGHT / 4;
-        TestMethods.triggerFakeDragSequence(
-          dll.background(),
-          { x: SVG_WIDTH / 2, y: startY },
-          { x: SVG_WIDTH / 2, y: endY }
-        );
-        TestMethods.assertLineAttrs(
-          dll.content().select(".guide-line"),
-          {
-            x1: 0,
-            y1: endY,
-            x2: SVG_WIDTH,
-            y2: endY
-          },
-          "line was dragged to the final location"
-        );
-        assert.strictEqual(dll.pixelPosition(), endY, "pixelPosition was updated correctly");
-        svg.remove();
-      });
+        const quarterPoint = {
+          x: SVG_WIDTH / 4,
+          y: SVG_HEIGHT / 4
+        };
+        const halfPoint = {
+          x: SVG_WIDTH / 2,
+          y: SVG_HEIGHT / 2
+        };
 
-      it("line can be dragged if drag starts within detectionRadius()", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        let dll = new Plottable.Components.DragLineLayer<void>("horizontal");
-        let linePosition = SVG_HEIGHT / 2;
-        dll.pixelPosition(linePosition);
-        dll.renderTo(svg);
-        let endY = SVG_HEIGHT / 4;
-        TestMethods.triggerFakeDragSequence(
-          dll.background(),
-          { x: SVG_WIDTH / 2, y: linePosition + dll.detectionRadius() },
-          { x: SVG_WIDTH / 2, y: endY }
-        );
-        TestMethods.assertLineAttrs(
-          dll.content().select(".guide-line"),
-          {
-            x1: 0,
-            y1: endY,
-            x2: SVG_WIDTH,
-            y2: endY
-          },
-          "line was dragged to the final location"
-        );
-        assert.strictEqual(dll.pixelPosition(), endY, "pixelPosition was updated correctly");
-        svg.remove();
-      });
+        let dll: Plottable.Components.DragLineLayer<number>;
+        let svg: d3.Selection<void>;
 
-      it("starting a drag outside the detection radius does nothing", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        let dll = new Plottable.Components.DragLineLayer<void>("horizontal");
-        let linePosition = SVG_HEIGHT / 2;
-        dll.pixelPosition(linePosition);
-        dll.renderTo(svg);
-        let endY = SVG_HEIGHT / 4;
-        TestMethods.triggerFakeDragSequence(
-          dll.background(),
-          { x: SVG_WIDTH / 2, y: linePosition + 2 * dll.detectionRadius() },
-          { x: SVG_WIDTH / 2, y: endY }
-        );
-        TestMethods.assertLineAttrs(
-          dll.content().select(".guide-line"),
-          {
-            x1: 0,
-            y1: linePosition,
-            x2: SVG_WIDTH,
-            y2: linePosition
-          },
-          "line did not move"
-        );
-        svg.remove();
-      });
+        beforeEach(() => {
+          svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+          dll = new Plottable.Components.DragLineLayer<number>(orientation);
+        });
 
-      it("can't be dragged if not enabled", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        let dll = new Plottable.Components.DragLineLayer<void>("horizontal");
-        dll.enabled(false);
-        let startY = SVG_HEIGHT / 2;
-        dll.pixelPosition(startY);
-        dll.renderTo(svg);
-        let endY = SVG_HEIGHT / 4;
-        TestMethods.triggerFakeDragSequence(
-          dll.background(),
-          { x: SVG_WIDTH / 2, y: startY },
-          { x: SVG_WIDTH / 2, y: endY }
-        );
-        TestMethods.assertLineAttrs(
-          dll.content().select(".guide-line"),
-          {
-            x1: 0,
-            y1: startY,
-            x2: SVG_WIDTH,
-            y2: startY
-          },
-          "line did not move"
-        );
-        svg.remove();
-      });
+        function getExpectedAttr(value: number) {
+          return {
+            x1: orientation === "vertical" ? value : 0,
+            x2: orientation === "vertical" ? value : SVG_WIDTH,
+            y1: orientation === "vertical" ? 0 : value,
+            y2: orientation === "vertical" ? SVG_HEIGHT : value
+          };
+        };
 
-      it("dragging does not affect the mode (value mode)", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        let dll = new Plottable.Components.DragLineLayer<number>("horizontal");
-        let scale = new Plottable.Scales.Linear();
-        scale.domain([0, 1]);
-        dll.scale(scale);
+        function getDragPoint(value: number) {
+          return {
+            x: orientation === "vertical" ? value : halfPoint.x,
+            y: orientation === "vertical" ? halfPoint.y : value
+          }
+        };
 
-        let startValue = 0.5;
-        dll.value(startValue);
-        dll.renderTo(svg);
+        function getRelventAttrFromPoint(point: Plottable.Point) {
+          return orientation === "vertical" ? point.x : point.y;
+        };
 
-        let startY = scale.scale(startValue);
-        let endY = SVG_HEIGHT / 4;
-        TestMethods.triggerFakeDragSequence(
-          dll.background(),
-          { x: SVG_WIDTH / 2, y: startY },
-          { x: SVG_WIDTH / 2, y: endY }
-        );
-        let endValue = scale.invert(endY);
-        assert.strictEqual(dll.value(), endValue, "value was updated correctly");
+        it("shows the correct cursor", () => {
+          dll.renderTo(svg);
+          const dragEdge = dll.content().select(DRAG_EDGE_CSSCLASS);
+          let computedStyles = window.getComputedStyle(<Element> dragEdge.node());
+          assert.notStrictEqual(computedStyles.stroke, "none", "drag-edge has a non-\"none\" stroke");
+          const expectCursor = orientation === "vertical" ? "ew-resize" : "ns-resize";
+          assert.strictEqual(computedStyles.cursor, expectCursor, "shows the resize cursor if enabled");
+          dll.enabled(false);
+          computedStyles = window.getComputedStyle(<Element> dragEdge.node());
+          assert.strictEqual(computedStyles.cursor, "auto", "cursor set to \"auto\" if not enabled");
+          svg.remove();
+        });
 
-        scale.domain([0, 2]);
-        assert.strictEqual(dll.value(), endValue, "remained in \"value\" mode: value did not change when scale updated");
-        svg.remove();
-      });
+        it("moves the line on drag", () => {
+          const startPosition = getRelventAttrFromPoint(halfPoint);
+          const endPosition = getRelventAttrFromPoint(quarterPoint);
+          dll.pixelPosition(startPosition);
+          dll.renderTo(svg);
 
-      it("dragging does not affect the mode (pixel mode)", () => {
-        let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        let dll = new Plottable.Components.DragLineLayer<number>("horizontal");
-        let scale = new Plottable.Scales.Linear();
-        scale.domain([0, 1]);
-        dll.scale(scale);
+          TestMethods.triggerFakeDragSequence(
+            dll.background(),
+            getDragPoint(startPosition),
+            getDragPoint(endPosition)
+          );
+          TestMethods.assertLineAttrs(dll.content().select(GUIDE_LINE_CSSCLASS), getExpectedAttr(endPosition), "line was dragged to the final location");
+          assert.strictEqual(dll.pixelPosition(), endPosition, "pixelPosition was updated correctly");
+          svg.remove();
+        });
 
-        let startY = SVG_HEIGHT / 2;
-        dll.pixelPosition(startY);
-        dll.renderTo(svg);
+        it("drags line if drag starts within detectionRadius", () => {
+          const startPosition = getRelventAttrFromPoint(halfPoint);
+          const endPosition = getRelventAttrFromPoint(quarterPoint);
+          dll.pixelPosition(startPosition);
+          dll.renderTo(svg);
+          TestMethods.triggerFakeDragSequence(
+            dll.background(),
+            getDragPoint(startPosition + dll.detectionRadius()),
+            getDragPoint(endPosition)
+          );
+          TestMethods.assertLineAttrs(dll.content().select(GUIDE_LINE_CSSCLASS), getExpectedAttr(endPosition), "line was dragged to the final location");
+          assert.strictEqual(dll.pixelPosition(), endPosition, "pixelPosition was updated correctly");
+          svg.remove();
+        });
 
-        let endY = SVG_HEIGHT / 4;
-        TestMethods.triggerFakeDragSequence(
-          dll.background(),
-          { x: SVG_WIDTH / 2, y: startY },
-          { x: SVG_WIDTH / 2, y: endY }
-        );
-        let endValue = scale.invert(endY);
-        assert.strictEqual(dll.value(), endValue, "value was updated correctly");
+        it("does nothing if drag starts outside the detection radius ", () => {
+          const startPosition = getRelventAttrFromPoint(halfPoint);
+          const endPosition = getRelventAttrFromPoint(quarterPoint);
+          dll.pixelPosition(startPosition);
+          dll.renderTo(svg);
+          TestMethods.triggerFakeDragSequence(
+            dll.background(),
+            getDragPoint(startPosition + 2 * dll.detectionRadius()),
+            getDragPoint(endPosition)
+          );
+          TestMethods.assertLineAttrs(dll.content().select(GUIDE_LINE_CSSCLASS), getExpectedAttr(startPosition), "line did not move");
+          assert.strictEqual(dll.pixelPosition(), startPosition, "pixelPosition was not changed");
+          svg.remove();
+        });
 
-        scale.domain([0, 2]);
-        assert.strictEqual(dll.pixelPosition(), endY, "remained in \"position\" mode: position did not change when scale updated");
-        svg.remove();
+        it("does nothing if not enabled", () => {
+          const startPosition = getRelventAttrFromPoint(halfPoint);
+          const endPosition = getRelventAttrFromPoint(quarterPoint);
+          dll.enabled(false);
+          dll.pixelPosition(startPosition);
+          dll.renderTo(svg);
+          TestMethods.triggerFakeDragSequence(
+            dll.background(),
+            getDragPoint(startPosition),
+            getDragPoint(endPosition)
+          );
+          TestMethods.assertLineAttrs(dll.content().select(GUIDE_LINE_CSSCLASS), getExpectedAttr(startPosition), "line did not move");
+          assert.strictEqual(dll.pixelPosition(), startPosition, "pixelPosition was not changed");
+          svg.remove();
+        });
+
+        it("does not affect the mode dragging in value mode", () => {
+          const scale = new Plottable.Scales.Linear();
+          scale.domain([0, 1]);
+          dll.scale(scale);
+
+          const startValue = 0.5;
+          dll.value(startValue);
+          dll.renderTo(svg);
+
+          const startPosition = scale.scale(startValue);
+          const endPosition = getRelventAttrFromPoint(quarterPoint);
+          TestMethods.triggerFakeDragSequence(
+            dll.background(),
+            getDragPoint(startPosition),
+            getDragPoint(endPosition)
+          );
+          const endValue = scale.invert(endPosition);
+          assert.strictEqual(dll.value(), endValue, "value was updated correctly");
+
+          scale.domain([0, 2]);
+          assert.strictEqual(dll.value(), endValue, "remained in \"value\" mode: value did not change when scale updated");
+          svg.remove();
+        });
+
+        it("does not affect the mode dragging in pixel mode", () => {
+          const scale = new Plottable.Scales.Linear();
+          scale.domain([0, 1]);
+          dll.scale(scale);
+
+          const startPosition = getRelventAttrFromPoint(halfPoint);
+          dll.pixelPosition(startPosition);
+          dll.renderTo(svg);
+
+          const endPosition = getRelventAttrFromPoint(quarterPoint);
+          TestMethods.triggerFakeDragSequence(
+            dll.background(),
+            getDragPoint(startPosition),
+            getDragPoint(endPosition)
+          );
+          const endValue = scale.invert(endPosition);
+          assert.strictEqual(dll.value(), endValue, "value was updated correctly");
+
+          scale.domain([0, 2]);
+          assert.strictEqual(dll.pixelPosition(), endPosition, "remained in \"position\" mode: position did not change when scale updated");
+          svg.remove();
+        });
       });
     });
 
-    it("onDragStart() / offDragStart()", () => {
-      let dll = new Plottable.Components.DragLineLayer<void>("vertical");
+    describe("Interactions", () => {
+      const SVG_WIDTH = 400;
+      const SVG_HEIGHT = 300;
+      const startPosition = SVG_WIDTH / 2;
 
+      let dll: Plottable.Components.DragLineLayer<void>;
       let callbackCalled = false;
       let pixelPositionOnCalling: number;
-      let callback = (layer: Plottable.Components.DragLineLayer<any>) => {
-        assert.strictEqual(layer, dll, "was passed the calling DragLineLayer");
-        pixelPositionOnCalling = dll.pixelPosition();
-        callbackCalled = true;
-      };
-      assert.strictEqual(dll.onDragStart(callback), dll, "onDragStart() returns the calling DragLineLayer");
+      let callback: (layer: Plottable.Components.DragLineLayer<any>) => void;
+      let svg: d3.Selection<void>;
 
-      let SVG_WIDTH = 400;
-      let SVG_HEIGHT = 300;
-      dll.pixelPosition(SVG_WIDTH / 2);
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      dll.renderTo(svg);
+      beforeEach(() => {
+        dll = new Plottable.Components.DragLineLayer<void>("vertical");
+        callback = (layer: Plottable.Components.DragLineLayer<any>) => {
+          assert.strictEqual(layer, dll, "was passed the calling DragLineLayer");
+          pixelPositionOnCalling = dll.pixelPosition();
+          callbackCalled = true;
+        };
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        dll.pixelPosition(startPosition);
+        dll.renderTo(svg);
+      })
+      it("calls callback onDragStart", () => {
+        assert.strictEqual(dll.onDragStart(callback), dll, "onDragStart() returns the calling DragLineLayer");
+        dll.renderTo(svg);
 
-      TestMethods.triggerFakeMouseEvent("mousedown", dll.background(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
-      assert.isTrue(callbackCalled, "callback was called on drag start");
-      assert.strictEqual(pixelPositionOnCalling, SVG_WIDTH / 2, "DragLineLayer's state was updated before calling callbacks");
-      TestMethods.triggerFakeMouseEvent("mouseup", dll.background(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        TestMethods.triggerFakeMouseEvent("mousedown", dll.background(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        assert.isTrue(callbackCalled, "callback was called on drag start");
+        assert.strictEqual(pixelPositionOnCalling, SVG_WIDTH / 2, "DragLineLayer's state was updated before calling callbacks");
+        TestMethods.triggerFakeMouseEvent("mouseup", dll.background(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
 
-      callbackCalled = false;
-      TestMethods.triggerFakeMouseEvent("mousedown", dll.background(), 0, SVG_HEIGHT / 2);
-      assert.isFalse(callbackCalled, "callback not called if line was not grabbed");
-      TestMethods.triggerFakeMouseEvent("mouseup", dll.background(), 0, SVG_HEIGHT / 2);
+        callbackCalled = false;
+        TestMethods.triggerFakeMouseEvent("mousedown", dll.background(), 0, SVG_HEIGHT / 2);
+        assert.isFalse(callbackCalled, "callback not called if line was not grabbed");
+        TestMethods.triggerFakeMouseEvent("mouseup", dll.background(), 0, SVG_HEIGHT / 2);
 
-      assert.strictEqual(dll.offDragStart(callback), dll, "offDragStart() returns the calling DragLineLayer");
-      TestMethods.triggerFakeMouseEvent("mousedown", dll.background(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
-      assert.isFalse(callbackCalled, "callback was deregistered successfully");
-      TestMethods.triggerFakeMouseEvent("mouseup", dll.background(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        assert.strictEqual(dll.offDragStart(callback), dll, "offDragStart() returns the calling DragLineLayer");
+        TestMethods.triggerFakeMouseEvent("mousedown", dll.background(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
+        assert.isFalse(callbackCalled, "callback was deregistered successfully");
+        TestMethods.triggerFakeMouseEvent("mouseup", dll.background(), SVG_WIDTH / 2, SVG_HEIGHT / 2);
 
-      svg.remove();
-    });
+        svg.remove();
+      });
 
-    it("onDrag()", () => {
-      let dll = new Plottable.Components.DragLineLayer<void>("vertical");
+      it("calls callback onDrag", () => {
+        assert.strictEqual(dll.onDrag(callback), dll, "onDrag() returns the calling DragLineLayer");
+        let midX = startPosition * 3 / 8;
+        let endX = SVG_WIDTH / 4;
+        TestMethods.triggerFakeMouseEvent("mousedown", dll.background(), startPosition, SVG_HEIGHT / 2);
+        TestMethods.triggerFakeMouseEvent("mousemove", dll.background(), midX, SVG_HEIGHT / 2);
+        assert.isTrue(callbackCalled, "callback was called on drag");
+        assert.strictEqual(pixelPositionOnCalling, midX, "DragLineLayer's state was updated before calling callbacks");
 
-      let callbackCalled = false;
-      let pixelPositionOnCalling: number;
-      let callback = (layer: Plottable.Components.DragLineLayer<any>) => {
-        assert.strictEqual(layer, dll, "was passed the calling DragLineLayer");
-        pixelPositionOnCalling = dll.pixelPosition();
-        callbackCalled = true;
-      };
-      assert.strictEqual(dll.onDrag(callback), dll, "onDrag() returns the calling DragLineLayer");
+        callbackCalled = false;
+        TestMethods.triggerFakeMouseEvent("mousemove", dll.background(), endX, SVG_HEIGHT / 2);
+        assert.isTrue(callbackCalled, "callback was called again on continued dragging");
+        assert.strictEqual(pixelPositionOnCalling, endX, "DragLineLayer's state was updated again");
+        TestMethods.triggerFakeMouseEvent("mouseup", dll.background(), endX, SVG_HEIGHT / 2);
 
-      let SVG_WIDTH = 400;
-      let SVG_HEIGHT = 300;
-      let startX = SVG_WIDTH / 2;
-      dll.pixelPosition(startX);
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      dll.renderTo(svg);
+        callbackCalled = false;
+        dll.pixelPosition(startPosition);
+        TestMethods.triggerFakeMouseEvent("mousedown", dll.background(), 0, SVG_HEIGHT / 2);
+        TestMethods.triggerFakeMouseEvent("mousemove", dll.background(), endX, SVG_HEIGHT / 2);
+        assert.isFalse(callbackCalled, "callback not called if line was not grabbed");
+        TestMethods.triggerFakeMouseEvent("mouseup", dll.background(), endX, SVG_HEIGHT / 2);
 
-      let midX = startX * 3 / 8;
-      let endX = SVG_WIDTH / 4;
-      TestMethods.triggerFakeMouseEvent("mousedown", dll.background(), startX, SVG_HEIGHT / 2);
-      TestMethods.triggerFakeMouseEvent("mousemove", dll.background(), midX, SVG_HEIGHT / 2);
-      assert.isTrue(callbackCalled, "callback was called on drag");
-      assert.strictEqual(pixelPositionOnCalling, midX, "DragLineLayer's state was updated before calling callbacks");
-      callbackCalled = false;
-      TestMethods.triggerFakeMouseEvent("mousemove", dll.background(), endX, SVG_HEIGHT / 2);
-      assert.isTrue(callbackCalled, "callback was called again on continued dragging");
-      assert.strictEqual(pixelPositionOnCalling, endX, "DragLineLayer's state was updated again");
-      TestMethods.triggerFakeMouseEvent("mouseup", dll.background(), endX, SVG_HEIGHT / 2);
+        assert.strictEqual(dll.offDrag(callback), dll, "offDrag() returns the calling DragLineLayer");
+        TestMethods.triggerFakeMouseEvent("mousedown", dll.background(), startPosition, SVG_HEIGHT / 2);
+        TestMethods.triggerFakeMouseEvent("mousemove", dll.background(), endX, SVG_HEIGHT / 2);
+        assert.isFalse(callbackCalled, "callback was deregistered successfully");
+        TestMethods.triggerFakeMouseEvent("mouseup", dll.background(), endX, SVG_HEIGHT / 2);
 
-      callbackCalled = false;
-      dll.pixelPosition(startX);
-      TestMethods.triggerFakeMouseEvent("mousedown", dll.background(), 0, SVG_HEIGHT / 2);
-      TestMethods.triggerFakeMouseEvent("mousemove", dll.background(), endX, SVG_HEIGHT / 2);
-      assert.isFalse(callbackCalled, "callback not called if line was not grabbed");
-      TestMethods.triggerFakeMouseEvent("mouseup", dll.background(), endX, SVG_HEIGHT / 2);
+        svg.remove();
+      });
 
-      assert.strictEqual(dll.offDrag(callback), dll, "offDrag() returns the calling DragLineLayer");
-      TestMethods.triggerFakeMouseEvent("mousedown", dll.background(), startX, SVG_HEIGHT / 2);
-      TestMethods.triggerFakeMouseEvent("mousemove", dll.background(), endX, SVG_HEIGHT / 2);
-      assert.isFalse(callbackCalled, "callback was deregistered successfully");
-      TestMethods.triggerFakeMouseEvent("mouseup", dll.background(), endX, SVG_HEIGHT / 2);
+      it("calls callback onDragEnd", () => {
+        assert.strictEqual(dll.onDragEnd(callback), dll, "onDragEnd() returns the calling DragLineLayer");
+        let endPosition = SVG_WIDTH / 4;
+        TestMethods.triggerFakeDragSequence(
+          dll.background(),
+          { x: startPosition, y: SVG_HEIGHT / 2 },
+          { x: endPosition, y: SVG_HEIGHT / 2 }
+        );
+        assert.isTrue(callbackCalled, "callback was called on drag end");
+        assert.strictEqual(pixelPositionOnCalling, endPosition, "DragLineLayer's state was updated before calling callbacks");
 
-      svg.remove();
-    });
+        callbackCalled = false;
+        dll.pixelPosition(startPosition);
+        TestMethods.triggerFakeDragSequence(
+          dll.background(),
+          { x: 0, y: SVG_HEIGHT / 2 },
+          { x: endPosition, y: SVG_HEIGHT / 2 }
+        );
+        assert.isFalse(callbackCalled, "callback not called if line was not grabbed");
 
-    it("onDragEnd()", () => {
-      let dll = new Plottable.Components.DragLineLayer<void>("vertical");
+        assert.strictEqual(dll.offDragEnd(callback), dll, "offDragEnd() returns the calling DragLineLayer");
+        TestMethods.triggerFakeDragSequence(
+          dll.background(),
+          { x: startPosition, y: SVG_HEIGHT / 2 },
+          { x: endPosition, y: SVG_HEIGHT / 2 }
+        );
+        assert.isFalse(callbackCalled, "callback was deregistered successfully");
 
-      let callbackCalled = false;
-      let pixelPositionOnCalling: number;
-      let callback = (layer: Plottable.Components.DragLineLayer<any>) => {
-        assert.strictEqual(layer, dll, "was passed the calling DragLineLayer");
-        pixelPositionOnCalling = dll.pixelPosition();
-        callbackCalled = true;
-      };
-      assert.strictEqual(dll.onDragEnd(callback), dll, "onDragEnd() returns the calling DragLineLayer");
-
-      let SVG_WIDTH = 400;
-      let SVG_HEIGHT = 300;
-      let startX = SVG_WIDTH / 2;
-      dll.pixelPosition(startX);
-      let svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-      dll.renderTo(svg);
-
-      let endX = SVG_WIDTH / 4;
-      TestMethods.triggerFakeDragSequence(
-        dll.background(),
-        { x: startX, y: SVG_HEIGHT / 2 },
-        { x: endX, y: SVG_HEIGHT / 2 }
-      );
-      assert.isTrue(callbackCalled, "callback was called on drag end");
-      assert.strictEqual(pixelPositionOnCalling, endX, "DragLineLayer's state was updated before calling callbacks");
-
-      callbackCalled = false;
-      dll.pixelPosition(startX);
-      TestMethods.triggerFakeDragSequence(
-        dll.background(),
-        { x: 0, y: SVG_HEIGHT / 2 },
-        { x: endX, y: SVG_HEIGHT / 2 }
-      );
-      assert.isFalse(callbackCalled, "callback not called if line was not grabbed");
-
-      assert.strictEqual(dll.offDragEnd(callback), dll, "offDragEnd() returns the calling DragLineLayer");
-      TestMethods.triggerFakeDragSequence(
-        dll.background(),
-        { x: startX, y: SVG_HEIGHT / 2 },
-        { x: endX, y: SVG_HEIGHT / 2 }
-      );
-      assert.isFalse(callbackCalled, "callback was deregistered successfully");
-
-      svg.remove();
-    });
-
-    it("destroy() removes all callbacks on the DragLineLayer", () => {
-      let dll = new Plottable.Components.DragLineLayer<void>("vertical");
-      let callback = () => "foo";
-      dll.onDragStart(callback);
-      dll.onDrag(callback);
-      dll.onDragEnd(callback);
-
-      dll.destroy();
-
-      let dragStartCallbacks = <Plottable.Utils.CallbackSet<Plottable.DragLineCallback<void>>> (<any> dll)._dragStartCallbacks;
-      let dragCallbacks = <Plottable.Utils.CallbackSet<Plottable.DragLineCallback<void>>> (<any> dll)._dragCallbacks;
-      let dragEndCallbacks = <Plottable.Utils.CallbackSet<Plottable.DragLineCallback<void>>> (<any> dll)._dragEndCallbacks;
-      assert.strictEqual(dragStartCallbacks.size, 0, "dragStart callbacks removed on destroy()");
-      assert.strictEqual(dragCallbacks.size, 0, "drag callbacks removed on destroy()");
-      assert.strictEqual(dragEndCallbacks.size, 0, "drag end callbacks removed on destroy()");
-    });
-
-    it("destroy() correctly disconnects from the internal Drag Interaction", () => {
-      let dll = new Plottable.Components.DragLineLayer<void>("vertical");
-      let dragInteraction = (<any> dll)._dragInteraction;
-
-      dll.destroy();
-
-      let interactionStartCallbacks = <Plottable.Utils.CallbackSet<Plottable.DragCallback>> dragInteraction._dragStartCallbacks;
-      let interactionCallbacks = <Plottable.Utils.CallbackSet<Plottable.DragCallback>> dragInteraction._dragCallbacks;
-      let interactionEndCallbacks = <Plottable.Utils.CallbackSet<Plottable.DragCallback>> dragInteraction._dragEndCallbacks;
-      assert.strictEqual(interactionStartCallbacks.size, 0, "Interaction dragStart callbacks removed on destroy()");
-      assert.strictEqual(interactionCallbacks.size, 0, "Interaction drag callbacks removed on destroy()");
-      assert.strictEqual(interactionEndCallbacks.size, 0, "Interaction drag end callbacks removed on destroy()");
-      assert.notStrictEqual((<any> dragInteraction)._componentAttachedTo, dll, "Interaction was detached");
+        svg.remove();
+      });
     });
   });
 });


### PR DESCRIPTION
![screen shot 2015-11-11 at 8 22 28 pm](https://cloud.githubusercontent.com/assets/1817638/11110533/f9e34b9c-88b1-11e5-88f9-8d9d9e5ccfaf.png)

restructure tests 
use `const` when possible
refactor vertical and horizontal tests
part of #2623 