### PR TITLE
Bugfix/bar chart modified log axis

### DIFF
--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -732,7 +732,8 @@ declare module Plottable {
         domain(values: D[]): this;
         protected _getDomain(): D[];
         protected _setDomain(values: D[]): void;
-        protected _setBackingScaleDomain(values: D[]): void;
+        protected _backingScaleDomain(): D[];
+        protected _backingScaleDomain(values: D[]): this;
         /**
          * Gets the range.
          *
@@ -897,7 +898,8 @@ declare module Plottable.Scales {
         protected _expandSingleValueDomain(singleValueDomain: number[]): number[];
         scale(value: number): number;
         protected _getDomain(): number[];
-        protected _setBackingScaleDomain(values: number[]): void;
+        protected _backingScaleDomain(): number[];
+        protected _backingScaleDomain(values: number[]): this;
         protected _getRange(): number[];
         protected _setRange(values: number[]): void;
         invert(value: number): number;
@@ -954,7 +956,8 @@ declare module Plottable.Scales {
         invert(x: number): number;
         protected _getDomain(): number[];
         protected _setDomain(values: number[]): void;
-        protected _setBackingScaleDomain(values: number[]): void;
+        protected _backingScaleDomain(): number[];
+        protected _backingScaleDomain(values: number[]): this;
         ticks(): number[];
         /**
          * Return an appropriate number of ticks from lower to upper.
@@ -1059,7 +1062,8 @@ declare module Plottable.Scales {
         outerPadding(outerPadding: number): this;
         scale(value: string): number;
         protected _getDomain(): string[];
-        protected _setBackingScaleDomain(values: string[]): void;
+        protected _backingScaleDomain(): string[];
+        protected _backingScaleDomain(values: string[]): this;
         protected _getRange(): number[];
         protected _setRange(values: number[]): void;
     }
@@ -1092,7 +1096,8 @@ declare module Plottable.Scales {
          */
         scale(value: string): string;
         protected _getDomain(): string[];
-        protected _setBackingScaleDomain(values: string[]): void;
+        protected _backingScaleDomain(): string[];
+        protected _backingScaleDomain(values: string[]): this;
         protected _getRange(): string[];
         protected _setRange(values: string[]): void;
     }
@@ -1119,7 +1124,8 @@ declare module Plottable.Scales {
         protected _expandSingleValueDomain(singleValueDomain: Date[]): Date[];
         scale(value: Date): number;
         protected _getDomain(): Date[];
-        protected _setBackingScaleDomain(values: Date[]): void;
+        protected _backingScaleDomain(): Date[];
+        protected _backingScaleDomain(values: Date[]): this;
         protected _getRange(): number[];
         protected _setRange(values: number[]): void;
         invert(value: number): Date;
@@ -1159,7 +1165,8 @@ declare module Plottable.Scales {
         autoDomain(): this;
         scale(value: number): string;
         protected _getDomain(): number[];
-        protected _setBackingScaleDomain(values: number[]): void;
+        protected _backingScaleDomain(): number[];
+        protected _backingScaleDomain(values: number[]): this;
         protected _getRange(): string[];
         protected _setRange(range: string[]): void;
     }

--- a/plottable.js
+++ b/plottable.js
@@ -1479,13 +1479,13 @@ var Plottable;
         Scale.prototype._setDomain = function (values) {
             if (!this._domainModificationInProgress) {
                 this._domainModificationInProgress = true;
-                this._setBackingScaleDomain(values);
+                this._backingScaleDomain(values);
                 this._dispatchUpdate();
                 this._domainModificationInProgress = false;
             }
         };
-        Scale.prototype._setBackingScaleDomain = function (values) {
-            throw new Error("Subclasses should override _setBackingDomain");
+        Scale.prototype._backingScaleDomain = function (values) {
+            throw new Error("Subclasses should override _backingDomain");
         };
         Scale.prototype.range = function (values) {
             if (values == null) {
@@ -1652,11 +1652,11 @@ var Plottable;
                     }
                 });
             });
-            var originalDomain = this._getDomain();
-            this._setBackingScaleDomain(domain);
+            var originalDomain = this._backingScaleDomain();
+            this._backingScaleDomain(domain);
             var newMin = minExistsInExceptions ? min : this.invert(this.scale(min) - (this.scale(max) - this.scale(min)) * p);
             var newMax = maxExistsInExceptions ? max : this.invert(this.scale(max) + (this.scale(max) - this.scale(min)) * p);
-            this._setBackingScaleDomain(originalDomain);
+            this._backingScaleDomain(originalDomain);
             if (this._snappingDomainEnabled) {
                 return this._niceDomain([newMin, newMax]);
             }
@@ -1787,10 +1787,16 @@ var Plottable;
                 return this._d3Scale(value);
             };
             Linear.prototype._getDomain = function () {
-                return this._d3Scale.domain();
+                return this._backingScaleDomain();
             };
-            Linear.prototype._setBackingScaleDomain = function (values) {
-                this._d3Scale.domain(values);
+            Linear.prototype._backingScaleDomain = function (values) {
+                if (values == null) {
+                    return this._d3Scale.domain();
+                }
+                else {
+                    this._d3Scale.domain(values);
+                    return this;
+                }
             };
             Linear.prototype._getRange = function () {
                 return this._d3Scale.range();
@@ -1899,8 +1905,14 @@ var Plottable;
                 var transformedDomain = [this._adjustedLog(values[0]), this._adjustedLog(values[1])];
                 _super.prototype._setDomain.call(this, transformedDomain);
             };
-            ModifiedLog.prototype._setBackingScaleDomain = function (values) {
-                this._d3Scale.domain(values);
+            ModifiedLog.prototype._backingScaleDomain = function (values) {
+                if (values == null) {
+                    return this._d3Scale.domain();
+                }
+                else {
+                    this._d3Scale.domain(values);
+                    return this;
+                }
             };
             ModifiedLog.prototype.ticks = function () {
                 // Say your domain is [-100, 100] and your pivot is 10.
@@ -2089,11 +2101,17 @@ var Plottable;
                 return this._d3Scale(value) + this.rangeBand() / 2;
             };
             Category.prototype._getDomain = function () {
-                return this._d3Scale.domain();
+                return this._backingScaleDomain();
             };
-            Category.prototype._setBackingScaleDomain = function (values) {
-                this._d3Scale.domain(values);
-                this._setBands();
+            Category.prototype._backingScaleDomain = function (values) {
+                if (values == null) {
+                    return this._d3Scale.domain();
+                }
+                else {
+                    this._d3Scale.domain(values);
+                    this._setBands();
+                    return this;
+                }
             };
             Category.prototype._getRange = function () {
                 return this._range;
@@ -2199,10 +2217,16 @@ var Plottable;
                 return Plottable.Utils.Color.lightenColor(color, modifyFactor);
             };
             Color.prototype._getDomain = function () {
-                return this._d3Scale.domain();
+                return this._backingScaleDomain();
             };
-            Color.prototype._setBackingScaleDomain = function (values) {
-                this._d3Scale.domain(values);
+            Color.prototype._backingScaleDomain = function (values) {
+                if (values == null) {
+                    return this._d3Scale.domain();
+                }
+                else {
+                    this._d3Scale.domain(values);
+                    return this;
+                }
             };
             Color.prototype._getRange = function () {
                 return this._d3Scale.range();
@@ -2274,10 +2298,16 @@ var Plottable;
                 return this._d3Scale(value);
             };
             Time.prototype._getDomain = function () {
-                return this._d3Scale.domain();
+                return this._backingScaleDomain();
             };
-            Time.prototype._setBackingScaleDomain = function (values) {
-                this._d3Scale.domain(values);
+            Time.prototype._backingScaleDomain = function (values) {
+                if (values == null) {
+                    return this._d3Scale.domain();
+                }
+                else {
+                    this._d3Scale.domain(values);
+                    return this;
+                }
             };
             Time.prototype._getRange = function () {
                 return this._d3Scale.range();
@@ -2411,10 +2441,16 @@ var Plottable;
                 return this._d3Scale(value);
             };
             InterpolatedColor.prototype._getDomain = function () {
-                return this._d3Scale.domain();
+                return this._backingScaleDomain();
             };
-            InterpolatedColor.prototype._setBackingScaleDomain = function (values) {
-                this._d3Scale.domain(values);
+            InterpolatedColor.prototype._backingScaleDomain = function (values) {
+                if (values == null) {
+                    return this._d3Scale.domain();
+                }
+                else {
+                    this._d3Scale.domain(values);
+                    return this;
+                }
             };
             InterpolatedColor.prototype._getRange = function () {
                 return this._colorRange;

--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -135,12 +135,19 @@ module Plottable.Scales {
     }
 
     protected _getDomain() {
-      return this._d3Scale.domain();
+      return this._backingScaleDomain();
     }
 
-    protected _setBackingScaleDomain(values: string[]) {
-      this._d3Scale.domain(values);
-      this._setBands();
+    protected _backingScaleDomain(): string[]
+    protected _backingScaleDomain(values: string[]): this
+    protected _backingScaleDomain(values?: string[]): any {
+      if (values == null) {
+        return this._d3Scale.domain();
+      } else {
+        this._d3Scale.domain(values);
+        this._setBands();
+        return this;
+      }
     }
 
     protected _getRange() {

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -103,11 +103,18 @@ module Plottable.Scales {
     }
 
     protected _getDomain() {
-      return this._d3Scale.domain();
+      return this._backingScaleDomain();
     }
 
-    protected _setBackingScaleDomain(values: string[]) {
-      this._d3Scale.domain(values);
+    protected _backingScaleDomain(): string[]
+    protected _backingScaleDomain(values: string[]): this
+    protected _backingScaleDomain(values?: string[]): any {
+      if (values == null) {
+        return this._d3Scale.domain();
+      } else {
+        this._d3Scale.domain(values);
+        return this;
+      }
     }
 
     protected _getRange() {

--- a/src/scales/interpolatedColorScale.ts
+++ b/src/scales/interpolatedColorScale.ts
@@ -135,11 +135,18 @@ module Plottable.Scales {
     }
 
     protected _getDomain() {
-      return this._d3Scale.domain();
+      return this._backingScaleDomain();
     }
 
-    protected _setBackingScaleDomain(values: number[]) {
-      this._d3Scale.domain(values);
+    protected _backingScaleDomain(): number[]
+    protected _backingScaleDomain(values: number[]): this
+    protected _backingScaleDomain(values?: number[]): any {
+      if (values == null) {
+        return this._d3Scale.domain();
+      } else {
+        this._d3Scale.domain(values);
+        return this;
+      }
     }
 
     protected _getRange() {

--- a/src/scales/linearScale.ts
+++ b/src/scales/linearScale.ts
@@ -26,11 +26,18 @@ module Plottable.Scales {
     }
 
     protected _getDomain() {
-      return this._d3Scale.domain();
+      return this._backingScaleDomain();
     }
 
-    protected _setBackingScaleDomain(values: number[]) {
-      this._d3Scale.domain(values);
+    protected _backingScaleDomain(): number[]
+    protected _backingScaleDomain(values: number[]): this
+    protected _backingScaleDomain(values?: number[]): any {
+      if (values == null) {
+        return this._d3Scale.domain();
+      } else {
+        this._d3Scale.domain(values);
+        return this;
+      }
     }
 
     protected _getRange() {

--- a/src/scales/modifiedLogScale.ts
+++ b/src/scales/modifiedLogScale.ts
@@ -19,7 +19,7 @@ module Plottable.Scales {
      *
      * For negative values, scale(-x) = -scale(x).
      *
-     * The range and domain for the scale should also be set, using the 
+     * The range and domain for the scale should also be set, using the
      * range() and domain() accessors, respectively.
      *
      * For `range`, provide a two-element array giving the minimum and
@@ -98,8 +98,15 @@ module Plottable.Scales {
       super._setDomain(transformedDomain);
     }
 
-    protected _setBackingScaleDomain(values: number[]) {
-      this._d3Scale.domain(values);
+    protected _backingScaleDomain(): number[]
+    protected _backingScaleDomain(values: number[]): this
+    protected _backingScaleDomain(values?: number[]): any {
+      if (values == null) {
+        return this._d3Scale.domain();
+      } else {
+        this._d3Scale.domain(values);
+        return this;
+      }
     }
 
     public ticks(): number[] {

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -150,11 +150,11 @@ export class QuantitativeScale<D> extends Scale<D, number> {
         }
       });
     });
-    const originalDomain = this._getDomain();
-    this._setBackingScaleDomain(domain);
+    const originalDomain = this._backingScaleDomain();
+    this._backingScaleDomain(domain);
     let newMin = minExistsInExceptions ? min : this.invert(this.scale(min) - (this.scale(max) - this.scale(min)) * p);
     let newMax = maxExistsInExceptions ? max : this.invert(this.scale(max) + (this.scale(max) - this.scale(min)) * p);
-    this._setBackingScaleDomain(originalDomain);
+    this._backingScaleDomain(originalDomain);
 
     if (this._snappingDomainEnabled) {
       return this._niceDomain([newMin, newMax]);

--- a/src/scales/scale.ts
+++ b/src/scales/scale.ts
@@ -151,14 +151,16 @@ export class Scale<D, R> {
   protected _setDomain(values: D[]) {
     if (!this._domainModificationInProgress) {
       this._domainModificationInProgress = true;
-      this._setBackingScaleDomain(values);
+      this._backingScaleDomain(values);
       this._dispatchUpdate();
       this._domainModificationInProgress = false;
     }
   }
 
-  protected _setBackingScaleDomain(values: D[]) {
-    throw new Error("Subclasses should override _setBackingDomain");
+  protected _backingScaleDomain(): D[]
+  protected _backingScaleDomain(values: D[]): this
+  protected _backingScaleDomain(values?: D[]): any {
+    throw new Error("Subclasses should override _backingDomain");
   }
 
   /**

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -57,11 +57,18 @@ module Plottable.Scales {
     }
 
     protected _getDomain() {
-      return this._d3Scale.domain();
+      return this._backingScaleDomain();
     }
 
-    protected _setBackingScaleDomain(values: Date[]) {
-      this._d3Scale.domain(values);
+    protected _backingScaleDomain(): Date[]
+    protected _backingScaleDomain(values: Date[]): this
+    protected _backingScaleDomain(values?: Date[]): any {
+      if (values == null) {
+        return this._d3Scale.domain();
+      } else {
+        this._d3Scale.domain(values);
+        return this;
+      }
     }
 
     protected _getRange() {

--- a/test/scales/scaleTests.ts
+++ b/test/scales/scaleTests.ts
@@ -17,11 +17,18 @@ describe("Scales", () => {
       }
 
       protected _getDomain() {
-        return this._domain;
+        return this._backingScaleDomain();
       }
 
-      protected _setBackingScaleDomain(values: D[]) {
-        this._domain = values;
+      protected _backingScaleDomain(): D[]
+      protected _backingScaleDomain(values: D[]): this
+      protected _backingScaleDomain(values?: D[]): any {
+        if (values == null) {
+          return this._domain;
+        } else {
+          this._domain = values;
+          return this;
+        }
       }
 
       protected _getRange() {


### PR DESCRIPTION
`ModifiedScale._getDomain` was returning untransformed domain, which is different than backing domain.

I introduce `Scale._backingDomain`, which returns and sets backing domain.

JsFiddle to verify fix - https://jsfiddle.net/0vrx17uu/1/

Closes #3045.
