### PR TITLE
Expose simpler API for selecting chart entities

### DIFF
--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -338,6 +338,15 @@ namespace Plottable.Plots {
       return attrToProjector;
     }
 
+    public entitiesAt(point: Point): PlotEntity[] {
+      const entity = this.entityNearestByXThenY(point);
+      if (entity != null) {
+        return [entity];
+      } else {
+        return [];
+      }
+    }
+
     /**
      * Returns the PlotEntity nearest to the query point by X then by Y, or undefined if no PlotEntity can be found.
      *

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -1,6 +1,7 @@
 namespace Plottable.Plots {
   export interface PlotEntity extends Entity<Plot> {
     dataset: Dataset;
+    datasetIndex: number;
     index: number;
     component: Plot;
   }
@@ -26,6 +27,7 @@ interface LightweightPlotEntity {
   datum: any;
   position: Point;
   dataset: Dataset;
+  datasetIndex: number;
   index: number;
   component: Plot;
   drawer: Plottable.Drawer;
@@ -486,19 +488,20 @@ export class Plot extends Component {
 
   private _lightweightEntities(datasets = this.datasets()) {
     let lightweightEntities: LightweightPlotEntity[] = [];
-    datasets.forEach((dataset) => {
+    datasets.forEach((dataset: Dataset, datasetIndex: number) => {
       let drawer = this._datasetToDrawer.get(dataset);
       let validDatumIndex = 0;
 
-      dataset.data().forEach((datum: any, datasetIndex: number) => {
-        let position = this._pixelPoint(datum, datasetIndex, dataset);
+      dataset.data().forEach((datum: any, datumIndex: number) => {
+        let position = this._pixelPoint(datum, datumIndex, dataset);
         if (Utils.Math.isNaN(position.x) || Utils.Math.isNaN(position.y)) {
           return;
         }
         lightweightEntities.push({
           datum: datum,
-          index: datasetIndex,
+          index: datumIndex,
           dataset: dataset,
+          datasetIndex: datasetIndex,
           position: position,
           component: this,
           drawer: drawer,
@@ -515,11 +518,27 @@ export class Plot extends Component {
       datum: entity.datum,
       position: entity.position,
       dataset: entity.dataset,
+      datasetIndex: entity.datasetIndex,
       index: entity.index,
       component: entity.component,
       selection: entity.drawer.selectionForIndex(entity.validDatumIndex),
     };
     return plotEntity;
+  }
+
+  /**
+   * Gets the PlotEntities at a particular Point.
+   *
+   * Each plot type determines how to locate entities at or near the query
+   * point. For example, line and area charts will return the nearest entity,
+   * but bar charts will only return the entities that fully contain the query
+   * point.
+   *
+   * @param {Point} point The point to query.
+   * @returns {PlotEntity[]} The PlotEntities at the particular point
+   */
+  public entitiesAt(point: Point): Plots.PlotEntity[] {
+    throw new Error("plots must implement entitiesAt");
   }
 
   /**

--- a/src/plots/segmentPlot.ts
+++ b/src/plots/segmentPlot.ts
@@ -170,6 +170,15 @@ namespace Plottable.Plots {
       return attrToProjector;
     }
 
+    public entitiesAt(point: Point): PlotEntity[] {
+      const entity = this.entityNearest(point);
+      if (entity != null) {
+        return [entity];
+      } else {
+        return [];
+      }
+    }
+
     /**
      * Gets the Entities that intersect the Bounds.
      *

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -648,6 +648,7 @@ describe("Plots", () => {
             datum: datum,
             index: index,
             dataset: dataset,
+            datasetIndex: 0,
             position: getPointFromBaseAndValuePositions(basePosition, valuePosition),
             selection: d3.select(barPlot.content().selectAll("rect")[0][index]),
             component: barPlot,


### PR DESCRIPTION
Add .entitiesAt method to base Plot class, which most plots
already implement.

Add missing .entitiesAt method using already existing "nearest"
methods for line and segment plots.

Add datasetIndex to Plot.PlotEntity object to easily determine
which series was selected.