### PR TITLE
Rename LinePlot#entityNearest to entityNearestByXThenY

### DIFF
--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -3611,7 +3611,7 @@ declare namespace Plottable.Plots {
          * @param {Point} queryPoint
          * @returns {PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
          */
-        entityNearest(queryPoint: Point): PlotEntity;
+        entityNearestByXThenY(queryPoint: Point): PlotEntity;
         protected _propertyProjectors(): AttributeToProjector;
         protected _constructLineProjector(xProjector: Projector, yProjector: Projector): (datum: any, index: number, dataset: Dataset) => string;
         protected _getDataToDraw(): Utils.Map<Dataset, any[]>;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3610,7 +3610,7 @@ declare namespace Plottable.Plots {
          * @param {Point} queryPoint
          * @returns {PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
          */
-        entityNearest(queryPoint: Point): PlotEntity;
+        entityNearestByXThenY(queryPoint: Point): PlotEntity;
         protected _propertyProjectors(): AttributeToProjector;
         protected _constructLineProjector(xProjector: Projector, yProjector: Projector): (datum: any, index: number, dataset: Dataset) => string;
         protected _getDataToDraw(): Utils.Map<Dataset, any[]>;

--- a/plottable.js
+++ b/plottable.js
@@ -9020,7 +9020,7 @@ var Plottable;
              * @param {Point} queryPoint
              * @returns {PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
              */
-            Line.prototype.entityNearest = function (queryPoint) {
+            Line.prototype.entityNearestByXThenY = function (queryPoint) {
                 var _this = this;
                 var minXDist = Infinity;
                 var minYDist = Infinity;

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -344,7 +344,7 @@ namespace Plottable.Plots {
      * @param {Point} queryPoint
      * @returns {PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
      */
-    public entityNearest(queryPoint: Point): PlotEntity {
+    public entityNearestByXThenY(queryPoint: Point): PlotEntity {
       let minXDist = Infinity;
       let minYDist = Infinity;
       let closest: PlotEntity;


### PR DESCRIPTION
Fixes #3070.

LinePlot now uses the default euclidean distance algorithm for nearest entities.
The old X-then-Y algorithm is preserved in this newly renamed method.
