### PR TITLE
[StackedArea Plot] Default to no cropping by default

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3665,6 +3665,8 @@ declare module Plottable.Plots {
          * @constructor
          */
         constructor();
+        croppedRenderingEnabled(): boolean;
+        croppedRenderingEnabled(croppedRendering: boolean): this;
         protected _getAnimator(key: string): Animator;
         protected _setup(): void;
         x(): Plots.AccessorScaleBinding<X, number>;

--- a/plottable.js
+++ b/plottable.js
@@ -9330,6 +9330,17 @@ var Plottable;
                 this._baselineValueProvider = function () { return [_this._baselineValue]; };
                 this.croppedRenderingEnabled(false);
             }
+            StackedArea.prototype.croppedRenderingEnabled = function (croppedRendering) {
+                if (croppedRendering == null) {
+                    return _super.prototype.croppedRenderingEnabled.call(this);
+                }
+                if (croppedRendering === true) {
+                    // HACKHACK #3032: cropped rendering doesn't currently work correctly on StackedArea
+                    Plottable.Utils.Window.warn("Warning: Stacked Area Plot does not support downsampling.");
+                    return this;
+                }
+                return _super.prototype.croppedRenderingEnabled.call(this, croppedRendering);
+            };
             StackedArea.prototype._getAnimator = function (key) {
                 return new Plottable.Animators.Null();
             };

--- a/plottable.js
+++ b/plottable.js
@@ -9336,7 +9336,7 @@ var Plottable;
                 }
                 if (croppedRendering === true) {
                     // HACKHACK #3032: cropped rendering doesn't currently work correctly on StackedArea
-                    Plottable.Utils.Window.warn("Warning: Stacked Area Plot does not support downsampling.");
+                    Plottable.Utils.Window.warn("Warning: Stacked Area Plot does not support cropped rendering.");
                     return this;
                 }
                 return _super.prototype.croppedRenderingEnabled.call(this, croppedRendering);

--- a/plottable.js
+++ b/plottable.js
@@ -9328,6 +9328,7 @@ var Plottable;
                 this._stackingResult = new Plottable.Utils.Map();
                 this._stackedExtent = [];
                 this._baselineValueProvider = function () { return [_this._baselineValue]; };
+                this.croppedRenderingEnabled(false);
             }
             StackedArea.prototype._getAnimator = function (key) {
                 return new Plottable.Animators.Null();

--- a/src/plots/stackedAreaPlot.ts
+++ b/src/plots/stackedAreaPlot.ts
@@ -29,7 +29,7 @@ module Plottable.Plots {
 
       if (croppedRendering === true) {
         // HACKHACK #3032: cropped rendering doesn't currently work correctly on StackedArea
-        Utils.Window.warn("Warning: Stacked Area Plot does not support downsampling.");
+        Utils.Window.warn("Warning: Stacked Area Plot does not support cropped rendering.");
         return this;
       }
 

--- a/src/plots/stackedAreaPlot.ts
+++ b/src/plots/stackedAreaPlot.ts
@@ -20,6 +20,22 @@ module Plottable.Plots {
       this.croppedRenderingEnabled(false);
     }
 
+    public croppedRenderingEnabled(): boolean;
+    public croppedRenderingEnabled(croppedRendering: boolean): this;
+    public croppedRenderingEnabled(croppedRendering?: boolean): any {
+      if (croppedRendering == null) {
+        return super.croppedRenderingEnabled();
+      }
+
+      if (croppedRendering === true) {
+        // HACKHACK #3032: cropped rendering doesn't currently work correctly on StackedArea
+        Utils.Window.warn("Warning: Stacked Area Plot does not support downsampling.");
+        return this;
+      }
+
+      return super.croppedRenderingEnabled(croppedRendering);
+    }
+
     protected _getAnimator(key: string): Animator {
       return new Animators.Null();
     }

--- a/src/plots/stackedAreaPlot.ts
+++ b/src/plots/stackedAreaPlot.ts
@@ -17,6 +17,7 @@ module Plottable.Plots {
       this._stackingResult = new Utils.Map<Dataset, Utils.Map<string, Utils.Stacking.StackedDatum>>();
       this._stackedExtent = [];
       this._baselineValueProvider = () => [this._baselineValue];
+      this.croppedRenderingEnabled(false);
     }
 
     protected _getAnimator(key: string): Animator {


### PR DESCRIPTION
Cropped rendering on `StackedArea` is currently broken (as per #3032), so disabling it by default for now until the algorithm can be fixed.