### PR TITLE
ModifiedLogScale Documentation Update

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -916,18 +916,28 @@ declare module Plottable.Scales {
          * As it approaches 0, it gradually becomes linear.
          * Consequently, a ModifiedLog Scale can process 0 and negative numbers.
          *
+         * For x >= base, scale(x) = log(x).
+         *
+         * For 0 < x < base, scale(x) will become more and more
+         * linear as it approaches 0.
+         *
+         * At x == 0, scale(x) == 0.
+         *
+         * For negative values, scale(-x) = -scale(x).
+         *
+         * The range and domain for the scale should also be set, using the
+         * range() and domain() accessors, respectively.
+         *
+         * For `range`, provide a two-element array giving the minimum and
+         * maximum of values produced when scaling.
+         *
+         * For `domain` provide a two-element array giving the minimum and
+         * maximum of the values that will be scaled.
+         *
          * @constructor
          * @param {number} [base=10]
          *        The base of the log. Must be > 1.
          *
-         *        For x <= base, scale(x) = log(x).
-         *
-         *        For 0 < x < base, scale(x) will become more and more
-         *        linear as it approaches 0.
-         *
-         *        At x == 0, scale(x) == 0.
-         *
-         *        For negative values, scale(-x) = -scale(x).
          */
         constructor(base?: number);
         /**

--- a/src/scales/modifiedLogScale.ts
+++ b/src/scales/modifiedLogScale.ts
@@ -10,18 +10,28 @@ module Plottable.Scales {
      * As it approaches 0, it gradually becomes linear.
      * Consequently, a ModifiedLog Scale can process 0 and negative numbers.
      *
+     * For x >= base, scale(x) = log(x).
+     *
+     * For 0 < x < base, scale(x) will become more and more
+     * linear as it approaches 0.
+     *
+     * At x == 0, scale(x) == 0.
+     *
+     * For negative values, scale(-x) = -scale(x).
+     *
+     * The range and domain for the scale should also be set, using the 
+     * range() and domain() accessors, respectively.
+     *
+     * For `range`, provide a two-element array giving the minimum and
+     * maximum of values produced when scaling.
+     *
+     * For `domain` provide a two-element array giving the minimum and
+     * maximum of the values that will be scaled.
+     *
      * @constructor
      * @param {number} [base=10]
      *        The base of the log. Must be > 1.
      *
-     *        For x <= base, scale(x) = log(x).
-     *
-     *        For 0 < x < base, scale(x) will become more and more
-     *        linear as it approaches 0.
-     *
-     *        At x == 0, scale(x) == 0.
-     *
-     *        For negative values, scale(-x) = -scale(x).
      */
     constructor(base = 10) {
       super();


### PR DESCRIPTION
For #3057 - Clarified usage of base, range and domain parameters.

It wasn't clear to me how to document the actual domain/range methods. they are defined in scale.ts and I got compilation errors when overriding them in modifiedLogScale.ts. Rather than figure that out, I just added the docs to the constructor.

I also moved the documentation the `base` parameter because it did not show up in the API documentation hosted http://plottablejs.org/docs/classes/plottable.scales.modifiedlog.html#constructor.
