### PR TITLE
Add onPan and onZoom to the PanZoom interaction

### DIFF
--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -4597,8 +4597,8 @@ declare namespace Plottable.Interactions {
         private _touchCancelCallback;
         private _minDomainExtents;
         private _maxDomainExtents;
-        private _panCallbacks;
-        private _zoomCallbacks;
+        private _panEndCallbacks;
+        private _zoomEndCallbacks;
         /**
          * A PanZoom Interaction updates the domains of an x-scale and/or a y-scale
          * in response to the user panning or zooming.
@@ -4717,28 +4717,28 @@ declare namespace Plottable.Interactions {
          * @param {PanCallback} callback
          * @returns {Event} The calling PanZoom Interaction.
          */
-        onPan(callback: PanCallback): this;
+        onPanEnd(callback: PanCallback): this;
         /**
          * Removes a callback that would be called when panning ends.
          *
          * @param {PanCallback} callback
          * @returns {Event} The calling PanZoom Interaction.
          */
-        offPan(callback: PanCallback): this;
+        offPanEnd(callback: PanCallback): this;
         /**
          * Adds a callback to be called when zooming ends.
          *
          * @param {ZoomCallback} callback
          * @returns {Event} The calling PanZoom Interaction.
          */
-        onZoom(callback: ZoomCallback): this;
+        onZoomEnd(callback: ZoomCallback): this;
         /**
          * Removes a callback that would be called when zooming ends.
          *
          * @param {ZoomCallback} callback
          * @returns {Event} The calling PanZoom Interaction.
          */
-        offZoom(callback: ZoomCallback): this;
+        offZoomEnd(callback: ZoomCallback): this;
     }
 }
 declare namespace Plottable {

--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -4577,8 +4577,8 @@ declare namespace Plottable.Interactions {
     }
 }
 declare namespace Plottable.Interactions {
-    type PanCallback = (e: Event) => void;
-    type ZoomCallback = (e: Event) => void;
+    type PanCallback = () => void;
+    type ZoomCallback = () => void;
     class PanZoom extends Interaction {
         /**
          * The number of pixels occupied in a line.
@@ -4715,28 +4715,28 @@ declare namespace Plottable.Interactions {
          * Adds a callback to be called when panning ends.
          *
          * @param {PanCallback} callback
-         * @returns {Event} The calling PanZoom Interaction.
+         * @returns {this} The calling PanZoom Interaction.
          */
         onPanEnd(callback: PanCallback): this;
         /**
          * Removes a callback that would be called when panning ends.
          *
          * @param {PanCallback} callback
-         * @returns {Event} The calling PanZoom Interaction.
+         * @returns {this} The calling PanZoom Interaction.
          */
         offPanEnd(callback: PanCallback): this;
         /**
          * Adds a callback to be called when zooming ends.
          *
          * @param {ZoomCallback} callback
-         * @returns {Event} The calling PanZoom Interaction.
+         * @returns {this} The calling PanZoom Interaction.
          */
         onZoomEnd(callback: ZoomCallback): this;
         /**
          * Removes a callback that would be called when zooming ends.
          *
          * @param {ZoomCallback} callback
-         * @returns {Event} The calling PanZoom Interaction.
+         * @returns {this} The calling PanZoom Interaction.
          */
         offZoomEnd(callback: ZoomCallback): this;
     }

--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -4577,6 +4577,8 @@ declare namespace Plottable.Interactions {
     }
 }
 declare namespace Plottable.Interactions {
+    type PanCallback = (e: Event) => void;
+    type ZoomCallback = (e: Event) => void;
     class PanZoom extends Interaction {
         /**
          * The number of pixels occupied in a line.
@@ -4595,6 +4597,8 @@ declare namespace Plottable.Interactions {
         private _touchCancelCallback;
         private _minDomainExtents;
         private _maxDomainExtents;
+        private _panCallbacks;
+        private _zoomCallbacks;
         /**
          * A PanZoom Interaction updates the domains of an x-scale and/or a y-scale
          * in response to the user panning or zooming.
@@ -4707,6 +4711,34 @@ declare namespace Plottable.Interactions {
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
         maxDomainExtent<D>(quantitativeScale: QuantitativeScale<D>, maxDomainExtent: D): this;
+        /**
+         * Adds a callback to be called when panning ends.
+         *
+         * @param {PanCallback} callback
+         * @returns {Event} The calling PanZoom Interaction.
+         */
+        onPan(callback: PanCallback): this;
+        /**
+         * Removes a callback that would be called when panning ends.
+         *
+         * @param {PanCallback} callback
+         * @returns {Event} The calling PanZoom Interaction.
+         */
+        offPan(callback: PanCallback): this;
+        /**
+         * Adds a callback to be called when zooming ends.
+         *
+         * @param {ZoomCallback} callback
+         * @returns {Event} The calling PanZoom Interaction.
+         */
+        onZoom(callback: ZoomCallback): this;
+        /**
+         * Removes a callback that would be called when zooming ends.
+         *
+         * @param {ZoomCallback} callback
+         * @returns {Event} The calling PanZoom Interaction.
+         */
+        offZoom(callback: ZoomCallback): this;
     }
 }
 declare namespace Plottable {

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -4576,8 +4576,8 @@ declare namespace Plottable.Interactions {
     }
 }
 declare namespace Plottable.Interactions {
-    type PanCallback = (e: Event) => void;
-    type ZoomCallback = (e: Event) => void;
+    type PanCallback = () => void;
+    type ZoomCallback = () => void;
     class PanZoom extends Interaction {
         /**
          * The number of pixels occupied in a line.
@@ -4714,28 +4714,28 @@ declare namespace Plottable.Interactions {
          * Adds a callback to be called when panning ends.
          *
          * @param {PanCallback} callback
-         * @returns {Event} The calling PanZoom Interaction.
+         * @returns {this} The calling PanZoom Interaction.
          */
         onPanEnd(callback: PanCallback): this;
         /**
          * Removes a callback that would be called when panning ends.
          *
          * @param {PanCallback} callback
-         * @returns {Event} The calling PanZoom Interaction.
+         * @returns {this} The calling PanZoom Interaction.
          */
         offPanEnd(callback: PanCallback): this;
         /**
          * Adds a callback to be called when zooming ends.
          *
          * @param {ZoomCallback} callback
-         * @returns {Event} The calling PanZoom Interaction.
+         * @returns {this} The calling PanZoom Interaction.
          */
         onZoomEnd(callback: ZoomCallback): this;
         /**
          * Removes a callback that would be called when zooming ends.
          *
          * @param {ZoomCallback} callback
-         * @returns {Event} The calling PanZoom Interaction.
+         * @returns {this} The calling PanZoom Interaction.
          */
         offZoomEnd(callback: ZoomCallback): this;
     }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -4576,6 +4576,8 @@ declare namespace Plottable.Interactions {
     }
 }
 declare namespace Plottable.Interactions {
+    type PanCallback = (e: Event) => void;
+    type ZoomCallback = (e: Event) => void;
     class PanZoom extends Interaction {
         /**
          * The number of pixels occupied in a line.
@@ -4594,6 +4596,8 @@ declare namespace Plottable.Interactions {
         private _touchCancelCallback;
         private _minDomainExtents;
         private _maxDomainExtents;
+        private _panCallbacks;
+        private _zoomCallbacks;
         /**
          * A PanZoom Interaction updates the domains of an x-scale and/or a y-scale
          * in response to the user panning or zooming.
@@ -4706,6 +4710,34 @@ declare namespace Plottable.Interactions {
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
         maxDomainExtent<D>(quantitativeScale: QuantitativeScale<D>, maxDomainExtent: D): this;
+        /**
+         * Adds a callback to be called when panning ends.
+         *
+         * @param {PanCallback} callback
+         * @returns {Event} The calling PanZoom Interaction.
+         */
+        onPan(callback: PanCallback): this;
+        /**
+         * Removes a callback that would be called when panning ends.
+         *
+         * @param {PanCallback} callback
+         * @returns {Event} The calling PanZoom Interaction.
+         */
+        offPan(callback: PanCallback): this;
+        /**
+         * Adds a callback to be called when zooming ends.
+         *
+         * @param {ZoomCallback} callback
+         * @returns {Event} The calling PanZoom Interaction.
+         */
+        onZoom(callback: ZoomCallback): this;
+        /**
+         * Removes a callback that would be called when zooming ends.
+         *
+         * @param {ZoomCallback} callback
+         * @returns {Event} The calling PanZoom Interaction.
+         */
+        offZoom(callback: ZoomCallback): this;
     }
 }
 declare namespace Plottable {

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -4596,8 +4596,8 @@ declare namespace Plottable.Interactions {
         private _touchCancelCallback;
         private _minDomainExtents;
         private _maxDomainExtents;
-        private _panCallbacks;
-        private _zoomCallbacks;
+        private _panEndCallbacks;
+        private _zoomEndCallbacks;
         /**
          * A PanZoom Interaction updates the domains of an x-scale and/or a y-scale
          * in response to the user panning or zooming.
@@ -4716,28 +4716,28 @@ declare namespace Plottable.Interactions {
          * @param {PanCallback} callback
          * @returns {Event} The calling PanZoom Interaction.
          */
-        onPan(callback: PanCallback): this;
+        onPanEnd(callback: PanCallback): this;
         /**
          * Removes a callback that would be called when panning ends.
          *
          * @param {PanCallback} callback
          * @returns {Event} The calling PanZoom Interaction.
          */
-        offPan(callback: PanCallback): this;
+        offPanEnd(callback: PanCallback): this;
         /**
          * Adds a callback to be called when zooming ends.
          *
          * @param {ZoomCallback} callback
          * @returns {Event} The calling PanZoom Interaction.
          */
-        onZoom(callback: ZoomCallback): this;
+        onZoomEnd(callback: ZoomCallback): this;
         /**
          * Removes a callback that would be called when zooming ends.
          *
          * @param {ZoomCallback} callback
          * @returns {Event} The calling PanZoom Interaction.
          */
-        offZoom(callback: ZoomCallback): this;
+        offZoomEnd(callback: ZoomCallback): this;
     }
 }
 declare namespace Plottable {

--- a/plottable.js
+++ b/plottable.js
@@ -11222,8 +11222,8 @@ var Plottable;
                 this._touchMoveCallback = function (ids, idToPoint, e) { return _this._handlePinch(ids, idToPoint, e); };
                 this._touchEndCallback = function (ids, idToPoint, e) { return _this._handleTouchEnd(ids, idToPoint, e); };
                 this._touchCancelCallback = function (ids, idToPoint, e) { return _this._handleTouchEnd(ids, idToPoint, e); };
-                this._panCallbacks = new Plottable.Utils.CallbackSet();
-                this._zoomCallbacks = new Plottable.Utils.CallbackSet();
+                this._panEndCallbacks = new Plottable.Utils.CallbackSet();
+                this._zoomEndCallbacks = new Plottable.Utils.CallbackSet();
                 this._xScales = new Plottable.Utils.Set();
                 this._yScales = new Plottable.Utils.Set();
                 this._dragInteraction = new Interactions.Drag();
@@ -11338,7 +11338,7 @@ var Plottable;
                     _this._touchIds.remove(id.toString());
                 });
                 if (this._touchIds.size() > 0) {
-                    this._zoomCallbacks.callCallbacks(e);
+                    this._zoomEndCallbacks.callCallbacks(e);
                 }
             };
             PanZoom.prototype._magnifyScale = function (scale, magnifyAmount, centerValue) {
@@ -11368,7 +11368,7 @@ var Plottable;
                     this.yScales().forEach(function (yScale) {
                         _this._magnifyScale(yScale, zoomAmount_1, translatedP.y);
                     });
-                    this._zoomCallbacks.callCallbacks(e);
+                    this._zoomEndCallbacks.callCallbacks(e);
                 }
             };
             PanZoom.prototype._constrainedZoomAmount = function (scale, zoomAmount) {
@@ -11401,7 +11401,7 @@ var Plottable;
                     });
                     lastDragPoint = endPoint;
                 });
-                this._dragInteraction.onDragEnd(function (e) { return _this._panCallbacks.callCallbacks(e); });
+                this._dragInteraction.onDragEnd(function (e) { return _this._panEndCallbacks.callCallbacks(e); });
             };
             PanZoom.prototype._nonLinearScaleWithExtents = function (scale) {
                 return this.minDomainExtent(scale) != null && this.maxDomainExtent(scale) != null &&
@@ -11521,8 +11521,8 @@ var Plottable;
              * @param {PanCallback} callback
              * @returns {Event} The calling PanZoom Interaction.
              */
-            PanZoom.prototype.onPan = function (callback) {
-                this._panCallbacks.add(callback);
+            PanZoom.prototype.onPanEnd = function (callback) {
+                this._panEndCallbacks.add(callback);
                 return this;
             };
             /**
@@ -11531,8 +11531,8 @@ var Plottable;
              * @param {PanCallback} callback
              * @returns {Event} The calling PanZoom Interaction.
              */
-            PanZoom.prototype.offPan = function (callback) {
-                this._panCallbacks.delete(callback);
+            PanZoom.prototype.offPanEnd = function (callback) {
+                this._panEndCallbacks.delete(callback);
                 return this;
             };
             /**
@@ -11541,8 +11541,8 @@ var Plottable;
              * @param {ZoomCallback} callback
              * @returns {Event} The calling PanZoom Interaction.
              */
-            PanZoom.prototype.onZoom = function (callback) {
-                this._zoomCallbacks.add(callback);
+            PanZoom.prototype.onZoomEnd = function (callback) {
+                this._zoomEndCallbacks.add(callback);
                 return this;
             };
             /**
@@ -11551,8 +11551,8 @@ var Plottable;
              * @param {ZoomCallback} callback
              * @returns {Event} The calling PanZoom Interaction.
              */
-            PanZoom.prototype.offZoom = function (callback) {
-                this._zoomCallbacks.delete(callback);
+            PanZoom.prototype.offZoomEnd = function (callback) {
+                this._zoomEndCallbacks.delete(callback);
                 return this;
             };
             /**

--- a/plottable.js
+++ b/plottable.js
@@ -11338,7 +11338,7 @@ var Plottable;
                     _this._touchIds.remove(id.toString());
                 });
                 if (this._touchIds.size() > 0) {
-                    this._zoomEndCallbacks.callCallbacks(e);
+                    this._zoomEndCallbacks.callCallbacks();
                 }
             };
             PanZoom.prototype._magnifyScale = function (scale, magnifyAmount, centerValue) {
@@ -11368,7 +11368,7 @@ var Plottable;
                     this.yScales().forEach(function (yScale) {
                         _this._magnifyScale(yScale, zoomAmount_1, translatedP.y);
                     });
-                    this._zoomEndCallbacks.callCallbacks(e);
+                    this._zoomEndCallbacks.callCallbacks();
                 }
             };
             PanZoom.prototype._constrainedZoomAmount = function (scale, zoomAmount) {
@@ -11401,7 +11401,7 @@ var Plottable;
                     });
                     lastDragPoint = endPoint;
                 });
-                this._dragInteraction.onDragEnd(function (e) { return _this._panEndCallbacks.callCallbacks(e); });
+                this._dragInteraction.onDragEnd(function () { return _this._panEndCallbacks.callCallbacks(); });
             };
             PanZoom.prototype._nonLinearScaleWithExtents = function (scale) {
                 return this.minDomainExtent(scale) != null && this.maxDomainExtent(scale) != null &&
@@ -11519,7 +11519,7 @@ var Plottable;
              * Adds a callback to be called when panning ends.
              *
              * @param {PanCallback} callback
-             * @returns {Event} The calling PanZoom Interaction.
+             * @returns {this} The calling PanZoom Interaction.
              */
             PanZoom.prototype.onPanEnd = function (callback) {
                 this._panEndCallbacks.add(callback);
@@ -11529,7 +11529,7 @@ var Plottable;
              * Removes a callback that would be called when panning ends.
              *
              * @param {PanCallback} callback
-             * @returns {Event} The calling PanZoom Interaction.
+             * @returns {this} The calling PanZoom Interaction.
              */
             PanZoom.prototype.offPanEnd = function (callback) {
                 this._panEndCallbacks.delete(callback);
@@ -11539,7 +11539,7 @@ var Plottable;
              * Adds a callback to be called when zooming ends.
              *
              * @param {ZoomCallback} callback
-             * @returns {Event} The calling PanZoom Interaction.
+             * @returns {this} The calling PanZoom Interaction.
              */
             PanZoom.prototype.onZoomEnd = function (callback) {
                 this._zoomEndCallbacks.add(callback);
@@ -11549,7 +11549,7 @@ var Plottable;
              * Removes a callback that would be called when zooming ends.
              *
              * @param {ZoomCallback} callback
-             * @returns {Event} The calling PanZoom Interaction.
+             * @returns {this} The calling PanZoom Interaction.
              */
             PanZoom.prototype.offZoomEnd = function (callback) {
                 this._zoomEndCallbacks.delete(callback);

--- a/plottable.js
+++ b/plottable.js
@@ -11222,6 +11222,8 @@ var Plottable;
                 this._touchMoveCallback = function (ids, idToPoint, e) { return _this._handlePinch(ids, idToPoint, e); };
                 this._touchEndCallback = function (ids, idToPoint, e) { return _this._handleTouchEnd(ids, idToPoint, e); };
                 this._touchCancelCallback = function (ids, idToPoint, e) { return _this._handleTouchEnd(ids, idToPoint, e); };
+                this._panCallbacks = new Plottable.Utils.CallbackSet();
+                this._zoomCallbacks = new Plottable.Utils.CallbackSet();
                 this._xScales = new Plottable.Utils.Set();
                 this._yScales = new Plottable.Utils.Set();
                 this._dragInteraction = new Interactions.Drag();
@@ -11335,6 +11337,9 @@ var Plottable;
                 ids.forEach(function (id) {
                     _this._touchIds.remove(id.toString());
                 });
+                if (this._touchIds.size() > 0) {
+                    this._zoomCallbacks.callCallbacks(e);
+                }
             };
             PanZoom.prototype._magnifyScale = function (scale, magnifyAmount, centerValue) {
                 var magnifyTransform = function (rangeValue) { return scale.invert(centerValue - (centerValue - rangeValue) * magnifyAmount); };
@@ -11363,6 +11368,7 @@ var Plottable;
                     this.yScales().forEach(function (yScale) {
                         _this._magnifyScale(yScale, zoomAmount_1, translatedP.y);
                     });
+                    this._zoomCallbacks.callCallbacks(e);
                 }
             };
             PanZoom.prototype._constrainedZoomAmount = function (scale, zoomAmount) {
@@ -11395,6 +11401,7 @@ var Plottable;
                     });
                     lastDragPoint = endPoint;
                 });
+                this._dragInteraction.onDragEnd(function (e) { return _this._panCallbacks.callCallbacks(e); });
             };
             PanZoom.prototype._nonLinearScaleWithExtents = function (scale) {
                 return this.minDomainExtent(scale) != null && this.maxDomainExtent(scale) != null &&
@@ -11506,6 +11513,46 @@ var Plottable;
                     Plottable.Utils.Window.warn("Panning and zooming with extents on a nonlinear scale may have unintended behavior.");
                 }
                 this._maxDomainExtents.set(quantitativeScale, maxDomainExtent);
+                return this;
+            };
+            /**
+             * Adds a callback to be called when panning ends.
+             *
+             * @param {PanCallback} callback
+             * @returns {Event} The calling PanZoom Interaction.
+             */
+            PanZoom.prototype.onPan = function (callback) {
+                this._panCallbacks.add(callback);
+                return this;
+            };
+            /**
+             * Removes a callback that would be called when panning ends.
+             *
+             * @param {PanCallback} callback
+             * @returns {Event} The calling PanZoom Interaction.
+             */
+            PanZoom.prototype.offPan = function (callback) {
+                this._panCallbacks.delete(callback);
+                return this;
+            };
+            /**
+             * Adds a callback to be called when zooming ends.
+             *
+             * @param {ZoomCallback} callback
+             * @returns {Event} The calling PanZoom Interaction.
+             */
+            PanZoom.prototype.onZoom = function (callback) {
+                this._zoomCallbacks.add(callback);
+                return this;
+            };
+            /**
+             * Removes a callback that would be called when zooming ends.
+             *
+             * @param {ZoomCallback} callback
+             * @returns {Event} The calling PanZoom Interaction.
+             */
+            PanZoom.prototype.offZoom = function (callback) {
+                this._zoomCallbacks.delete(callback);
                 return this;
             };
             /**

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -1,7 +1,7 @@
 namespace Plottable.Interactions {
 
-  export type PanCallback = (e: Event) => void;
-  export type ZoomCallback = (e: Event) => void;
+  export type PanCallback = () => void;
+  export type ZoomCallback = () => void;
 
   export class PanZoom extends Interaction {
     /**
@@ -180,7 +180,7 @@ namespace Plottable.Interactions {
       });
 
       if (this._touchIds.size() > 0) {
-        this._zoomEndCallbacks.callCallbacks(e);
+        this._zoomEndCallbacks.callCallbacks();
       }
     }
 
@@ -216,7 +216,7 @@ namespace Plottable.Interactions {
         this.yScales().forEach((yScale) => {
           this._magnifyScale(yScale, zoomAmount, translatedP.y);
         });
-        this._zoomEndCallbacks.callCallbacks(e);
+        this._zoomEndCallbacks.callCallbacks();
       }
     }
 
@@ -254,7 +254,7 @@ namespace Plottable.Interactions {
         });
         lastDragPoint = endPoint;
       });
-      this._dragInteraction.onDragEnd((e) => this._panEndCallbacks.callCallbacks(e));
+      this._dragInteraction.onDragEnd(() => this._panEndCallbacks.callCallbacks());
     }
 
     private _nonLinearScaleWithExtents(scale: QuantitativeScale<any>) {
@@ -442,7 +442,7 @@ namespace Plottable.Interactions {
      * Adds a callback to be called when panning ends.
      *
      * @param {PanCallback} callback
-     * @returns {Event} The calling PanZoom Interaction.
+     * @returns {this} The calling PanZoom Interaction.
      */
     public onPanEnd(callback: PanCallback) {
       this._panEndCallbacks.add(callback);
@@ -453,7 +453,7 @@ namespace Plottable.Interactions {
      * Removes a callback that would be called when panning ends.
      *
      * @param {PanCallback} callback
-     * @returns {Event} The calling PanZoom Interaction.
+     * @returns {this} The calling PanZoom Interaction.
      */
     public offPanEnd(callback: PanCallback) {
       this._panEndCallbacks.delete(callback);
@@ -464,7 +464,7 @@ namespace Plottable.Interactions {
      * Adds a callback to be called when zooming ends.
      *
      * @param {ZoomCallback} callback
-     * @returns {Event} The calling PanZoom Interaction.
+     * @returns {this} The calling PanZoom Interaction.
      */
     public onZoomEnd(callback: ZoomCallback) {
       this._zoomEndCallbacks.add(callback);
@@ -475,7 +475,7 @@ namespace Plottable.Interactions {
      * Removes a callback that would be called when zooming ends.
      *
      * @param {ZoomCallback} callback
-     * @returns {Event} The calling PanZoom Interaction.
+     * @returns {this} The calling PanZoom Interaction.
      */
     public offZoomEnd(callback: ZoomCallback) {
       this._zoomEndCallbacks.delete(callback);

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -26,8 +26,8 @@ namespace Plottable.Interactions {
     private _minDomainExtents: Utils.Map<QuantitativeScale<any>, any>;
     private _maxDomainExtents: Utils.Map<QuantitativeScale<any>, any>;
 
-    private _panCallbacks = new Utils.CallbackSet<PanCallback>();
-    private _zoomCallbacks = new Utils.CallbackSet<ZoomCallback>();
+    private _panEndCallbacks = new Utils.CallbackSet<PanCallback>();
+    private _zoomEndCallbacks = new Utils.CallbackSet<ZoomCallback>();
 
     /**
      * A PanZoom Interaction updates the domains of an x-scale and/or a y-scale
@@ -180,7 +180,7 @@ namespace Plottable.Interactions {
       });
 
       if (this._touchIds.size() > 0) {
-        this._zoomCallbacks.callCallbacks(e);
+        this._zoomEndCallbacks.callCallbacks(e);
       }
     }
 
@@ -216,7 +216,7 @@ namespace Plottable.Interactions {
         this.yScales().forEach((yScale) => {
           this._magnifyScale(yScale, zoomAmount, translatedP.y);
         });
-        this._zoomCallbacks.callCallbacks(e);
+        this._zoomEndCallbacks.callCallbacks(e);
       }
     }
 
@@ -254,7 +254,7 @@ namespace Plottable.Interactions {
         });
         lastDragPoint = endPoint;
       });
-      this._dragInteraction.onDragEnd((e) => this._panCallbacks.callCallbacks(e));
+      this._dragInteraction.onDragEnd((e) => this._panEndCallbacks.callCallbacks(e));
     }
 
     private _nonLinearScaleWithExtents(scale: QuantitativeScale<any>) {
@@ -444,8 +444,8 @@ namespace Plottable.Interactions {
      * @param {PanCallback} callback
      * @returns {Event} The calling PanZoom Interaction.
      */
-    public onPan(callback: PanCallback) {
-      this._panCallbacks.add(callback);
+    public onPanEnd(callback: PanCallback) {
+      this._panEndCallbacks.add(callback);
       return this;
     }
 
@@ -455,8 +455,8 @@ namespace Plottable.Interactions {
      * @param {PanCallback} callback
      * @returns {Event} The calling PanZoom Interaction.
      */
-    public offPan(callback: PanCallback) {
-      this._panCallbacks.delete(callback);
+    public offPanEnd(callback: PanCallback) {
+      this._panEndCallbacks.delete(callback);
       return this;
     }
 
@@ -466,8 +466,8 @@ namespace Plottable.Interactions {
      * @param {ZoomCallback} callback
      * @returns {Event} The calling PanZoom Interaction.
      */
-    public onZoom(callback: ZoomCallback) {
-      this._zoomCallbacks.add(callback);
+    public onZoomEnd(callback: ZoomCallback) {
+      this._zoomEndCallbacks.add(callback);
       return this;
     }
 
@@ -477,8 +477,8 @@ namespace Plottable.Interactions {
      * @param {ZoomCallback} callback
      * @returns {Event} The calling PanZoom Interaction.
      */
-    public offZoom(callback: ZoomCallback) {
-      this._zoomCallbacks.delete(callback);
+    public offZoomEnd(callback: ZoomCallback) {
+      this._zoomEndCallbacks.delete(callback);
       return this;
     }
   }

--- a/test/interactions/panZoomInteractionTests.ts
+++ b/test/interactions/panZoomInteractionTests.ts
@@ -624,12 +624,12 @@ describe("Interactions", () => {
         eventTarget = component.background();
       });
 
-      it("registers callback using onPan", () => {
+      it("registers callback using onPanEnd", () => {
         let callback = makeCallback();
         let startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
         let endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
 
-        assert.strictEqual(panZoomInteraction.onPan(callback), panZoomInteraction, "registration returns the calling Interaction");
+        assert.strictEqual(panZoomInteraction.onPanEnd(callback), panZoomInteraction, "registration returns the calling Interaction");
 
         TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint]);
         TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint]);
@@ -647,14 +647,14 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("registers callback using onZoom", () => {
+      it("registers callback using onZoomEnd", () => {
         let callback = makeCallback();
         let startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
         let endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
         let scrollPoint = { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 };
         let deltaY = 3000;
 
-        assert.strictEqual(panZoomInteraction.onZoom(callback), panZoomInteraction, "registration returns the calling Interaction");
+        assert.strictEqual(panZoomInteraction.onZoomEnd(callback), panZoomInteraction, "registration returns the calling Interaction");
 
         TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint, scrollPoint], [0, 1]);
         TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint], [1]);
@@ -682,14 +682,14 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("deregisters callback using offPan", () => {
+      it("deregisters callback using offPanEnd", () => {
         let callback = makeCallback();
         let startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
         let endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
 
-        panZoomInteraction.onPan(callback);
+        panZoomInteraction.onPanEnd(callback);
 
-        assert.strictEqual(panZoomInteraction.offPan(callback), panZoomInteraction, "deregistration returns the calling Interaction");
+        assert.strictEqual(panZoomInteraction.offPanEnd(callback), panZoomInteraction, "deregistration returns the calling Interaction");
 
         TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint]);
         TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint]);
@@ -699,14 +699,14 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("deregisters callback using offZoom", () => {
+      it("deregisters callback using offZoomEnd", () => {
         let callback = makeCallback();
         let startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
         let endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
         let scrollPoint = { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 };
-        panZoomInteraction.onZoom(callback);
+        panZoomInteraction.onZoomEnd(callback);
 
-        assert.strictEqual(panZoomInteraction.offZoom(callback), panZoomInteraction, "deregistration returns the calling Interaction");
+        assert.strictEqual(panZoomInteraction.offZoomEnd(callback), panZoomInteraction, "deregistration returns the calling Interaction");
 
         TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint, scrollPoint], [0, 1]);
         TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint], [1]);
@@ -717,14 +717,14 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can register multiple onPan callbacks", () => {
+      it("can register multiple onPanEnd callbacks", () => {
         let callback1 = makeCallback();
         let callback2 = makeCallback();
         let startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
         let endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
 
-        panZoomInteraction.onPan(callback1);
-        panZoomInteraction.onPan(callback2);
+        panZoomInteraction.onPanEnd(callback1);
+        panZoomInteraction.onPanEnd(callback2);
 
         TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint]);
         TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint]);
@@ -734,15 +734,15 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can register multiple onZoom callbacks", () => {
+      it("can register multiple onZoomEnd callbacks", () => {
         let callback1 = makeCallback();
         let callback2 = makeCallback();
         let startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
         let endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
         let scrollPoint = { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 };
 
-        panZoomInteraction.onZoom(callback1);
-        panZoomInteraction.onZoom(callback2);
+        panZoomInteraction.onZoomEnd(callback1);
+        panZoomInteraction.onZoomEnd(callback2);
 
         TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint, scrollPoint], [0, 1]);
         TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint], [1]);
@@ -753,15 +753,15 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can deregister a onPan callback without affecting the other ones", () => {
+      it("can deregister a onPanEnd callback without affecting the other ones", () => {
         let callback1 = makeCallback();
         let callback2 = makeCallback();
         let startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
         let endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
 
-        panZoomInteraction.onPan(callback1);
-        panZoomInteraction.onPan(callback2);
-        panZoomInteraction.offPan(callback1);
+        panZoomInteraction.onPanEnd(callback1);
+        panZoomInteraction.onPanEnd(callback2);
+        panZoomInteraction.offPanEnd(callback1);
 
         TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint]);
         TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint]);
@@ -771,16 +771,16 @@ describe("Interactions", () => {
         svg.remove();
       });
 
-      it("can deregister a onZoom callback without affecting the other ones", () => {
+      it("can deregister a onZoomEnd callback without affecting the other ones", () => {
         let callback1 = makeCallback();
         let callback2 = makeCallback();
         let startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
         let endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
         let scrollPoint = { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 };
 
-        panZoomInteraction.onZoom(callback1);
-        panZoomInteraction.onZoom(callback2);
-        panZoomInteraction.offZoom(callback1);
+        panZoomInteraction.onZoomEnd(callback1);
+        panZoomInteraction.onZoomEnd(callback2);
+        panZoomInteraction.offZoomEnd(callback1);
 
         TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint, scrollPoint], [0, 1]);
         TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint], [1]);

--- a/test/interactions/panZoomInteractionTests.ts
+++ b/test/interactions/panZoomInteractionTests.ts
@@ -581,5 +581,215 @@ describe("Interactions", () => {
       });
     });
 
+    describe("Registering and deregistering Pan and Zoom event callbacks", () => {
+      let svg: d3.Selection<void>;
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 500;
+
+      let eventTarget: d3.Selection<void>;
+
+      let xScale: Plottable.QuantitativeScale<number>;
+      let panZoomInteraction: Plottable.Interactions.PanZoom;
+
+      interface PanZoomTestCallback {
+        called: boolean;
+        reset: () => void;
+        (e: Event): void;
+      }
+
+      function makeCallback () {
+        let callback = <PanZoomTestCallback> function(e: Event) {
+          callback.called = true;
+        };
+        callback.called = false;
+        callback.reset =  () => {
+          callback.called = false;
+        };
+        return callback;
+      }
+
+      beforeEach(() => {
+        xScale = new Plottable.Scales.Linear();
+        xScale.domain([0, SVG_WIDTH / 2]);
+
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+
+        let component = new Plottable.Component();
+        component.renderTo(svg);
+
+        panZoomInteraction = new Plottable.Interactions.PanZoom();
+        panZoomInteraction.addXScale(xScale);
+        panZoomInteraction.attachTo(component);
+
+        eventTarget = component.background();
+      });
+
+      it("registers callback using onPan", () => {
+        let callback = makeCallback();
+        let startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
+        let endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
+
+        assert.strictEqual(panZoomInteraction.onPan(callback), panZoomInteraction, "registration returns the calling Interaction");
+
+        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint]);
+        TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint]);
+        TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint]);
+        assert.isTrue(callback.called, "Interaction correctly triggers the callback (touch)");
+
+        callback.reset();
+
+        TestMethods.triggerFakeMouseEvent("mousedown", eventTarget, startPoint.x, startPoint.y);
+        TestMethods.triggerFakeMouseEvent("mousemove", eventTarget, endPoint.x, endPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseend", eventTarget, endPoint.x, endPoint.y);
+        TestMethods.triggerFakeMouseEvent("mouseup", eventTarget, endPoint.x, endPoint.y);
+        assert.isTrue(callback.called, "Interaction correctly triggers the callback (mouse)");
+
+        svg.remove();
+      });
+
+      it("registers callback using onZoom", () => {
+        let callback = makeCallback();
+        let startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
+        let endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
+        let scrollPoint = { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 };
+        let deltaY = 3000;
+
+        assert.strictEqual(panZoomInteraction.onZoom(callback), panZoomInteraction, "registration returns the calling Interaction");
+
+        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint, scrollPoint], [0, 1]);
+        TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint], [1]);
+        TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint], [1]);
+        assert.isTrue(callback.called, "Interaction correctly triggers the callback (touch)");
+
+        callback.reset();
+
+        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint]);
+        TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint]);
+        TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint]);
+        assert.isFalse(callback.called, "Interaction does not trigger zoom callback on pan event (touch)");
+
+        callback.reset();
+
+        // HACKHACK PhantomJS doesn't implement fake creation of WheelEvents
+        // https://github.com/ariya/phantomjs/issues/11289
+        if (window.PHANTOMJS) {
+          svg.remove();
+          return;
+        }
+
+        TestMethods.triggerFakeWheelEvent("wheel", svg, scrollPoint.x, scrollPoint.y, deltaY);
+        assert.isTrue(callback.called, "Interaction correctly triggers the callback (mouse)");
+        svg.remove();
+      });
+
+      it("deregisters callback using offPan", () => {
+        let callback = makeCallback();
+        let startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
+        let endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
+
+        panZoomInteraction.onPan(callback);
+
+        assert.strictEqual(panZoomInteraction.offPan(callback), panZoomInteraction, "deregistration returns the calling Interaction");
+
+        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint]);
+        TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint]);
+        TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint]);
+        assert.isFalse(callback.called, "callback should be disconnected from the Interaction");
+
+        svg.remove();
+      });
+
+      it("deregisters callback using offZoom", () => {
+        let callback = makeCallback();
+        let startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
+        let endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
+        let scrollPoint = { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 };
+        panZoomInteraction.onZoom(callback);
+
+        assert.strictEqual(panZoomInteraction.offZoom(callback), panZoomInteraction, "deregistration returns the calling Interaction");
+
+        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint, scrollPoint], [0, 1]);
+        TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint], [1]);
+        TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint], [1]);
+
+        assert.isFalse(callback.called, "callback should be disconnected from the Interaction");
+
+        svg.remove();
+      });
+
+      it("can register multiple onPan callbacks", () => {
+        let callback1 = makeCallback();
+        let callback2 = makeCallback();
+        let startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
+        let endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
+
+        panZoomInteraction.onPan(callback1);
+        panZoomInteraction.onPan(callback2);
+
+        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint]);
+        TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint]);
+        TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint]);
+        assert.isTrue(callback1.called, "Interaction should trigger the first callback");
+        assert.isTrue(callback1.called, "Interaction should trigger the second callback");
+        svg.remove();
+      });
+
+      it("can register multiple onZoom callbacks", () => {
+        let callback1 = makeCallback();
+        let callback2 = makeCallback();
+        let startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
+        let endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
+        let scrollPoint = { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 };
+
+        panZoomInteraction.onZoom(callback1);
+        panZoomInteraction.onZoom(callback2);
+
+        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint, scrollPoint], [0, 1]);
+        TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint], [1]);
+        TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint], [1]);
+
+        assert.isTrue(callback1.called, "Interaction should trigger the first callback");
+        assert.isTrue(callback1.called, "Interaction should trigger the second callback");
+        svg.remove();
+      });
+
+      it("can deregister a onPan callback without affecting the other ones", () => {
+        let callback1 = makeCallback();
+        let callback2 = makeCallback();
+        let startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
+        let endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
+
+        panZoomInteraction.onPan(callback1);
+        panZoomInteraction.onPan(callback2);
+        panZoomInteraction.offPan(callback1);
+
+        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint]);
+        TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint]);
+        TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint]);
+        assert.isFalse(callback1.called, "Callback1 should be disconnected from the Interaction");
+        assert.isTrue(callback2.called, "Callback2 should still exist on the Interaction");
+        svg.remove();
+      });
+
+      it("can deregister a onZoom callback without affecting the other ones", () => {
+        let callback1 = makeCallback();
+        let callback2 = makeCallback();
+        let startPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
+        let endPoint = { x: -SVG_WIDTH / 2, y: -SVG_HEIGHT / 2 };
+        let scrollPoint = { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 };
+
+        panZoomInteraction.onZoom(callback1);
+        panZoomInteraction.onZoom(callback2);
+        panZoomInteraction.offZoom(callback1);
+
+        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint, scrollPoint], [0, 1]);
+        TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint], [1]);
+        TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint], [1]);
+
+        assert.isFalse(callback1.called, "Callback1 should be disconnected from the Interaction");
+        assert.isTrue(callback2.called, "Callback2 should still exist on the Interaction");
+        svg.remove();
+      });
+    });
   });
 });

--- a/test/interactions/panZoomInteractionTests.ts
+++ b/test/interactions/panZoomInteractionTests.ts
@@ -594,7 +594,7 @@ describe("Interactions", () => {
       interface PanZoomTestCallback {
         called: boolean;
         reset: () => void;
-        (e: Event): void;
+        (): void;
       }
 
       function makeCallback () {


### PR DESCRIPTION
As mentioned in #3086 I am proposing to add events for Pan and Zoom, so that users can automatically retrieve more data for charts.

The proposed API is such:

``` javascript
panZoomInteraction = new Plottable.Interactions.PanZoom();

panZoomInteraction.onPan(callback);
panZoomInteraction.offPan(callback);

panZoomInteraction.onZoom(callback);
panZoomInteraction.offZoom(callback);

```

Callbacks occur on the most applicable end event (touchend, dragend or scroll), in an attempt to minimise the number of calls where possible, as this will most likely be used for retrieving server data.
