### PR TITLE
[Axis] Restore _computedWidth and _computedHeight

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1673,6 +1673,8 @@ declare module Plottable {
         protected _scale: Scale<D, number>;
         private _formatter;
         private _orientation;
+        protected _computedWidth: number;
+        protected _computedHeight: number;
         private _endTickLength;
         private _innerTickLength;
         private _tickLabelPadding;
@@ -1697,8 +1699,8 @@ declare module Plottable {
         constructor(scale: Scale<D, number>, orientation: string);
         destroy(): void;
         protected _isHorizontal(): boolean;
-        protected _computeWidth(): any;
-        protected _computeHeight(): any;
+        protected _computeWidth(): number;
+        protected _computeHeight(): number;
         requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
         fixedHeight(): boolean;
         fixedWidth(): boolean;
@@ -1936,7 +1938,7 @@ declare module Plottable.Axes {
         private _getMostPreciseConfigurationIndex();
         orientation(): string;
         orientation(orientation: string): this;
-        protected _computeHeight(): any;
+        protected _computeHeight(): number;
         private _getIntervalLength(config);
         private _maxWidthForInterval(config);
         /**
@@ -1979,10 +1981,10 @@ declare module Plottable.Axes {
          */
         constructor(scale: QuantitativeScale<number>, orientation: string);
         protected _setup(): void;
-        protected _computeWidth(): any;
+        protected _computeWidth(): number;
         private _computeExactTextWidth();
         private _computeApproximateTextWidth();
-        protected _computeHeight(): any;
+        protected _computeHeight(): number;
         protected _getTickValues(): number[];
         protected _rescale(): void;
         renderImmediately(): this;

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -35,6 +35,8 @@ export class Axis<D> extends Component {
   protected _scale: Scale<D, number>;
   private _formatter: Formatter;
   private _orientation: string;
+  protected _computedWidth: number;
+  protected _computedHeight: number;
   private _endTickLength = 5;
   private _innerTickLength = 5;
   private _tickLabelPadding = 10;


### PR DESCRIPTION
These fields were removed in #3011, but were not actually deprecated and so should not have been removed.