### PR TITLE
add preventDefault API point on keyInteraction

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -4486,10 +4486,19 @@ declare module Plottable {
             private _downedKeys;
             private _keyDownCallback;
             private _keyUpCallback;
+            private _preventDefault;
             protected _anchor(component: Component): void;
             protected _unanchor(): void;
             private _handleKeyDownEvent(keyCode, event);
-            private _handleKeyUpEvent(keyCode);
+            private _handleKeyUpEvent(keyCode, event);
+            /**
+             * Returns whether preventDefault is enabled for Key Interaction
+             */
+            preventDefault(): boolean;
+            /**
+             * Enables or disables preventDefault
+             */
+            preventDefault(preventDefault: boolean): Key;
             /**
              * Adds a callback to be called when the key with the given keyCode is
              * pressed and the user is moused over the Component.

--- a/plottable.js
+++ b/plottable.js
@@ -10914,7 +10914,8 @@ var Plottable;
                 this._mouseMoveCallback = function (point) { return false; }; // HACKHACK: registering a listener
                 this._downedKeys = new Plottable.Utils.Set();
                 this._keyDownCallback = function (keyCode, event) { return _this._handleKeyDownEvent(keyCode, event); };
-                this._keyUpCallback = function (keyCode) { return _this._handleKeyUpEvent(keyCode); };
+                this._keyUpCallback = function (keyCode, event) { return _this._handleKeyUpEvent(keyCode, event); };
+                this._preventDefault = false;
             }
             Key.prototype._anchor = function (component) {
                 _super.prototype._anchor.call(this, component);
@@ -10936,16 +10937,29 @@ var Plottable;
                 var p = this._translateToComponentSpace(this._positionDispatcher.lastMousePosition());
                 if (this._isInsideComponent(p) && !event.repeat) {
                     if (this._keyPressCallbacks[keyCode]) {
+                        if (this.preventDefault()) {
+                            event.preventDefault();
+                        }
                         this._keyPressCallbacks[keyCode].callCallbacks(keyCode);
                     }
                     this._downedKeys.add(keyCode);
                 }
             };
-            Key.prototype._handleKeyUpEvent = function (keyCode) {
+            Key.prototype._handleKeyUpEvent = function (keyCode, event) {
                 if (this._downedKeys.has(keyCode) && this._keyReleaseCallbacks[keyCode]) {
+                    if (this.preventDefault()) {
+                        event.preventDefault();
+                    }
                     this._keyReleaseCallbacks[keyCode].callCallbacks(keyCode);
                 }
                 this._downedKeys.delete(keyCode);
+            };
+            Key.prototype.preventDefault = function (preventDefault) {
+                if (preventDefault == null) {
+                    return this._preventDefault;
+                }
+                this._preventDefault = preventDefault;
+                return this;
             };
             /**
              * Adds a callback to be called when the key with the given keyCode is

--- a/src/interactions/keyInteraction.ts
+++ b/src/interactions/keyInteraction.ts
@@ -15,7 +15,8 @@ export module Interactions {
     private _mouseMoveCallback = (point: Point) => false; // HACKHACK: registering a listener
     private _downedKeys = new Plottable.Utils.Set();
     private _keyDownCallback = (keyCode: number, event: KeyboardEvent) => this._handleKeyDownEvent(keyCode, event);
-    private _keyUpCallback = (keyCode: number) => this._handleKeyUpEvent(keyCode);
+    private _keyUpCallback = (keyCode: number, event: KeyboardEvent) => this._handleKeyUpEvent(keyCode, event);
+    private _preventDefault= false;
 
     protected _anchor(component: Component) {
       super._anchor(component);
@@ -43,17 +44,39 @@ export module Interactions {
       let p = this._translateToComponentSpace(this._positionDispatcher.lastMousePosition());
       if (this._isInsideComponent(p) && !event.repeat) {
         if (this._keyPressCallbacks[keyCode]) {
+          if (this.preventDefault()) {
+            event.preventDefault();
+          }
           this._keyPressCallbacks[keyCode].callCallbacks(keyCode);
         }
         this._downedKeys.add(keyCode);
       }
     }
 
-    private _handleKeyUpEvent(keyCode: number) {
+    private _handleKeyUpEvent(keyCode: number, event: KeyboardEvent) {
       if (this._downedKeys.has(keyCode) && this._keyReleaseCallbacks[keyCode]) {
+        if (this.preventDefault()) {
+          event.preventDefault();
+        }
         this._keyReleaseCallbacks[keyCode].callCallbacks(keyCode);
       }
       this._downedKeys.delete(keyCode);
+    }
+
+    /**
+     * Returns whether preventDefault is enabled for Key Interaction
+     */
+    public preventDefault(): boolean;
+    /**
+     * Enables or disables preventDefault
+     */
+    public preventDefault(preventDefault: boolean): Key;
+    public preventDefault(preventDefault: boolean): any {
+      if (preventDefault == null) {
+        return this._preventDefault;
+      }
+      this._preventDefault = preventDefault;
+      return this;
     }
 
     /**

--- a/test/testMethods.ts
+++ b/test/testMethods.ts
@@ -328,6 +328,7 @@ module TestMethods {
       Object.keys(options).forEach((key) => (<any> event)[key] = options[key] );
     }
     target.node().dispatchEvent(event);
+    return event;
   }
 
   export function assertAreaPathCloseTo(actualPath: string, expectedPath: string, precision: number, msg: string) {


### PR DESCRIPTION
demo: http://jsfiddle.net/ztsai/4mac484s/
command + p would open a printing dialog for example, after enabling preventDefault, command + p does not trigger printing dialog

`preventDefault(): boolean` gets the correct setting
`preventDefault(preventDefault: boolean): Key` sets preventDefault setting and returns the calling object

closes #2601 
