### PR TITLE
Add backing <rect> to catch events on Safari.

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1368,6 +1368,7 @@ declare module Plottable {
         private _clipPathID;
         private _onAnchorCallbacks;
         private _onDetachCallbacks;
+        private static _SAFARI_EVENT_BACKING_CLASS;
         constructor();
         /**
          * Attaches the Component as a child of a given d3 Selection.

--- a/plottable.js
+++ b/plottable.js
@@ -2857,6 +2857,16 @@ var Plottable;
                 this._rootSVG.classed("plottable", true);
                 // visible overflow for firefox https://stackoverflow.com/questions/5926986/why-does-firefox-appear-to-truncate-embedded-svgs
                 this._rootSVG.style("overflow", "visible");
+                // HACKHACK: Safari fails to register events on the <svg> itself
+                var safariBacking = this._rootSVG.select("." + Component._SAFARI_EVENT_BACKING_CLASS);
+                if (safariBacking.empty()) {
+                    this._rootSVG.append("rect").classed(Component._SAFARI_EVENT_BACKING_CLASS, true).attr({
+                        x: 0,
+                        y: 0,
+                        width: "100%",
+                        height: "100%"
+                    }).style("opacity", 0);
+                }
             }
             if (this._element != null) {
                 // reattach existing element
@@ -3198,6 +3208,9 @@ var Plottable;
             this.parent(null);
             if (this._isAnchored) {
                 this._element.remove();
+                if (this._isTopLevelComponent) {
+                    this._rootSVG.select("." + Component._SAFARI_EVENT_BACKING_CLASS).remove();
+                }
             }
             this._isAnchored = false;
             this._onDetachCallbacks.callCallbacks(this);
@@ -3320,6 +3333,7 @@ var Plottable;
             "center": 0.5,
             "bottom": 1
         };
+        Component._SAFARI_EVENT_BACKING_CLASS = "safari-event-backing";
         return Component;
     })();
     Plottable.Component = Component;

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -887,8 +887,8 @@ describe("Component", () => {
       assert.strictEqual(+backing.style("opacity"), 0, "backing element is transparent");
 
       const backingElementBCR = (<Element> backing.node()).getBoundingClientRect();
-      assert.strictEqual(backingElementBCR.width, TestMethods.numAttr(svg, "width"), "backing's width is equal to the SVG's");
-      assert.strictEqual(backingElementBCR.height, TestMethods.numAttr(svg, "height"), "backing's height is equal to the SVG's");
+      assert.operator(backingElementBCR.width, ">=", TestMethods.numAttr(svg, "width"), "backing is at least as wide as the SVG");
+      assert.operator(backingElementBCR.height, ">=", TestMethods.numAttr(svg, "height"), "backing is at least as tall as the SVG");
 
       svg.remove();
     });
@@ -907,8 +907,8 @@ describe("Component", () => {
 
       const backing = svg.select(`.${backingClass}`);
       const backingElementBCR = (<Element> backing.node()).getBoundingClientRect();
-      assert.strictEqual(backingElementBCR.width, expectedWidth, "backing's width is equal to the SVG's");
-      assert.strictEqual(backingElementBCR.height, expectedHeight, "backing's height is equal to the SVG's");
+      assert.operator(backingElementBCR.width, ">=", expectedWidth, "backing is at least as wide as the SVG");
+      assert.operator(backingElementBCR.height, ">=", expectedHeight, "backing is at least as tall as the SVG");
 
       svg.remove();
     });

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -954,7 +954,7 @@ describe("Component", () => {
       const backingAsRoot = svg.select(`.${backingClass}`);
       assert.isFalse(backingAsRoot.empty(), "backing was added when Component was root");
 
-      component.detach();
+      component.detach(); // HACKHACK #3013: need to detach before re-anchoring()
       const g = svg.append("g");
       component.anchor(g);
       const backingNotAsRoot = svg.select(`.${backingClass}`);
@@ -967,7 +967,7 @@ describe("Component", () => {
       const component = new Plottable.Component();
       const svg = TestMethods.generateSVG();
       component.anchor(svg);
-      component.detach();
+      component.detach(); // HACKHACK #3013: need to detach before re-anchoring()
 
       const backingWithoutComponents = svg.select(`.${backingClass}`);
       assert.isTrue(backingWithoutComponents.empty(), "no backing with no Components");

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -946,5 +946,38 @@ describe("Component", () => {
       assert.isTrue(backing.empty(), "backing element was removed");
       svg.remove();
     });
+
+    it("doesn't add the backing even if it was previously the root Component", () => {
+      const component = new Plottable.Component();
+      const svg = TestMethods.generateSVG();
+      component.anchor(svg);
+      const backingAsRoot = svg.select(`.${backingClass}`);
+      assert.isFalse(backingAsRoot.empty(), "backing was added when Component was root");
+
+      component.detach();
+      const g = svg.append("g");
+      component.anchor(g);
+      const backingNotAsRoot = svg.select(`.${backingClass}`);
+      assert.isTrue(backingNotAsRoot.empty(), "backing element was removed");
+
+      svg.remove();
+    });
+
+    it("will add a backing even if it's not the first root Component anchored to an svg", () => {
+      const component = new Plottable.Component();
+      const svg = TestMethods.generateSVG();
+      component.anchor(svg);
+      component.detach();
+
+      const backingWithoutComponents = svg.select(`.${backingClass}`);
+      assert.isTrue(backingWithoutComponents.empty(), "no backing with no Components");
+
+      const component2 = new Plottable.Component();
+      component2.anchor(svg);
+      const backingWithNewRoot = svg.select(`.${backingClass}`);
+      assert.isFalse(backingWithNewRoot.empty(), "new root Component recreated backing");
+
+      svg.remove();
+    });
   });
 });


### PR DESCRIPTION
As referenced in https://github.com/palantir/plottable/pull/2984.

The top-level `Component` now adds an `opacity: 0` `<rect>` to the `<svg>` before anchoring, and removes it when detaching.

On **`develop`**: https://jsfiddle.net/j6c01b1e/
On **`develop-2.0`**: https://jsfiddle.net/xwpvdrns/
On **`safariEvents`**: https://jsfiddle.net/zs8tuctx/

Repro with all three event types:
* On **`develop`**: https://jsfiddle.net/324pawue/
* On **`develop-2.0`**: https://jsfiddle.net/5fhzscr9/
* On **`safariEvents`**: https://jsfiddle.net/yen85gLp/