### PR TITLE
remove unused cached variables

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1697,8 +1697,8 @@ declare module Plottable {
         constructor(scale: Scale<D, number>, orientation: string);
         destroy(): void;
         protected _isHorizontal(): boolean;
-        protected _computeWidth(): any;
-        protected _computeHeight(): any;
+        protected _computeWidth(): number;
+        protected _computeHeight(): number;
         requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
         fixedHeight(): boolean;
         fixedWidth(): boolean;
@@ -1936,7 +1936,7 @@ declare module Plottable.Axes {
         private _getMostPreciseConfigurationIndex();
         orientation(): string;
         orientation(orientation: string): this;
-        protected _computeHeight(): any;
+        protected _computeHeight(): number;
         private _getIntervalLength(config);
         private _maxWidthForInterval(config);
         /**
@@ -1979,10 +1979,10 @@ declare module Plottable.Axes {
          */
         constructor(scale: QuantitativeScale<number>, orientation: string);
         protected _setup(): void;
-        protected _computeWidth(): any;
+        protected _computeWidth(): number;
         private _computeExactTextWidth();
         private _computeApproximateTextWidth();
-        protected _computeHeight(): any;
+        protected _computeHeight(): number;
         protected _getTickValues(): number[];
         protected _rescale(): void;
         renderImmediately(): this;

--- a/plottable.js
+++ b/plottable.js
@@ -3518,13 +3518,11 @@ var Plottable;
         };
         Axis.prototype._computeWidth = function () {
             // to be overridden by subclass logic
-            this._computedWidth = this._maxLabelTickLength();
-            return this._computedWidth;
+            return this._maxLabelTickLength();
         };
         Axis.prototype._computeHeight = function () {
             // to be overridden by subclass logic
-            this._computedHeight = this._maxLabelTickLength();
-            return this._computedHeight;
+            return this._maxLabelTickLength();
         };
         Axis.prototype.requestedSpace = function (offeredWidth, offeredHeight) {
             var requestedWidth = 0;
@@ -4116,8 +4114,7 @@ var Plottable;
                     this._tierHeights.push(textHeight + this.tickLabelPadding() +
                         ((this._tierLabelPositions[i]) === "between" ? 0 : this._maxLabelTickLength()));
                 }
-                this._computedHeight = d3.sum(this._tierHeights);
-                return this._computedHeight;
+                return d3.sum(this._tierHeights);
             };
             Time.prototype._getIntervalLength = function (config) {
                 var startDate = this._scale.domain()[0];
@@ -4521,12 +4518,11 @@ var Plottable;
             Numeric.prototype._computeWidth = function () {
                 var maxTextWidth = this._usesTextWidthApproximation ? this._computeApproximateTextWidth() : this._computeExactTextWidth();
                 if (this._tickLabelPositioning === "center") {
-                    this._computedWidth = this._maxLabelTickLength() + this.tickLabelPadding() + maxTextWidth;
+                    return this._maxLabelTickLength() + this.tickLabelPadding() + maxTextWidth;
                 }
                 else {
-                    this._computedWidth = Math.max(this._maxLabelTickLength(), this.tickLabelPadding() + maxTextWidth);
+                    return Math.max(this._maxLabelTickLength(), this.tickLabelPadding() + maxTextWidth);
                 }
-                return this._computedWidth;
             };
             Numeric.prototype._computeExactTextWidth = function () {
                 var _this = this;
@@ -4550,12 +4546,11 @@ var Plottable;
             Numeric.prototype._computeHeight = function () {
                 var textHeight = this._measurer.measure().height;
                 if (this._tickLabelPositioning === "center") {
-                    this._computedHeight = this._maxLabelTickLength() + this.tickLabelPadding() + textHeight;
+                    return this._maxLabelTickLength() + this.tickLabelPadding() + textHeight;
                 }
                 else {
-                    this._computedHeight = Math.max(this._maxLabelTickLength(), this.tickLabelPadding() + textHeight);
+                    return Math.max(this._maxLabelTickLength(), this.tickLabelPadding() + textHeight);
                 }
-                return this._computedHeight;
             };
             Numeric.prototype._getTickValues = function () {
                 var scale = this._scale;

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -91,14 +91,12 @@ export class Axis<D> extends Component {
 
   protected _computeWidth() {
     // to be overridden by subclass logic
-    this._computedWidth = this._maxLabelTickLength();
-    return this._computedWidth;
+    return this._maxLabelTickLength();
   }
 
   protected _computeHeight() {
     // to be overridden by subclass logic
-    this._computedHeight = this._maxLabelTickLength();
-    return this._computedHeight;
+    return this._maxLabelTickLength();
   }
 
   public requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest {

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -30,12 +30,10 @@ module Plottable.Axes {
       let maxTextWidth = this._usesTextWidthApproximation ? this._computeApproximateTextWidth() : this._computeExactTextWidth();
 
       if (this._tickLabelPositioning === "center") {
-        this._computedWidth = this._maxLabelTickLength() + this.tickLabelPadding() + maxTextWidth;
+        return this._maxLabelTickLength() + this.tickLabelPadding() + maxTextWidth;
       } else {
-        this._computedWidth = Math.max(this._maxLabelTickLength(), this.tickLabelPadding() + maxTextWidth);
+        return Math.max(this._maxLabelTickLength(), this.tickLabelPadding() + maxTextWidth);
       }
-
-      return this._computedWidth;
     }
 
     private _computeExactTextWidth(): number {
@@ -63,12 +61,10 @@ module Plottable.Axes {
       let textHeight = this._measurer.measure().height;
 
       if (this._tickLabelPositioning === "center") {
-        this._computedHeight = this._maxLabelTickLength() + this.tickLabelPadding() + textHeight;
+        return this._maxLabelTickLength() + this.tickLabelPadding() + textHeight;
       } else {
-        this._computedHeight = Math.max(this._maxLabelTickLength(), this.tickLabelPadding() + textHeight);
+        return Math.max(this._maxLabelTickLength(), this.tickLabelPadding() + textHeight);
       }
-
-      return this._computedHeight;
     }
 
     protected _getTickValues() {

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -276,8 +276,7 @@ module Plottable.Axes {
                               ((this._tierLabelPositions[i]) === "between" ? 0 : this._maxLabelTickLength()));
       }
 
-      this._computedHeight = d3.sum(this._tierHeights);
-      return this._computedHeight;
+      return d3.sum(this._tierHeights);
     }
 
     private _getIntervalLength(config: TimeAxisTierConfiguration) {


### PR DESCRIPTION
`_computedHeight` and `_computedWidth` are calculated every time; these are unnecessary cached variables