### PR TITLE
[Testing Audit] Animators

### DIFF
--- a/test/animators/easingAnimatorTests.ts
+++ b/test/animators/easingAnimatorTests.ts
@@ -136,40 +136,6 @@ describe("Animators", () => {
           "The total duration constraint is just an upper bound");
       });
 
-      it("maxTotalDuration() edge case for 1 step", () => {
-        const iterationSteps = 1;
-        const startDelay = 0;
-        const stepDuration = 333;
-        const stepDelay = 432;
-
-        const animator = new Plottable.Animators.Easing();
-        animator.startDelay(startDelay);
-        animator.stepDuration(stepDuration);
-        animator.stepDelay(stepDelay);
-
-        const actualTotalTime = animator.totalTime(iterationSteps);
-        assert.strictEqual(actualTotalTime, stepDuration,
-          "The total time is just the time for one step");
-      });
-
-      it("maxTotalDuration() edge case for 1 step and startDelay", () => {
-        const iterationSteps = 1;
-        const startDelay = 213;
-        const stepDuration = 333;
-        const stepDelay = 432;
-
-        const expectedTotalTime = startDelay + stepDuration;
-
-        const animator = new Plottable.Animators.Easing();
-        animator.startDelay(startDelay);
-        animator.stepDuration(stepDuration);
-        animator.stepDelay(stepDelay);
-
-        const actualTotalTime = animator.totalTime(iterationSteps);
-        assert.strictEqual(actualTotalTime, expectedTotalTime,
-          "Total time is the time for one step, plus waiting for the start delay");
-      });
-
       it("_getAdjustedIterativeDelay() works with maxTotalDuration constraint", () => {
         const iterationSteps = 2;
         const startDelay = 0;

--- a/test/animators/easingAnimatorTests.ts
+++ b/test/animators/easingAnimatorTests.ts
@@ -2,6 +2,44 @@
 
 describe("Animators", () => {
   describe("EasingAnimator", () => {
+    describe("getters and setters", () => {
+      let animator: Plottable.Animators.Easing;
+
+      beforeEach(() => {
+        animator = new Plottable.Animators.Easing();
+      });
+
+      it("can get and set the start delay", () => {
+        const adjustedStartDelay = animator.startDelay() + 10;
+        assert.strictEqual(animator.startDelay(adjustedStartDelay), animator, "setter mode returns the Animator");
+        assert.strictEqual(animator.startDelay(), adjustedStartDelay, "retrieved the set value");
+      });
+
+      it("can get and set the step duration", () => {
+        const adjustedStepDuration = animator.stepDuration() + 10;
+        assert.strictEqual(animator.stepDuration(adjustedStepDuration), animator, "setter mode returns the Animator");
+        assert.strictEqual(animator.stepDuration(), adjustedStepDuration, "retrieved the set value");
+      });
+
+      it("can get and set the step delay", () => {
+        const adjustedStepDelay = animator.stepDelay() + 10;
+        assert.strictEqual(animator.stepDelay(adjustedStepDelay), animator, "setter mode returns the Animator");
+        assert.strictEqual(animator.stepDelay(), adjustedStepDelay, "retrieved the set value");
+      });
+
+      it("can get and set the max total duration", () => {
+        const setMaxTotalDuration = 10;
+        assert.strictEqual(animator.maxTotalDuration(setMaxTotalDuration), animator, "setter mode returns the Animator");
+        assert.strictEqual(animator.maxTotalDuration(), setMaxTotalDuration, "retrieved the set value");
+      });
+
+      it("can get and set the easing mode", () => {
+        const setEasingMode = "test-easing";
+        assert.strictEqual(animator.easingMode(setEasingMode), animator, "setter mode returns the Animator");
+        assert.strictEqual(animator.easingMode(), setEasingMode, "retrieved the set value");
+      });
+    });
+
     describe("Time computations", () => {
 
       it("totalTime() defaults", () => {

--- a/test/animators/easingAnimatorTests.ts
+++ b/test/animators/easingAnimatorTests.ts
@@ -2,12 +2,13 @@
 
 describe("Animators", () => {
   describe("EasingAnimator", () => {
-    describe("getters and setters", () => {
-      let animator: Plottable.Animators.Easing;
+    let animator: Plottable.Animators.Easing;
 
-      beforeEach(() => {
-        animator = new Plottable.Animators.Easing();
-      });
+    beforeEach(() => {
+      animator = new Plottable.Animators.Easing();
+    });
+
+    describe("getters and setters", () => {
 
       it("can get and set the start delay", () => {
         const adjustedStartDelay = animator.startDelay() + 10;
@@ -42,11 +43,6 @@ describe("Animators", () => {
 
     describe("total time", () => {
       const NUM_STEPS = 10;
-      let animator: Plottable.Animators.Easing;
-
-      beforeEach(() => {
-        animator = new Plottable.Animators.Easing();
-      });
 
       it("includes start delay in the total time", () => {
         const startDelay = 123;
@@ -87,7 +83,6 @@ describe("Animators", () => {
         const stepDelay = 1000;
         const expectedTotalTime = 2000;
 
-        const animator = new Plottable.Animators.Easing();
         animator.startDelay(startDelay);
         animator.stepDuration(stepDuration);
         animator.stepDelay(stepDelay);
@@ -105,7 +100,6 @@ describe("Animators", () => {
         const stepDelay = 100;
         const expectedTotalTime = 2000;
 
-        const animator = new Plottable.Animators.Easing();
         animator.startDelay(startDelay);
         animator.stepDuration(stepDuration);
         animator.stepDelay(stepDelay);
@@ -125,7 +119,6 @@ describe("Animators", () => {
 
         const expectedTotalTime = 200;
 
-        const animator = new Plottable.Animators.Easing();
         animator.startDelay(startDelay);
         animator.stepDuration(stepDuration);
         animator.stepDelay(stepDelay);
@@ -143,7 +136,6 @@ describe("Animators", () => {
         const stepDelay = 1000000;
         const maxTotalDuration = 1500;
 
-        const animator = new Plottable.Animators.Easing();
         animator.startDelay(startDelay);
         animator.stepDuration(stepDuration);
         animator.stepDelay(stepDelay);

--- a/test/animators/easingAnimatorTests.ts
+++ b/test/animators/easingAnimatorTests.ts
@@ -41,148 +41,147 @@ describe("Animators", () => {
     });
 
     describe("Time computations", () => {
-
       it("totalTime() defaults", () => {
-        let iterationSteps = 10;
-        let startDelay = 0;
-        let stepDuration = 300;
-        let stepDelay = 15;
-        let expectedTotalTime = startDelay + (iterationSteps - 1) * stepDelay + stepDuration;
+        const iterationSteps = 10;
+        const startDelay = 0;
+        const stepDuration = 300;
+        const stepDelay = 15;
+        const expectedTotalTime = startDelay + (iterationSteps - 1) * stepDelay + stepDuration;
 
-        let animator = new Plottable.Animators.Easing();
-        let actualTotalTime = animator.totalTime(iterationSteps);
+        const animator = new Plottable.Animators.Easing();
+        const actualTotalTime = animator.totalTime(iterationSteps);
 
         assert.strictEqual(actualTotalTime, expectedTotalTime,
           "Formula for calculating total time should work");
       });
 
       it("totalTime() takes setters into account", () => {
-        let iterationSteps = 17;
-        let startDelay = 135;
-        let stepDuration = 453;
-        let stepDelay = 265;
-        let expectedTotalTime = startDelay + (iterationSteps - 1) * stepDelay + stepDuration;
+        const iterationSteps = 17;
+        const startDelay = 135;
+        const stepDuration = 453;
+        const stepDelay = 265;
+        const expectedTotalTime = startDelay + (iterationSteps - 1) * stepDelay + stepDuration;
 
-        let animator = new Plottable.Animators.Easing();
+        const animator = new Plottable.Animators.Easing();
         animator.startDelay(startDelay);
         animator.stepDuration(stepDuration);
         animator.stepDelay(stepDelay);
 
-        let actualTotalTime = animator.totalTime(iterationSteps);
+        const actualTotalTime = animator.totalTime(iterationSteps);
         assert.strictEqual(actualTotalTime, expectedTotalTime,
           "Setters should work");
       });
 
       it("maxTotalDuration() with many steps", () => {
-        let iterationSteps = 10000;
-        let startDelay = 0;
-        let stepDuration = 100;
-        let stepDelay = 1000;
-        let expectedTotalTime = 2000;
+        const iterationSteps = 10000;
+        const startDelay = 0;
+        const stepDuration = 100;
+        const stepDelay = 1000;
+        const expectedTotalTime = 2000;
 
-        let animator = new Plottable.Animators.Easing();
+        const animator = new Plottable.Animators.Easing();
         animator.startDelay(startDelay);
         animator.stepDuration(stepDuration);
         animator.stepDelay(stepDelay);
         animator.maxTotalDuration(expectedTotalTime);
 
-        let actualTotalTime = animator.totalTime(iterationSteps);
+        const actualTotalTime = animator.totalTime(iterationSteps);
         assert.strictEqual(actualTotalTime, expectedTotalTime,
           "Animation should not exceed the maxTotalDuration time constraint when presented with lots of iteration steps");
       });
 
       it("maxTotalDuration() long steps", () => {
-        let iterationSteps = 2;
-        let startDelay = 0;
-        let stepDuration = 10000;
-        let stepDelay = 100;
-        let expectedTotalTime = 2000;
+        const iterationSteps = 2;
+        const startDelay = 0;
+        const stepDuration = 10000;
+        const stepDelay = 100;
+        const expectedTotalTime = 2000;
 
-        let animator = new Plottable.Animators.Easing();
+        const animator = new Plottable.Animators.Easing();
         animator.startDelay(startDelay);
         animator.stepDuration(stepDuration);
         animator.stepDelay(stepDelay);
         animator.maxTotalDuration(expectedTotalTime);
 
-        let actualTotalTime = animator.totalTime(iterationSteps);
+        const actualTotalTime = animator.totalTime(iterationSteps);
         assert.strictEqual(actualTotalTime, expectedTotalTime,
           "Animation should not exceed the maxTotalDuration time constraint when step duration set too high");
       });
 
       it("maxTotalDuration() is just a constraint", () => {
-        let iterationSteps = 2;
-        let startDelay = 0;
-        let stepDuration = 100;
-        let stepDelay = 100;
-        let maxTotalDuration = 5000;
+        const iterationSteps = 2;
+        const startDelay = 0;
+        const stepDuration = 100;
+        const stepDelay = 100;
+        const maxTotalDuration = 5000;
 
-        let expectedTotalTime = 200;
+        const expectedTotalTime = 200;
 
-        let animator = new Plottable.Animators.Easing();
+        const animator = new Plottable.Animators.Easing();
         animator.startDelay(startDelay);
         animator.stepDuration(stepDuration);
         animator.stepDelay(stepDelay);
         animator.maxTotalDuration(maxTotalDuration);
 
-        let actualTotalTime = animator.totalTime(iterationSteps);
+        const actualTotalTime = animator.totalTime(iterationSteps);
         assert.strictEqual(actualTotalTime, expectedTotalTime,
           "The total duration constraint is just an upper bound");
       });
 
       it("maxTotalDuration() edge case for 1 step", () => {
-        let iterationSteps = 1;
-        let startDelay = 0;
-        let stepDuration = 333;
-        let stepDelay = 432;
+        const iterationSteps = 1;
+        const startDelay = 0;
+        const stepDuration = 333;
+        const stepDelay = 432;
 
-        let animator = new Plottable.Animators.Easing();
+        const animator = new Plottable.Animators.Easing();
         animator.startDelay(startDelay);
         animator.stepDuration(stepDuration);
         animator.stepDelay(stepDelay);
 
-        let actualTotalTime = animator.totalTime(iterationSteps);
+        const actualTotalTime = animator.totalTime(iterationSteps);
         assert.strictEqual(actualTotalTime, stepDuration,
           "The total time is just the time for one step");
       });
 
       it("maxTotalDuration() edge case for 1 step and startDelay", () => {
-        let iterationSteps = 1;
-        let startDelay = 213;
-        let stepDuration = 333;
-        let stepDelay = 432;
+        const iterationSteps = 1;
+        const startDelay = 213;
+        const stepDuration = 333;
+        const stepDelay = 432;
 
-        let expectedTotalTime = startDelay + stepDuration;
+        const expectedTotalTime = startDelay + stepDuration;
 
-        let animator = new Plottable.Animators.Easing();
+        const animator = new Plottable.Animators.Easing();
         animator.startDelay(startDelay);
         animator.stepDuration(stepDuration);
         animator.stepDelay(stepDelay);
 
-        let actualTotalTime = animator.totalTime(iterationSteps);
+        const actualTotalTime = animator.totalTime(iterationSteps);
         assert.strictEqual(actualTotalTime, expectedTotalTime,
           "Total time is the time for one step, plus waiting for the start delay");
       });
 
       it("_getAdjustedIterativeDelay() works with maxTotalDuration constraint", () => {
-        let iterationSteps = 2;
-        let startDelay = 0;
-        let stepDuration = 1000;
-        let stepDelay = 1000000;
-        let maxTotalDuration = 1500;
+        const iterationSteps = 2;
+        const startDelay = 0;
+        const stepDuration = 1000;
+        const stepDelay = 1000000;
+        const maxTotalDuration = 1500;
 
-        let animator = new Plottable.Animators.Easing();
+        const animator = new Plottable.Animators.Easing();
         animator.startDelay(startDelay);
         animator.stepDuration(stepDuration);
         animator.stepDelay(stepDelay);
         animator.maxTotalDuration(maxTotalDuration);
 
-        let expectedIterativeDelay = 500;
+        const expectedIterativeDelay = 500;
         // 1 |  ###########
         // 2 |       ###########
         //   +------------------------
         //   |  |    |    |    |    |
         //     0.0  0.5  1.0  1.5  2.0
-        let actualIterativeDelay = (<any>animator)._getAdjustedIterativeDelay(iterationSteps);
+        const actualIterativeDelay = (<any>animator)._getAdjustedIterativeDelay(iterationSteps);
         assert.strictEqual(actualIterativeDelay, expectedIterativeDelay,
           "The total duration constraint is just an upper bound");
       });

--- a/test/animators/easingAnimatorTests.ts
+++ b/test/animators/easingAnimatorTests.ts
@@ -101,14 +101,14 @@ describe("Animators", () => {
         animator.stepDelay(2 * ORIGINAL_STEP_DELAY);
         const longerStepDelayTotalTime = animator.totalTime(NUM_STEPS);
         assert.closeTo(longerStepDelayTotalTime, totalTimeLimit, EPSILON,
-          "adding more steps does not increase the total time past the limit");
+          "increasing step delay does not increase the total time past the limit");
       });
 
       it("restricts the total time when the step duration increases", () => {
         animator.stepDuration(2 * ORIGINAL_STEP_DURATION);
         const longerStepDurationTotalTime = animator.totalTime(NUM_STEPS);
         assert.closeTo(longerStepDurationTotalTime, totalTimeLimit, EPSILON,
-          "adding more steps does not increase the total time past the limit");
+          "increasing step duration does not increase the total time past the limit");
       });
 
       it("allows the start delay to increase the total time", () => {

--- a/test/animators/easingAnimatorTests.ts
+++ b/test/animators/easingAnimatorTests.ts
@@ -40,38 +40,46 @@ describe("Animators", () => {
       });
     });
 
-    describe("Time computations", () => {
-      it("totalTime() defaults", () => {
-        const iterationSteps = 10;
-        const startDelay = 0;
-        const stepDuration = 300;
-        const stepDelay = 15;
-        const expectedTotalTime = startDelay + (iterationSteps - 1) * stepDelay + stepDuration;
+    describe("total time", () => {
+      const NUM_STEPS = 10;
+      let animator: Plottable.Animators.Easing;
 
-        const animator = new Plottable.Animators.Easing();
-        const actualTotalTime = animator.totalTime(iterationSteps);
-
-        assert.strictEqual(actualTotalTime, expectedTotalTime,
-          "Formula for calculating total time should work");
+      beforeEach(() => {
+        animator = new Plottable.Animators.Easing();
       });
 
-      it("totalTime() takes setters into account", () => {
-        const iterationSteps = 17;
-        const startDelay = 135;
-        const stepDuration = 453;
-        const stepDelay = 265;
-        const expectedTotalTime = startDelay + (iterationSteps - 1) * stepDelay + stepDuration;
-
-        const animator = new Plottable.Animators.Easing();
+      it("includes start delay in the total time", () => {
+        const startDelay = 123;
         animator.startDelay(startDelay);
-        animator.stepDuration(stepDuration);
-        animator.stepDelay(stepDelay);
+        animator.stepDelay(0);
+        animator.stepDuration(0);
 
-        const actualTotalTime = animator.totalTime(iterationSteps);
-        assert.strictEqual(actualTotalTime, expectedTotalTime,
-          "Setters should work");
+        const expectedTotalTime = startDelay;
+        assert.strictEqual(animator.totalTime(NUM_STEPS), expectedTotalTime, "total time includes start delay (when other values are 0)");
       });
 
+      it("includes step delay in the total time", () => {
+        animator.startDelay(0);
+        const stepDelay = 123;
+        animator.stepDelay(stepDelay);
+        animator.stepDuration(0);
+
+        const expectedTotalTime = (NUM_STEPS - 1) * stepDelay;
+        assert.strictEqual(animator.totalTime(NUM_STEPS), expectedTotalTime, "total time increased by each delay between steps");
+      });
+
+      it("includes step duration in the total time", () => {
+        animator.startDelay(0);
+        animator.stepDelay(0);
+        const stepDuration = 123;
+        animator.stepDuration(stepDuration);
+
+        const expectedTotalTime = stepDuration;
+        assert.strictEqual(animator.totalTime(NUM_STEPS), expectedTotalTime, "total time increased by one step duration");
+      });
+    });
+
+    describe("max total duration", () => {
       it("maxTotalDuration() with many steps", () => {
         const iterationSteps = 10000;
         const startDelay = 0;

--- a/test/animators/nullAnimatorTests.ts
+++ b/test/animators/nullAnimatorTests.ts
@@ -1,0 +1,34 @@
+///<reference path="../testReference.ts" />
+
+describe("Animators", () => {
+  describe("Null Animator", () => {
+    it("has a total animation time of zero", () => {
+      const animator = new Plottable.Animators.Null();
+      assert.strictEqual(animator.totalTime(null), 0);
+    });
+
+    it("applies the requested attributes to the selection", () => {
+      const attributeName = "foo";
+      const attributeValues = ["A", "B", "C"];
+      const attributeProjector = (d: any, i: number) => attributeValues[i];
+      const attrToAppliedProjector: Plottable.AttributeToAppliedProjector = {};
+      attrToAppliedProjector[attributeName] = attributeProjector;
+
+      const svg = TestMethods.generateSVG();
+      const elementName = "g";
+      attributeValues.forEach(() => svg.append(elementName));
+      const elements = svg.selectAll(elementName);
+
+      const animator = new Plottable.Animators.Null();
+      animator.animate(elements, attrToAppliedProjector);
+
+      elements.each(function(d, i) {
+        const actualAttribute = d3.select(this).attr(attributeName);
+        const expectedAttribute = attributeProjector(d, i);
+        assert.strictEqual(actualAttribute, expectedAttribute, `set the correct attribute on element with index ${i}`);
+      });
+
+      svg.remove();
+    });
+  });
+});

--- a/test/testReference.ts
+++ b/test/testReference.ts
@@ -14,6 +14,7 @@
 ///<reference path="drawers/drawerTests.ts" />
 ///<reference path="drawers/lineDrawerTests.ts" />
 
+///<reference path="animators/nullAnimatorTests.ts" />
 ///<reference path="animators/easingAnimatorTests.ts" />
 
 ///<reference path="axes/axisTests.ts" />


### PR DESCRIPTION
Here's the new test battery:
<img width="392" alt="screen shot 2015-11-19 at 5 18 30 pm" src="https://cloud.githubusercontent.com/assets/1440449/11289489/414c101e-8ee2-11e5-9394-bf925e2d65e4.png">

Changes:
* `Animators.Null` actually has tests now
* `Animators.Easing` had its tests broken out to test the effects of step count, `startDelay()`, `stepDelay()`, and `stepDuration()` independently.

Should finish off #2622.