### PR TITLE
[Plots.Scatter] "reset" path attribute is no longer empty string

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -8003,7 +8003,8 @@ var Plottable;
                 var drawSteps = [];
                 if (this._animateOnNextRender()) {
                     var resetAttrToProjector = this._generateAttrToProjector();
-                    resetAttrToProjector["d"] = function () { return ""; };
+                    var symbolProjector = Plottable.Plot._scaledAccessor(this.symbol());
+                    resetAttrToProjector["d"] = function (datum, index, dataset) { return symbolProjector(datum, index, dataset)(0); };
                     drawSteps.push({ attrToProjector: resetAttrToProjector, animator: this._getAnimator(Plots.Animator.RESET) });
                 }
                 drawSteps.push({ attrToProjector: this._generateAttrToProjector(), animator: this._getAnimator(Plots.Animator.MAIN) });

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -82,7 +82,9 @@ module Plottable.Plots {
       let drawSteps: Drawers.DrawStep[] = [];
       if (this._animateOnNextRender()) {
         let resetAttrToProjector = this._generateAttrToProjector();
-        resetAttrToProjector["d"] = () => "";
+
+        let symbolProjector = Plot._scaledAccessor(this.symbol());
+        resetAttrToProjector["d"] = (datum: any, index: number, dataset: Dataset) => symbolProjector(datum, index, dataset)(0);
         drawSteps.push({attrToProjector: resetAttrToProjector, animator: this._getAnimator(Plots.Animator.RESET)});
       }
 

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -26,4 +26,19 @@ module Mocks {
       return true;
     }
   }
+
+  export class NoOpAnimator implements Plottable.Animator {
+    /*
+     * A do-nothing Animator.
+     * Useful for testing the reset states of Plots by blanking the MAIN Animator.
+     */
+
+    public totalTime(selection: any) {
+      return 0;
+    }
+
+    public animate(selection: d3.Selection<any>) {
+      return selection;
+    }
+  }
 }

--- a/test/plots/scatterPlotTests.ts
+++ b/test/plots/scatterPlotTests.ts
@@ -57,10 +57,11 @@ describe("Plots", () => {
 
         plot.renderTo(svg);
 
-        const expectedPathString = TestMethods.normalizePath(symbolFactory(0));
-        const path = plot.content().select("path");
-        const normalizedActualPath = TestMethods.normalizePath(path.attr("d"));
-        assert.strictEqual(normalizedActualPath, expectedPathString, "path string is initialized with the correct symbol and a size of 0");
+        const pathString = plot.content().select("path").attr("d");
+        const zeroSizePathString = symbolFactory(0);
+        const normalizingPath = svg.append("path"); // generated and normalized paths don't align on all browsers
+        const expectedPathString = normalizingPath.attr("d", zeroSizePathString).attr("d");
+        assert.strictEqual(pathString, expectedPathString, "path string is initialized with the correct symbol and a size of 0");
       });
 
       it.skip("correctly handles NaN, undefined, Infinity, and non-number x and y values", () => {

--- a/test/plots/scatterPlotTests.ts
+++ b/test/plots/scatterPlotTests.ts
@@ -19,11 +19,17 @@ describe("Plots", () => {
             .y((d: any) => d.y, yScale);
       });
 
+      afterEach(function() {
+        if (this.currentTest.state === "passed") {
+          plot.destroy();
+          svg.remove();
+        }
+      });
+
       it("renders correctly with no data", () => {
         assert.doesNotThrow(() => plot.renderTo(svg), Error);
         assert.strictEqual(plot.width(), SVG_WIDTH, "was allocated width");
         assert.strictEqual(plot.height(), SVG_HEIGHT, "was allocated height");
-        svg.remove();
       });
 
       it("is initialized correctly", () => {
@@ -34,8 +40,6 @@ describe("Plots", () => {
         assert.isDefined(plot.animator(Plottable.Plots.Animator.MAIN), "main animator is defined");
         assert.isDefined(plot.size(), "size() is defined");
         assert.isDefined(plot.symbol(), "symbol() is defined");
-
-        svg.remove();
       });
 
       it("initially draws the points with a size of 0 when resetting", () => {
@@ -57,9 +61,6 @@ describe("Plots", () => {
         const path = plot.content().select("path");
         const normalizedActualPath = TestMethods.normalizePath(path.attr("d"));
         assert.strictEqual(normalizedActualPath, expectedPathString, "path string is initialized with the correct symbol and a size of 0");
-
-        plot.destroy();
-        svg.remove();
       });
 
       it.skip("correctly handles NaN, undefined, Infinity, and non-number x and y values", () => {
@@ -123,7 +124,6 @@ describe("Plots", () => {
         dataset.data(dataWithError);
         assert.strictEqual(plot.selections().size(), 4, "only 4 data points are drawn when one of the x values is \"abc\"");
         assert.lengthOf(plot.entities(), 4, "only 4 Entities returned when one of the x values is \"abc\"");
-        svg.remove();
       });
     });
 

--- a/test/plots/scatterPlotTests.ts
+++ b/test/plots/scatterPlotTests.ts
@@ -38,6 +38,30 @@ describe("Plots", () => {
         svg.remove();
       });
 
+      it("initially draws the points with a size of 0 when resetting", () => {
+        const data = [
+          { x: 0, y: 0 }
+        ];
+        const dataset = new Plottable.Dataset(data);
+        plot.addDataset(dataset);
+
+        const symbolFactory = Plottable.SymbolFactories.square();
+        plot.symbol(() => symbolFactory);
+
+        plot.animator(Plottable.Plots.Animator.MAIN, new Mocks.NoOpAnimator());
+        plot.animated(true);
+
+        plot.renderTo(svg);
+
+        const expectedPathString = TestMethods.normalizePath(symbolFactory(0));
+        const path = plot.content().select("path");
+        const normalizedActualPath = TestMethods.normalizePath(path.attr("d"));
+        assert.strictEqual(normalizedActualPath, expectedPathString, "path string is initialized with the correct symbol and a size of 0");
+
+        plot.destroy();
+        svg.remove();
+      });
+
       it.skip("correctly handles NaN, undefined, Infinity, and non-number x and y values", () => {
         let data = [
           { x: 0.0, y: 0.0 },


### PR DESCRIPTION
Instead, it uses the `SymbolFactory` with a size of `0`. This means that animation now work properly, with the points "growing" to their final size.

**Before**: https://jsfiddle.net/kejm7xuy/
**After**: https://jsfiddle.net/7vb5ozv2/

Close #3037.
