### PR TITLE
Constrain pan/zoom to min/max domain values

### DIFF
--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -2738,6 +2738,7 @@ declare namespace Plottable.Components {
 declare namespace Plottable.Plots {
     interface PlotEntity extends Entity<Plot> {
         dataset: Dataset;
+        datasetIndex: number;
         index: number;
         component: Plot;
     }
@@ -2889,6 +2890,18 @@ declare namespace Plottable {
         entities(datasets?: Dataset[]): Plots.PlotEntity[];
         private _lightweightEntities(datasets?);
         private _lightweightPlotEntityToPlotEntity(entity);
+        /**
+         * Gets the PlotEntities at a particular Point.
+         *
+         * Each plot type determines how to locate entities at or near the query
+         * point. For example, line and area charts will return the nearest entity,
+         * but bar charts will only return the entities that fully contain the query
+         * point.
+         *
+         * @param {Point} point The point to query.
+         * @returns {PlotEntity[]} The PlotEntities at the particular point
+         */
+        entitiesAt(point: Point): Plots.PlotEntity[];
         /**
          * Returns the PlotEntity nearest to the query point by the Euclidian norm, or undefined if no PlotEntity can be found.
          *
@@ -3605,6 +3618,7 @@ declare namespace Plottable.Plots {
         protected _generateAttrToProjector(): {
             [attr: string]: Projector;
         };
+        entitiesAt(point: Point): PlotEntity[];
         /**
          * Returns the PlotEntity nearest to the query point by X then by Y, or undefined if no PlotEntity can be found.
          *
@@ -3846,6 +3860,7 @@ declare namespace Plottable.Plots {
          */
         y2(y2: number | Accessor<number> | Y | Accessor<Y>): this;
         protected _propertyProjectors(): AttributeToProjector;
+        entitiesAt(point: Point): PlotEntity[];
         /**
          * Gets the Entities that intersect the Bounds.
          *
@@ -4597,6 +4612,8 @@ declare namespace Plottable.Interactions {
         private _touchCancelCallback;
         private _minDomainExtents;
         private _maxDomainExtents;
+        private _minDomainValues;
+        private _maxDomainValues;
         private _panEndCallbacks;
         private _zoomEndCallbacks;
         /**
@@ -4618,8 +4635,26 @@ declare namespace Plottable.Interactions {
         private _magnifyScale<D>(scale, magnifyAmount, centerValue);
         private _translateScale<D>(scale, translateAmount);
         private _handleWheelEvent(p, e);
-        private _constrainedZoomAmount(scale, zoomAmount);
+        private _constrainedZoom(scale, zoomAmount, centerPoint);
+        private _constrainZoomExtents(scale, zoomAmount);
+        private _constrainZoomValues(scale, zoomAmount, centerPoint);
+        /**
+         * Performs a zoom transformation of the `value` argument scaled by the
+         * `zoom` argument about the point defined by the `center` argument.
+         */
+        private _zoomAt(value, zoom, center);
+        /**
+         * Returns the `center` value to be used with `_zoomAt` that will produce
+         * the `target` value given the same `value` and `zoom` arguments. Algebra
+         * brought to you by Wolfram Alpha.
+         */
+        private _getZoomCenterForTarget(value, zoom, target);
         private _setupDragInteraction();
+        /**
+         * Returns a new translation value that respects domain min/max value
+         * constraints.
+         */
+        private _constrainedTranslation(scale, translation);
         private _nonLinearScaleWithExtents(scale);
         /**
          * Gets the x scales for this PanZoom Interaction.
@@ -4711,6 +4746,76 @@ declare namespace Plottable.Interactions {
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
         maxDomainExtent<D>(quantitativeScale: QuantitativeScale<D>, maxDomainExtent: D): this;
+        /**
+         * Gets the minimum domain value for the scale, constraining the pan/zoom
+         * interaction to a minimum value in the domain.
+         *
+         * Note that this differs from minDomainExtent/maxDomainExtent, in that
+         * those methods provide constraints such as showing at least 2 but no more
+         * than 5 values at a time.
+         *
+         * By contrast, minDomainValue/maxDomainValue set a boundary beyond which
+         * the user cannot pan/zoom.
+         *
+         * @param {QuantitativeScale<any>} quantitativeScale The scale to query
+         * @returns {D} The minimum domain value for the scale.
+         */
+        minDomainValue<D>(quantitativeScale: QuantitativeScale<D>): D;
+        /**
+         * Sets the minimum domain value for the scale, constraining the pan/zoom
+         * interaction to a minimum value in the domain.
+         *
+         * Note that this differs from minDomainExtent/maxDomainExtent, in that
+         * those methods provide constraints such as showing at least 2 but no more
+         * than 5 values at a time.
+         *
+         * By contrast, minDomainValue/maxDomainValue set a boundary beyond which
+         * the user cannot pan/zoom.
+         *
+         * @param {QuantitativeScale<any>} quantitativeScale The scale to query
+         * @param {D} minDomainExtent The minimum domain value for the scale.
+         * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+         */
+        minDomainValue<D>(quantitativeScale: QuantitativeScale<D>, minDomainValue: D): this;
+        /**
+         * Gets the maximum domain value for the scale, constraining the pan/zoom
+         * interaction to a maximum value in the domain.
+         *
+         * Note that this differs from minDomainExtent/maxDomainExtent, in that
+         * those methods provide constraints such as showing at least 2 but no more
+         * than 5 values at a time.
+         *
+         * By contrast, minDomainValue/maxDomainValue set a boundary beyond which
+         * the user cannot pan/zoom.
+         *
+         * @param {QuantitativeScale<any>} quantitativeScale The scale to query
+         * @returns {D} The maximum domain value for the scale.
+         */
+        maxDomainValue<D>(quantitativeScale: QuantitativeScale<D>): D;
+        /**
+         * Sets the maximum domain value for the scale, constraining the pan/zoom
+         * interaction to a maximum value in the domain.
+         *
+         * Note that this differs from minDomainExtent/maxDomainExtent, in that
+         * those methods provide constraints such as showing at least 2 but no more
+         * than 5 values at a time.
+         *
+         * By contrast, minDomainValue/maxDomainValue set a boundary beyond which
+         * the user cannot pan/zoom.
+         *
+         * @param {QuantitativeScale<any>} quantitativeScale The scale to query
+         * @param {D} maxDomainExtent The maximum domain value for the scale.
+         * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+         */
+        maxDomainValue<D>(quantitativeScale: QuantitativeScale<D>, maxDomainValue: D): this;
+        /**
+         * Uses the current domain of the scale to apply a minimum and maximum
+         * domain value for that scale.
+         *
+         * This constrains the pan/zoom interaction to show no more than the domain
+         * of the scale.
+         */
+        setMinMaxDomainValuesTo<D>(scale: QuantitativeScale<D>): void;
         /**
          * Adds a callback to be called when panning ends.
          *

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -26,6 +26,9 @@ namespace Plottable.Interactions {
     private _minDomainExtents: Utils.Map<QuantitativeScale<any>, any>;
     private _maxDomainExtents: Utils.Map<QuantitativeScale<any>, any>;
 
+    private _minDomainValues: Utils.Map<QuantitativeScale<any>, any>;
+    private _maxDomainValues: Utils.Map<QuantitativeScale<any>, any>;
+
     private _panEndCallbacks = new Utils.CallbackSet<PanCallback>();
     private _zoomEndCallbacks = new Utils.CallbackSet<ZoomCallback>();
 
@@ -46,6 +49,8 @@ namespace Plottable.Interactions {
       this._touchIds = d3.map<Point>();
       this._minDomainExtents = new Utils.Map<QuantitativeScale<any>, number>();
       this._maxDomainExtents = new Utils.Map<QuantitativeScale<any>, number>();
+      this._minDomainValues = new Utils.Map<QuantitativeScale<any>, number>();
+      this._maxDomainValues = new Utils.Map<QuantitativeScale<any>, number>();
       if (xScale != null) {
         this.addXScale(xScale);
       }
@@ -126,12 +131,20 @@ namespace Plottable.Interactions {
         return { x: (point.x - oldPoints[i].x) / magnifyAmount, y: (point.y - oldPoints[i].y) / magnifyAmount };
       });
 
+      let oldCenterPoint = PanZoom._centerPoint(oldPoints[0], oldPoints[1]);
+      let centerX = oldCenterPoint.x;
+      let centerY = oldCenterPoint.y;
+
       this.xScales().forEach((xScale) => {
-        magnifyAmount = this._constrainedZoomAmount(xScale, magnifyAmount);
+        const constrained = this._constrainedZoom(xScale, magnifyAmount, centerX);
+        centerX = constrained.centerPoint;
+        magnifyAmount = constrained.zoomAmount;
       });
 
       this.yScales().forEach((yScale) => {
-        magnifyAmount = this._constrainedZoomAmount(yScale, magnifyAmount);
+        const constrained = this._constrainedZoom(yScale, magnifyAmount, centerY);
+        centerY = constrained.centerPoint;
+        magnifyAmount = constrained.zoomAmount;
       });
 
       let constrainedPoints = oldPoints.map((oldPoint, i) => {
@@ -141,17 +154,15 @@ namespace Plottable.Interactions {
         };
       });
 
-      let oldCenterPoint = PanZoom._centerPoint(oldPoints[0], oldPoints[1]);
-
-      let translateAmountX = oldCenterPoint.x - ((constrainedPoints[0].x + constrainedPoints[1].x) / 2);
+      let translateAmountX = centerX - ((constrainedPoints[0].x + constrainedPoints[1].x) / 2);
       this.xScales().forEach((xScale) => {
-        this._magnifyScale(xScale, magnifyAmount, oldCenterPoint.x);
+        this._magnifyScale(xScale, magnifyAmount, centerX);
         this._translateScale(xScale, translateAmountX);
       });
 
-      let translateAmountY = oldCenterPoint.y - ((constrainedPoints[0].y + constrainedPoints[1].y) / 2);
+      let translateAmountY = centerY - ((constrainedPoints[0].y + constrainedPoints[1].y) / 2);
       this.yScales().forEach((yScale) => {
-        this._magnifyScale(yScale, magnifyAmount, oldCenterPoint.y);
+        this._magnifyScale(yScale, magnifyAmount, centerY);
         this._translateScale(yScale, translateAmountY);
       });
     }
@@ -185,7 +196,7 @@ namespace Plottable.Interactions {
     }
 
     private _magnifyScale<D>(scale: QuantitativeScale<D>, magnifyAmount: number, centerValue: number) {
-      let magnifyTransform = (rangeValue: number) => scale.invert(centerValue - (centerValue - rangeValue) * magnifyAmount);
+      let magnifyTransform = (rangeValue: number) => scale.invert(this._zoomAt(rangeValue, magnifyAmount, centerValue));
       scale.domain(scale.range().map(magnifyTransform));
     }
 
@@ -201,26 +212,38 @@ namespace Plottable.Interactions {
 
         let deltaPixelAmount = e.deltaY * (e.deltaMode ? PanZoom._PIXELS_PER_LINE : 1);
         let zoomAmount = Math.pow(2, deltaPixelAmount * .002);
+        let centerX = translatedP.x;
+        let centerY = translatedP.y;
 
         this.xScales().forEach((xScale) => {
-          zoomAmount = this._constrainedZoomAmount(xScale, zoomAmount);
+          const constrained = this._constrainedZoom(xScale, zoomAmount, centerX);
+          centerX = constrained.centerPoint;
+          zoomAmount = constrained.zoomAmount;
         });
 
         this.yScales().forEach((yScale) => {
-          zoomAmount = this._constrainedZoomAmount(yScale, zoomAmount);
+          const constrained = this._constrainedZoom(yScale, zoomAmount, centerY);
+          centerY = constrained.centerPoint;
+          zoomAmount = constrained.zoomAmount;
         });
 
         this.xScales().forEach((xScale) => {
-          this._magnifyScale(xScale, zoomAmount, translatedP.x);
+          this._magnifyScale(xScale, zoomAmount, centerX);
         });
         this.yScales().forEach((yScale) => {
-          this._magnifyScale(yScale, zoomAmount, translatedP.y);
+          this._magnifyScale(yScale, zoomAmount, centerY);
         });
+
         this._zoomEndCallbacks.callCallbacks();
       }
     }
 
-    private _constrainedZoomAmount(scale: QuantitativeScale<any>, zoomAmount: number) {
+    private _constrainedZoom(scale: QuantitativeScale<number>, zoomAmount: number, centerPoint: number) {
+      zoomAmount = this._constrainZoomExtents(scale, zoomAmount);
+      return this._constrainZoomValues(scale, zoomAmount, centerPoint);
+    }
+
+    private _constrainZoomExtents(scale: QuantitativeScale<any>, zoomAmount: number) {
       let extentIncreasing = zoomAmount > 1;
 
       let boundingDomainExtent = extentIncreasing ? this.maxDomainExtent(scale) : this.minDomainExtent(scale);
@@ -230,6 +253,92 @@ namespace Plottable.Interactions {
       let domainExtent = Math.abs(scaleDomain[1] - scaleDomain[0]);
       let compareF = extentIncreasing ? Math.min : Math.max;
       return compareF(zoomAmount, boundingDomainExtent / domainExtent);
+    }
+
+    private _constrainZoomValues(scale: QuantitativeScale<number>, zoomAmount: number, centerPoint: number) {
+      // when zooming in, we don't have to worry about overflowing domain
+      if (zoomAmount <= 1) {
+        return { centerPoint, zoomAmount };
+      }
+
+      const minDomain = this.minDomainValue(scale);
+      const maxDomain = this.maxDomainValue(scale);
+
+      // if no constraints set, we're done
+      if (minDomain == null && maxDomain == null) {
+        return { centerPoint, zoomAmount };
+      }
+
+      const scaleDomain = scale.domain();
+
+      if (maxDomain != null) {
+        // compute max range point if zoom applied
+        const maxRange = scale.scale(maxDomain);
+        const currentMaxRange = scale.scale(scaleDomain[1]);
+        const testMaxRange = this._zoomAt(currentMaxRange, zoomAmount, centerPoint);
+
+        // move the center point to prevent max overflow, if necessary
+        if (testMaxRange > maxRange) {
+          centerPoint = this._getZoomCenterForTarget(currentMaxRange, zoomAmount, maxRange);
+        }
+      }
+
+      if (minDomain != null) {
+        // compute min range point if zoom applied
+        const minRange = scale.scale(minDomain);
+        const currentMinRange = scale.scale(scaleDomain[0]);
+        const testMinRange = this._zoomAt(currentMinRange, zoomAmount, centerPoint);
+
+        // move the center point to prevent min overflow, if necessary
+        if (testMinRange < minRange) {
+          centerPoint = this._getZoomCenterForTarget(currentMinRange, zoomAmount, minRange);
+        }
+      }
+
+      // add fallback to prevent overflowing both min and max
+      if (maxDomain != null && maxDomain != null) {
+        const maxRange = scale.scale(maxDomain);
+        const currentMaxRange = scale.scale(scaleDomain[1]);
+        const testMaxRange = this._zoomAt(currentMaxRange, zoomAmount, centerPoint);
+
+        const minRange = scale.scale(minDomain);
+        const currentMinRange = scale.scale(scaleDomain[0]);
+        const testMinRange = this._zoomAt(currentMinRange, zoomAmount, centerPoint);
+
+        // If we overflow both, use some algebra to solve for centerPoint and
+        // zoomAmount that will make the domain match the min/max exactly.
+        // Algebra brought to you by Wolfram Alpha.
+        if (testMaxRange > maxRange || testMinRange < minRange) {
+          const denominator = (currentMaxRange - currentMinRange + minRange - maxRange);
+          if (denominator === 0) {
+            // In this case the domains already match, so just return no-op values.
+            centerPoint = (currentMaxRange + currentMinRange) / 2;
+            zoomAmount = 1;
+          } else {
+            centerPoint = (currentMaxRange * minRange - currentMinRange * maxRange) / denominator;
+            zoomAmount = (maxRange - minRange) / (currentMaxRange - currentMinRange);
+          }
+        }
+      }
+
+      return { centerPoint, zoomAmount };
+    }
+
+    /**
+     * Performs a zoom transformation of the `value` argument scaled by the
+     * `zoom` argument about the point defined by the `center` argument.
+     */
+    private _zoomAt(value: number, zoom: number, center: number) {
+      return center - (center - value) * zoom;
+    }
+
+    /**
+     * Returns the `center` value to be used with `_zoomAt` that will produce
+     * the `target` value given the same `value` and `zoom` arguments. Algebra
+     * brought to you by Wolfram Alpha.
+     */
+    private _getZoomCenterForTarget(value: number, zoom: number, target: number) {
+      return (value * zoom - target) / (zoom - 1);
     }
 
     private _setupDragInteraction() {
@@ -244,17 +353,42 @@ namespace Plottable.Interactions {
         let translateAmountX = (lastDragPoint == null ? startPoint.x : lastDragPoint.x) - endPoint.x;
 
         this.xScales().forEach((xScale) => {
-          this._translateScale(xScale, translateAmountX);
+          this._translateScale(xScale, this._constrainedTranslation(xScale, translateAmountX));
         });
 
         let translateAmountY = (lastDragPoint == null ? startPoint.y : lastDragPoint.y) - endPoint.y;
 
         this.yScales().forEach((yScale) => {
-          this._translateScale(yScale, translateAmountY);
+          this._translateScale(yScale, this._constrainedTranslation(yScale, translateAmountY));
         });
         lastDragPoint = endPoint;
       });
+
       this._dragInteraction.onDragEnd(() => this._panEndCallbacks.callCallbacks());
+    }
+
+    /**
+     * Returns a new translation value that respects domain min/max value
+     * constraints.
+     */
+    private _constrainedTranslation(scale: QuantitativeScale<number>, translation: number) {
+      const scaleDomain = scale.domain();
+      if (translation > 0) {
+        const bound = this.maxDomainValue(scale);
+        if (bound != null) {
+          const currentRange = scale.scale(scaleDomain[1]);
+          const maxRange = scale.scale(bound);
+          translation = Math.min(currentRange + translation, maxRange) - currentRange;
+        }
+      } else {
+        const bound = this.minDomainValue(scale);
+        if (bound != null) {
+          const currentRange = scale.scale(scaleDomain[0]);
+          const minRange = scale.scale(bound);
+          translation = Math.max(currentRange + translation, minRange) - currentRange;
+        }
+      }
+      return translation;
     }
 
     private _nonLinearScaleWithExtents(scale: QuantitativeScale<any>) {
@@ -333,6 +467,8 @@ namespace Plottable.Interactions {
       this._xScales.delete(xScale);
       this._minDomainExtents.delete(xScale);
       this._maxDomainExtents.delete(xScale);
+      this._minDomainValues.delete(xScale);
+      this._maxDomainValues.delete(xScale);
       return this;
     }
 
@@ -357,6 +493,8 @@ namespace Plottable.Interactions {
       this._yScales.delete(yScale);
       this._minDomainExtents.delete(yScale);
       this._maxDomainExtents.delete(yScale);
+      this._minDomainValues.delete(yScale);
+      this._maxDomainValues.delete(yScale);
       return this;
     }
 
@@ -436,6 +574,117 @@ namespace Plottable.Interactions {
       }
       this._maxDomainExtents.set(quantitativeScale, maxDomainExtent);
       return this;
+    }
+
+    /**
+     * Gets the minimum domain value for the scale, constraining the pan/zoom
+     * interaction to a minimum value in the domain.
+     *
+     * Note that this differs from minDomainExtent/maxDomainExtent, in that
+     * those methods provide constraints such as showing at least 2 but no more
+     * than 5 values at a time.
+     *
+     * By contrast, minDomainValue/maxDomainValue set a boundary beyond which
+     * the user cannot pan/zoom.
+     *
+     * @param {QuantitativeScale<any>} quantitativeScale The scale to query
+     * @returns {D} The minimum domain extent for the scale.
+     */
+    public minDomainValue<D>(quantitativeScale: QuantitativeScale<D>): D;
+    /**
+     * Sets the minimum domain value for the scale, constraining the pan/zoom
+     * interaction to a minimum value in the domain.
+     *
+     * Note that this differs from minDomainExtent/maxDomainExtent, in that
+     * those methods provide constraints such as showing at least 2 but no more
+     * than 5 values at a time.
+     *
+     * By contrast, minDomainValue/maxDomainValue set a boundary beyond which
+     * the user cannot pan/zoom.
+     *
+     * @param {QuantitativeScale<any>} quantitativeScale The scale to query
+     * @param {D} minDomainExtent The minimum domain extent for the scale.
+     * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+     */
+    public minDomainValue<D>(quantitativeScale: QuantitativeScale<D>, minDomainValue: D): this;
+    public minDomainValue<D>(quantitativeScale: QuantitativeScale<D>, minDomainValue?: D): any {
+      if (minDomainValue == null) {
+        return this._minDomainValues.get(quantitativeScale);
+      }
+      let maxValueForScale = this.maxDomainValue(quantitativeScale);
+      if (maxValueForScale != null && maxValueForScale.valueOf() < minDomainValue.valueOf()) {
+        throw new Error("minDomainValue must be smaller than maxDomainValue for the same Scale");
+      }
+      this._minDomainValues.set(quantitativeScale, minDomainValue);
+      return this;
+    }
+
+    /**
+     * Gets the maximum domain value for the scale, constraining the pan/zoom
+     * interaction to a maximum value in the domain.
+     *
+     * Note that this differs from minDomainExtent/maxDomainExtent, in that
+     * those methods provide constraints such as showing at least 2 but no more
+     * than 5 values at a time.
+     *
+     * By contrast, minDomainValue/maxDomainValue set a boundary beyond which
+     * the user cannot pan/zoom.
+     *
+     * @param {QuantitativeScale<any>} quantitativeScale The scale to query
+     * @returns {D} The maximum domain extent for the scale.
+     */
+    public maxDomainValue<D>(quantitativeScale: QuantitativeScale<D>): D;
+    /**
+     * Sets the maximum domain value for the scale, constraining the pan/zoom
+     * interaction to a maximum value in the domain.
+     *
+     * Note that this differs from minDomainExtent/maxDomainExtent, in that
+     * those methods provide constraints such as showing at least 2 but no more
+     * than 5 values at a time.
+     *
+     * By contrast, minDomainValue/maxDomainValue set a boundary beyond which
+     * the user cannot pan/zoom.
+     *
+     * @param {QuantitativeScale<any>} quantitativeScale The scale to query
+     * @param {D} maxDomainExtent The maximum domain extent for the scale.
+     * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
+     */
+    public maxDomainValue<D>(quantitativeScale: QuantitativeScale<D>, maxDomainValue: D): this;
+    public maxDomainValue<D>(quantitativeScale: QuantitativeScale<D>, maxDomainValue?: D): any {
+      if (maxDomainValue == null) {
+        return this._maxDomainValues.get(quantitativeScale);
+      }
+      let minValueForScale = this.minDomainValue(quantitativeScale);
+      if (minValueForScale != null && maxDomainValue.valueOf() < minValueForScale.valueOf()) {
+        throw new Error("maxDomainValue must be larger than minDomainValue for the same Scale");
+      }
+      this._maxDomainValues.set(quantitativeScale, maxDomainValue);
+      return this;
+    }
+
+    /**
+     * Uses the current domain of each scale to apply a minimum and maximum
+     * domain value for that scale.
+     *
+     * This constrains the pan/zoom interaction to show no more than the domain
+     * of the scale.
+     */
+    public constrainToScaleDomainValues() {
+      this.xScales().forEach((scale) => {
+        this._minDomainValues.delete(scale);
+        this._maxDomainValues.delete(scale);
+        const domain = scale.domain();
+        this.minDomainValue(scale, domain[0]);
+        this.maxDomainValue(scale, domain[1]);
+      });
+
+      this.yScales().forEach((scale) => {
+        this._minDomainValues.delete(scale);
+        this._maxDomainValues.delete(scale);
+        const domain = scale.domain();
+        this.minDomainValue(scale, domain[0]);
+        this.maxDomainValue(scale, domain[1]);
+      });
     }
 
     /**

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -519,7 +519,7 @@ namespace Plottable.Interactions {
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
     public minDomainExtent<D>(quantitativeScale: QuantitativeScale<D>, minDomainExtent: D): this;
-    public minDomainExtent<D>(quantitativeScale: QuantitativeScale<D>, minDomainExtent?: D): any {
+    public minDomainExtent<D>(quantitativeScale: QuantitativeScale<D>, minDomainExtent?: D): D | this {
       if (minDomainExtent == null) {
         return this._minDomainExtents.get(quantitativeScale);
       }
@@ -558,7 +558,7 @@ namespace Plottable.Interactions {
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
     public maxDomainExtent<D>(quantitativeScale: QuantitativeScale<D>, maxDomainExtent: D): this;
-    public maxDomainExtent<D>(quantitativeScale: QuantitativeScale<D>, maxDomainExtent?: D): any {
+    public maxDomainExtent<D>(quantitativeScale: QuantitativeScale<D>, maxDomainExtent?: D): D | this {
       if (maxDomainExtent == null) {
         return this._maxDomainExtents.get(quantitativeScale);
       }
@@ -607,7 +607,7 @@ namespace Plottable.Interactions {
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
     public minDomainValue<D>(quantitativeScale: QuantitativeScale<D>, minDomainValue: D): this;
-    public minDomainValue<D>(quantitativeScale: QuantitativeScale<D>, minDomainValue?: D): any {
+    public minDomainValue<D>(quantitativeScale: QuantitativeScale<D>, minDomainValue?: D): D | this {
       if (minDomainValue == null) {
         return this._minDomainValues.get(quantitativeScale);
       }
@@ -650,7 +650,7 @@ namespace Plottable.Interactions {
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
     public maxDomainValue<D>(quantitativeScale: QuantitativeScale<D>, maxDomainValue: D): this;
-    public maxDomainValue<D>(quantitativeScale: QuantitativeScale<D>, maxDomainValue?: D): any {
+    public maxDomainValue<D>(quantitativeScale: QuantitativeScale<D>, maxDomainValue?: D): D | this {
       if (maxDomainValue == null) {
         return this._maxDomainValues.get(quantitativeScale);
       }

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -157,13 +157,13 @@ namespace Plottable.Interactions {
       let translateAmountX = centerX - ((constrainedPoints[0].x + constrainedPoints[1].x) / 2);
       this.xScales().forEach((xScale) => {
         this._magnifyScale(xScale, magnifyAmount, centerX);
-        this._translateScale(xScale, translateAmountX);
+        this._translateScale(xScale, this._constrainedTranslation(xScale, translateAmountX));
       });
 
       let translateAmountY = centerY - ((constrainedPoints[0].y + constrainedPoints[1].y) / 2);
       this.yScales().forEach((yScale) => {
         this._magnifyScale(yScale, magnifyAmount, centerY);
-        this._translateScale(yScale, translateAmountY);
+        this._translateScale(yScale, this._constrainedTranslation(yScale, translateAmountY));
       });
     }
 

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -663,18 +663,13 @@ namespace Plottable.Interactions {
     }
 
     /**
-     * Uses the current domain of each scale to apply a minimum and maximum
+     * Uses the current domain of the scale to apply a minimum and maximum
      * domain value for that scale.
      *
      * This constrains the pan/zoom interaction to show no more than the domain
      * of the scale.
      */
-    public constrainToScaleDomainValues() {
-      this.xScales().forEach((scale) => this._constrainToScaleDomainValues(scale));
-      this.yScales().forEach((scale) => this._constrainToScaleDomainValues(scale));
-    }
-
-    private _constrainToScaleDomainValues<D>(scale: QuantitativeScale<D>) {
+    public setMinMaxDomainValuesTo<D>(scale: QuantitativeScale<D>) {
       this._minDomainValues.delete(scale);
       this._maxDomainValues.delete(scale);
       const [ domainMin, domainMax ] = scale.domain();

--- a/test/interactions/panZoomInteractionTests.ts
+++ b/test/interactions/panZoomInteractionTests.ts
@@ -581,6 +581,289 @@ describe("Interactions", () => {
       });
     });
 
+    describe("Setting minDomainValue", () => {
+      let svg: d3.Selection<void>;
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 500;
+      let eventTarget: d3.Selection<void>;
+      let xScale: Plottable.QuantitativeScale<number>;
+      let panZoomInteraction: Plottable.Interactions.PanZoom;
+
+      beforeEach(() => {
+        xScale = new Plottable.Scales.Linear();
+        xScale.domain([0, SVG_WIDTH / 2]).range([0, SVG_WIDTH]);
+
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+
+        let component = new Plottable.Component();
+        component.renderTo(svg);
+
+        panZoomInteraction = new Plottable.Interactions.PanZoom();
+        panZoomInteraction.addXScale(xScale);
+        panZoomInteraction.attachTo(component);
+
+        eventTarget = component.background();
+      });
+
+      afterEach(() => {
+        svg.remove();
+      });
+
+      it("can set minDomainValue", () => {
+        let domainValue = SVG_WIDTH / 4;
+        panZoomInteraction.minDomainValue(xScale, domainValue);
+        assert.strictEqual(panZoomInteraction.minDomainValue(xScale), domainValue,
+          "returns the correct minDomainValue");
+      });
+
+      it("can't set minDomainValue() be larger than maxDomainValue() for the same Scale", () => {
+        let domainValue = SVG_WIDTH / 2;
+        panZoomInteraction.maxDomainValue(xScale, domainValue);
+
+        let tooBigValue = domainValue * 2;
+        // HACKHACK #2661: Cannot assert errors being thrown with description
+        (<any> assert).throws(() => panZoomInteraction.minDomainValue(xScale, tooBigValue), Error,
+          "minDomainValue must be smaller than maxDomainValue for the same Scale",
+          "cannot have minDomainValue larger than maxDomainValue");
+      });
+
+      it("cannot go beyond the specified minDomainValue (mousewheel)", () => {
+        // HACKHACK PhantomJS doesn't implement fake creation of WheelEvents
+        // https://github.com/ariya/phantomjs/issues/11289
+        if (window.PHANTOMJS) {
+          return;
+        }
+
+        let domainValue = SVG_WIDTH / 4;
+
+        // simulate massive scroll zoom out
+        let scrollPoint = { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 };
+        let deltaY = 3000;
+        TestMethods.triggerFakeWheelEvent("wheel", svg, scrollPoint.x, scrollPoint.y, deltaY);
+        assert.operator(xScale.domain()[0], "<", domainValue, "no initial limit");
+
+        // add limit
+        panZoomInteraction.minDomainValue(xScale, domainValue);
+
+        TestMethods.triggerFakeWheelEvent("wheel", svg, scrollPoint.x, scrollPoint.y, deltaY);
+        assert.strictEqual(xScale.domain()[0], domainValue, "limit works");
+      });
+
+      it("cannot go beyond the specified minDomainValue (pinching)", () => {
+        let domainValue = SVG_WIDTH / 4;
+
+        let startPoint = { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 };
+        let startPoint2 = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 2 };
+        let zoomAmount = 1 / 6;
+        let endX = (startPoint2.x - startPoint.x) * zoomAmount + startPoint.x;
+        let endY = (startPoint2.y - startPoint.y) * zoomAmount + startPoint.y;
+        let endPoint = { x: endX, y: endY };
+
+        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint, startPoint2], [0, 1]);
+        TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint], [1]);
+        TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint], [1]);
+
+        assert.operator(xScale.domain()[0], "<", domainValue, "no initial limit");
+
+        // add limit
+        panZoomInteraction.minDomainValue(xScale, domainValue);
+
+        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint, startPoint2], [0, 1]);
+        TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint], [1]);
+        TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint], [1]);
+
+        assert.strictEqual(xScale.domain()[0], domainValue, "limit works");
+      });
+    });
+
+    describe("Setting maxDomainValue", () => {
+      let svg: d3.Selection<void>;
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 500;
+      let eventTarget: d3.Selection<void>;
+      let xScale: Plottable.QuantitativeScale<number>;
+      let panZoomInteraction: Plottable.Interactions.PanZoom;
+
+      beforeEach(() => {
+        xScale = new Plottable.Scales.Linear();
+        xScale.domain([0, SVG_WIDTH / 2]).range([0, SVG_WIDTH]);
+
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+
+        let component = new Plottable.Component();
+        component.renderTo(svg);
+
+        panZoomInteraction = new Plottable.Interactions.PanZoom();
+        panZoomInteraction.addXScale(xScale);
+        panZoomInteraction.attachTo(component);
+
+        eventTarget = component.background();
+      });
+
+      afterEach(() => {
+        svg.remove();
+      });
+
+      it("can set maxDomainValue", () => {
+        let domainValue = SVG_WIDTH / 4;
+        panZoomInteraction.maxDomainValue(xScale, domainValue);
+        assert.strictEqual(panZoomInteraction.maxDomainValue(xScale), domainValue,
+          "returns the correct minDomainValue");
+      });
+
+      it("can't set maxDomainValue() be smaller than maxDomainValue() for the same Scale", () => {
+        let domainValue = SVG_WIDTH / 2;
+        panZoomInteraction.minDomainValue(xScale, domainValue);
+
+        let tooSmallValue = domainValue / 2;
+        // HACKHACK #2661: Cannot assert errors being thrown with description
+        (<any> assert).throws(() => panZoomInteraction.maxDomainValue(xScale, tooSmallValue), Error,
+          "maxDomainValue must be larger than minDomainValue for the same Scale",
+          "cannot have minDomainValue larger than maxDomainValue");
+      });
+
+      it("cannot go beyond the specified maxDomainValue (mousewheel)", () => {
+        // HACKHACK PhantomJS doesn't implement fake creation of WheelEvents
+        // https://github.com/ariya/phantomjs/issues/11289
+        if (window.PHANTOMJS) {
+          return;
+        }
+
+        let domainValue = SVG_WIDTH / 2;
+
+        // simulate massive scroll zoom out
+        let scrollPoint = { x: SVG_WIDTH / 4, y: SVG_HEIGHT / 4 };
+        let deltaY = 3000;
+        TestMethods.triggerFakeWheelEvent("wheel", svg, scrollPoint.x, scrollPoint.y, deltaY);
+        assert.operator(xScale.domain()[1], ">", domainValue, "no initial limit");
+
+        // add limit
+        panZoomInteraction.maxDomainValue(xScale, domainValue);
+
+        TestMethods.triggerFakeWheelEvent("wheel", svg, scrollPoint.x, scrollPoint.y, deltaY);
+        assert.strictEqual(xScale.domain()[1], domainValue, "limit works");
+      });
+
+      it("cannot go beyond the specified maxDomainValue (pinching)", () => {
+        let domainValue = SVG_WIDTH / 2;
+
+        let fromCenter = (dx: number, dy: number) => {
+          return { x: SVG_WIDTH / 4 + dx, y: SVG_HEIGHT / 4 + dy };
+        };
+
+        let startPoint1 = fromCenter(-60, 0);
+        let startPoint2 = fromCenter(60, 0);
+        let endPoint1 = fromCenter(-10, 0);
+        let endPoint2 = fromCenter(10, 0);
+
+        // zoom out pinch
+        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint1, startPoint2], [0, 1]);
+        TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint1, endPoint2], [0, 1]);
+        TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint1, endPoint2], [0, 1]);
+
+        assert.operator(xScale.domain()[1], ">", domainValue, "no initial limit " + xScale.domain());
+
+        // add limit
+        panZoomInteraction.maxDomainValue(xScale, domainValue);
+
+        // zoom out pinch
+        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint1, startPoint2], [0, 1]);
+        TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint1, endPoint2], [0, 1]);
+        TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint1, endPoint2], [0, 1]);
+
+        assert.strictEqual(xScale.domain()[1], domainValue, "limit works");
+      });
+    });
+
+    describe("Setting both minDomainValue and maxDomainValue", () => {
+      let svg: d3.Selection<void>;
+      let SVG_WIDTH = 400;
+      let SVG_HEIGHT = 500;
+      let eventTarget: d3.Selection<void>;
+      let xScale: Plottable.QuantitativeScale<number>;
+      let panZoomInteraction: Plottable.Interactions.PanZoom;
+
+      beforeEach(() => {
+        xScale = new Plottable.Scales.Linear();
+        xScale.domain([0, SVG_WIDTH / 2]).range([0, SVG_WIDTH]);
+
+        svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+
+        let component = new Plottable.Component();
+        component.renderTo(svg);
+
+        panZoomInteraction = new Plottable.Interactions.PanZoom();
+        panZoomInteraction.addXScale(xScale);
+        panZoomInteraction.attachTo(component);
+
+        eventTarget = component.background();
+      });
+
+      afterEach(() => {
+        svg.remove();
+      });
+
+      it("cannot go beyond the specified maxDomainValue (mousewheel)", () => {
+        // HACKHACK PhantomJS doesn't implement fake creation of WheelEvents
+        // https://github.com/ariya/phantomjs/issues/11289
+        if (window.PHANTOMJS) {
+          return;
+        }
+
+        let domainMinValue = SVG_WIDTH / 4;
+        let domainMaxValue = domainMinValue + SVG_WIDTH / 2;
+
+        // simulate massive scroll zoom out
+        let scrollPoint = { x: SVG_WIDTH / 2, y: SVG_HEIGHT / 4 };
+        let deltaY = 3000;
+        TestMethods.triggerFakeWheelEvent("wheel", svg, scrollPoint.x, scrollPoint.y, deltaY);
+        assert.operator(xScale.domain()[0], "<", domainMinValue, "no initial min limit");
+        assert.operator(xScale.domain()[1], ">", domainMaxValue, "no initial max limit");
+
+        // add limit
+        xScale.domain([domainMinValue, domainMaxValue]);
+        panZoomInteraction.constrainToScaleDomainValues();
+
+        TestMethods.triggerFakeWheelEvent("wheel", svg, scrollPoint.x, scrollPoint.y, deltaY);
+        assert.strictEqual(xScale.domain()[0], domainMinValue, "min limit works");
+        assert.strictEqual(xScale.domain()[1], domainMaxValue, "max limit works");
+      });
+
+      it("cannot go beyond the specified minDomainValue (pinching)", () => {
+        let fromCenter = (dx: number, dy: number) => {
+          return { x: SVG_WIDTH / 4 + dx, y: SVG_HEIGHT / 4 + dy };
+        };
+
+        let domainMinValue = SVG_WIDTH / 4;
+        let domainMaxValue = domainMinValue + SVG_WIDTH / 2;
+
+        let startPoint1 = fromCenter(-60, 0);
+        let startPoint2 = fromCenter(60, 0);
+        let endPoint1 = fromCenter(-10, 0);
+        let endPoint2 = fromCenter(10, 0);
+
+        // zoom out pinch
+        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint1, startPoint2], [0, 1]);
+        TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint1, endPoint2], [0, 1]);
+        TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint1, endPoint2], [0, 1]);
+
+        assert.operator(xScale.domain()[0], "<", domainMinValue, "no initial min limit");
+        assert.operator(xScale.domain()[1], ">", domainMaxValue, "no initial max limit");
+
+        // add limit
+        xScale.domain([domainMinValue, domainMaxValue]);
+        panZoomInteraction.constrainToScaleDomainValues();
+
+        // zoom out pinch
+        TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint1, startPoint2], [0, 1]);
+        TestMethods.triggerFakeTouchEvent("touchmove", eventTarget, [endPoint1, endPoint2], [0, 1]);
+        TestMethods.triggerFakeTouchEvent("touchend", eventTarget, [endPoint1, endPoint2], [0, 1]);
+
+        assert.strictEqual(xScale.domain()[0], domainMinValue, "min limit works");
+        assert.strictEqual(xScale.domain()[1], domainMaxValue, "max limit works");
+      });
+    });
+
     describe("Registering and deregistering Pan and Zoom event callbacks", () => {
       let svg: d3.Selection<void>;
       let SVG_WIDTH = 400;

--- a/test/interactions/panZoomInteractionTests.ts
+++ b/test/interactions/panZoomInteractionTests.ts
@@ -822,7 +822,7 @@ describe("Interactions", () => {
 
         // add limit
         xScale.domain([domainMinValue, domainMaxValue]);
-        panZoomInteraction.constrainToScaleDomainValues();
+        panZoomInteraction.setMinMaxDomainValuesTo(xScale);
 
         TestMethods.triggerFakeWheelEvent("wheel", svg, scrollPoint.x, scrollPoint.y, deltaY);
         assert.strictEqual(xScale.domain()[0], domainMinValue, "min limit works");
@@ -852,7 +852,7 @@ describe("Interactions", () => {
 
         // add limit
         xScale.domain([domainMinValue, domainMaxValue]);
-        panZoomInteraction.constrainToScaleDomainValues();
+        panZoomInteraction.setMinMaxDomainValuesTo(xScale);
 
         // zoom out pinch
         TestMethods.triggerFakeTouchEvent("touchstart", eventTarget, [startPoint1, startPoint2], [0, 1]);


### PR DESCRIPTION
Previously it was only possible to set the min/max
domain EXTENT. This was only respected by the total
zoom level.

For example, if min/max extent was set to [0, 10],
then it was possible to pan to [10, 20] or zoom to
[-5, 5].

This change adds domain VALUE constraints to both pan
and zoom to respect the absolute domain boundaries.

The implementation for zoom constraints must consider
that the zoom interaction may violate the constraints
for min, max, or both.

We handle each of these cases seperately:
min only: We adjust the "center" coordinate of the zoom.
max only: We adjust the "center" coordinate of the zoom.
min and max: We adjust both the "center" and "zoom" values.

This also supports partial constraints (i.e. only min
or max set).