### PR TITLE
add tickLabelMaxLines property to category scale

### DIFF
--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -2165,6 +2165,10 @@ declare namespace Plottable.Axes {
          * Maximum allowable px width of tick labels.
          */
         private _tickLabelMaxWidth;
+        /**
+         * Maximum allowable number of wrapped lines for tick labels.
+         */
+        private _tickLabelMaxLines;
         private _measurer;
         /**
          * A Wrapper configured according to the other properties on this axis.
@@ -2216,6 +2220,8 @@ declare namespace Plottable.Axes {
         tickLabelAngle(angle: number): this;
         tickLabelMaxWidth(): number;
         tickLabelMaxWidth(maxWidth: number): this;
+        tickLabelMaxLines(): number;
+        tickLabelMaxLines(maxLines: number): this;
         /**
          * Return the space required by the ticks, padding included.
          * @returns {number}

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2164,6 +2164,10 @@ declare namespace Plottable.Axes {
          * Maximum allowable px width of tick labels.
          */
         private _tickLabelMaxWidth;
+        /**
+         * Maximum allowable number of wrapped lines for tick labels.
+         */
+        private _tickLabelMaxLines;
         private _measurer;
         /**
          * A Wrapper configured according to the other properties on this axis.
@@ -2215,6 +2219,8 @@ declare namespace Plottable.Axes {
         tickLabelAngle(angle: number): this;
         tickLabelMaxWidth(): number;
         tickLabelMaxWidth(maxWidth: number): this;
+        tickLabelMaxLines(): number;
+        tickLabelMaxLines(maxLines: number): this;
         /**
          * Return the space required by the ticks, padding included.
          * @returns {number}

--- a/plottable.js
+++ b/plottable.js
@@ -5029,8 +5029,8 @@ var Plottable;
                  */
                 get: function () {
                     var wrapper = new SVGTypewriter.Wrappers.Wrapper();
-                    if (this._tickLabelMaxWidth != null) {
-                        wrapper.maxLines(1);
+                    if (this._tickLabelMaxLines != null) {
+                        wrapper.maxLines(this._tickLabelMaxLines);
                     }
                     return wrapper;
                 },
@@ -5116,8 +5116,7 @@ var Plottable;
             };
             /**
              * Set or get the tick label's max width on this axis. When set, tick labels will be truncated with ellipsis to be
-             * at most `tickLabelMaxWidth()` pixels wide, and will also never span more than one line. This ensures the axis
-             * doesn't grow to an undesirable width (or, through wrapping, grow to an undesirable height).
+             * at most `tickLabelMaxWidth()` pixels wide. This ensures the axis doesn't grow to an undesirable width.
              *
              * Passing no arguments retrieves the value, while passing a number sets the value. Pass undefined to un-set the max
              * width.
@@ -5130,6 +5129,25 @@ var Plottable;
                     return this._tickLabelMaxWidth;
                 }
                 this._tickLabelMaxWidth = maxWidth;
+                this.redraw();
+                return this;
+            };
+            /**
+             * Set or get the tick label's max number of wrapped lines on this axis. By default, a Category Axis will line-wrap
+             * long tick labels onto multiple lines in order to fit the width of the axis. When set, long tick labels will be
+             * rendered on at most `tickLabelMaxLines()` lines. This ensures the axis doesn't grow to an undesirable height.
+             *
+             * Passing no arguments retrieves the value, while passing a number sets the value. Pass undefined to un-set the
+             * max lines.
+             * @param maxLines
+             * @returns {number | this}
+             */
+            Category.prototype.tickLabelMaxLines = function (maxLines) {
+                // allow user to un-set tickLabelMaxLines by passing in null or undefined explicitly
+                if (arguments.length === 0) {
+                    return this._tickLabelMaxLines;
+                }
+                this._tickLabelMaxLines = maxLines;
                 this.redraw();
                 return this;
             };

--- a/src/axes/categoryAxis.ts
+++ b/src/axes/categoryAxis.ts
@@ -1,10 +1,17 @@
 namespace Plottable.Axes {
   export class Category extends Axis<string> {
     private _tickLabelAngle = 0;
+
     /**
      * Maximum allowable px width of tick labels.
      */
     private _tickLabelMaxWidth: number;
+
+    /**
+     * Maximum allowable number of wrapped lines for tick labels.
+     */
+    private _tickLabelMaxLines: number;
+
     private _measurer: SVGTypewriter.Measurers.CacheCharacterMeasurer;
 
     /**
@@ -13,8 +20,8 @@ namespace Plottable.Axes {
      */
     private get _wrapper() {
       const wrapper = new SVGTypewriter.Wrappers.Wrapper();
-      if (this._tickLabelMaxWidth != null) {
-        wrapper.maxLines(1);
+      if (this._tickLabelMaxLines != null) {
+        wrapper.maxLines(this._tickLabelMaxLines)
       }
       return wrapper;
     }
@@ -132,8 +139,7 @@ namespace Plottable.Axes {
     public tickLabelMaxWidth(maxWidth: number): this;
     /**
      * Set or get the tick label's max width on this axis. When set, tick labels will be truncated with ellipsis to be
-     * at most `tickLabelMaxWidth()` pixels wide, and will also never span more than one line. This ensures the axis
-     * doesn't grow to an undesirable width (or, through wrapping, grow to an undesirable height).
+     * at most `tickLabelMaxWidth()` pixels wide. This ensures the axis doesn't grow to an undesirable width.
      *
      * Passing no arguments retrieves the value, while passing a number sets the value. Pass undefined to un-set the max
      * width.
@@ -146,6 +152,29 @@ namespace Plottable.Axes {
         return this._tickLabelMaxWidth;
       }
       this._tickLabelMaxWidth = maxWidth;
+      this.redraw();
+      return this;
+    }
+
+    public tickLabelMaxLines(): number;
+    public tickLabelMaxLines(maxLines: number): this;
+
+    /**
+     * Set or get the tick label's max number of wrapped lines on this axis. By default, a Category Axis will line-wrap
+     * long tick labels onto multiple lines in order to fit the width of the axis. When set, long tick labels will be
+     * rendered on at most `tickLabelMaxLines()` lines. This ensures the axis doesn't grow to an undesirable height.
+     *
+     * Passing no arguments retrieves the value, while passing a number sets the value. Pass undefined to un-set the
+     * max lines.
+     * @param maxLines
+     * @returns {number | this}
+     */
+    public tickLabelMaxLines(maxLines?: number): number | this {
+      // allow user to un-set tickLabelMaxLines by passing in null or undefined explicitly
+      if (arguments.length === 0) {
+        return this._tickLabelMaxLines;
+      }
+      this._tickLabelMaxLines = maxLines;
       this.redraw();
       return this;
     }

--- a/test/axes/categoryAxisTests.ts
+++ b/test/axes/categoryAxisTests.ts
@@ -76,7 +76,7 @@ describe("Category Axes", () => {
       axis.tickLabelMaxLines(2);
       axis.renderTo("svg");
 
-      const tickLabels = axis.content().select(".tick-label");
+      const tickLabels = axis.content().selectAll(".tick-label");
       assert.strictEqual(tickLabels.size(), 2, "only renders two labels");
       const [longLabel, shortLabel] = tickLabels[0];
       assert.strictEqual(d3.select(longLabel).selectAll("text").size(), 2, "first label is only two lines long");

--- a/test/axes/categoryAxisTests.ts
+++ b/test/axes/categoryAxisTests.ts
@@ -60,7 +60,7 @@ describe("Category Axes", () => {
       axis.tickLabelMaxWidth(TICK_LABEL_MAX_WIDTH);
       axis.renderTo("svg");
 
-      let tickLabelContainer = axis.content().node() as SVGGElement;
+      let tickLabelContainer = axis.content().select(".tick-label-container").node() as SVGGElement;
       // add 8px padding to account for https://github.com/palantir/svg-typewriter/issues/40
       assert.isBelow(tickLabelContainer.getBBox().width, TICK_LABEL_MAX_WIDTH + 8, "tick width was capped");
 

--- a/test/axes/categoryAxisTests.ts
+++ b/test/axes/categoryAxisTests.ts
@@ -60,11 +60,27 @@ describe("Category Axes", () => {
       axis.tickLabelMaxWidth(TICK_LABEL_MAX_WIDTH);
       axis.renderTo("svg");
 
-      let ticks = axis.content().selectAll("text");
-      ticks.each(function (this: SVGTextElement) {
-        // add 5px padding to account for https://github.com/palantir/svg-typewriter/issues/40
-        assert.isBelow(this.getBBox().width, TICK_LABEL_MAX_WIDTH + 5, "tick width was capped");
-      });
+      let tickLabelContainer = axis.content().node() as SVGGElement;
+      // add 8px padding to account for https://github.com/palantir/svg-typewriter/issues/40
+      assert.isBelow(tickLabelContainer.getBBox().width, TICK_LABEL_MAX_WIDTH + 8, "tick width was capped");
+
+      svg.remove();
+    });
+
+    it("has a maximum number of lines when ticklabelMaxLines is set", () => {
+      const svg = TestMethods.generateSVG();
+      const domain = ["albatross long long long long long long long long long long long long title", "short"];
+      const scale = new Plottable.Scales.Category().domain(domain);
+      const axis = new Plottable.Axes.Category(scale, "left");
+      axis.tickLabelMaxWidth(60);
+      axis.tickLabelMaxLines(2);
+      axis.renderTo("svg");
+
+      const tickLabels = axis.content().select(".tick-label");
+      assert.strictEqual(tickLabels.size(), 2, "only renders two labels");
+      const [longLabel, shortLabel] = tickLabels[0];
+      assert.strictEqual(d3.select(longLabel).selectAll("text").size(), 2, "first label is only two lines long");
+      assert.strictEqual(d3.select(shortLabel).selectAll("text").size(), 1, "second label is only one line long");
 
       svg.remove();
     });


### PR DESCRIPTION
Allows fine grained control over how many lines the tick label should be.

**Warning**: This modifies the existing behavior of `tickLabelMaxWidth` -- when set, maxLines no longer defaults to 1. Instead, maxLines is fully controlled by `tickLabelMaxLines`.