### PR TITLE
refactor pointerInteractionTests

### DIFF
--- a/test/interactions/pointerInteractionTests.ts
+++ b/test/interactions/pointerInteractionTests.ts
@@ -34,33 +34,33 @@ describe("Interactions", () => {
       TestMethods.triggerFakeInteractionEvent(mode, type, target, p.x, p.y);
     }
 
-    describe("Basic usage", () => {
+    [TestMethods.InteractionMode.Mouse, TestMethods.InteractionMode.Touch].forEach((mode) => {
+      describe(`Listening to ${MODE_NAME[mode]} events`, () => {
 
-      let svg: d3.Selection<void>;
-      let pointerInteraction: Plottable.Interactions.Pointer;
-      let eventTarget: d3.Selection<void>;
-      let callback: PointerTestCallback;
+        let svg: d3.Selection<void>;
+        let pointerInteraction: Plottable.Interactions.Pointer;
+        let eventTarget: d3.Selection<void>;
+        let callback: PointerTestCallback;
 
-      beforeEach(() => {
-        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+        beforeEach(() => {
+          svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
 
-        const component = new Plottable.Component();
-        component.renderTo(svg);
-        eventTarget = component.background();
+          const component = new Plottable.Component();
+          component.renderTo(svg);
+          eventTarget = component.background();
 
-        pointerInteraction = new Plottable.Interactions.Pointer();
-        pointerInteraction.attachTo(component);
-        callback = makePointerCallback();
-      });
+          pointerInteraction = new Plottable.Interactions.Pointer();
+          pointerInteraction.attachTo(component);
+          callback = makePointerCallback();
+        });
 
-      afterEach(function() {
-        if (this.currentTest.state === "passed") {
-          svg.remove();
-        }
-      });
+        afterEach(function() {
+          if (this.currentTest.state === "passed") {
+            svg.remove();
+          }
+        });
 
-      [TestMethods.InteractionMode.Mouse, TestMethods.InteractionMode.Touch].forEach((mode) => {
-        it(`calls the onPointerEnter callback with ${MODE_NAME[mode]}`, () => {
+        it("calls the onPointerEnter callback", () => {
           pointerInteraction.onPointerEnter(callback);
 
           triggerPointerEvent(HALF_POINT, mode, eventTarget);
@@ -79,7 +79,7 @@ describe("Interactions", () => {
           assert.isFalse(callback.called, `callback not called after disconnecting (${MODE_NAME[mode]})`);
         });
 
-        it(`calls the onPointerMove callback with ${MODE_NAME[mode]}`, () => {
+        it("calls the onPointerMove callback", () => {
           pointerInteraction.onPointerMove(callback);
 
           triggerPointerEvent(HALF_POINT, mode, eventTarget);
@@ -100,7 +100,7 @@ describe("Interactions", () => {
           assert.isFalse(callback.called, `callback not called after disconnecting (${MODE_NAME[mode]})`);
         });
 
-        it(`calls the onPointerExit callback with ${MODE_NAME[mode]}`, () => {
+        it("calls the onPointerExit callback", () => {
           pointerInteraction.onPointerExit(callback);
 
           triggerPointerEvent(OUTSIDE_POINT, mode, eventTarget);
@@ -121,7 +121,7 @@ describe("Interactions", () => {
           assert.isFalse(callback.called, `callback not called after disconnecting (${MODE_NAME[mode]})`);
         });
 
-        it(`can register two callbacks for the same pointer event with ${MODE_NAME[mode]}`, () => {
+        it("can register two callbacks for the same pointer event", () => {
           const callback2 = makePointerCallback();
 
           pointerInteraction.onPointerEnter(callback);
@@ -146,47 +146,45 @@ describe("Interactions", () => {
           svg.remove();
         });
       });
-    });
 
-    describe("Interactions under overlay", () => {
-      let svg: d3.Selection<void>;
-      let pointerInteraction: Plottable.Interactions.Pointer;
-      let eventTarget: d3.Selection<void>;
+      describe(`Interactions under overlay for ${MODE_NAME[mode]} events`, () => {
+        let svg: d3.Selection<void>;
+        let pointerInteraction: Plottable.Interactions.Pointer;
+        let eventTarget: d3.Selection<void>;
 
-      let callback: PointerTestCallback;
-      let overlay: d3.Selection<void>;
+        let callback: PointerTestCallback;
+        let overlay: d3.Selection<void>;
 
-      beforeEach(() => {
-        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
-        overlay = TestMethods.getSVGParent().append("div").style({
-          height: `${SVG_HEIGHT}px`,
-          width: `${SVG_WIDTH}px`,
-          position: "relative",
-          top: `-${SVG_HEIGHT / 2}px`,
-          left: `${SVG_WIDTH / 2}px`,
-          background: "black"
+        beforeEach(() => {
+          svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+          overlay = TestMethods.getSVGParent().append("div").style({
+            height: `${SVG_HEIGHT}px`,
+            width: `${SVG_WIDTH}px`,
+            position: "relative",
+            top: `-${SVG_HEIGHT / 2}px`,
+            left: `${SVG_WIDTH / 2}px`,
+            background: "black"
+          });
+
+          const component = new Plottable.Component();
+          component.renderTo(svg);
+          eventTarget = component.background();
+
+          pointerInteraction = new Plottable.Interactions.Pointer();
+          pointerInteraction.attachTo(component);
+
+          eventTarget = component.background();
+
+          callback = makePointerCallback();
+        });
+        afterEach(function() {
+          if (this.currentTest.state === "passed") {
+            svg.remove();
+            overlay.remove();
+          }
         });
 
-        const component = new Plottable.Component();
-        component.renderTo(svg);
-        eventTarget = component.background();
-
-        pointerInteraction = new Plottable.Interactions.Pointer();
-        pointerInteraction.attachTo(component);
-
-        eventTarget = component.background();
-
-        callback = makePointerCallback();
-      });
-      afterEach(function() {
-        if (this.currentTest.state === "passed") {
-          svg.remove();
-          overlay.remove();
-        }
-      });
-
-      [TestMethods.InteractionMode.Mouse, TestMethods.InteractionMode.Touch].forEach((mode) => {
-        it(`does not call the onPointerEnter moving from within overlay with ${MODE_NAME[mode]}`, () => {
+        it("does not call the onPointerEnter moving from within overlay", () => {
           pointerInteraction.onPointerEnter(callback);
 
           triggerPointerEvent(QUARTER_POINT, mode, eventTarget);
@@ -202,7 +200,7 @@ describe("Interactions", () => {
           assert.isFalse(callback.called, `callback not called on entering Component from overlay (${MODE_NAME[mode]})`);
         });
 
-        it(`calls the onPointerMove callback under overlay with ${MODE_NAME[mode]}`, () => {
+        it("calls the onPointerMove callback under overlay", () => {
           pointerInteraction.onPointerMove(callback);
 
           triggerPointerEvent(QUARTER_POINT, mode, eventTarget);
@@ -213,7 +211,7 @@ describe("Interactions", () => {
           assert.isTrue(callback.called, `called on moving inside overlay (${MODE_NAME[mode]})`);
         });
 
-        it(`does not the onPointerExit callback moving into overlay with ${MODE_NAME[mode]}`, () => {
+        it("does not the onPointerExit callback moving into overlay", () => {
           pointerInteraction.onPointerExit(callback);
 
           triggerPointerEvent(QUARTER_POINT, mode, eventTarget);

--- a/test/interactions/pointerInteractionTests.ts
+++ b/test/interactions/pointerInteractionTests.ts
@@ -2,347 +2,236 @@
 
 describe("Interactions", () => {
   describe("Pointer Interaction", () => {
+    const SVG_WIDTH = 400;
+    const SVG_HEIGHT = 400;
+    const HALF_POINT = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
+    const QUARTER_POINT = { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 };
+    const OUTSIDE_POINT = { x: SVG_WIDTH * 2, y: SVG_HEIGHT * 2 };
+    const MODE_NAME = ["mouse", "touch"];
+
+    type PointerTestCallback = {
+      lastPoint: Plottable.Point;
+      called: boolean;
+      reset: () => void;
+      (p: Plottable.Point): void;
+    }
+
+    function makePointerCallback() {
+      const callback = <PointerTestCallback> function(p?: Plottable.Point) {
+        callback.lastPoint = p;
+        callback.called = true;
+      };
+      callback.called = false;
+      callback.reset = () => {
+        callback.lastPoint = undefined;
+        callback.called = false;
+      };
+      return callback;
+    }
+
+    function triggerPointerEvent(p: Plottable.Point, mode: TestMethods.InteractionMode, target: d3.Selection<void>) {
+      const type = mode === TestMethods.InteractionMode.Mouse ? TestMethods.InteractionType.Move : TestMethods.InteractionType.Start;
+      TestMethods.triggerFakeInteractionEvent(mode, type, target, p.x, p.y);
+    }
+
     describe("Basic usage", () => {
-      let SVG_WIDTH = 400;
-      let SVG_HEIGHT = 400;
 
       let svg: d3.Selection<void>;
       let pointerInteraction: Plottable.Interactions.Pointer;
       let eventTarget: d3.Selection<void>;
-
-      let callbackCalled: boolean;
-      let lastPoint: Plottable.Point;
-      let callback: Plottable.PointerCallback;
+      let callback: PointerTestCallback;
 
       beforeEach(() => {
         svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
 
-        let component = new Plottable.Component();
+        const component = new Plottable.Component();
         component.renderTo(svg);
+        eventTarget = component.background();
 
         pointerInteraction = new Plottable.Interactions.Pointer();
         pointerInteraction.attachTo(component);
-
-        eventTarget = component.background();
-
-        callbackCalled = false;
-        callback = (point) => {
-          callbackCalled = true;
-          lastPoint = point;
-        };
+        callback = makePointerCallback();
       });
 
-      it("calls the onPointerEnter callback with mouse", () => {
-        pointerInteraction.onPointerEnter(callback);
-
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, SVG_WIDTH / 2, SVG_HEIGHT / 2);
-        assert.isTrue(callbackCalled, "callback called on entering Component (mouse)");
-        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (mouse)");
-
-        callbackCalled = false;
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, SVG_WIDTH / 4, SVG_HEIGHT / 4);
-        assert.isFalse(callbackCalled, "callback not called again if already in Component (mouse)");
-
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
-        assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
-
-        pointerInteraction.offPointerEnter(callback);
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, SVG_WIDTH / 2, SVG_HEIGHT / 2);
-        assert.isFalse(callbackCalled, "callback removed by passing null");
-
-        svg.remove();
+      afterEach(function() {
+        if (this.currentTest.state === "passed") {
+          svg.remove();
+        }
       });
 
-      it("calls the onPointerEnter callback with touch", () => {
-        pointerInteraction.onPointerEnter(callback);
+      [TestMethods.InteractionMode.Mouse, TestMethods.InteractionMode.Touch].forEach((mode) => {
+        it(`calls the onPointerEnter callback with ${MODE_NAME[mode]}`, () => {
+          pointerInteraction.onPointerEnter(callback);
 
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-        assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
-        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (touch)");
+          triggerPointerEvent(HALF_POINT, mode, eventTarget);
+          assert.isTrue(callback.called, `callback called on entering Component (${MODE_NAME[mode]})`);
+          assert.deepEqual(callback.lastPoint, HALF_POINT, `was passed correct point ${MODE_NAME[mode]}`);
 
-        callbackCalled = false;
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4}]);
-        assert.isFalse(callbackCalled, "callback not called again if already in Component (touch)");
+          callback.reset();
+          triggerPointerEvent(QUARTER_POINT, mode, eventTarget);
+          assert.isFalse(callback.called, `callback not called again if already in Component (${MODE_NAME[mode]})`);
 
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: 2 * SVG_WIDTH, y: 2 * SVG_HEIGHT}]);
-        assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
+          triggerPointerEvent(OUTSIDE_POINT, mode, eventTarget);
+          assert.isFalse(callback.called, `callback not called when moving outside of the Component (${MODE_NAME[mode]})`);
 
-        pointerInteraction.offPointerEnter(callback);
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4}]);
-        assert.isFalse(callbackCalled, "callback removed by passing null");
+          pointerInteraction.offPointerEnter(callback);
+          triggerPointerEvent(HALF_POINT, mode, eventTarget);
+          assert.isFalse(callback.called, `callback not called after disconnecting (${MODE_NAME[mode]})`);
+        });
 
-        svg.remove();
-      });
+        it(`calls the onPointerMove callback with ${MODE_NAME[mode]}`, () => {
+          pointerInteraction.onPointerMove(callback);
 
-      it("calls the onPointerMove callback with mouse", () => {
-        pointerInteraction.onPointerMove(callback);
+          triggerPointerEvent(HALF_POINT, mode, eventTarget);
+          assert.isTrue(callback.called, `callback called on entering Component (${MODE_NAME[mode]})`);
+          assert.deepEqual(callback.lastPoint, HALF_POINT, `was passed correct point (${MODE_NAME[mode]})`);
 
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, SVG_WIDTH / 2, SVG_HEIGHT / 2);
-        assert.isTrue(callbackCalled, "callback called on entering Component (mouse)");
-        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (mouse)");
+          callback.reset();
+          triggerPointerEvent(QUARTER_POINT, mode, eventTarget);
+          assert.isTrue(callback.called, `callback on moving inside Component (${MODE_NAME[mode]})`);
+          assert.deepEqual(callback.lastPoint, QUARTER_POINT, `was passed correct point (${MODE_NAME[mode]})`);
 
-        callbackCalled = false;
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, SVG_WIDTH / 4, SVG_HEIGHT / 4);
-        assert.isTrue(callbackCalled, "callback on moving inside Component (mouse)");
-        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed correct point (mouse)");
+          callback.reset();
+          triggerPointerEvent(OUTSIDE_POINT, mode, eventTarget);
+          assert.isFalse(callback.called, `not called when moving outside of the Component (${MODE_NAME[mode]})`);
 
-        callbackCalled = false;
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
-        assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
+          pointerInteraction.offPointerMove(callback);
+          triggerPointerEvent(HALF_POINT, mode, eventTarget);
+          assert.isFalse(callback.called, `callback not called after disconnecting (${MODE_NAME[mode]})`);
+        });
 
-        pointerInteraction.offPointerMove(callback);
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, SVG_WIDTH / 2, SVG_HEIGHT / 2);
-        assert.isFalse(callbackCalled, "callback removed by passing null");
+        it(`calls the onPointerExit callback with ${MODE_NAME[mode]}`, () => {
+          pointerInteraction.onPointerExit(callback);
 
-        svg.remove();
-      });
+          triggerPointerEvent(OUTSIDE_POINT, mode, eventTarget);
+          assert.isFalse(callback.called, `not called when moving outside of the Component (${MODE_NAME[mode]})`);
 
-      it("calls the onPointerMove callback with touch", () => {
-        pointerInteraction.onPointerMove(callback);
+          TestMethods.triggerFakeMouseEvent(`mousemove`, eventTarget, SVG_WIDTH / 2, SVG_HEIGHT / 2);
+          triggerPointerEvent(OUTSIDE_POINT, mode, eventTarget);
+          assert.isTrue(callback.called, `callback called on exiting Component (${MODE_NAME[mode]})`);
+          assert.deepEqual(callback.lastPoint, OUTSIDE_POINT, `was passed correct point (${MODE_NAME[mode]})`);
 
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-        assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
-        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 }, "was passed correct point (touch)");
+          callback.reset();
+          triggerPointerEvent({ x: 3 * SVG_WIDTH, y: 3 * SVG_HEIGHT }, mode, eventTarget);
+          assert.isFalse(callback.called, `callback not called again if already outside of Component (${MODE_NAME[mode]})`);
 
-        callbackCalled = false;
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4}]);
-        assert.isTrue(callbackCalled, "callback on moving inside Component (touch)");
-        assert.deepEqual(lastPoint, { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 }, "was passed correct point (touch)");
+          pointerInteraction.offPointerExit(callback);
+          triggerPointerEvent(HALF_POINT, mode, eventTarget);
+          triggerPointerEvent(OUTSIDE_POINT, mode, eventTarget);
+          assert.isFalse(callback.called, `callback not called after disconnecting (${MODE_NAME[mode]})`);
+        });
 
-        callbackCalled = false;
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: 2 * SVG_WIDTH, y: 2 * SVG_HEIGHT}]);
-        assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
+        it(`can register two callbacks for the same pointer event with ${MODE_NAME[mode]}`, () => {
+          const callback2 = makePointerCallback();
 
-        pointerInteraction.offPointerMove(callback);
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4}]);
-        assert.isFalse(callbackCalled, "callback removed by passing null");
+          pointerInteraction.onPointerEnter(callback);
+          pointerInteraction.onPointerEnter(callback2);
 
-        svg.remove();
-      });
+          triggerPointerEvent(OUTSIDE_POINT, mode, eventTarget);
+          triggerPointerEvent(HALF_POINT, mode, eventTarget);
 
-      it("calls the onPointerExit callback with mouse", () => {
-        pointerInteraction.onPointerExit(callback);
+          assert.isTrue(callback.called, `callback 1 was called on entering Component (${MODE_NAME[mode]})`);
+          assert.isTrue(callback2.called, `callback 2 was called on entering Component (${MODE_NAME[mode]})`);
 
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
-        assert.isFalse(callbackCalled, "not called when moving outside of the Component (mouse)");
+          callback.reset();
+          callback2.reset();
+          pointerInteraction.offPointerEnter(callback);
 
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, SVG_WIDTH / 2, SVG_HEIGHT / 2);
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
-        assert.isTrue(callbackCalled, "callback called on exiting Component (mouse)");
-        assert.deepEqual(lastPoint, { x: 2 * SVG_WIDTH, y: 2 * SVG_HEIGHT }, "was passed correct point (mouse)");
+          triggerPointerEvent(OUTSIDE_POINT, mode, eventTarget);
+          triggerPointerEvent(HALF_POINT, mode, eventTarget);
 
-        callbackCalled = false;
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, 3 * SVG_WIDTH, 3 * SVG_HEIGHT);
-        assert.isFalse(callbackCalled, "callback not called again if already outside of Component (mouse)");
+          assert.isFalse(callback.called, `callback 1 was disconnected from pointer enter interaction (${MODE_NAME[mode]})`);
+          assert.isTrue(callback2.called, `callback 2 is still connected to the pointer enter interaction (${MODE_NAME[mode]})`);
 
-        pointerInteraction.offPointerExit(callback);
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, SVG_WIDTH / 2, SVG_HEIGHT / 2);
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
-        assert.isFalse(callbackCalled, "callback removed by passing null");
-
-        svg.remove();
-      });
-
-      it("calls the onPointerExit callback with touch", () => {
-        pointerInteraction.onPointerExit(callback);
-
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: 2 * SVG_WIDTH, y: 2 * SVG_HEIGHT}]);
-        assert.isFalse(callbackCalled, "not called when moving outside of the Component (touch)");
-
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: 2 * SVG_WIDTH, y: 2 * SVG_HEIGHT}]);
-        assert.isTrue(callbackCalled, "callback called on exiting Component (touch)");
-        assert.deepEqual(lastPoint, { x: 2 * SVG_WIDTH, y: 2 * SVG_HEIGHT }, "was passed correct point (touch)");
-
-        callbackCalled = false;
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: 3 * SVG_WIDTH, y: 3 * SVG_HEIGHT}]);
-        assert.isFalse(callbackCalled, "callback not called again if already outside of Component (touch)");
-
-        pointerInteraction.offPointerExit(callback);
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2}]);
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: 2 * SVG_WIDTH, y: 2 * SVG_HEIGHT}]);
-        assert.isFalse(callbackCalled, "callback removed by passing null");
-
-        svg.remove();
-      });
-
-      it("can register two callbacks for the same pointer event with mouse", () => {
-        let enterCallback1Called = false;
-        let enterCallback2Called = false;
-
-        let enterCallback1 = () => enterCallback1Called = true;
-        let enterCallback2 = () => enterCallback2Called = true;
-
-        pointerInteraction.onPointerEnter(enterCallback1);
-        pointerInteraction.onPointerEnter(enterCallback2);
-
-        let insidePoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
-        let outsidePoint = { x: SVG_WIDTH * 2, y: SVG_HEIGHT * 2 };
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, outsidePoint.x, outsidePoint.y);
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, insidePoint.x, insidePoint.y);
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, outsidePoint.x, outsidePoint.y);
-
-        assert.isTrue(enterCallback1Called, "callback 1 was called on entering Component (mouse)");
-        assert.isTrue(enterCallback2Called, "callback 2 was called on entering Component (mouse)");
-
-        enterCallback1Called = false;
-        enterCallback2Called = false;
-        pointerInteraction.offPointerEnter(enterCallback1);
-
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, outsidePoint.x, outsidePoint.y);
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, insidePoint.x, insidePoint.y);
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, outsidePoint.x, outsidePoint.y);
-
-        assert.isFalse(enterCallback1Called, "callback 1 was disconnected from pointer enter interaction");
-        assert.isTrue(enterCallback2Called, "callback 2 is still connected to the pointer enter interaction");
-
-        svg.remove();
+          svg.remove();
+        });
       });
     });
 
     describe("Interactions under overlay", () => {
-      let SVG_WIDTH = 400;
-      let SVG_HEIGHT = 400;
-
       let svg: d3.Selection<void>;
       let pointerInteraction: Plottable.Interactions.Pointer;
       let eventTarget: d3.Selection<void>;
 
-      let callbackCalled: boolean;
-      let lastPoint: Plottable.Point;
-      let callback: Plottable.PointerCallback;
+      let callback: PointerTestCallback;
       let overlay: d3.Selection<void>;
 
       beforeEach(() => {
         svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
         overlay = TestMethods.getSVGParent().append("div").style({
-          height: SVG_HEIGHT + "px",
-          width: SVG_WIDTH + "px",
+          height: `${SVG_HEIGHT}px`,
+          width: `${SVG_WIDTH}px`,
           position: "relative",
-          top: -SVG_HEIGHT / 2 + "px",
-          left: SVG_WIDTH / 2 + "px",
+          top: `-${SVG_HEIGHT / 2}px`,
+          left: `${SVG_WIDTH / 2}px`,
           background: "black"
         });
 
-        let component = new Plottable.Component();
+        const component = new Plottable.Component();
         component.renderTo(svg);
+        eventTarget = component.background();
 
         pointerInteraction = new Plottable.Interactions.Pointer();
         pointerInteraction.attachTo(component);
 
         eventTarget = component.background();
 
-        callbackCalled = false;
-        callback = (point) => {
-          callbackCalled = true;
-          lastPoint = point;
-        };
+        callback = makePointerCallback();
+      });
+      afterEach(function() {
+        if (this.currentTest.state === "passed") {
+          svg.remove();
+          overlay.remove();
+        }
       });
 
-      it("does not call the onPointerEnter moving from within overlay with mouse", () => {
-        pointerInteraction.onPointerEnter(callback);
+      [TestMethods.InteractionMode.Mouse, TestMethods.InteractionMode.Touch].forEach((mode) => {
+        it(`does not call the onPointerEnter moving from within overlay with ${MODE_NAME[mode]}`, () => {
+          pointerInteraction.onPointerEnter(callback);
 
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, SVG_WIDTH / 4, SVG_HEIGHT / 4);
-        assert.isTrue(callbackCalled, "callback called on entering Component (mouse)");
+          triggerPointerEvent(QUARTER_POINT, mode, eventTarget);
+          assert.isTrue(callback.called, `callback called on entering Component (${MODE_NAME[mode]})`);
 
-        callbackCalled = false;
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, SVG_WIDTH * 2, SVG_HEIGHT * 2);
-        TestMethods.triggerFakeMouseEvent("mousemove", overlay, SVG_WIDTH / 4, SVG_HEIGHT / 4);
-        assert.isTrue(callbackCalled, "called when moving inside overlay (mouse)");
+          callback.reset();
+          triggerPointerEvent(OUTSIDE_POINT, mode, eventTarget);
+          triggerPointerEvent(QUARTER_POINT, mode, overlay);
+          assert.isTrue(callback.called, `called when moving inside overlay (${MODE_NAME[mode]})`);
 
-        callbackCalled = false;
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, SVG_WIDTH / 4, SVG_HEIGHT / 4);
-        assert.isFalse(callbackCalled, "callback not called on entering Component from overlay (mouse)");
+          callback.reset();
+          triggerPointerEvent(QUARTER_POINT, mode, eventTarget);
+          assert.isFalse(callback.called, `callback not called on entering Component from overlay (${MODE_NAME[mode]})`);
+        });
 
-        pointerInteraction.offPointerEnter(callback);
-        svg.remove();
-        overlay.remove();
+        it(`calls the onPointerMove callback under overlay with ${MODE_NAME[mode]}`, () => {
+          pointerInteraction.onPointerMove(callback);
+
+          triggerPointerEvent(QUARTER_POINT, mode, eventTarget);
+          assert.isTrue(callback.called, `callback called on entering Component (${MODE_NAME[mode]})`);
+
+          callback.reset();
+          triggerPointerEvent(QUARTER_POINT, mode, overlay);
+          assert.isTrue(callback.called, `called on moving inside overlay (${MODE_NAME[mode]})`);
+        });
+
+        it(`does not the onPointerExit callback moving into overlay with ${MODE_NAME[mode]}`, () => {
+          pointerInteraction.onPointerExit(callback);
+
+          triggerPointerEvent(QUARTER_POINT, mode, eventTarget);
+          triggerPointerEvent(QUARTER_POINT, mode, overlay);
+          assert.isFalse(callback.called, `callback not called on moving inside overlay (${MODE_NAME[mode]})`);
+
+          triggerPointerEvent(OUTSIDE_POINT, mode, eventTarget);
+          assert.isTrue(callback.called, `callback called moving from overlay to outside of Component (${MODE_NAME[mode]})`);
+
+          callback.reset();
+          triggerPointerEvent(QUARTER_POINT, mode, overlay);
+          assert.isFalse(callback.called, `callback not called moving from outside of Component into overlay (${MODE_NAME[mode]})`);
+
+          pointerInteraction.offPointerExit(callback);
+          svg.remove();
+          overlay.remove();
+        });
       });
-
-      it("does not call the onPointerEnter moving from within overlay with touch", () => {
-        pointerInteraction.onPointerEnter(callback);
-
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4}]);
-        assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
-
-        callbackCalled = false;
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: SVG_WIDTH * 2, y: SVG_HEIGHT * 2}]);
-        TestMethods.triggerFakeTouchEvent("touchstart", overlay, [{x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4}]);
-        assert.isTrue(callbackCalled, "called when moving to overlay (touch)");
-
-        callbackCalled = false;
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4}]);
-        assert.isFalse(callbackCalled, "callback not called on entering Component from overlay (touch)");
-
-        pointerInteraction.offPointerEnter(callback);
-        svg.remove();
-        overlay.remove();
-      });
-
-      it("calls the onPointerMove callback under overlay with mouse", () => {
-        pointerInteraction.onPointerMove(callback);
-
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, SVG_WIDTH / 4, SVG_HEIGHT / 4);
-        assert.isTrue(callbackCalled, "callback called on entering Component (mouse)");
-
-        callbackCalled = false;
-        TestMethods.triggerFakeMouseEvent("mousemove", overlay, SVG_WIDTH / 4, SVG_HEIGHT / 4);
-        assert.isTrue(callbackCalled, "called on moving inside overlay (mouse)");
-
-        pointerInteraction.offPointerMove(callback);
-        svg.remove();
-        overlay.remove();
-      });
-
-      it("calls the onPointerMove callback under overlay with touch", () => {
-        pointerInteraction.onPointerMove(callback);
-
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4}]);
-        assert.isTrue(callbackCalled, "callback called on entering Component (touch)");
-
-        callbackCalled = false;
-        TestMethods.triggerFakeTouchEvent("touchstart", overlay, [{x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4}]);
-        assert.isTrue(callbackCalled, "called on moving inside overlay (touch)");
-
-        pointerInteraction.offPointerMove(callback);
-        svg.remove();
-        overlay.remove();
-      });
-
-      it("does not the onPointerExit callback moving into overlay with mouse", () => {
-        pointerInteraction.onPointerExit(callback);
-
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, SVG_WIDTH / 4, SVG_HEIGHT / 4);
-        TestMethods.triggerFakeMouseEvent("mousemove", overlay, SVG_WIDTH / 4 * 3, SVG_HEIGHT / 4 * 3);
-        assert.isTrue(callbackCalled, "callback called on moving inside overlay (mouse)");
-
-        callbackCalled = false;
-        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, 2 * SVG_WIDTH, 2 * SVG_HEIGHT);
-        assert.isFalse(callbackCalled, "callback not called moving from overlay to outside of Component (mouse)");
-
-        TestMethods.triggerFakeMouseEvent("mousemove", overlay, SVG_WIDTH / 4, SVG_HEIGHT / 4);
-        assert.isFalse(callbackCalled, "callback not called moving from outside of Component into overlay (mouse)");
-
-        pointerInteraction.offPointerExit(callback);
-        svg.remove();
-        overlay.remove();
-      });
-
-      it("does not the onPointerExit callback moving into overlay with touch", () => {
-        pointerInteraction.onPointerExit(callback);
-
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4}]);
-        TestMethods.triggerFakeTouchEvent("touchstart", overlay, [{x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4}]);
-        assert.isFalse(callbackCalled, "callback not called on moving inside overlay (touch)");
-
-        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [{x: 2 * SVG_WIDTH, y: 2 * SVG_HEIGHT}]);
-        assert.isTrue(callbackCalled, "callback called moving from overlay to outside of Component (touch)");
-
-        pointerInteraction.offPointerExit(callback);
-        svg.remove();
-        overlay.remove();
-      });
-
     });
   });
 });


### PR DESCRIPTION
#2628 
- loop through mouse event and pointer event
- use const when possible

![screen shot 2015-11-19 at 8 10 39 pm](https://cloud.githubusercontent.com/assets/1817638/11291789/a1048bfa-8ef9-11e5-8834-f768fbd80d81.png)

