### PR TITLE
[Dispatchers] Refactor architecture for clarity

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -4087,7 +4087,6 @@ declare module Plottable {
         protected _eventToCallback: {
             [eventName: string]: (e: Event) => any;
         };
-        protected _callbacks: Utils.CallbackSet<Function>[];
         private _eventNameToCallbackSet;
         private _connected;
         private _hasNoCallbacks();
@@ -4096,8 +4095,6 @@ declare module Plottable {
         protected _addCallbackForEvent(eventName: string, callback: Function): void;
         protected _removeCallbackForEvent(eventName: string, callback: Function): void;
         protected _callCallbacksForEvent(eventName: string, ...args: any[]): void;
-        protected _setCallback(callbackSet: Utils.CallbackSet<Function>, callback: Function): void;
-        protected _unsetCallback(callbackSet: Utils.CallbackSet<Function>, callback: Function): void;
     }
 }
 declare module Plottable.Dispatchers {

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -4106,11 +4106,13 @@ declare module Plottable.Dispatchers {
         private static _DISPATCHER_KEY;
         private _translator;
         private _lastMousePosition;
-        private _moveCallbacks;
-        private _downCallbacks;
-        private _upCallbacks;
-        private _wheelCallbacks;
-        private _dblClickCallbacks;
+        private static _MOUSEOVER_EVENT_NAME;
+        private static _MOUSEMOVE_EVENT_NAME;
+        private static _MOUSEOUT_EVENT_NAME;
+        private static _MOUSEDOWN_EVENT_NAME;
+        private static _MOUSEUP_EVENT_NAME;
+        private static _WHEEL_EVENT_NAME;
+        private static _DBLCLICK_EVENT_NAME;
         /**
          * Get a Mouse Dispatcher for the <svg> containing elem.
          * If one already exists on that <svg>, it will be returned; otherwise, a new one will be created.
@@ -4200,7 +4202,7 @@ declare module Plottable.Dispatchers {
          * Computes the mouse position from the given event, and if successful
          * calls all the callbacks in the provided callbackSet.
          */
-        private _measureAndDispatch(event, callbackSet, scope?);
+        private _measureAndDispatch(event, eventName, scope?);
         eventInsideSVG(event: MouseEvent): boolean;
         /**
          * Returns the last computed mouse position in <svg> coordinate space.
@@ -4216,11 +4218,11 @@ declare module Plottable.Dispatchers {
     }, event: TouchEvent) => void;
     class Touch extends Dispatcher {
         private static _DISPATCHER_KEY;
+        private static _TOUCHSTART_EVENT_NAME;
+        private static _TOUCHMOVE_EVENT_NAME;
+        private static _TOUCHEND_EVENT_NAME;
+        private static _TOUCHCANCEL_EVENT_NAME;
         private _translator;
-        private _startCallbacks;
-        private _moveCallbacks;
-        private _endCallbacks;
-        private _cancelCallbacks;
         /**
          * Gets a Touch Dispatcher for the <svg> containing elem.
          * If one already exists on that <svg>, it will be returned; otherwise, a new one will be created.
@@ -4296,7 +4298,7 @@ declare module Plottable.Dispatchers {
          * Computes the Touch position from the given event, and if successful
          * calls all the callbacks in the provided callbackSet.
          */
-        private _measureAndDispatch(event, callbackSet, scope?);
+        private _measureAndDispatch(event, eventName, scope?);
         eventInsideSVG(event: TouchEvent): boolean;
     }
 }
@@ -4304,8 +4306,8 @@ declare module Plottable.Dispatchers {
     type KeyCallback = (keyCode: number, event: KeyboardEvent) => void;
     class Key extends Dispatcher {
         private static _DISPATCHER_KEY;
-        private _keydownCallbacks;
-        private _keyupCallbacks;
+        private static _KEYDOWN_EVENT_NAME;
+        private static _KEYUP_EVENT_NAME;
         /**
          * Gets a Key Dispatcher. If one already exists it will be returned;
          * otherwise, a new one will be created.
@@ -4319,6 +4321,8 @@ declare module Plottable.Dispatchers {
          * @constructor
          */
         constructor();
+        private _processKeydown(event);
+        private _processKeyup(event);
         /**
          * Registers a callback to be called whenever a key is pressed.
          *
@@ -4346,8 +4350,6 @@ declare module Plottable.Dispatchers {
          * @return {Dispatchers.Key} The calling Key Dispatcher.
          */
         offKeyUp(callback: KeyCallback): Key;
-        private _processKeydown(event);
-        private _processKeyup(event);
     }
 }
 declare module Plottable {

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -4084,7 +4084,7 @@ declare module Plottable.Animators {
 }
 declare module Plottable {
     class Dispatcher {
-        protected _eventToCallback: {
+        protected _eventToProcessingFunction: {
             [eventName: string]: (e: Event) => any;
         };
         private _eventNameToCallbackSet;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -4088,10 +4088,14 @@ declare module Plottable {
             [eventName: string]: (e: Event) => any;
         };
         protected _callbacks: Utils.CallbackSet<Function>[];
+        private _eventNameToCallbackSet;
         private _connected;
-        private _hasNoListeners();
+        private _hasNoCallbacks();
         private _connect();
         private _disconnect();
+        protected _addCallbackForEvent(eventName: string, callback: Function): void;
+        protected _removeCallbackForEvent(eventName: string, callback: Function): void;
+        protected _callCallbacksForEvent(eventName: string, ...args: any[]): void;
         protected _setCallback(callbackSet: Utils.CallbackSet<Function>, callback: Function): void;
         protected _unsetCallback(callbackSet: Utils.CallbackSet<Function>, callback: Function): void;
     }

--- a/plottable.js
+++ b/plottable.js
@@ -10158,7 +10158,7 @@ var Plottable;
 (function (Plottable) {
     var Dispatcher = (function () {
         function Dispatcher() {
-            this._eventToCallback = {};
+            this._eventToProcessingFunction = {};
             this._eventNameToCallbackSet = {};
             this._connected = false;
         }
@@ -10176,8 +10176,8 @@ var Plottable;
             if (this._connected) {
                 return;
             }
-            Object.keys(this._eventToCallback).forEach(function (event) {
-                var callback = _this._eventToCallback[event];
+            Object.keys(this._eventToProcessingFunction).forEach(function (event) {
+                var callback = _this._eventToProcessingFunction[event];
                 document.addEventListener(event, callback);
             });
             this._connected = true;
@@ -10185,8 +10185,8 @@ var Plottable;
         Dispatcher.prototype._disconnect = function () {
             var _this = this;
             if (this._connected && this._hasNoCallbacks()) {
-                Object.keys(this._eventToCallback).forEach(function (event) {
-                    var callback = _this._eventToCallback[event];
+                Object.keys(this._eventToProcessingFunction).forEach(function (event) {
+                    var callback = _this._eventToProcessingFunction[event];
                     document.removeEventListener(event, callback);
                 });
                 this._connected = false;
@@ -10237,13 +10237,13 @@ var Plottable;
                 this._translator = Plottable.Utils.ClientToSVGTranslator.getTranslator(svg);
                 this._lastMousePosition = { x: -1, y: -1 };
                 var processMoveCallback = function (e) { return _this._measureAndDispatch(e, Mouse._MOUSEMOVE_EVENT_NAME, "page"); };
-                this._eventToCallback[Mouse._MOUSEOVER_EVENT_NAME] = processMoveCallback;
-                this._eventToCallback[Mouse._MOUSEMOVE_EVENT_NAME] = processMoveCallback;
-                this._eventToCallback[Mouse._MOUSEOUT_EVENT_NAME] = processMoveCallback;
-                this._eventToCallback[Mouse._MOUSEDOWN_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Mouse._MOUSEDOWN_EVENT_NAME); };
-                this._eventToCallback[Mouse._MOUSEUP_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Mouse._MOUSEUP_EVENT_NAME, "page"); };
-                this._eventToCallback[Mouse._WHEEL_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Mouse._WHEEL_EVENT_NAME); };
-                this._eventToCallback[Mouse._DBLCLICK_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Mouse._DBLCLICK_EVENT_NAME); };
+                this._eventToProcessingFunction[Mouse._MOUSEOVER_EVENT_NAME] = processMoveCallback;
+                this._eventToProcessingFunction[Mouse._MOUSEMOVE_EVENT_NAME] = processMoveCallback;
+                this._eventToProcessingFunction[Mouse._MOUSEOUT_EVENT_NAME] = processMoveCallback;
+                this._eventToProcessingFunction[Mouse._MOUSEDOWN_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Mouse._MOUSEDOWN_EVENT_NAME); };
+                this._eventToProcessingFunction[Mouse._MOUSEUP_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Mouse._MOUSEUP_EVENT_NAME, "page"); };
+                this._eventToProcessingFunction[Mouse._WHEEL_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Mouse._WHEEL_EVENT_NAME); };
+                this._eventToProcessingFunction[Mouse._DBLCLICK_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Mouse._DBLCLICK_EVENT_NAME); };
             }
             /**
              * Get a Mouse Dispatcher for the <svg> containing elem.
@@ -10418,13 +10418,13 @@ var Plottable;
                 var _this = this;
                 _super.call(this);
                 this._translator = Plottable.Utils.ClientToSVGTranslator.getTranslator(svg);
-                this._eventToCallback[Touch._TOUCHSTART_EVENT_NAME] =
+                this._eventToProcessingFunction[Touch._TOUCHSTART_EVENT_NAME] =
                     function (e) { return _this._measureAndDispatch(e, Touch._TOUCHSTART_EVENT_NAME, "page"); };
-                this._eventToCallback[Touch._TOUCHMOVE_EVENT_NAME] =
+                this._eventToProcessingFunction[Touch._TOUCHMOVE_EVENT_NAME] =
                     function (e) { return _this._measureAndDispatch(e, Touch._TOUCHMOVE_EVENT_NAME, "page"); };
-                this._eventToCallback[Touch._TOUCHEND_EVENT_NAME] =
+                this._eventToProcessingFunction[Touch._TOUCHEND_EVENT_NAME] =
                     function (e) { return _this._measureAndDispatch(e, Touch._TOUCHEND_EVENT_NAME, "page"); };
-                this._eventToCallback[Touch._TOUCHCANCEL_EVENT_NAME] =
+                this._eventToProcessingFunction[Touch._TOUCHCANCEL_EVENT_NAME] =
                     function (e) { return _this._measureAndDispatch(e, Touch._TOUCHCANCEL_EVENT_NAME, "page"); };
             }
             /**
@@ -10579,8 +10579,8 @@ var Plottable;
             function Key() {
                 var _this = this;
                 _super.call(this);
-                this._eventToCallback[Key._KEYDOWN_EVENT_NAME] = function (e) { return _this._processKeydown(e); };
-                this._eventToCallback[Key._KEYUP_EVENT_NAME] = function (e) { return _this._processKeyup(e); };
+                this._eventToProcessingFunction[Key._KEYDOWN_EVENT_NAME] = function (e) { return _this._processKeydown(e); };
+                this._eventToProcessingFunction[Key._KEYUP_EVENT_NAME] = function (e) { return _this._processKeyup(e); };
             }
             /**
              * Gets a Key Dispatcher. If one already exists it will be returned;

--- a/plottable.js
+++ b/plottable.js
@@ -10418,10 +10418,14 @@ var Plottable;
                 var _this = this;
                 _super.call(this);
                 this._translator = Plottable.Utils.ClientToSVGTranslator.getTranslator(svg);
-                this._eventToCallback[Touch._TOUCHSTART_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Touch._TOUCHSTART_EVENT_NAME, "page"); };
-                this._eventToCallback[Touch._TOUCHMOVE_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Touch._TOUCHMOVE_EVENT_NAME, "page"); };
-                this._eventToCallback[Touch._TOUCHEND_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Touch._TOUCHEND_EVENT_NAME, "page"); };
-                this._eventToCallback[Touch._TOUCHCANCEL_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Touch._TOUCHCANCEL_EVENT_NAME, "page"); };
+                this._eventToCallback[Touch._TOUCHSTART_EVENT_NAME] =
+                    function (e) { return _this._measureAndDispatch(e, Touch._TOUCHSTART_EVENT_NAME, "page"); };
+                this._eventToCallback[Touch._TOUCHMOVE_EVENT_NAME] =
+                    function (e) { return _this._measureAndDispatch(e, Touch._TOUCHMOVE_EVENT_NAME, "page"); };
+                this._eventToCallback[Touch._TOUCHEND_EVENT_NAME] =
+                    function (e) { return _this._measureAndDispatch(e, Touch._TOUCHEND_EVENT_NAME, "page"); };
+                this._eventToCallback[Touch._TOUCHCANCEL_EVENT_NAME] =
+                    function (e) { return _this._measureAndDispatch(e, Touch._TOUCHCANCEL_EVENT_NAME, "page"); };
             }
             /**
              * Gets a Touch Dispatcher for the <svg> containing elem.

--- a/plottable.js
+++ b/plottable.js
@@ -10240,10 +10240,14 @@ var Plottable;
                 this._eventToProcessingFunction[Mouse._MOUSEOVER_EVENT_NAME] = processMoveCallback;
                 this._eventToProcessingFunction[Mouse._MOUSEMOVE_EVENT_NAME] = processMoveCallback;
                 this._eventToProcessingFunction[Mouse._MOUSEOUT_EVENT_NAME] = processMoveCallback;
-                this._eventToProcessingFunction[Mouse._MOUSEDOWN_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Mouse._MOUSEDOWN_EVENT_NAME); };
-                this._eventToProcessingFunction[Mouse._MOUSEUP_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Mouse._MOUSEUP_EVENT_NAME, "page"); };
-                this._eventToProcessingFunction[Mouse._WHEEL_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Mouse._WHEEL_EVENT_NAME); };
-                this._eventToProcessingFunction[Mouse._DBLCLICK_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Mouse._DBLCLICK_EVENT_NAME); };
+                this._eventToProcessingFunction[Mouse._MOUSEDOWN_EVENT_NAME] =
+                    function (e) { return _this._measureAndDispatch(e, Mouse._MOUSEDOWN_EVENT_NAME); };
+                this._eventToProcessingFunction[Mouse._MOUSEUP_EVENT_NAME] =
+                    function (e) { return _this._measureAndDispatch(e, Mouse._MOUSEUP_EVENT_NAME, "page"); };
+                this._eventToProcessingFunction[Mouse._WHEEL_EVENT_NAME] =
+                    function (e) { return _this._measureAndDispatch(e, Mouse._WHEEL_EVENT_NAME); };
+                this._eventToProcessingFunction[Mouse._DBLCLICK_EVENT_NAME] =
+                    function (e) { return _this._measureAndDispatch(e, Mouse._DBLCLICK_EVENT_NAME); };
             }
             /**
              * Get a Mouse Dispatcher for the <svg> containing elem.
@@ -10374,7 +10378,7 @@ var Plottable;
                     var newMousePosition = this._translator.computePosition(event.clientX, event.clientY);
                     if (newMousePosition != null) {
                         this._lastMousePosition = newMousePosition;
-                        this._callCallbacksForEvent(eventName, this._lastMousePosition, event);
+                        this._callCallbacksForEvent(eventName, this.lastMousePosition(), event);
                     }
                 }
             };

--- a/plottable.js
+++ b/plottable.js
@@ -10248,21 +10248,14 @@ var Plottable;
                 _super.call(this);
                 this._translator = Plottable.Utils.ClientToSVGTranslator.getTranslator(svg);
                 this._lastMousePosition = { x: -1, y: -1 };
-                this._moveCallbacks = new Plottable.Utils.CallbackSet();
-                this._downCallbacks = new Plottable.Utils.CallbackSet();
-                this._upCallbacks = new Plottable.Utils.CallbackSet();
-                this._wheelCallbacks = new Plottable.Utils.CallbackSet();
-                this._dblClickCallbacks = new Plottable.Utils.CallbackSet();
-                this._callbacks = [this._moveCallbacks, this._downCallbacks, this._upCallbacks, this._wheelCallbacks,
-                    this._dblClickCallbacks];
-                var processMoveCallback = function (e) { return _this._measureAndDispatch(e, _this._moveCallbacks, "page"); };
-                this._eventToCallback["mouseover"] = processMoveCallback;
-                this._eventToCallback["mousemove"] = processMoveCallback;
-                this._eventToCallback["mouseout"] = processMoveCallback;
-                this._eventToCallback["mousedown"] = function (e) { return _this._measureAndDispatch(e, _this._downCallbacks); };
-                this._eventToCallback["mouseup"] = function (e) { return _this._measureAndDispatch(e, _this._upCallbacks, "page"); };
-                this._eventToCallback["wheel"] = function (e) { return _this._measureAndDispatch(e, _this._wheelCallbacks); };
-                this._eventToCallback["dblclick"] = function (e) { return _this._measureAndDispatch(e, _this._dblClickCallbacks); };
+                var processMoveCallback = function (e) { return _this._measureAndDispatch(e, Mouse._MOUSEMOVE_EVENT_NAME, "page"); };
+                this._eventToCallback[Mouse._MOUSEOVER_EVENT_NAME] = processMoveCallback;
+                this._eventToCallback[Mouse._MOUSEMOVE_EVENT_NAME] = processMoveCallback;
+                this._eventToCallback[Mouse._MOUSEOUT_EVENT_NAME] = processMoveCallback;
+                this._eventToCallback[Mouse._MOUSEDOWN_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Mouse._MOUSEDOWN_EVENT_NAME); };
+                this._eventToCallback[Mouse._MOUSEUP_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Mouse._MOUSEUP_EVENT_NAME, "page"); };
+                this._eventToCallback[Mouse._WHEEL_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Mouse._WHEEL_EVENT_NAME); };
+                this._eventToCallback[Mouse._DBLCLICK_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Mouse._DBLCLICK_EVENT_NAME); };
             }
             /**
              * Get a Mouse Dispatcher for the <svg> containing elem.
@@ -10287,7 +10280,7 @@ var Plottable;
              * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
              */
             Mouse.prototype.onMouseMove = function (callback) {
-                this._setCallback(this._moveCallbacks, callback);
+                this._addCallbackForEvent(Mouse._MOUSEMOVE_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10297,7 +10290,7 @@ var Plottable;
              * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
              */
             Mouse.prototype.offMouseMove = function (callback) {
-                this._unsetCallback(this._moveCallbacks, callback);
+                this._removeCallbackForEvent(Mouse._MOUSEMOVE_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10307,7 +10300,7 @@ var Plottable;
              * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
              */
             Mouse.prototype.onMouseDown = function (callback) {
-                this._setCallback(this._downCallbacks, callback);
+                this._addCallbackForEvent(Mouse._MOUSEDOWN_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10317,7 +10310,7 @@ var Plottable;
              * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
              */
             Mouse.prototype.offMouseDown = function (callback) {
-                this._unsetCallback(this._downCallbacks, callback);
+                this._removeCallbackForEvent(Mouse._MOUSEDOWN_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10327,7 +10320,7 @@ var Plottable;
              * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
              */
             Mouse.prototype.onMouseUp = function (callback) {
-                this._setCallback(this._upCallbacks, callback);
+                this._addCallbackForEvent(Mouse._MOUSEUP_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10337,7 +10330,7 @@ var Plottable;
              * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
              */
             Mouse.prototype.offMouseUp = function (callback) {
-                this._unsetCallback(this._upCallbacks, callback);
+                this._removeCallbackForEvent(Mouse._MOUSEUP_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10347,7 +10340,7 @@ var Plottable;
              * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
              */
             Mouse.prototype.onWheel = function (callback) {
-                this._setCallback(this._wheelCallbacks, callback);
+                this._addCallbackForEvent(Mouse._WHEEL_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10357,7 +10350,7 @@ var Plottable;
              * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
              */
             Mouse.prototype.offWheel = function (callback) {
-                this._unsetCallback(this._wheelCallbacks, callback);
+                this._removeCallbackForEvent(Mouse._WHEEL_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10367,7 +10360,7 @@ var Plottable;
              * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
              */
             Mouse.prototype.onDblClick = function (callback) {
-                this._setCallback(this._dblClickCallbacks, callback);
+                this._addCallbackForEvent(Mouse._DBLCLICK_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10377,14 +10370,14 @@ var Plottable;
              * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
              */
             Mouse.prototype.offDblClick = function (callback) {
-                this._unsetCallback(this._dblClickCallbacks, callback);
+                this._removeCallbackForEvent(Mouse._DBLCLICK_EVENT_NAME, callback);
                 return this;
             };
             /**
              * Computes the mouse position from the given event, and if successful
              * calls all the callbacks in the provided callbackSet.
              */
-            Mouse.prototype._measureAndDispatch = function (event, callbackSet, scope) {
+            Mouse.prototype._measureAndDispatch = function (event, eventName, scope) {
                 if (scope === void 0) { scope = "element"; }
                 if (scope !== "page" && scope !== "element") {
                     throw new Error("Invalid scope '" + scope + "', must be 'element' or 'page'");
@@ -10393,7 +10386,7 @@ var Plottable;
                     var newMousePosition = this._translator.computePosition(event.clientX, event.clientY);
                     if (newMousePosition != null) {
                         this._lastMousePosition = newMousePosition;
-                        callbackSet.callCallbacks(this.lastMousePosition(), event);
+                        this._callCallbacksForEvent(eventName, this._lastMousePosition, event);
                     }
                 }
             };
@@ -10409,6 +10402,13 @@ var Plottable;
                 return this._lastMousePosition;
             };
             Mouse._DISPATCHER_KEY = "__Plottable_Dispatcher_Mouse";
+            Mouse._MOUSEOVER_EVENT_NAME = "mouseover";
+            Mouse._MOUSEMOVE_EVENT_NAME = "mousemove";
+            Mouse._MOUSEOUT_EVENT_NAME = "mouseout";
+            Mouse._MOUSEDOWN_EVENT_NAME = "mousedown";
+            Mouse._MOUSEUP_EVENT_NAME = "mouseup";
+            Mouse._WHEEL_EVENT_NAME = "wheel";
+            Mouse._DBLCLICK_EVENT_NAME = "dblclick";
             return Mouse;
         })(Plottable.Dispatcher);
         Dispatchers.Mouse = Mouse;
@@ -10430,15 +10430,10 @@ var Plottable;
                 var _this = this;
                 _super.call(this);
                 this._translator = Plottable.Utils.ClientToSVGTranslator.getTranslator(svg);
-                this._startCallbacks = new Plottable.Utils.CallbackSet();
-                this._moveCallbacks = new Plottable.Utils.CallbackSet();
-                this._endCallbacks = new Plottable.Utils.CallbackSet();
-                this._cancelCallbacks = new Plottable.Utils.CallbackSet();
-                this._callbacks = [this._moveCallbacks, this._startCallbacks, this._endCallbacks, this._cancelCallbacks];
-                this._eventToCallback["touchstart"] = function (e) { return _this._measureAndDispatch(e, _this._startCallbacks, "page"); };
-                this._eventToCallback["touchmove"] = function (e) { return _this._measureAndDispatch(e, _this._moveCallbacks, "page"); };
-                this._eventToCallback["touchend"] = function (e) { return _this._measureAndDispatch(e, _this._endCallbacks, "page"); };
-                this._eventToCallback["touchcancel"] = function (e) { return _this._measureAndDispatch(e, _this._cancelCallbacks, "page"); };
+                this._eventToCallback[Touch._TOUCHSTART_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Touch._TOUCHSTART_EVENT_NAME, "page"); };
+                this._eventToCallback[Touch._TOUCHMOVE_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Touch._TOUCHMOVE_EVENT_NAME, "page"); };
+                this._eventToCallback[Touch._TOUCHEND_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Touch._TOUCHEND_EVENT_NAME, "page"); };
+                this._eventToCallback[Touch._TOUCHCANCEL_EVENT_NAME] = function (e) { return _this._measureAndDispatch(e, Touch._TOUCHCANCEL_EVENT_NAME, "page"); };
             }
             /**
              * Gets a Touch Dispatcher for the <svg> containing elem.
@@ -10463,7 +10458,7 @@ var Plottable;
              * @return {Dispatchers.Touch} The calling Touch Dispatcher.
              */
             Touch.prototype.onTouchStart = function (callback) {
-                this._setCallback(this._startCallbacks, callback);
+                this._addCallbackForEvent(Touch._TOUCHSTART_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10473,7 +10468,7 @@ var Plottable;
              * @return {Dispatchers.Touch} The calling Touch Dispatcher.
              */
             Touch.prototype.offTouchStart = function (callback) {
-                this._unsetCallback(this._startCallbacks, callback);
+                this._removeCallbackForEvent(Touch._TOUCHSTART_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10483,7 +10478,7 @@ var Plottable;
              * @return {Dispatchers.Touch} The calling Touch Dispatcher.
              */
             Touch.prototype.onTouchMove = function (callback) {
-                this._setCallback(this._moveCallbacks, callback);
+                this._addCallbackForEvent(Touch._TOUCHMOVE_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10493,7 +10488,7 @@ var Plottable;
              * @return {Dispatchers.Touch} The calling Touch Dispatcher.
              */
             Touch.prototype.offTouchMove = function (callback) {
-                this._unsetCallback(this._moveCallbacks, callback);
+                this._removeCallbackForEvent(Touch._TOUCHMOVE_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10503,7 +10498,7 @@ var Plottable;
              * @return {Dispatchers.Touch} The calling Touch Dispatcher.
              */
             Touch.prototype.onTouchEnd = function (callback) {
-                this._setCallback(this._endCallbacks, callback);
+                this._addCallbackForEvent(Touch._TOUCHEND_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10513,7 +10508,7 @@ var Plottable;
              * @return {Dispatchers.Touch} The calling Touch Dispatcher.
              */
             Touch.prototype.offTouchEnd = function (callback) {
-                this._unsetCallback(this._endCallbacks, callback);
+                this._removeCallbackForEvent(Touch._TOUCHEND_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10523,7 +10518,7 @@ var Plottable;
              * @return {Dispatchers.Touch} The calling Touch Dispatcher.
              */
             Touch.prototype.onTouchCancel = function (callback) {
-                this._setCallback(this._cancelCallbacks, callback);
+                this._addCallbackForEvent(Touch._TOUCHCANCEL_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10533,14 +10528,14 @@ var Plottable;
              * @return {Dispatchers.Touch} The calling Touch Dispatcher.
              */
             Touch.prototype.offTouchCancel = function (callback) {
-                this._unsetCallback(this._cancelCallbacks, callback);
+                this._removeCallbackForEvent(Touch._TOUCHCANCEL_EVENT_NAME, callback);
                 return this;
             };
             /**
              * Computes the Touch position from the given event, and if successful
              * calls all the callbacks in the provided callbackSet.
              */
-            Touch.prototype._measureAndDispatch = function (event, callbackSet, scope) {
+            Touch.prototype._measureAndDispatch = function (event, eventName, scope) {
                 if (scope === void 0) { scope = "element"; }
                 if (scope !== "page" && scope !== "element") {
                     throw new Error("Invalid scope '" + scope + "', must be 'element' or 'page'");
@@ -10562,13 +10557,17 @@ var Plottable;
                 }
                 ;
                 if (touchIdentifiers.length > 0) {
-                    callbackSet.callCallbacks(touchIdentifiers, touchPositions, event);
+                    this._callCallbacksForEvent(eventName, touchIdentifiers, touchPositions, event);
                 }
             };
             Touch.prototype.eventInsideSVG = function (event) {
                 return this._translator.insideSVG(event);
             };
             Touch._DISPATCHER_KEY = "__Plottable_Dispatcher_Touch";
+            Touch._TOUCHSTART_EVENT_NAME = "touchstart";
+            Touch._TOUCHMOVE_EVENT_NAME = "touchmove";
+            Touch._TOUCHEND_EVENT_NAME = "touchend";
+            Touch._TOUCHCANCEL_EVENT_NAME = "touchcancel";
             return Touch;
         })(Plottable.Dispatcher);
         Dispatchers.Touch = Touch;
@@ -10588,11 +10587,8 @@ var Plottable;
             function Key() {
                 var _this = this;
                 _super.call(this);
-                this._eventToCallback["keydown"] = function (e) { return _this._processKeydown(e); };
-                this._eventToCallback["keyup"] = function (e) { return _this._processKeyup(e); };
-                this._keydownCallbacks = new Plottable.Utils.CallbackSet();
-                this._keyupCallbacks = new Plottable.Utils.CallbackSet();
-                this._callbacks = [this._keydownCallbacks, this._keyupCallbacks];
+                this._eventToCallback[Key._KEYDOWN_EVENT_NAME] = function (e) { return _this._processKeydown(e); };
+                this._eventToCallback[Key._KEYUP_EVENT_NAME] = function (e) { return _this._processKeyup(e); };
             }
             /**
              * Gets a Key Dispatcher. If one already exists it will be returned;
@@ -10608,6 +10604,12 @@ var Plottable;
                 }
                 return dispatcher;
             };
+            Key.prototype._processKeydown = function (event) {
+                this._callCallbacksForEvent(Key._KEYDOWN_EVENT_NAME, event.keyCode, event);
+            };
+            Key.prototype._processKeyup = function (event) {
+                this._callCallbacksForEvent(Key._KEYUP_EVENT_NAME, event.keyCode, event);
+            };
             /**
              * Registers a callback to be called whenever a key is pressed.
              *
@@ -10615,7 +10617,7 @@ var Plottable;
              * @return {Dispatchers.Key} The calling Key Dispatcher.
              */
             Key.prototype.onKeyDown = function (callback) {
-                this._setCallback(this._keydownCallbacks, callback);
+                this._addCallbackForEvent(Key._KEYDOWN_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10625,7 +10627,7 @@ var Plottable;
              * @return {Dispatchers.Key} The calling Key Dispatcher.
              */
             Key.prototype.offKeyDown = function (callback) {
-                this._unsetCallback(this._keydownCallbacks, callback);
+                this._removeCallbackForEvent(Key._KEYDOWN_EVENT_NAME, callback);
                 return this;
             };
             /** Registers a callback to be called whenever a key is released.
@@ -10634,7 +10636,7 @@ var Plottable;
              * @return {Dispatchers.Key} The calling Key Dispatcher.
              */
             Key.prototype.onKeyUp = function (callback) {
-                this._setCallback(this._keyupCallbacks, callback);
+                this._addCallbackForEvent(Key._KEYUP_EVENT_NAME, callback);
                 return this;
             };
             /**
@@ -10644,16 +10646,12 @@ var Plottable;
              * @return {Dispatchers.Key} The calling Key Dispatcher.
              */
             Key.prototype.offKeyUp = function (callback) {
-                this._unsetCallback(this._keyupCallbacks, callback);
+                this._removeCallbackForEvent(Key._KEYUP_EVENT_NAME, callback);
                 return this;
             };
-            Key.prototype._processKeydown = function (event) {
-                this._keydownCallbacks.callCallbacks(event.keyCode, event);
-            };
-            Key.prototype._processKeyup = function (event) {
-                this._keyupCallbacks.callCallbacks(event.keyCode, event);
-            };
             Key._DISPATCHER_KEY = "__Plottable_Dispatcher_Key";
+            Key._KEYDOWN_EVENT_NAME = "keydown";
+            Key._KEYUP_EVENT_NAME = "keyup";
             return Key;
         })(Plottable.Dispatcher);
         Dispatchers.Key = Key;

--- a/plottable.js
+++ b/plottable.js
@@ -10159,14 +10159,10 @@ var Plottable;
     var Dispatcher = (function () {
         function Dispatcher() {
             this._eventToCallback = {};
-            this._callbacks = [];
             this._eventNameToCallbackSet = {};
             this._connected = false;
         }
         Dispatcher.prototype._hasNoCallbacks = function () {
-            if (this._callbacks.some(function (callbackSet) { return callbackSet.size > 0; })) {
-                return false;
-            }
             var eventNames = Object.keys(this._eventNameToCallbackSet);
             for (var i = 0; i < eventNames.length; i++) {
                 if (this._eventNameToCallbackSet[eventNames[i]].size !== 0) {
@@ -10218,14 +10214,6 @@ var Plottable;
             if (callbackSet != null) {
                 callbackSet.callCallbacks.apply(callbackSet, args);
             }
-        };
-        Dispatcher.prototype._setCallback = function (callbackSet, callback) {
-            callbackSet.add(callback);
-            this._connect();
-        };
-        Dispatcher.prototype._unsetCallback = function (callbackSet, callback) {
-            callbackSet.delete(callback);
-            this._disconnect();
         };
         return Dispatcher;
     })();

--- a/plottable.js
+++ b/plottable.js
@@ -10177,8 +10177,8 @@ var Plottable;
                 return;
             }
             Object.keys(this._eventToProcessingFunction).forEach(function (event) {
-                var callback = _this._eventToProcessingFunction[event];
-                document.addEventListener(event, callback);
+                var processingFunction = _this._eventToProcessingFunction[event];
+                document.addEventListener(event, processingFunction);
             });
             this._connected = true;
         };
@@ -10186,8 +10186,8 @@ var Plottable;
             var _this = this;
             if (this._connected && this._hasNoCallbacks()) {
                 Object.keys(this._eventToProcessingFunction).forEach(function (event) {
-                    var callback = _this._eventToProcessingFunction[event];
-                    document.removeEventListener(event, callback);
+                    var processingFunction = _this._eventToProcessingFunction[event];
+                    document.removeEventListener(event, processingFunction);
                 });
                 this._connected = false;
             }

--- a/src/dispatchers/dispatcher.ts
+++ b/src/dispatchers/dispatcher.ts
@@ -1,6 +1,6 @@
 module Plottable {
 export class Dispatcher {
-  protected _eventToCallback: { [eventName: string]: (e: Event) => any; } = {};
+  protected _eventToProcessingFunction: { [eventName: string]: (e: Event) => any; } = {};
   private _eventNameToCallbackSet: { [eventName: string]: Utils.CallbackSet<Function>; } = {};
   private _connected = false;
 
@@ -18,8 +18,8 @@ export class Dispatcher {
     if (this._connected) {
       return;
     }
-    Object.keys(this._eventToCallback).forEach((event: string) => {
-      let callback = this._eventToCallback[event];
+    Object.keys(this._eventToProcessingFunction).forEach((event: string) => {
+      let callback = this._eventToProcessingFunction[event];
       document.addEventListener(event, callback);
     });
     this._connected = true;
@@ -27,8 +27,8 @@ export class Dispatcher {
 
   private _disconnect() {
     if (this._connected && this._hasNoCallbacks()) {
-      Object.keys(this._eventToCallback).forEach((event: string) => {
-        let callback = this._eventToCallback[event];
+      Object.keys(this._eventToProcessingFunction).forEach((event: string) => {
+        let callback = this._eventToProcessingFunction[event];
         document.removeEventListener(event, callback);
       });
       this._connected = false;

--- a/src/dispatchers/dispatcher.ts
+++ b/src/dispatchers/dispatcher.ts
@@ -1,14 +1,10 @@
 module Plottable {
 export class Dispatcher {
   protected _eventToCallback: { [eventName: string]: (e: Event) => any; } = {};
-  protected _callbacks: Utils.CallbackSet<Function>[] = [];
   private _eventNameToCallbackSet: { [eventName: string]: Utils.CallbackSet<Function>; } = {};
   private _connected = false;
 
   private _hasNoCallbacks() {
-    if (this._callbacks.some((callbackSet) => callbackSet.size > 0)) {
-      return false;
-    }
     const eventNames = Object.keys(this._eventNameToCallbackSet);
     for (let i = 0; i < eventNames.length; i++) { // for-loop so return can break out
       if (this._eventNameToCallbackSet[eventNames[i]].size !== 0) {
@@ -59,16 +55,6 @@ export class Dispatcher {
     if (callbackSet != null) {
       callbackSet.callCallbacks.apply(callbackSet, args);
     }
-  }
-
-  protected _setCallback(callbackSet: Utils.CallbackSet<Function>, callback: Function) {
-    callbackSet.add(callback);
-    this._connect();
-  }
-
-  protected _unsetCallback(callbackSet: Utils.CallbackSet<Function>, callback: Function) {
-    callbackSet.delete(callback);
-    this._disconnect();
   }
 }
 }

--- a/src/dispatchers/dispatcher.ts
+++ b/src/dispatchers/dispatcher.ts
@@ -19,8 +19,8 @@ export class Dispatcher {
       return;
     }
     Object.keys(this._eventToProcessingFunction).forEach((event: string) => {
-      let callback = this._eventToProcessingFunction[event];
-      document.addEventListener(event, callback);
+      const processingFunction = this._eventToProcessingFunction[event];
+      document.addEventListener(event, processingFunction);
     });
     this._connected = true;
   }
@@ -28,8 +28,8 @@ export class Dispatcher {
   private _disconnect() {
     if (this._connected && this._hasNoCallbacks()) {
       Object.keys(this._eventToProcessingFunction).forEach((event: string) => {
-        let callback = this._eventToProcessingFunction[event];
-        document.removeEventListener(event, callback);
+        const processingFunction = this._eventToProcessingFunction[event];
+        document.removeEventListener(event, processingFunction);
       });
       this._connected = false;
     }

--- a/src/dispatchers/dispatcher.ts
+++ b/src/dispatchers/dispatcher.ts
@@ -2,10 +2,20 @@ module Plottable {
 export class Dispatcher {
   protected _eventToCallback: { [eventName: string]: (e: Event) => any; } = {};
   protected _callbacks: Utils.CallbackSet<Function>[] = [];
+  private _eventNameToCallbackSet: { [eventName: string]: Utils.CallbackSet<Function>; } = {};
   private _connected = false;
 
-  private _hasNoListeners() {
-    return this._callbacks.every((cbs) => cbs.size === 0);
+  private _hasNoCallbacks() {
+    if (this._callbacks.some((callbackSet) => callbackSet.size > 0)) {
+      return false;
+    }
+    const eventNames = Object.keys(this._eventNameToCallbackSet);
+    for (let i = 0; i < eventNames.length; i++) { // for-loop so return can break out
+      if (this._eventNameToCallbackSet[eventNames[i]].size !== 0) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private _connect() {
@@ -20,7 +30,7 @@ export class Dispatcher {
   }
 
   private _disconnect() {
-    if (this._connected && this._hasNoListeners()) {
+    if (this._connected && this._hasNoCallbacks()) {
       Object.keys(this._eventToCallback).forEach((event: string) => {
         let callback = this._eventToCallback[event];
         document.removeEventListener(event, callback);
@@ -29,9 +39,31 @@ export class Dispatcher {
     }
   }
 
-  protected _setCallback(callbackSet: Utils.CallbackSet<Function>, callback: Function) {
+  protected _addCallbackForEvent(eventName: string, callback: Function) {
+    if (this._eventNameToCallbackSet[eventName] == null) {
+      this._eventNameToCallbackSet[eventName] = new Utils.CallbackSet<Function>();
+    }
+    this._eventNameToCallbackSet[eventName].add(callback);
     this._connect();
+  }
+
+  protected _removeCallbackForEvent(eventName: string, callback: Function) {
+    if (this._eventNameToCallbackSet[eventName] != null) {
+      this._eventNameToCallbackSet[eventName].delete(callback);
+    }
+    this._disconnect();
+  }
+
+  protected _callCallbacksForEvent(eventName: string, ...args: any[]) {
+    const callbackSet = this._eventNameToCallbackSet[eventName];
+    if (callbackSet != null) {
+      callbackSet.callCallbacks.apply(callbackSet, args);
+    }
+  }
+
+  protected _setCallback(callbackSet: Utils.CallbackSet<Function>, callback: Function) {
     callbackSet.add(callback);
+    this._connect();
   }
 
   protected _unsetCallback(callbackSet: Utils.CallbackSet<Function>, callback: Function) {

--- a/src/dispatchers/keyDispatcher.ts
+++ b/src/dispatchers/keyDispatcher.ts
@@ -3,8 +3,8 @@ module Plottable.Dispatchers {
 
   export class Key extends Dispatcher {
     private static _DISPATCHER_KEY = "__Plottable_Dispatcher_Key";
-    private _keydownCallbacks: Utils.CallbackSet<KeyCallback>;
-    private _keyupCallbacks: Utils.CallbackSet<KeyCallback>;
+    private static _KEYDOWN_EVENT_NAME = "keydown";
+    private static _KEYUP_EVENT_NAME = "keyup";
 
     /**
      * Gets a Key Dispatcher. If one already exists it will be returned;
@@ -29,11 +29,17 @@ module Plottable.Dispatchers {
     constructor() {
       super();
 
-      this._eventToCallback["keydown"] = (e: KeyboardEvent) => this._processKeydown(e);
-      this._eventToCallback["keyup"] = (e: KeyboardEvent) => this._processKeyup(e);
-      this._keydownCallbacks = new Utils.CallbackSet<KeyCallback>();
-      this._keyupCallbacks = new Utils.CallbackSet<KeyCallback>();
-      this._callbacks = [this._keydownCallbacks, this._keyupCallbacks];
+      this._eventToCallback[Key._KEYDOWN_EVENT_NAME] = (e: KeyboardEvent) => this._processKeydown(e);
+      this._eventToCallback[Key._KEYUP_EVENT_NAME] = (e: KeyboardEvent) => this._processKeyup(e);
+    }
+
+
+    private _processKeydown(event: KeyboardEvent) {
+      this._callCallbacksForEvent(Key._KEYDOWN_EVENT_NAME, event.keyCode, event);
+    }
+
+    private _processKeyup(event: KeyboardEvent) {
+      this._callCallbacksForEvent(Key._KEYUP_EVENT_NAME, event.keyCode, event);
     }
 
     /**
@@ -43,7 +49,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Key} The calling Key Dispatcher.
      */
     public onKeyDown(callback: KeyCallback): Key {
-      this._setCallback(this._keydownCallbacks, callback);
+      this._addCallbackForEvent(Key._KEYDOWN_EVENT_NAME, callback);
       return this;
     }
 
@@ -54,7 +60,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Key} The calling Key Dispatcher.
      */
     public offKeyDown(callback: KeyCallback): Key {
-      this._unsetCallback(this._keydownCallbacks, callback);
+      this._removeCallbackForEvent(Key._KEYDOWN_EVENT_NAME, callback);
       return this;
     }
 
@@ -64,7 +70,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Key} The calling Key Dispatcher.
      */
     public onKeyUp(callback: KeyCallback): Key {
-      this._setCallback(this._keyupCallbacks, callback);
+      this._addCallbackForEvent(Key._KEYUP_EVENT_NAME, callback);
       return this;
     }
 
@@ -75,16 +81,8 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Key} The calling Key Dispatcher.
      */
     public offKeyUp(callback: KeyCallback): Key {
-      this._unsetCallback(this._keyupCallbacks, callback);
+      this._removeCallbackForEvent(Key._KEYUP_EVENT_NAME, callback);
       return this;
-    }
-
-    private _processKeydown(event: KeyboardEvent) {
-      this._keydownCallbacks.callCallbacks(event.keyCode, event);
-    }
-
-    private _processKeyup(event: KeyboardEvent) {
-      this._keyupCallbacks.callCallbacks(event.keyCode, event);
     }
   }
 }

--- a/src/dispatchers/keyDispatcher.ts
+++ b/src/dispatchers/keyDispatcher.ts
@@ -33,7 +33,6 @@ module Plottable.Dispatchers {
       this._eventToCallback[Key._KEYUP_EVENT_NAME] = (e: KeyboardEvent) => this._processKeyup(e);
     }
 
-
     private _processKeydown(event: KeyboardEvent) {
       this._callCallbacksForEvent(Key._KEYDOWN_EVENT_NAME, event.keyCode, event);
     }

--- a/src/dispatchers/keyDispatcher.ts
+++ b/src/dispatchers/keyDispatcher.ts
@@ -29,8 +29,8 @@ module Plottable.Dispatchers {
     constructor() {
       super();
 
-      this._eventToCallback[Key._KEYDOWN_EVENT_NAME] = (e: KeyboardEvent) => this._processKeydown(e);
-      this._eventToCallback[Key._KEYUP_EVENT_NAME] = (e: KeyboardEvent) => this._processKeyup(e);
+      this._eventToProcessingFunction[Key._KEYDOWN_EVENT_NAME] = (e: KeyboardEvent) => this._processKeydown(e);
+      this._eventToProcessingFunction[Key._KEYUP_EVENT_NAME] = (e: KeyboardEvent) => this._processKeyup(e);
     }
 
     private _processKeydown(event: KeyboardEvent) {

--- a/src/dispatchers/mouseDispatcher.ts
+++ b/src/dispatchers/mouseDispatcher.ts
@@ -180,7 +180,7 @@ module Plottable.Dispatchers {
         let newMousePosition = this._translator.computePosition(event.clientX, event.clientY);
         if (newMousePosition != null) {
           this._lastMousePosition = newMousePosition;
-          this._callCallbacksForEvent(eventName, this._lastMousePosition, event);
+          this._callCallbacksForEvent(eventName, this.lastMousePosition(), event);
         }
       }
     }

--- a/src/dispatchers/mouseDispatcher.ts
+++ b/src/dispatchers/mouseDispatcher.ts
@@ -5,12 +5,13 @@ module Plottable.Dispatchers {
     private static _DISPATCHER_KEY = "__Plottable_Dispatcher_Mouse";
     private _translator: Utils.ClientToSVGTranslator;
     private _lastMousePosition: Point;
-
-    private _moveCallbacks: Utils.CallbackSet<MouseCallback>;
-    private _downCallbacks: Utils.CallbackSet<MouseCallback>;
-    private _upCallbacks: Utils.CallbackSet<MouseCallback>;
-    private _wheelCallbacks: Utils.CallbackSet<MouseCallback>;
-    private _dblClickCallbacks: Utils.CallbackSet<MouseCallback>;
+    private static _MOUSEOVER_EVENT_NAME = "mouseover";
+    private static _MOUSEMOVE_EVENT_NAME = "mousemove";
+    private static _MOUSEOUT_EVENT_NAME = "mouseout";
+    private static _MOUSEDOWN_EVENT_NAME = "mousedown";
+    private static _MOUSEUP_EVENT_NAME = "mouseup";
+    private static _WHEEL_EVENT_NAME = "wheel";
+    private static _DBLCLICK_EVENT_NAME = "dblclick";
 
     /**
      * Get a Mouse Dispatcher for the <svg> containing elem.
@@ -43,22 +44,14 @@ module Plottable.Dispatchers {
 
       this._lastMousePosition = { x: -1, y: -1 };
 
-      this._moveCallbacks = new Plottable.Utils.CallbackSet<MouseCallback>();
-      this._downCallbacks = new Plottable.Utils.CallbackSet<MouseCallback>();
-      this._upCallbacks = new Plottable.Utils.CallbackSet<MouseCallback>();
-      this._wheelCallbacks = new Plottable.Utils.CallbackSet<MouseCallback>();
-      this._dblClickCallbacks = new Plottable.Utils.CallbackSet<MouseCallback>();
-      this._callbacks = [this._moveCallbacks, this._downCallbacks, this._upCallbacks, this._wheelCallbacks,
-                         this._dblClickCallbacks];
-
-      let processMoveCallback = (e: MouseEvent) => this._measureAndDispatch(e, this._moveCallbacks, "page");
-      this._eventToCallback["mouseover"] = processMoveCallback;
-      this._eventToCallback["mousemove"] = processMoveCallback;
-      this._eventToCallback["mouseout"] = processMoveCallback;
-      this._eventToCallback["mousedown"] = (e: MouseEvent) => this._measureAndDispatch(e, this._downCallbacks);
-      this._eventToCallback["mouseup"] = (e: MouseEvent) => this._measureAndDispatch(e, this._upCallbacks, "page");
-      this._eventToCallback["wheel"] = (e: WheelEvent) => this._measureAndDispatch(e, this._wheelCallbacks);
-      this._eventToCallback["dblclick"] = (e: MouseEvent) => this._measureAndDispatch(e, this._dblClickCallbacks);
+      let processMoveCallback = (e: MouseEvent) => this._measureAndDispatch(e, Mouse._MOUSEMOVE_EVENT_NAME, "page");
+      this._eventToCallback[Mouse._MOUSEOVER_EVENT_NAME] = processMoveCallback;
+      this._eventToCallback[Mouse._MOUSEMOVE_EVENT_NAME] = processMoveCallback;
+      this._eventToCallback[Mouse._MOUSEOUT_EVENT_NAME] = processMoveCallback;
+      this._eventToCallback[Mouse._MOUSEDOWN_EVENT_NAME] = (e: MouseEvent) => this._measureAndDispatch(e, Mouse._MOUSEDOWN_EVENT_NAME);
+      this._eventToCallback[Mouse._MOUSEUP_EVENT_NAME] = (e: MouseEvent) => this._measureAndDispatch(e, Mouse._MOUSEUP_EVENT_NAME, "page");
+      this._eventToCallback[Mouse._WHEEL_EVENT_NAME] = (e: WheelEvent) => this._measureAndDispatch(e, Mouse._WHEEL_EVENT_NAME);
+      this._eventToCallback[Mouse._DBLCLICK_EVENT_NAME] = (e: MouseEvent) => this._measureAndDispatch(e, Mouse._DBLCLICK_EVENT_NAME);
     }
 
     /**
@@ -68,7 +61,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
      */
     public onMouseMove(callback: MouseCallback): Dispatchers.Mouse {
-      this._setCallback(this._moveCallbacks, callback);
+      this._addCallbackForEvent(Mouse._MOUSEMOVE_EVENT_NAME, callback)
       return this;
     }
 
@@ -79,7 +72,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
      */
     public offMouseMove(callback: MouseCallback): Dispatchers.Mouse {
-      this._unsetCallback(this._moveCallbacks, callback);
+      this._removeCallbackForEvent(Mouse._MOUSEMOVE_EVENT_NAME, callback);
       return this;
     }
 
@@ -90,7 +83,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
      */
     public onMouseDown(callback: MouseCallback): Dispatchers.Mouse {
-      this._setCallback(this._downCallbacks, callback);
+      this._addCallbackForEvent(Mouse._MOUSEDOWN_EVENT_NAME, callback);
       return this;
     }
 
@@ -101,7 +94,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
      */
     public offMouseDown(callback: MouseCallback): Dispatchers.Mouse {
-      this._unsetCallback(this._downCallbacks, callback);
+      this._removeCallbackForEvent(Mouse._MOUSEDOWN_EVENT_NAME, callback);
       return this;
     }
 
@@ -112,7 +105,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
      */
     public onMouseUp(callback: MouseCallback): Dispatchers.Mouse {
-      this._setCallback(this._upCallbacks, callback);
+      this._addCallbackForEvent(Mouse._MOUSEUP_EVENT_NAME, callback);
       return this;
     }
 
@@ -123,7 +116,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
      */
     public offMouseUp(callback: MouseCallback): Dispatchers.Mouse {
-      this._unsetCallback(this._upCallbacks, callback);
+      this._removeCallbackForEvent(Mouse._MOUSEUP_EVENT_NAME, callback);
       return this;
     }
 
@@ -134,7 +127,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
      */
     public onWheel(callback: MouseCallback): Dispatchers.Mouse {
-      this._setCallback(this._wheelCallbacks, callback);
+      this._addCallbackForEvent(Mouse._WHEEL_EVENT_NAME, callback);
       return this;
     }
 
@@ -145,7 +138,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
      */
     public offWheel(callback: MouseCallback): Dispatchers.Mouse {
-      this._unsetCallback(this._wheelCallbacks, callback);
+      this._removeCallbackForEvent(Mouse._WHEEL_EVENT_NAME, callback);
       return this;
     }
 
@@ -156,7 +149,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
      */
     public onDblClick(callback: MouseCallback): Dispatchers.Mouse {
-      this._setCallback(this._dblClickCallbacks, callback);
+      this._addCallbackForEvent(Mouse._DBLCLICK_EVENT_NAME, callback);
       return this;
     }
 
@@ -167,7 +160,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
      */
     public offDblClick(callback: MouseCallback): Dispatchers.Mouse {
-      this._unsetCallback(this._dblClickCallbacks, callback);
+      this._removeCallbackForEvent(Mouse._DBLCLICK_EVENT_NAME, callback);
       return this;
     }
 
@@ -175,7 +168,7 @@ module Plottable.Dispatchers {
      * Computes the mouse position from the given event, and if successful
      * calls all the callbacks in the provided callbackSet.
      */
-    private _measureAndDispatch(event: MouseEvent, callbackSet: Utils.CallbackSet<MouseCallback>, scope: string = "element") {
+    private _measureAndDispatch(event: MouseEvent, eventName: string, scope: string = "element") {
       if (scope !== "page" && scope !== "element") {
         throw new Error("Invalid scope '" + scope + "', must be 'element' or 'page'");
       }
@@ -183,7 +176,7 @@ module Plottable.Dispatchers {
         let newMousePosition = this._translator.computePosition(event.clientX, event.clientY);
         if (newMousePosition != null) {
           this._lastMousePosition = newMousePosition;
-          callbackSet.callCallbacks(this.lastMousePosition(), event);
+          this._callCallbacksForEvent(eventName, this._lastMousePosition, event);
         }
       }
     }

--- a/src/dispatchers/mouseDispatcher.ts
+++ b/src/dispatchers/mouseDispatcher.ts
@@ -45,13 +45,17 @@ module Plottable.Dispatchers {
       this._lastMousePosition = { x: -1, y: -1 };
 
       let processMoveCallback = (e: MouseEvent) => this._measureAndDispatch(e, Mouse._MOUSEMOVE_EVENT_NAME, "page");
-      this._eventToCallback[Mouse._MOUSEOVER_EVENT_NAME] = processMoveCallback;
-      this._eventToCallback[Mouse._MOUSEMOVE_EVENT_NAME] = processMoveCallback;
-      this._eventToCallback[Mouse._MOUSEOUT_EVENT_NAME] = processMoveCallback;
-      this._eventToCallback[Mouse._MOUSEDOWN_EVENT_NAME] = (e: MouseEvent) => this._measureAndDispatch(e, Mouse._MOUSEDOWN_EVENT_NAME);
-      this._eventToCallback[Mouse._MOUSEUP_EVENT_NAME] = (e: MouseEvent) => this._measureAndDispatch(e, Mouse._MOUSEUP_EVENT_NAME, "page");
-      this._eventToCallback[Mouse._WHEEL_EVENT_NAME] = (e: WheelEvent) => this._measureAndDispatch(e, Mouse._WHEEL_EVENT_NAME);
-      this._eventToCallback[Mouse._DBLCLICK_EVENT_NAME] = (e: MouseEvent) => this._measureAndDispatch(e, Mouse._DBLCLICK_EVENT_NAME);
+      this._eventToProcessingFunction[Mouse._MOUSEOVER_EVENT_NAME] = processMoveCallback;
+      this._eventToProcessingFunction[Mouse._MOUSEMOVE_EVENT_NAME] = processMoveCallback;
+      this._eventToProcessingFunction[Mouse._MOUSEOUT_EVENT_NAME] = processMoveCallback;
+      this._eventToProcessingFunction[Mouse._MOUSEDOWN_EVENT_NAME] =
+        (e: MouseEvent) => this._measureAndDispatch(e, Mouse._MOUSEDOWN_EVENT_NAME);
+      this._eventToProcessingFunction[Mouse._MOUSEUP_EVENT_NAME] =
+        (e: MouseEvent) => this._measureAndDispatch(e, Mouse._MOUSEUP_EVENT_NAME, "page");
+      this._eventToProcessingFunction[Mouse._WHEEL_EVENT_NAME] =
+        (e: WheelEvent) => this._measureAndDispatch(e, Mouse._WHEEL_EVENT_NAME);
+      this._eventToProcessingFunction[Mouse._DBLCLICK_EVENT_NAME] =
+        (e: MouseEvent) => this._measureAndDispatch(e, Mouse._DBLCLICK_EVENT_NAME);
     }
 
     /**

--- a/src/dispatchers/mouseDispatcher.ts
+++ b/src/dispatchers/mouseDispatcher.ts
@@ -61,7 +61,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Mouse} The calling Mouse Dispatcher.
      */
     public onMouseMove(callback: MouseCallback): Dispatchers.Mouse {
-      this._addCallbackForEvent(Mouse._MOUSEMOVE_EVENT_NAME, callback)
+      this._addCallbackForEvent(Mouse._MOUSEMOVE_EVENT_NAME, callback);
       return this;
     }
 

--- a/src/dispatchers/touchDispatcher.ts
+++ b/src/dispatchers/touchDispatcher.ts
@@ -3,11 +3,11 @@ module Plottable.Dispatchers {
 
   export class Touch extends Dispatcher {
     private static _DISPATCHER_KEY = "__Plottable_Dispatcher_Touch";
+    private static _TOUCHSTART_EVENT_NAME = "touchstart";
+    private static _TOUCHMOVE_EVENT_NAME = "touchmove";
+    private static _TOUCHEND_EVENT_NAME = "touchend";
+    private static _TOUCHCANCEL_EVENT_NAME = "touchcancel";
     private _translator: Utils.ClientToSVGTranslator;
-    private _startCallbacks: Utils.CallbackSet<TouchCallback>;
-    private _moveCallbacks: Utils.CallbackSet<TouchCallback>;
-    private _endCallbacks: Utils.CallbackSet<TouchCallback>;
-    private _cancelCallbacks: Utils.CallbackSet<TouchCallback>;
 
     /**
      * Gets a Touch Dispatcher for the <svg> containing elem.
@@ -38,16 +38,10 @@ module Plottable.Dispatchers {
 
       this._translator = Utils.ClientToSVGTranslator.getTranslator(svg);
 
-      this._startCallbacks = new Utils.CallbackSet<TouchCallback>();
-      this._moveCallbacks = new Utils.CallbackSet<TouchCallback>();
-      this._endCallbacks = new Utils.CallbackSet<TouchCallback>();
-      this._cancelCallbacks = new Utils.CallbackSet<TouchCallback>();
-      this._callbacks = [this._moveCallbacks, this._startCallbacks, this._endCallbacks, this._cancelCallbacks];
-
-      this._eventToCallback["touchstart"] = (e: TouchEvent) => this._measureAndDispatch(e, this._startCallbacks, "page");
-      this._eventToCallback["touchmove"] = (e: TouchEvent) => this._measureAndDispatch(e, this._moveCallbacks, "page");
-      this._eventToCallback["touchend"] = (e: TouchEvent) => this._measureAndDispatch(e, this._endCallbacks, "page");
-      this._eventToCallback["touchcancel"] = (e: TouchEvent) => this._measureAndDispatch(e, this._cancelCallbacks, "page");
+      this._eventToCallback[Touch._TOUCHSTART_EVENT_NAME] = (e: TouchEvent) => this._measureAndDispatch(e, Touch._TOUCHSTART_EVENT_NAME, "page");
+      this._eventToCallback[Touch._TOUCHMOVE_EVENT_NAME] = (e: TouchEvent) => this._measureAndDispatch(e, Touch._TOUCHMOVE_EVENT_NAME, "page");
+      this._eventToCallback[Touch._TOUCHEND_EVENT_NAME] = (e: TouchEvent) => this._measureAndDispatch(e, Touch._TOUCHEND_EVENT_NAME, "page");
+      this._eventToCallback[Touch._TOUCHCANCEL_EVENT_NAME] = (e: TouchEvent) => this._measureAndDispatch(e, Touch._TOUCHCANCEL_EVENT_NAME, "page");
     }
 
     /**
@@ -57,7 +51,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Touch} The calling Touch Dispatcher.
      */
     public onTouchStart(callback: TouchCallback): Dispatchers.Touch {
-      this._setCallback(this._startCallbacks, callback);
+      this._addCallbackForEvent(Touch._TOUCHSTART_EVENT_NAME, callback);
       return this;
     }
 
@@ -68,7 +62,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Touch} The calling Touch Dispatcher.
      */
     public offTouchStart(callback: TouchCallback): Dispatchers.Touch {
-      this._unsetCallback(this._startCallbacks, callback);
+      this._removeCallbackForEvent(Touch._TOUCHSTART_EVENT_NAME, callback);
       return this;
     }
 
@@ -79,7 +73,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Touch} The calling Touch Dispatcher.
      */
     public onTouchMove(callback: TouchCallback): Dispatchers.Touch {
-      this._setCallback(this._moveCallbacks, callback);
+      this._addCallbackForEvent(Touch._TOUCHMOVE_EVENT_NAME, callback);
       return this;
     }
 
@@ -90,7 +84,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Touch} The calling Touch Dispatcher.
      */
     public offTouchMove(callback: TouchCallback): Dispatchers.Touch {
-      this._unsetCallback(this._moveCallbacks, callback);
+      this._removeCallbackForEvent(Touch._TOUCHMOVE_EVENT_NAME, callback);
       return this;
     }
 
@@ -101,7 +95,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Touch} The calling Touch Dispatcher.
      */
     public onTouchEnd(callback: TouchCallback): Dispatchers.Touch {
-      this._setCallback(this._endCallbacks, callback);
+      this._addCallbackForEvent(Touch._TOUCHEND_EVENT_NAME, callback);
       return this;
     }
 
@@ -112,7 +106,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Touch} The calling Touch Dispatcher.
      */
     public offTouchEnd(callback: TouchCallback): Dispatchers.Touch {
-      this._unsetCallback(this._endCallbacks, callback);
+      this._removeCallbackForEvent(Touch._TOUCHEND_EVENT_NAME, callback);
       return this;
     }
 
@@ -123,7 +117,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Touch} The calling Touch Dispatcher.
      */
     public onTouchCancel(callback: TouchCallback): Dispatchers.Touch {
-      this._setCallback(this._cancelCallbacks, callback);
+      this._addCallbackForEvent(Touch._TOUCHCANCEL_EVENT_NAME, callback);
       return this;
     }
 
@@ -134,7 +128,7 @@ module Plottable.Dispatchers {
      * @return {Dispatchers.Touch} The calling Touch Dispatcher.
      */
     public offTouchCancel(callback: TouchCallback): Dispatchers.Touch {
-      this._unsetCallback(this._cancelCallbacks, callback);
+      this._removeCallbackForEvent(Touch._TOUCHCANCEL_EVENT_NAME, callback);
       return this;
     }
 
@@ -142,7 +136,7 @@ module Plottable.Dispatchers {
      * Computes the Touch position from the given event, and if successful
      * calls all the callbacks in the provided callbackSet.
      */
-    private _measureAndDispatch(event: TouchEvent, callbackSet: Utils.CallbackSet<TouchCallback>, scope = "element") {
+    private _measureAndDispatch(event: TouchEvent, eventName: string, scope = "element") {
       if (scope !== "page" && scope !== "element") {
         throw new Error("Invalid scope '" + scope + "', must be 'element' or 'page'");
       }
@@ -162,7 +156,7 @@ module Plottable.Dispatchers {
         }
       };
       if (touchIdentifiers.length > 0) {
-        callbackSet.callCallbacks(touchIdentifiers, touchPositions, event);
+        this._callCallbacksForEvent(eventName, touchIdentifiers, touchPositions, event);
       }
     }
 

--- a/src/dispatchers/touchDispatcher.ts
+++ b/src/dispatchers/touchDispatcher.ts
@@ -38,10 +38,14 @@ module Plottable.Dispatchers {
 
       this._translator = Utils.ClientToSVGTranslator.getTranslator(svg);
 
-      this._eventToCallback[Touch._TOUCHSTART_EVENT_NAME] = (e: TouchEvent) => this._measureAndDispatch(e, Touch._TOUCHSTART_EVENT_NAME, "page");
-      this._eventToCallback[Touch._TOUCHMOVE_EVENT_NAME] = (e: TouchEvent) => this._measureAndDispatch(e, Touch._TOUCHMOVE_EVENT_NAME, "page");
-      this._eventToCallback[Touch._TOUCHEND_EVENT_NAME] = (e: TouchEvent) => this._measureAndDispatch(e, Touch._TOUCHEND_EVENT_NAME, "page");
-      this._eventToCallback[Touch._TOUCHCANCEL_EVENT_NAME] = (e: TouchEvent) => this._measureAndDispatch(e, Touch._TOUCHCANCEL_EVENT_NAME, "page");
+      this._eventToCallback[Touch._TOUCHSTART_EVENT_NAME] =
+        (e: TouchEvent) => this._measureAndDispatch(e, Touch._TOUCHSTART_EVENT_NAME, "page");
+      this._eventToCallback[Touch._TOUCHMOVE_EVENT_NAME] =
+        (e: TouchEvent) => this._measureAndDispatch(e, Touch._TOUCHMOVE_EVENT_NAME, "page");
+      this._eventToCallback[Touch._TOUCHEND_EVENT_NAME] =
+        (e: TouchEvent) => this._measureAndDispatch(e, Touch._TOUCHEND_EVENT_NAME, "page");
+      this._eventToCallback[Touch._TOUCHCANCEL_EVENT_NAME] =
+        (e: TouchEvent) => this._measureAndDispatch(e, Touch._TOUCHCANCEL_EVENT_NAME, "page");
     }
 
     /**

--- a/src/dispatchers/touchDispatcher.ts
+++ b/src/dispatchers/touchDispatcher.ts
@@ -38,13 +38,13 @@ module Plottable.Dispatchers {
 
       this._translator = Utils.ClientToSVGTranslator.getTranslator(svg);
 
-      this._eventToCallback[Touch._TOUCHSTART_EVENT_NAME] =
+      this._eventToProcessingFunction[Touch._TOUCHSTART_EVENT_NAME] =
         (e: TouchEvent) => this._measureAndDispatch(e, Touch._TOUCHSTART_EVENT_NAME, "page");
-      this._eventToCallback[Touch._TOUCHMOVE_EVENT_NAME] =
+      this._eventToProcessingFunction[Touch._TOUCHMOVE_EVENT_NAME] =
         (e: TouchEvent) => this._measureAndDispatch(e, Touch._TOUCHMOVE_EVENT_NAME, "page");
-      this._eventToCallback[Touch._TOUCHEND_EVENT_NAME] =
+      this._eventToProcessingFunction[Touch._TOUCHEND_EVENT_NAME] =
         (e: TouchEvent) => this._measureAndDispatch(e, Touch._TOUCHEND_EVENT_NAME, "page");
-      this._eventToCallback[Touch._TOUCHCANCEL_EVENT_NAME] =
+      this._eventToProcessingFunction[Touch._TOUCHCANCEL_EVENT_NAME] =
         (e: TouchEvent) => this._measureAndDispatch(e, Touch._TOUCHCANCEL_EVENT_NAME, "page");
     }
 

--- a/test/dispatchers/dispatcherTests.ts
+++ b/test/dispatchers/dispatcherTests.ts
@@ -7,7 +7,8 @@ describe("Dispatchers", () => {
 
       constructor() {
         super();
-        this._eventToCallback[InstrumentedDispatcher.EVENT_NAME] = () => this._callCallbacksForEvent(InstrumentedDispatcher.EVENT_NAME);
+        this._eventToProcessingFunction[InstrumentedDispatcher.EVENT_NAME] =
+          () => this._callCallbacksForEvent(InstrumentedDispatcher.EVENT_NAME);
       }
 
       public addCallback(callback: Function) {
@@ -25,7 +26,7 @@ describe("Dispatchers", () => {
       const dispatcher = new Plottable.Dispatcher();
 
       let callbackCalled = false;
-      (<any> dispatcher)._eventToCallback[TEST_EVENT_NAME] = () => callbackCalled = true;
+      (<any> dispatcher)._eventToProcessingFunction[TEST_EVENT_NAME] = () => callbackCalled = true;
 
       let d3document = d3.select(document);
       (<any> dispatcher)._connect();
@@ -47,7 +48,7 @@ describe("Dispatchers", () => {
       const dispatcher = new InstrumentedDispatcher();
 
       let processingFunctionWasCalled = false;
-      (<any> dispatcher)._eventToCallback[TEST_EVENT_NAME] = () => processingFunctionWasCalled = true;
+      (<any> dispatcher)._eventToProcessingFunction[TEST_EVENT_NAME] = () => processingFunctionWasCalled = true;
 
       const callback = () => { return; };
       dispatcher.addCallback(callback);

--- a/test/dispatchers/dispatcherTests.ts
+++ b/test/dispatchers/dispatcherTests.ts
@@ -2,6 +2,23 @@
 
 describe("Dispatchers", () => {
   describe("Dispatcher", () => {
+    class InstrumentedDispatcher extends Plottable.Dispatcher {
+      public static EVENT_NAME = "instrumented";
+
+      constructor() {
+        super();
+        this._eventToCallback[InstrumentedDispatcher.EVENT_NAME] = () => this._callCallbacksForEvent(InstrumentedDispatcher.EVENT_NAME);
+      }
+
+      public addCallback(callback: Function) {
+        this._addCallbackForEvent(InstrumentedDispatcher.EVENT_NAME, callback);
+      }
+
+      public removeCallback(callback: Function) {
+        this._removeCallbackForEvent(InstrumentedDispatcher.EVENT_NAME, callback);
+      }
+    }
+
     const TEST_EVENT_NAME = "test";
 
     it("connects and disconnects correctly", () => {

--- a/test/dispatchers/touchDispatcherTests.ts
+++ b/test/dispatchers/touchDispatcherTests.ts
@@ -7,9 +7,9 @@ describe("Dispatchers", () => {
       it("creates only one Dispatcher.Touch per element", () => {
         const svg = TestMethods.generateSVG();
 
-        const td1 = Plottable.Dispatchers.Touch.getDispatcher(svg.node());
+        const td1 = Plottable.Dispatchers.Touch.getDispatcher(<SVGElement> svg.node());
         assert.isNotNull(td1, "created a new Dispatcher on an SVG");
-        const td2 = Plottable.Dispatchers.Touch.getDispatcher(svg.node());
+        const td2 = Plottable.Dispatchers.Touch.getDispatcher(<SVGElement> svg.node());
         assert.strictEqual(td1, td2, "returned the existing Dispatcher if called again with same <svg>");
 
         svg.remove();


### PR DESCRIPTION
Refactored how `Dispatcher` registers events. Previously it used these methods:
```Typescript
// OLD DESIGN
protected _setCallback(callbackSet: Utils.CallbackSet<Function>, callback: Function): void;
protected _unsetCallback(callbackSet: Utils.CallbackSet<Function>, callback: Function): void;
```
This seemed kind of odd, since there was a method that modified non-instance fields, and subclasses had to define a new `CallbackSet` for each type of event they wanted to add listeners for, and then call `.callCallbacks()` manually. This seemed silly.

The refactored version:
```Typescript
// NEW DESIGN
protected _addCallbackForEvent(eventName: string, callback: Function): void;
protected _removeCallbackForEvent(eventName: string, callback: Function): void;
protected _callCallbacksForEvent(eventName: string, ...args: any[]): void;
```
Now, subclasses register callbacks using a unique event-name, and the root `Dispatcher` class handles creating `CallbackSet`s. This change also meant we could remove the `protected` (and [misleadingly named](https://github.com/palantir/plottable/issues/2968)!) `_callbacks` array.

Summary of changes:
* ` _eventToCallback` --> `_eventToProcessingFunction`
* `_setCallback()` and `_unsetCallback()` replaced by `_addCallbackForEvent()` and `_removeCallbackForEvent()`.
* `_callCallbacksForEvent()` added.
* `protected` `_callbacks` array removed.
* `private` `CallbackSet`s removed and replaced with registration-strings.

Close #2968.