### PR TITLE
[QuantitativeScale] Compute padded domain based off of candidate doma…

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -1652,8 +1652,11 @@ var Plottable;
                     }
                 });
             });
+            var originalDomain = this._getDomain();
+            this._setBackingScaleDomain(domain);
             var newMin = minExistsInExceptions ? min : this.invert(this.scale(min) - (this.scale(max) - this.scale(min)) * p);
             var newMax = maxExistsInExceptions ? max : this.invert(this.scale(max) + (this.scale(max) - this.scale(min)) * p);
+            this._setBackingScaleDomain(originalDomain);
             if (this._snappingDomainEnabled) {
                 return this._niceDomain([newMin, newMax]);
             }

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -133,6 +133,7 @@ export class QuantitativeScale<D> extends Scale<D, number> {
     if (this._padProportion === 0) {
       return domain;
     }
+
     let p = this._padProportion / 2;
     let min = domain[0];
     let max = domain[1];
@@ -149,8 +150,11 @@ export class QuantitativeScale<D> extends Scale<D, number> {
         }
       });
     });
+    const originalDomain = this._getDomain();
+    this._setBackingScaleDomain(domain);
     let newMin = minExistsInExceptions ? min : this.invert(this.scale(min) - (this.scale(max) - this.scale(min)) * p);
     let newMax = maxExistsInExceptions ? max : this.invert(this.scale(max) + (this.scale(max) - this.scale(min)) * p);
+    this._setBackingScaleDomain(originalDomain);
 
     if (this._snappingDomainEnabled) {
       return this._niceDomain([newMin, newMax]);

--- a/test/scales/modifiedLogScaleTests.ts
+++ b/test/scales/modifiedLogScaleTests.ts
@@ -113,6 +113,19 @@ describe("Scales", () => {
           "zero single-value extent was expanded to [base, -base]");
       });
 
+      it("doesn't lock up if a zero-width domain is set while there are value providers", () => {
+        scale.padProportion(0.1);
+        const provider = () => [0, 1];
+        scale.addIncludedValuesProvider(provider);
+        scale.autoDomain();
+        const originalAutoDomain = scale.domain();
+
+        scale.domain([0, 0]);
+        scale.autoDomain();
+
+        assert.deepEqual(scale.domain(), originalAutoDomain, "autodomained as expected");
+      });
+
       it("can force the minimum of the domain with domainMin()", () => {
         let requestedDomain = [-5, 5];
         scale.addIncludedValuesProvider(() => requestedDomain);

--- a/test/scales/timeScaleTests.ts
+++ b/test/scales/timeScaleTests.ts
@@ -128,7 +128,7 @@ describe("Scales", () => {
       });
 
       it("doesn't lock up if a zero-width domain is set while there are value providers", () => {
-        let scale = new Plottable.Scales.Time();
+        const scale = new Plottable.Scales.Time();
         scale.padProportion(0.1);
         const provider = () => [new Date(2000, 5, 5), new Date(2000, 5, 6)];
         scale.addIncludedValuesProvider(provider);

--- a/test/scales/timeScaleTests.ts
+++ b/test/scales/timeScaleTests.ts
@@ -126,6 +126,23 @@ describe("Scales", () => {
         assert.strictEqual(domain[0].getTime(), dayBefore.getTime(), "left side of domain was expaded by one day");
         assert.strictEqual(domain[1].getTime(), dayAfter.getTime(), "right side of domain was expaded by one day");
       });
+
+      it("doesn't lock up if a zero-width domain is set while there are value providers", () => {
+        let scale = new Plottable.Scales.Time();
+        scale.padProportion(0.1);
+        const provider = () => [new Date(2000, 5, 5), new Date(2000, 5, 6)];
+        scale.addIncludedValuesProvider(provider);
+        scale.autoDomain();
+        const originalAutoDomain = scale.domain();
+
+        scale.domain([new Date(0), new Date(0)]);
+        scale.autoDomain();
+
+        const domainAfter = scale.domain();
+
+        const numberize = (d: Date) => d.getTime();
+        assert.deepEqual(domainAfter.map(numberize), originalAutoDomain.map(numberize), "autodomained as expected");
+      });
     });
 
     describe("Domain constraints with domainMin() and domainMax()", () => {


### PR DESCRIPTION
…in, not current domain

Since scale() and invert() calls are used to compute the padded domain, the padded size
depends on the current domain and range, which causes problems if the domain or range
have been set to span zero width. This change temporarily sets the domain when computing
the padded domain.

Also took the opportunity to fix a test for snappingDomainEnabled to use less fragile numbers.

Close #3019.