### PR TITLE
[slightly breaking] Fix ts2.0 errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-saucelabs": "8.6.2",
     "grunt-sed": "0.1.1",
     "grunt-shell": "1.1.2",
-    "grunt-ts": "5.3.2",
+    "grunt-ts": "5.5.0",
     "grunt-tslint": "3.0.3",
     "grunt-umd": "2.3.5",
     "jquery": "2.1.0",

--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -1665,6 +1665,7 @@ declare namespace Plottable.Components {
     }
 }
 declare namespace Plottable {
+    type AxisOrientation = "left" | "top" | "right" | "bottom";
     class Axis<D> extends Component {
         /**
          * The css class applied to each end tick mark (the line on the end tick).
@@ -1720,9 +1721,9 @@ declare namespace Plottable {
          *
          * @constructor
          * @param {Scale} scale
-         * @param {string} orientation One of "top"/"bottom"/"left"/"right".
+         * @param {AxisOrientation} orientation Orientation of this Axis.
          */
-        constructor(scale: Scale<D, number>, orientation: string);
+        constructor(scale: Scale<D, number>, orientation: AxisOrientation);
         destroy(): void;
         protected _isHorizontal(): boolean;
         protected _computeWidth(): number;
@@ -1858,14 +1859,14 @@ declare namespace Plottable {
         /**
          * Gets the orientation of the Axis.
          */
-        orientation(): string;
+        orientation(): AxisOrientation;
         /**
          * Sets the orientation of the Axis.
          *
-         * @param {number} orientation One of "top"/"bottom"/"left"/"right".
+         * @param {AxisOrientation} orientation The orientation to apply to this axis.
          * @returns {Axis} The calling Axis.
          */
-        orientation(orientation: string): this;
+        orientation(orientation: AxisOrientation): this;
         /**
          * Gets whether the Axis shows the end tick labels.
          */
@@ -1909,6 +1910,10 @@ declare namespace Plottable.Axes {
      * Currently, up to two tiers are supported.
      */
     type TimeAxisConfiguration = TimeAxisTierConfiguration[];
+    /**
+     * Possible orientations for a Time Axis.
+     */
+    type TimeAxisOrientation = "top" | "bottom";
     class Time extends Axis<Date> {
         /**
          * The CSS class applied to each Time Axis tier
@@ -1932,9 +1937,10 @@ declare namespace Plottable.Axes {
          *
          * @constructor
          * @param {Scales.Time} scale
-         * @param {string} orientation One of "top"/"bottom".
+         * @param {AxisOrientation} orientation Orientation of this Time Axis. Time Axes can only have "top" or "bottom"
+         * orientations.
          */
-        constructor(scale: Scales.Time, orientation: string);
+        constructor(scale: Scales.Time, orientation: TimeAxisOrientation);
         /**
          * Gets the label positions for each tier.
          */
@@ -1962,8 +1968,8 @@ declare namespace Plottable.Axes {
          * Gets the index of the most precise TimeAxisConfiguration that will fit in the current width.
          */
         private _getMostPreciseConfigurationIndex();
-        orientation(): string;
-        orientation(orientation: string): this;
+        orientation(): TimeAxisOrientation;
+        orientation(orientation: TimeAxisOrientation): this;
         protected _computeHeight(): number;
         private _getIntervalLength(config);
         private _maxWidthForInterval(config);
@@ -2003,9 +2009,9 @@ declare namespace Plottable.Axes {
          *
          * @constructor
          * @param {QuantitativeScale} scale
-         * @param {string} orientation One of "top"/"bottom"/"left"/"right".
+         * @param {AxisOrientaiton} orientation Orientation of this Numeric Axis.
          */
-        constructor(scale: QuantitativeScale<number>, orientation: string);
+        constructor(scale: QuantitativeScale<number>, orientation: AxisOrientation);
         protected _setup(): void;
         protected _computeWidth(): number;
         private _computeExactTextWidth();
@@ -2078,9 +2084,9 @@ declare namespace Plottable.Axes {
          *
          * @constructor
          * @param {Scales.Category} scale
-         * @param {string} [orientation="bottom"] One of "top"/"bottom"/"left"/"right".
+         * @param {AxisOrientation} [orientation="bottom"] Orientation of this Category Axis.
          */
-        constructor(scale: Scales.Category, orientation: string);
+        constructor(scale: Scales.Category, orientation?: AxisOrientation);
         protected _setup(): void;
         protected _rescale(): this;
         requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;

--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -1665,7 +1665,7 @@ declare namespace Plottable.Components {
     }
 }
 declare namespace Plottable {
-    type AxisOrientation = "left" | "top" | "right" | "bottom";
+    type AxisOrientation = "bottom" | "left" | "right" | "top";
     class Axis<D> extends Component {
         /**
          * The css class applied to each end tick mark (the line on the end tick).
@@ -2009,7 +2009,7 @@ declare namespace Plottable.Axes {
          *
          * @constructor
          * @param {QuantitativeScale} scale
-         * @param {AxisOrientaiton} orientation Orientation of this Numeric Axis.
+         * @param {AxisOrientation} orientation Orientation of this Numeric Axis.
          */
         constructor(scale: QuantitativeScale<number>, orientation: AxisOrientation);
         protected _setup(): void;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1664,7 +1664,7 @@ declare namespace Plottable.Components {
     }
 }
 declare namespace Plottable {
-    type AxisOrientation = "left" | "top" | "right" | "bottom";
+    type AxisOrientation = "bottom" | "left" | "right" | "top";
     class Axis<D> extends Component {
         /**
          * The css class applied to each end tick mark (the line on the end tick).
@@ -2008,7 +2008,7 @@ declare namespace Plottable.Axes {
          *
          * @constructor
          * @param {QuantitativeScale} scale
-         * @param {AxisOrientaiton} orientation Orientation of this Numeric Axis.
+         * @param {AxisOrientation} orientation Orientation of this Numeric Axis.
          */
         constructor(scale: QuantitativeScale<number>, orientation: AxisOrientation);
         protected _setup(): void;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1664,6 +1664,7 @@ declare namespace Plottable.Components {
     }
 }
 declare namespace Plottable {
+    type AxisOrientation = "left" | "top" | "right" | "bottom";
     class Axis<D> extends Component {
         /**
          * The css class applied to each end tick mark (the line on the end tick).
@@ -1719,9 +1720,9 @@ declare namespace Plottable {
          *
          * @constructor
          * @param {Scale} scale
-         * @param {string} orientation One of "top"/"bottom"/"left"/"right".
+         * @param {AxisOrientation} orientation Orientation of this Axis.
          */
-        constructor(scale: Scale<D, number>, orientation: string);
+        constructor(scale: Scale<D, number>, orientation: AxisOrientation);
         destroy(): void;
         protected _isHorizontal(): boolean;
         protected _computeWidth(): number;
@@ -1857,14 +1858,14 @@ declare namespace Plottable {
         /**
          * Gets the orientation of the Axis.
          */
-        orientation(): string;
+        orientation(): AxisOrientation;
         /**
          * Sets the orientation of the Axis.
          *
-         * @param {number} orientation One of "top"/"bottom"/"left"/"right".
+         * @param {AxisOrientation} orientation The orientation to apply to this axis.
          * @returns {Axis} The calling Axis.
          */
-        orientation(orientation: string): this;
+        orientation(orientation: AxisOrientation): this;
         /**
          * Gets whether the Axis shows the end tick labels.
          */
@@ -1908,6 +1909,10 @@ declare namespace Plottable.Axes {
      * Currently, up to two tiers are supported.
      */
     type TimeAxisConfiguration = TimeAxisTierConfiguration[];
+    /**
+     * Possible orientations for a Time Axis.
+     */
+    type TimeAxisOrientation = "top" | "bottom";
     class Time extends Axis<Date> {
         /**
          * The CSS class applied to each Time Axis tier
@@ -1931,9 +1936,10 @@ declare namespace Plottable.Axes {
          *
          * @constructor
          * @param {Scales.Time} scale
-         * @param {string} orientation One of "top"/"bottom".
+         * @param {AxisOrientation} orientation Orientation of this Time Axis. Time Axes can only have "top" or "bottom"
+         * orientations.
          */
-        constructor(scale: Scales.Time, orientation: string);
+        constructor(scale: Scales.Time, orientation: TimeAxisOrientation);
         /**
          * Gets the label positions for each tier.
          */
@@ -1961,8 +1967,8 @@ declare namespace Plottable.Axes {
          * Gets the index of the most precise TimeAxisConfiguration that will fit in the current width.
          */
         private _getMostPreciseConfigurationIndex();
-        orientation(): string;
-        orientation(orientation: string): this;
+        orientation(): TimeAxisOrientation;
+        orientation(orientation: TimeAxisOrientation): this;
         protected _computeHeight(): number;
         private _getIntervalLength(config);
         private _maxWidthForInterval(config);
@@ -2002,9 +2008,9 @@ declare namespace Plottable.Axes {
          *
          * @constructor
          * @param {QuantitativeScale} scale
-         * @param {string} orientation One of "top"/"bottom"/"left"/"right".
+         * @param {AxisOrientaiton} orientation Orientation of this Numeric Axis.
          */
-        constructor(scale: QuantitativeScale<number>, orientation: string);
+        constructor(scale: QuantitativeScale<number>, orientation: AxisOrientation);
         protected _setup(): void;
         protected _computeWidth(): number;
         private _computeExactTextWidth();
@@ -2077,9 +2083,9 @@ declare namespace Plottable.Axes {
          *
          * @constructor
          * @param {Scales.Category} scale
-         * @param {string} [orientation="bottom"] One of "top"/"bottom"/"left"/"right".
+         * @param {AxisOrientation} [orientation="bottom"] Orientation of this Category Axis.
          */
-        constructor(scale: Scales.Category, orientation: string);
+        constructor(scale: Scales.Category, orientation?: AxisOrientation);
         protected _setup(): void;
         protected _rescale(): this;
         requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;

--- a/plottable.js
+++ b/plottable.js
@@ -1285,49 +1285,44 @@ var Plottable;
          * @returns {Formatter} A formatter for time/date values.
          */
         function multiTime() {
-            var numFormats = 8;
-            // these defaults were taken from d3
+            // Formatter tiers going from shortest time scale to largest - these were taken from d3
             // https://github.com/mbostock/d3/wiki/Time-Formatting#format_multi
-            var timeFormat = {};
-            timeFormat[0] = {
-                format: ".%L",
-                filter: function (d) { return d.getMilliseconds() !== 0; },
-            };
-            timeFormat[1] = {
-                format: ":%S",
-                filter: function (d) { return d.getSeconds() !== 0; },
-            };
-            timeFormat[2] = {
-                format: "%I:%M",
-                filter: function (d) { return d.getMinutes() !== 0; },
-            };
-            timeFormat[3] = {
-                format: "%I %p",
-                filter: function (d) { return d.getHours() !== 0; },
-            };
-            timeFormat[4] = {
-                format: "%a %d",
-                filter: function (d) { return d.getDay() !== 0 && d.getDate() !== 1; },
-            };
-            timeFormat[5] = {
-                format: "%b %d",
-                filter: function (d) { return d.getDate() !== 1; },
-            };
-            timeFormat[6] = {
-                format: "%b",
-                filter: function (d) { return d.getMonth() !== 0; },
-            };
-            timeFormat[7] = {
-                format: "%Y",
-                filter: function () { return true; },
-            };
+            var candidateFormats = [
+                {
+                    specifier: ".%L",
+                    predicate: function (d) { return d.getMilliseconds() !== 0; },
+                },
+                {
+                    specifier: ":%S",
+                    predicate: function (d) { return d.getSeconds() !== 0; },
+                },
+                {
+                    specifier: "%I:%M",
+                    predicate: function (d) { return d.getMinutes() !== 0; },
+                },
+                {
+                    specifier: "%I %p",
+                    predicate: function (d) { return d.getHours() !== 0; },
+                },
+                {
+                    specifier: "%a %d",
+                    predicate: function (d) { return d.getDay() !== 0 && d.getDate() !== 1; },
+                },
+                {
+                    specifier: "%b %d",
+                    predicate: function (d) { return d.getDate() !== 1; },
+                },
+                {
+                    specifier: "%b",
+                    predicate: function (d) { return d.getMonth() !== 0; },
+                },
+            ];
             return function (d) {
-                for (var i = 0; i < numFormats; i++) {
-                    if (timeFormat[i].filter(d)) {
-                        return d3.time.format(timeFormat[i].format)(d);
-                    }
-                }
-                return undefined;
+                var acceptableFormats = candidateFormats.filter(function (candidate) { return candidate.predicate(d); });
+                var specifier = acceptableFormats.length > 0
+                    ? acceptableFormats[0].specifier
+                    : "%Y";
+                return d3.time.format(specifier)(d);
             };
         }
         Formatters.multiTime = multiTime;
@@ -4591,7 +4586,7 @@ var Plottable;
              *
              * @constructor
              * @param {QuantitativeScale} scale
-             * @param {AxisOrientaiton} orientation Orientation of this Numeric Axis.
+             * @param {AxisOrientation} orientation Orientation of this Numeric Axis.
              */
             function Numeric(scale, orientation) {
                 _super.call(this, scale, orientation);
@@ -9885,7 +9880,7 @@ var Plottable;
                         return _this._lineIntersectsSegment(startPoint, endPoint, point, corners[index - 1]) &&
                             _this._lineIntersectsSegment(point, corners[index - 1], startPoint, endPoint);
                     }
-                    return undefined;
+                    return false;
                 });
                 return intersections.length > 0;
             };

--- a/plottable.js
+++ b/plottable.js
@@ -1327,6 +1327,7 @@ var Plottable;
                         return d3.time.format(timeFormat[i].format)(d);
                     }
                 }
+                return undefined;
             };
         }
         Formatters.multiTime = multiTime;
@@ -3564,7 +3565,7 @@ var Plottable;
          *
          * @constructor
          * @param {Scale} scale
-         * @param {string} orientation One of "top"/"bottom"/"left"/"right".
+         * @param {AxisOrientation} orientation Orientation of this Axis.
          */
         function Axis(scale, orientation) {
             var _this = this;
@@ -4047,6 +4048,7 @@ var Plottable;
                 return this._orientation;
             }
             else {
+                // ensure backwards compatibility for older versions that supply orientation in different cases
                 var newOrientationLC = orientation.toLowerCase();
                 if (newOrientationLC !== "top" &&
                     newOrientationLC !== "bottom" &&
@@ -4127,7 +4129,8 @@ var Plottable;
              *
              * @constructor
              * @param {Scales.Time} scale
-             * @param {string} orientation One of "top"/"bottom".
+             * @param {AxisOrientation} orientation Orientation of this Time Axis. Time Axes can only have "top" or "bottom"
+             * orientations.
              */
             function Time(scale, orientation) {
                 _super.call(this, scale, orientation);
@@ -4588,7 +4591,7 @@ var Plottable;
              *
              * @constructor
              * @param {QuantitativeScale} scale
-             * @param {string} orientation One of "top"/"bottom"/"left"/"right".
+             * @param {AxisOrientaiton} orientation Orientation of this Numeric Axis.
              */
             function Numeric(scale, orientation) {
                 _super.call(this, scale, orientation);
@@ -4916,9 +4919,10 @@ var Plottable;
              *
              * @constructor
              * @param {Scales.Category} scale
-             * @param {string} [orientation="bottom"] One of "top"/"bottom"/"left"/"right".
+             * @param {AxisOrientation} [orientation="bottom"] Orientation of this Category Axis.
              */
             function Category(scale, orientation) {
+                if (orientation === void 0) { orientation = "bottom"; }
                 _super.call(this, scale, orientation);
                 this._tickLabelAngle = 0;
                 this.addClass("category-axis");
@@ -9881,6 +9885,7 @@ var Plottable;
                         return _this._lineIntersectsSegment(startPoint, endPoint, point, corners[index - 1]) &&
                             _this._lineIntersectsSegment(point, corners[index - 1], startPoint, endPoint);
                     }
+                    return undefined;
                 });
                 return intersections.length > 0;
             };
@@ -12119,8 +12124,8 @@ var Plottable;
                         this._detectionCornerBL.attr({ cx: l, cy: b, r: this._detectionRadius });
                         this._detectionCornerBR.attr({ cx: r, cy: b, r: this._detectionRadius });
                     }
-                    return this;
                 }
+                return this;
             };
             DragBoxLayer.prototype.detectionRadius = function (r) {
                 if (r == null) {

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -1,4 +1,6 @@
 namespace Plottable {
+export type AxisOrientation = "left" | "top" | "right" | "bottom";
+
 export class Axis<D> extends Component {
   /**
    * The css class applied to each end tick mark (the line on the end tick).
@@ -34,7 +36,7 @@ export class Axis<D> extends Component {
   protected _baseline: d3.Selection<void>;
   protected _scale: Scale<D, number>;
   private _formatter: Formatter;
-  private _orientation: string;
+  private _orientation: AxisOrientation;
   private _endTickLength = 5;
   private _innerTickLength = 5;
   private _tickLabelPadding = 10;
@@ -56,9 +58,9 @@ export class Axis<D> extends Component {
    *
    * @constructor
    * @param {Scale} scale
-   * @param {string} orientation One of "top"/"bottom"/"left"/"right".
+   * @param {AxisOrientation} orientation Orientation of this Axis.
    */
-  constructor(scale: Scale<D, number>, orientation: string) {
+  constructor(scale: Scale<D, number>, orientation: AxisOrientation) {
     super();
     if (scale == null || orientation == null) { throw new Error("Axis requires a scale and orientation"); }
     this._scale = scale;
@@ -677,19 +679,20 @@ export class Axis<D> extends Component {
   /**
    * Gets the orientation of the Axis.
    */
-  public orientation(): string;
+  public orientation(): AxisOrientation;
   /**
    * Sets the orientation of the Axis.
    *
-   * @param {number} orientation One of "top"/"bottom"/"left"/"right".
+   * @param {AxisOrientation} orientation The orientation to apply to this axis.
    * @returns {Axis} The calling Axis.
    */
-  public orientation(orientation: string): this;
-  public orientation(orientation?: string): any {
+  public orientation(orientation: AxisOrientation): this;
+  public orientation(orientation?: AxisOrientation): AxisOrientation | this {
     if (orientation == null) {
       return this._orientation;
     } else {
-      let newOrientationLC = orientation.toLowerCase();
+      // ensure backwards compatibility for older versions that supply orientation in different cases
+      let newOrientationLC = orientation.toLowerCase() as AxisOrientation;
       if (newOrientationLC !== "top" &&
           newOrientationLC !== "bottom" &&
           newOrientationLC !== "left" &&

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -1,5 +1,5 @@
 namespace Plottable {
-export type AxisOrientation = "left" | "top" | "right" | "bottom";
+export type AxisOrientation =  "bottom" | "left" | "right" | "top";
 
 export class Axis<D> extends Component {
   /**

--- a/src/axes/categoryAxis.ts
+++ b/src/axes/categoryAxis.ts
@@ -12,9 +12,9 @@ namespace Plottable.Axes {
      *
      * @constructor
      * @param {Scales.Category} scale
-     * @param {string} [orientation="bottom"] One of "top"/"bottom"/"left"/"right".
+     * @param {AxisOrientation} [orientation="bottom"] Orientation of this Category Axis.
      */
-    constructor(scale: Scales.Category, orientation: string) {
+    constructor(scale: Scales.Category, orientation: AxisOrientation = "bottom") {
       super(scale, orientation);
       this.addClass("category-axis");
     }

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -13,7 +13,7 @@ namespace Plottable.Axes {
      *
      * @constructor
      * @param {QuantitativeScale} scale
-     * @param {AxisOrientaiton} orientation Orientation of this Numeric Axis.
+     * @param {AxisOrientation} orientation Orientation of this Numeric Axis.
      */
     constructor(scale: QuantitativeScale<number>, orientation: AxisOrientation) {
       super(scale, orientation);

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -13,9 +13,9 @@ namespace Plottable.Axes {
      *
      * @constructor
      * @param {QuantitativeScale} scale
-     * @param {string} orientation One of "top"/"bottom"/"left"/"right".
+     * @param {AxisOrientaiton} orientation Orientation of this Numeric Axis.
      */
-    constructor(scale: QuantitativeScale<number>, orientation: string) {
+    constructor(scale: QuantitativeScale<number>, orientation: AxisOrientation) {
       super(scale, orientation);
       this.formatter(Formatters.general());
     }

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -266,7 +266,7 @@ namespace Plottable.Axes {
 
     public orientation(): TimeAxisOrientation;
     public orientation(orientation: TimeAxisOrientation): this;
-    public orientation(orientation?: TimeAxisOrientation): any {
+    public orientation(orientation?: TimeAxisOrientation): TimeAxisOrientation | this {
       if (orientation && (orientation.toLowerCase() === "right" || orientation.toLowerCase() === "left")) {
         throw new Error(orientation + " is not a supported orientation for TimeAxis - only horizontal orientations are supported");
       }

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -33,6 +33,11 @@ namespace Plottable.Axes {
    */
   export type TimeAxisConfiguration = TimeAxisTierConfiguration[];
 
+  /**
+   * Possible orientations for a Time Axis.
+   */
+  export type TimeAxisOrientation = "top" | "bottom";
+
   export class Time extends Axis<Date> {
     /**
      * The CSS class applied to each Time Axis tier
@@ -170,9 +175,10 @@ namespace Plottable.Axes {
      *
      * @constructor
      * @param {Scales.Time} scale
-     * @param {string} orientation One of "top"/"bottom".
+     * @param {AxisOrientation} orientation Orientation of this Time Axis. Time Axes can only have "top" or "bottom"
+     * orientations.
      */
-    constructor(scale: Scales.Time, orientation: string) {
+    constructor(scale: Scales.Time, orientation: TimeAxisOrientation) {
       super(scale, orientation);
       this.addClass("time-axis");
       this.tickLabelPadding(5);
@@ -258,9 +264,9 @@ namespace Plottable.Axes {
       return mostPreciseIndex;
     }
 
-    public orientation(): string;
-    public orientation(orientation: string): this;
-    public orientation(orientation?: string): any {
+    public orientation(): TimeAxisOrientation;
+    public orientation(orientation: TimeAxisOrientation): this;
+    public orientation(orientation?: TimeAxisOrientation): any {
       if (orientation && (orientation.toLowerCase() === "right" || orientation.toLowerCase() === "left")) {
         throw new Error(orientation + " is not a supported orientation for TimeAxis - only horizontal orientations are supported");
       }

--- a/src/components/dragBoxLayer.ts
+++ b/src/components/dragBoxLayer.ts
@@ -257,8 +257,8 @@ namespace Plottable.Components {
           this._detectionCornerBL.attr({ cx: l, cy: b, r: this._detectionRadius });
           this._detectionCornerBR.attr({ cx: r, cy: b, r: this._detectionRadius });
         }
-        return this;
       }
+      return this;
     }
 
     /**

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -216,6 +216,7 @@ namespace Plottable.Formatters {
           return d3.time.format(timeFormat[i].format)(d);
         }
       }
+      return undefined;
     };
   }
 

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -6,9 +6,9 @@ namespace Plottable {
 
 namespace Plottable.Formatters {
 
-  interface TimeFilterFormat {
-    format: string;
-    filter: (d: any) => any;
+  interface PredicatedFormat {
+    specifier: string;
+    predicate: (d: Date) => boolean;
   }
 
   /**
@@ -170,53 +170,52 @@ namespace Plottable.Formatters {
    * @returns {Formatter} A formatter for time/date values.
    */
   export function multiTime() {
-
-    let numFormats = 8;
-
-    // these defaults were taken from d3
+    // Formatter tiers going from shortest time scale to largest - these were taken from d3
     // https://github.com/mbostock/d3/wiki/Time-Formatting#format_multi
-    let timeFormat: { [index: number]: TimeFilterFormat } = {};
+    const candidateFormats: PredicatedFormat[] = [
+      {
+        specifier: ".%L",
+        predicate: (d) => d.getMilliseconds() !== 0,
+      },
 
-    timeFormat[0] = {
-      format: ".%L",
-      filter: (d: any) => d.getMilliseconds() !== 0,
-    };
-    timeFormat[1] = {
-      format: ":%S",
-      filter: (d: any) => d.getSeconds() !== 0,
-    };
-    timeFormat[2] = {
-      format: "%I:%M",
-      filter: (d: any) => d.getMinutes() !== 0,
-    };
-    timeFormat[3] = {
-      format: "%I %p",
-      filter: (d: any) => d.getHours() !== 0,
-    };
-    timeFormat[4] = {
-      format: "%a %d",
-      filter: (d: any) => d.getDay() !== 0 && d.getDate() !== 1,
-    };
-    timeFormat[5] = {
-      format: "%b %d",
-      filter: (d: any) => d.getDate() !== 1,
-    };
-    timeFormat[6] = {
-      format: "%b",
-      filter: (d: any) => d.getMonth() !== 0,
-    };
-    timeFormat[7] = {
-      format: "%Y",
-      filter: () => true,
-    };
+      {
+        specifier: ":%S",
+        predicate: (d) => d.getSeconds() !== 0,
+      },
+
+      {
+        specifier: "%I:%M",
+        predicate: (d) => d.getMinutes() !== 0,
+      },
+
+      {
+        specifier: "%I %p",
+        predicate: (d) => d.getHours() !== 0,
+      },
+
+      {
+        specifier: "%a %d",
+        predicate: (d) => d.getDay() !== 0 && d.getDate() !== 1,
+      },
+
+      {
+        specifier: "%b %d",
+        predicate: (d) => d.getDate() !== 1,
+      },
+
+      {
+        specifier: "%b",
+        predicate: (d) => d.getMonth() !== 0,
+      },
+    ];
 
     return (d: any) => {
-      for (let i = 0; i < numFormats; i++) {
-        if (timeFormat[i].filter(d)) {
-          return d3.time.format(timeFormat[i].format)(d);
-        }
-      }
-      return undefined;
+      const acceptableFormats = candidateFormats.filter((candidate) => candidate.predicate(d));
+      let specifier = acceptableFormats.length > 0
+        ? acceptableFormats[0].specifier
+        : "%Y";
+
+      return d3.time.format(specifier)(d);
     };
   }
 

--- a/src/plots/segmentPlot.ts
+++ b/src/plots/segmentPlot.ts
@@ -243,9 +243,9 @@ namespace Plottable.Plots {
           if (index !== 0) {
             // return true if border formed by conecting current corner and previous corner intersects with the segment
             return this._lineIntersectsSegment(startPoint, endPoint, point, corners[index - 1]) &&
-                   this._lineIntersectsSegment(point, corners[index - 1], startPoint, endPoint) ;
+                   this._lineIntersectsSegment(point, corners[index - 1], startPoint, endPoint);
           }
-          return undefined;
+          return false;
       });
       return intersections.length > 0;
     }

--- a/src/plots/segmentPlot.ts
+++ b/src/plots/segmentPlot.ts
@@ -245,6 +245,7 @@ namespace Plottable.Plots {
             return this._lineIntersectsSegment(startPoint, endPoint, point, corners[index - 1]) &&
                    this._lineIntersectsSegment(point, corners[index - 1], startPoint, endPoint) ;
           }
+          return undefined;
       });
       return intersections.length > 0;
     }

--- a/test/axes/axisTests.ts
+++ b/test/axes/axisTests.ts
@@ -2,11 +2,11 @@
 
 describe("Axis", () => {
 
-  const horizontalOrientations = ["top", "bottom"];
-  const verticalOrientations = ["left", "right"];
+  const horizontalOrientations: Plottable.AxisOrientation[] = ["top", "bottom"];
+  const verticalOrientations: Plottable.AxisOrientation[] = ["left", "right"];
   const orientations = horizontalOrientations.concat(verticalOrientations);
 
-  const isHorizOrient = (orientation: string) => horizontalOrientations.indexOf(orientation) > -1;
+  const isHorizOrient = (orientation: Plottable.AxisOrientation) => horizontalOrientations.indexOf(orientation) > -1;
   const numAttr = TestMethods.numAttr;
 
   horizontalOrientations.forEach((horizontalOrientation) => {
@@ -33,7 +33,7 @@ describe("Axis", () => {
 
   it("throws an error when setting an invalid orientation", () => {
     let scale = new Plottable.Scales.Linear();
-    assert.throws(() => new Plottable.Axis(scale, "blargh"), "unsupported");
+    assert.throws(() => new Plottable.Axis(scale, "blargh" as any), "unsupported");
   });
 
   it("throws an error when setting a negative tickLabelPadding", () => {

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -16,11 +16,11 @@ describe("Axes", () => {
       });
     }
 
-    const horizontalOrientations = ["bottom", "top"];
-    const verticalOrientations = ["left", "right"];
+    const horizontalOrientations: Plottable.AxisOrientation[] = ["top", "bottom"];
+    const verticalOrientations: Plottable.AxisOrientation[] = ["left", "right"];
     const orientations = horizontalOrientations.concat(verticalOrientations);
 
-    const isHorizontalOrientation = (orientation: string) => horizontalOrientations.indexOf(orientation) >= 0;
+    const isHorizontalOrientation = (orientation: Plottable.AxisOrientation) => horizontalOrientations.indexOf(orientation) >= 0;
 
     describe("managing tick labels", () => {
       const verticalTickLabelPositions = ["top", "bottom"];

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -2,21 +2,21 @@
 
 describe("TimeAxis", () => {
 
-  let orientations = ["top", "bottom"];
+  let orientations: ["top", "bottom"] = ["top", "bottom"];
 
   describe("setting the orientation", () => {
     it("throws an error when setting a vertical orientation", () => {
       let scale = new Plottable.Scales.Time();
-      assert.throws(() => new Plottable.Axes.Time(scale, "left"), "horizontal");
-      assert.throws(() => new Plottable.Axes.Time(scale, "right"), "horizontal");
+      assert.throws(() => new Plottable.Axes.Time(scale, "left" as any), "horizontal");
+      assert.throws(() => new Plottable.Axes.Time(scale, "right" as any), "horizontal");
     });
 
     it("cannot change to a vertical orientation", () => {
       let scale = new Plottable.Scales.Time();
-      let originalOrientation = "bottom";
+      let originalOrientation: "bottom" = "bottom";
       let axis = new Plottable.Axes.Time(scale, originalOrientation);
-      assert.throws(() => axis.orientation("left"), "horizontal");
-      assert.throws(() => axis.orientation("right"), "horizontal");
+      assert.throws(() => axis.orientation("left" as any), "horizontal");
+      assert.throws(() => axis.orientation("right" as any), "horizontal");
       assert.strictEqual(axis.orientation(), originalOrientation, "orientation unchanged");
       axis.destroy();
     });


### PR DESCRIPTION
We were on typescript 2.0 but `grunt-ts` wasn't updated and didn't support the new features. This change upgrades grunt-ts to understand ts2.0 errors and fixes the ones that existed.

The main change is that Axis orientations previously were any `"string"` type, but now we've defined an alias `type AxisOrientation = "left" | "top" | "right" | "bottom";` that `.orientation()` sets/gets. 

This will break existing ts users who pass a `"string"` type into orientation, although it's unclear how many users will actually be affected (how many are even using typescript?). Alternatively we could push back that change into our next major rev. Thoughts?

Also: can someone point me to how to generate docs locally?
