### PR TITLE
[Testing Audit] Added tests for Drawer subclasses.

### DIFF
--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -2,7 +2,7 @@
 
 describe("Labels", () => {
   const LABEL_CLASS = "label";
-  let CLOSETO_REQUIRMENT;
+  let CLOSETO_REQUIRMENT: number;
   before(() => {
     CLOSETO_REQUIRMENT = window.Pixel_CloseTo_Requirement;
     // HACKHACK #2422: use an open source web font by default for Plottable

--- a/test/drawers/arcDrawerTests.ts
+++ b/test/drawers/arcDrawerTests.ts
@@ -1,0 +1,45 @@
+///<reference path="../testReference.ts" />
+
+describe("Drawers", () => {
+  describe("Arc Drawer", () => {
+    it("has a stroke of \"none\"", () => {
+      const drawer = new Plottable.Drawers.Arc(null);
+      const svg = TestMethods.generateSVG();
+      drawer.renderArea(svg);
+
+      const data = [["A", "B", "C"]]; // arc normally takes single array of data
+      const drawSteps: Plottable.Drawers.DrawStep[] = [
+        {
+          attrToProjector: {},
+          animator: new Plottable.Animators.Null()
+        }
+      ];
+      drawer.draw(data, drawSteps);
+
+      assert.strictEqual(drawer.selection().style("stroke"), "none");
+
+      svg.remove();
+    });
+  });
+
+  describe("Arc Outline Drawer", () => {
+    it("has a fill of \"none\"", () => {
+      const drawer = new Plottable.Drawers.ArcOutline(null);
+      const svg = TestMethods.generateSVG();
+      drawer.renderArea(svg);
+
+      const data = [["A", "B", "C"]]; // arc outline normally takes single array of data
+      const drawSteps: Plottable.Drawers.DrawStep[] = [
+        {
+          attrToProjector: {},
+          animator: new Plottable.Animators.Null()
+        }
+      ];
+      drawer.draw(data, drawSteps);
+
+      assert.strictEqual(drawer.selection().style("fill"), "none");
+
+      svg.remove();
+    });
+  });
+});

--- a/test/drawers/arcOutlineDrawerTests.ts
+++ b/test/drawers/arcOutlineDrawerTests.ts
@@ -1,13 +1,13 @@
 ///<reference path="../testReference.ts" />
 
 describe("Drawers", () => {
-  describe("Arc Drawer", () => {
-    it("has a stroke of \"none\"", () => {
-      const drawer = new Plottable.Drawers.Arc(null);
+  describe("Arc Outline Drawer", () => {
+    it("has a fill of \"none\"", () => {
+      const drawer = new Plottable.Drawers.ArcOutline(null);
       const svg = TestMethods.generateSVG();
       drawer.renderArea(svg);
 
-      const data = [["A", "B", "C"]]; // arc normally takes single array of data
+      const data = [["A", "B", "C"]]; // arc outline normally takes single array of data
       const drawSteps: Plottable.Drawers.DrawStep[] = [
         {
           attrToProjector: {},
@@ -16,7 +16,7 @@ describe("Drawers", () => {
       ];
       drawer.draw(data, drawSteps);
 
-      assert.strictEqual(drawer.selection().style("stroke"), "none");
+      assert.strictEqual(drawer.selection().style("fill"), "none");
 
       svg.remove();
     });

--- a/test/drawers/areaDrawerTests.ts
+++ b/test/drawers/areaDrawerTests.ts
@@ -1,14 +1,14 @@
 ///<reference path="../testReference.ts" />
 
 describe("Drawers", () => {
-  describe("Line Drawer", () => {
-    const data = [["A", "B", "C"]]; // line normally takes single array of data
+  describe("Area Drawer", () => {
+    const data = [["A", "B", "C"]]; // area normally takes single array of data
     let svg: d3.Selection<void>;
-    let drawer: Plottable.Drawers.Line;
+    let drawer: Plottable.Drawers.Area;
 
     beforeEach(() => {
       svg = TestMethods.generateSVG();
-      drawer = new Plottable.Drawers.Line(null);
+      drawer = new Plottable.Drawers.Area(null);
       drawer.renderArea(svg);
 
       const drawSteps: Plottable.Drawers.DrawStep[] = [
@@ -26,8 +26,8 @@ describe("Drawers", () => {
       }
     });
 
-    it("has a fill of \"none\"", () => {
-      assert.strictEqual(drawer.selection().style("fill"), "none");
+    it("has a stroke of \"none\"", () => {
+      assert.strictEqual(drawer.selection().style("stroke"), "none");
     });
 
     it("retrieves the same path regardless of requested selection index", () => {

--- a/test/drawers/lineDrawerTests.ts
+++ b/test/drawers/lineDrawerTests.ts
@@ -2,26 +2,25 @@
 
 describe("Drawers", () => {
   describe("Line Drawer", () => {
-    it("selectionForIndex()", () => {
-      let svg = TestMethods.generateSVG(300, 300);
-      let data = [{a: 12, b: 10}, {a: 13, b: 24}, {a: 14, b: 21}, {a: 15, b: 14}];
-      let dataset = new Plottable.Dataset(data);
-      let xScale = new Plottable.Scales.Linear();
-      let yScale = new Plottable.Scales.Linear();
-      let linePlot = new Plottable.Plots.Line();
+    it("retrieves the same line regardless of requested selection index", () => {
+      const svg = TestMethods.generateSVG();
+      const drawer = new Plottable.Drawers.Line(null);
+      drawer.renderArea(svg);
 
-      let drawer = new Plottable.Drawers.Line(dataset);
-      (<any> linePlot)._createDrawer = () => drawer;
+      const data = [["A", "B", "C"]]; // line normally takes single array of data
+      const drawSteps: Plottable.Drawers.DrawStep[] = [
+        {
+          attrToProjector: {},
+          animator: new Plottable.Animators.Null()
+        }
+      ];
+      drawer.draw(data, drawSteps);
 
-      linePlot.addDataset(dataset);
-      linePlot.x((d: any) => d.a, xScale);
-      linePlot.y((d: any) => d.b, yScale);
-      linePlot.renderTo(svg);
-
-      let lineSelection = linePlot.selections();
-      data.forEach((datum: any, index: number) => {
-        let selection = drawer.selectionForIndex(index);
-        assert.strictEqual(selection.node(), lineSelection.node(), "line selection retrieved");
+      const expectedSelection = svg.selectAll("path");
+      data[0].forEach((datum, index) => {
+        const selectionForIndex = drawer.selectionForIndex(index);
+        assert.strictEqual(selectionForIndex.size(), 1, `selection for index ${index} contains only one element`);
+        assert.strictEqual(selectionForIndex.node(), expectedSelection.node(), `selection for index ${index} contains the correct element`);
       });
 
       svg.remove();

--- a/test/drawers/lineDrawerTests.ts
+++ b/test/drawers/lineDrawerTests.ts
@@ -2,12 +2,15 @@
 
 describe("Drawers", () => {
   describe("Line Drawer", () => {
-    it("retrieves the same line regardless of requested selection index", () => {
-      const svg = TestMethods.generateSVG();
-      const drawer = new Plottable.Drawers.Line(null);
+    const data = [["A", "B", "C"]]; // line normally takes single array of data
+    let svg: d3.Selection<void>;
+    let drawer: Plottable.Drawers.Line;
+
+    beforeEach(() => {
+      svg = TestMethods.generateSVG();
+      drawer = new Plottable.Drawers.Line(null);
       drawer.renderArea(svg);
 
-      const data = [["A", "B", "C"]]; // line normally takes single array of data
       const drawSteps: Plottable.Drawers.DrawStep[] = [
         {
           attrToProjector: {},
@@ -15,15 +18,25 @@ describe("Drawers", () => {
         }
       ];
       drawer.draw(data, drawSteps);
+    });
 
+    afterEach(function() {
+      if (this.currentTest.state === "passed") {
+        svg.remove();
+      }
+    });
+
+    it("has a fill of \"none\"", () => {
+      assert.strictEqual(drawer.selection().style("fill"), "none");
+    });
+
+    it("retrieves the same line regardless of requested selection index", () => {
       const expectedSelection = svg.selectAll("path");
       data[0].forEach((datum, index) => {
         const selectionForIndex = drawer.selectionForIndex(index);
         assert.strictEqual(selectionForIndex.size(), 1, `selection for index ${index} contains only one element`);
         assert.strictEqual(selectionForIndex.node(), expectedSelection.node(), `selection for index ${index} contains the correct element`);
       });
-
-      svg.remove();
     });
   });
 });

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -12,6 +12,7 @@
 ///<reference path="testMethods.ts" />
 
 ///<reference path="drawers/drawerTests.ts" />
+///<reference path="drawers/areaDrawerTests.ts" />
 ///<reference path="drawers/lineDrawerTests.ts" />
 
 ///<reference path="animators/easingAnimatorTests.ts" />

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -12,6 +12,7 @@
 ///<reference path="testMethods.ts" />
 
 ///<reference path="drawers/drawerTests.ts" />
+///<reference path="drawers/arcDrawerTests.ts" />
 ///<reference path="drawers/areaDrawerTests.ts" />
 ///<reference path="drawers/lineDrawerTests.ts" />
 

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -13,6 +13,7 @@
 
 ///<reference path="drawers/drawerTests.ts" />
 ///<reference path="drawers/arcDrawerTests.ts" />
+///<reference path="drawers/arcOutlineDrawerTests.ts" />
 ///<reference path="drawers/areaDrawerTests.ts" />
 ///<reference path="drawers/lineDrawerTests.ts" />
 


### PR DESCRIPTION
Added tests for `Drawer` subclasses. Most of them only define an element name and class name, which is tested [in the superclass tests](https://github.com/palantir/plottable/pull/2976).

<img width="413" alt="screen shot 2015-11-18 at 1 13 50 pm" src="https://cloud.githubusercontent.com/assets/1440449/11255151/854fcc7c-8df9-11e5-9f09-20f501ed25c2.png">

Part of #2622.