### PR TITLE
Add alignment and start/end angle to pie plots

### DIFF
--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -2966,8 +2966,12 @@ declare namespace Plottable.Plots {
         private static _INNER_RADIUS_KEY;
         private static _OUTER_RADIUS_KEY;
         private static _SECTOR_VALUE_KEY;
+        private _startAngle;
+        private _endAngle;
         private _startAngles;
         private _endAngles;
+        private _hAlign;
+        private _vAlign;
         private _labelFormatter;
         private _labelsEnabled;
         private _strokeDrawers;
@@ -3047,6 +3051,32 @@ declare namespace Plottable.Plots {
          */
         outerRadius<R>(outerRadius: R | Accessor<R>, scale: Scale<R, number>): this;
         /**
+         * Gets the start angle of the Pie Plot
+         *
+         * @returns {number} Returns the start angle
+         */
+        startAngle(): number;
+        /**
+         * Sets the end angle of the Pie Plot.
+         *
+         * @param {number} endAngle
+         * @returns {Pie} The calling Pie Plot.
+         */
+        startAngle(angle: number): this;
+        /**
+         * Gets whether slice labels are enabled.
+         *
+         * @returns {number} Returns the end angle
+         */
+        endAngle(): number;
+        /**
+         * Sets the end angle of the Pie Plot.
+         *
+         * @param {number} endAngle
+         * @returns {Pie} The calling Pie Plot.
+         */
+        endAngle(angle: number): this;
+        /**
          * Get whether slice labels are enabled.
          *
          * @returns {boolean} Whether slices should display labels or not.
@@ -3059,6 +3089,32 @@ declare namespace Plottable.Plots {
          * @returns {Pie} The calling Pie Plot.
          */
         labelsEnabled(enabled: boolean): this;
+        /**
+          * Get whether slice labels are enabled.
+          *
+          * @returns {boolean} Whether slices should display labels or not.
+          */
+        hAlign(): string;
+        /**
+         * Sets whether labels are enabled.
+         *
+         * @param {string} hAlign
+         * @returns {Pie} The calling Pie Plot.
+         */
+        hAlign(alignment: string): this;
+        /**
+         * Get whether slice labels are enabled.
+         *
+         * @returns {boolean} Whether slices should display labels or not.
+         */
+        vAlign(): string;
+        /**
+         * Sets whether labels are enabled.
+         *
+         * @param {string} vAlign
+         * @returns {Pie} The calling Pie Plot.
+         */
+        vAlign(alignment: string): this;
         /**
          * Gets the Formatter for the labels.
          */

--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -3064,7 +3064,7 @@ declare namespace Plottable.Plots {
          */
         startAngle(angle: number): this;
         /**
-         * Gets whether slice labels are enabled.
+         * Gets the end angle of the Pie Plot.
          *
          * @returns {number} Returns the end angle
          */

--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -2970,8 +2970,6 @@ declare namespace Plottable.Plots {
         private _endAngle;
         private _startAngles;
         private _endAngles;
-        private _hAlign;
-        private _vAlign;
         private _labelFormatter;
         private _labelsEnabled;
         private _strokeDrawers;
@@ -3057,9 +3055,9 @@ declare namespace Plottable.Plots {
          */
         startAngle(): number;
         /**
-         * Sets the end angle of the Pie Plot.
+         * Sets the start angle of the Pie Plot.
          *
-         * @param {number} endAngle
+         * @param {number} startAngle
          * @returns {Pie} The calling Pie Plot.
          */
         startAngle(angle: number): this;
@@ -3090,32 +3088,6 @@ declare namespace Plottable.Plots {
          */
         labelsEnabled(enabled: boolean): this;
         /**
-          * Get whether slice labels are enabled.
-          *
-          * @returns {boolean} Whether slices should display labels or not.
-          */
-        hAlign(): string;
-        /**
-         * Sets whether labels are enabled.
-         *
-         * @param {string} hAlign
-         * @returns {Pie} The calling Pie Plot.
-         */
-        hAlign(alignment: string): this;
-        /**
-         * Get whether slice labels are enabled.
-         *
-         * @returns {boolean} Whether slices should display labels or not.
-         */
-        vAlign(): string;
-        /**
-         * Sets whether labels are enabled.
-         *
-         * @param {string} vAlign
-         * @returns {Pie} The calling Pie Plot.
-         */
-        vAlign(alignment: string): this;
-        /**
          * Gets the Formatter for the labels.
          */
         labelFormatter(): Formatter;
@@ -3129,6 +3101,7 @@ declare namespace Plottable.Plots {
         entitiesAt(queryPoint: Point): PlotEntity[];
         protected _propertyProjectors(): AttributeToProjector;
         private _updatePieAngles();
+        private _pieCenter();
         protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
         protected static _isValidData(value: any): boolean;
         protected _pixelPoint(datum: any, index: number, dataset: Dataset): {

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2969,8 +2969,6 @@ declare namespace Plottable.Plots {
         private _endAngle;
         private _startAngles;
         private _endAngles;
-        private _hAlign;
-        private _vAlign;
         private _labelFormatter;
         private _labelsEnabled;
         private _strokeDrawers;
@@ -3056,9 +3054,9 @@ declare namespace Plottable.Plots {
          */
         startAngle(): number;
         /**
-         * Sets the end angle of the Pie Plot.
+         * Sets the start angle of the Pie Plot.
          *
-         * @param {number} endAngle
+         * @param {number} startAngle
          * @returns {Pie} The calling Pie Plot.
          */
         startAngle(angle: number): this;
@@ -3089,32 +3087,6 @@ declare namespace Plottable.Plots {
          */
         labelsEnabled(enabled: boolean): this;
         /**
-          * Get whether slice labels are enabled.
-          *
-          * @returns {boolean} Whether slices should display labels or not.
-          */
-        hAlign(): string;
-        /**
-         * Sets whether labels are enabled.
-         *
-         * @param {string} hAlign
-         * @returns {Pie} The calling Pie Plot.
-         */
-        hAlign(alignment: string): this;
-        /**
-         * Get whether slice labels are enabled.
-         *
-         * @returns {boolean} Whether slices should display labels or not.
-         */
-        vAlign(): string;
-        /**
-         * Sets whether labels are enabled.
-         *
-         * @param {string} vAlign
-         * @returns {Pie} The calling Pie Plot.
-         */
-        vAlign(alignment: string): this;
-        /**
          * Gets the Formatter for the labels.
          */
         labelFormatter(): Formatter;
@@ -3128,6 +3100,7 @@ declare namespace Plottable.Plots {
         entitiesAt(queryPoint: Point): PlotEntity[];
         protected _propertyProjectors(): AttributeToProjector;
         private _updatePieAngles();
+        private _pieCenter();
         protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
         protected static _isValidData(value: any): boolean;
         protected _pixelPoint(datum: any, index: number, dataset: Dataset): {

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2965,8 +2965,12 @@ declare namespace Plottable.Plots {
         private static _INNER_RADIUS_KEY;
         private static _OUTER_RADIUS_KEY;
         private static _SECTOR_VALUE_KEY;
+        private _startAngle;
+        private _endAngle;
         private _startAngles;
         private _endAngles;
+        private _hAlign;
+        private _vAlign;
         private _labelFormatter;
         private _labelsEnabled;
         private _strokeDrawers;
@@ -3046,6 +3050,32 @@ declare namespace Plottable.Plots {
          */
         outerRadius<R>(outerRadius: R | Accessor<R>, scale: Scale<R, number>): this;
         /**
+         * Gets the start angle of the Pie Plot
+         *
+         * @returns {number} Returns the start angle
+         */
+        startAngle(): number;
+        /**
+         * Sets the end angle of the Pie Plot.
+         *
+         * @param {number} endAngle
+         * @returns {Pie} The calling Pie Plot.
+         */
+        startAngle(angle: number): this;
+        /**
+         * Gets whether slice labels are enabled.
+         *
+         * @returns {number} Returns the end angle
+         */
+        endAngle(): number;
+        /**
+         * Sets the end angle of the Pie Plot.
+         *
+         * @param {number} endAngle
+         * @returns {Pie} The calling Pie Plot.
+         */
+        endAngle(angle: number): this;
+        /**
          * Get whether slice labels are enabled.
          *
          * @returns {boolean} Whether slices should display labels or not.
@@ -3058,6 +3088,32 @@ declare namespace Plottable.Plots {
          * @returns {Pie} The calling Pie Plot.
          */
         labelsEnabled(enabled: boolean): this;
+        /**
+          * Get whether slice labels are enabled.
+          *
+          * @returns {boolean} Whether slices should display labels or not.
+          */
+        hAlign(): string;
+        /**
+         * Sets whether labels are enabled.
+         *
+         * @param {string} hAlign
+         * @returns {Pie} The calling Pie Plot.
+         */
+        hAlign(alignment: string): this;
+        /**
+         * Get whether slice labels are enabled.
+         *
+         * @returns {boolean} Whether slices should display labels or not.
+         */
+        vAlign(): string;
+        /**
+         * Sets whether labels are enabled.
+         *
+         * @param {string} vAlign
+         * @returns {Pie} The calling Pie Plot.
+         */
+        vAlign(alignment: string): this;
         /**
          * Gets the Formatter for the labels.
          */

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3063,7 +3063,7 @@ declare namespace Plottable.Plots {
          */
         startAngle(angle: number): this;
         /**
-         * Gets whether slice labels are enabled.
+         * Gets the end angle of the Pie Plot.
          *
          * @returns {number} Returns the end angle
          */

--- a/plottable.js
+++ b/plottable.js
@@ -7187,6 +7187,8 @@ var Plottable;
             function Pie() {
                 var _this = this;
                 _super.call(this);
+                this._startAngle = 0;
+                this._endAngle = 2 * Math.PI;
                 this._labelFormatter = Plottable.Formatters.identity();
                 this._labelsEnabled = false;
                 this.innerRadius(0);
@@ -7202,7 +7204,9 @@ var Plottable;
             };
             Pie.prototype.computeLayout = function (origin, availableWidth, availableHeight) {
                 _super.prototype.computeLayout.call(this, origin, availableWidth, availableHeight);
-                this._renderArea.attr("transform", "translate(" + this.width() / 2 + "," + this.height() / 2 + ")");
+                var hAlign = this.hAlign() === "left" ? 0 : (this.hAlign() === "right" ? 1 : 0.5);
+                var vAlign = this.vAlign() === "top" ? 0 : (this.vAlign() === "bottom" ? 1 : 0.5);
+                this._renderArea.attr("transform", "translate(" + this.width() * hAlign + "," + this.height() * vAlign + ")");
                 var radiusLimit = Math.min(this.width(), this.height()) / 2;
                 if (this.innerRadius().scale != null) {
                     this.innerRadius().scale.range([0, radiusLimit]);
@@ -7304,12 +7308,54 @@ var Plottable;
                 this.render();
                 return this;
             };
+            Pie.prototype.startAngle = function (angle) {
+                if (angle == null) {
+                    return this._startAngle;
+                }
+                else {
+                    this._startAngle = angle;
+                    this._updatePieAngles();
+                    this.render();
+                    return this;
+                }
+            };
+            Pie.prototype.endAngle = function (angle) {
+                if (angle == null) {
+                    return this._endAngle;
+                }
+                else {
+                    this._endAngle = angle;
+                    this._updatePieAngles();
+                    this.render();
+                    return this;
+                }
+            };
             Pie.prototype.labelsEnabled = function (enabled) {
                 if (enabled == null) {
                     return this._labelsEnabled;
                 }
                 else {
                     this._labelsEnabled = enabled;
+                    this.render();
+                    return this;
+                }
+            };
+            Pie.prototype.hAlign = function (alignment) {
+                if (alignment == null) {
+                    return this._hAlign;
+                }
+                else {
+                    this._hAlign = alignment;
+                    this.render();
+                    return this;
+                }
+            };
+            Pie.prototype.vAlign = function (alignment) {
+                if (alignment == null) {
+                    return this._vAlign;
+                }
+                else {
+                    this._vAlign = alignment;
                     this.render();
                     return this;
                 }
@@ -7350,6 +7396,7 @@ var Plottable;
                 return attrToProjector;
             };
             Pie.prototype._updatePieAngles = function () {
+                var _this = this;
                 if (this.sectorValue() == null) {
                     return;
                 }
@@ -7360,8 +7407,9 @@ var Plottable;
                 var dataset = this.datasets()[0];
                 var data = this._getDataToDraw().get(dataset);
                 var pie = d3.layout.pie().sort(null).value(function (d, i) { return sectorValueAccessor(d, i, dataset); })(data);
-                this._startAngles = pie.map(function (slice) { return slice.startAngle; });
-                this._endAngles = pie.map(function (slice) { return slice.endAngle; });
+                var factor = (this.endAngle() - this.startAngle()) / (2 * Math.PI);
+                this._startAngles = pie.map(function (slice) { return slice.startAngle * factor + _this.startAngle(); });
+                this._endAngles = pie.map(function (slice) { return slice.endAngle * factor + _this.startAngle(); });
             };
             Pie.prototype._getDataToDraw = function () {
                 var dataToDraw = _super.prototype._getDataToDraw.call(this);

--- a/plottable.js
+++ b/plottable.js
@@ -7192,7 +7192,10 @@ var Plottable;
                 this._labelFormatter = Plottable.Formatters.identity();
                 this._labelsEnabled = false;
                 this.innerRadius(0);
-                this.outerRadius(function () { return Math.min(_this.width(), _this.height()) / 2; });
+                this.outerRadius(function () {
+                    var pieCenter = _this._pieCenter();
+                    return Math.min(Math.max(_this.width() - pieCenter.x, pieCenter.x), Math.max(_this.height() - pieCenter.y, pieCenter.y));
+                });
                 this.addClass("pie-plot");
                 this.attr("fill", function (d, i) { return String(i); }, new Plottable.Scales.Color());
                 this._strokeDrawers = new Plottable.Utils.Map();
@@ -7206,7 +7209,7 @@ var Plottable;
                 _super.prototype.computeLayout.call(this, origin, availableWidth, availableHeight);
                 var pieCenter = this._pieCenter();
                 this._renderArea.attr("transform", "translate(" + pieCenter.x + "," + pieCenter.y + ")");
-                var radiusLimit = Math.max(Math.sqrt(Math.pow(pieCenter.x, 2) + Math.pow(pieCenter.y, 2)), Math.sqrt(Math.pow(this.height() - pieCenter.y, 2) + Math.pow(this.width() - pieCenter.y, 2)));
+                var radiusLimit = Math.min(Math.max(this.width() - pieCenter.x, pieCenter.x), Math.max(this.height() - pieCenter.y, pieCenter.y));
                 if (this.innerRadius().scale != null) {
                     this.innerRadius().scale.range([0, radiusLimit]);
                 }
@@ -7400,24 +7403,30 @@ var Plottable;
                 var hBottom;
                 var wRight;
                 var wLeft;
+                /**
+                 *  The center of the pie is computed using the sine and cosine of the start angle and the end angle
+                 *  The sine indicates whether the start and end fall on the right half or the left half of the pie
+                 *  The cosine indicates whether the start and end fall on the top or the bottom half of the pie
+                 *  Different combinations provide the different heights and widths the pie needs from the center to the sides
+                 */
                 if (sinA >= 0 && sinB >= 0) {
                     if (cosA >= 0 && cosB >= 0) {
                         hTop = cosA;
                         hBottom = 0;
                         wLeft = 0;
-                        wRight = Math.max(sinA, sinB);
+                        wRight = sinB;
                     }
                     else if (cosA < 0 && cosB < 0) {
                         hTop = 0;
-                        hBottom = Math.abs(Math.min(cosA, cosB));
+                        hBottom = -cosB;
                         wLeft = 0;
-                        wRight = Math.max(sinA, sinB);
+                        wRight = sinA;
                     }
                     else if (cosA >= 0 && cosB < 0) {
                         hTop = cosA;
                         hBottom = -cosB;
                         wLeft = 0;
-                        wRight = Math.max(sinA, sinB);
+                        wRight = sinA;
                     }
                     else if (cosA < 0 && cosB >= 0) {
                         hTop = 1;

--- a/plottable.js
+++ b/plottable.js
@@ -7396,7 +7396,6 @@ var Plottable;
                 return attrToProjector;
             };
             Pie.prototype._updatePieAngles = function () {
-                var _this = this;
                 if (this.sectorValue() == null) {
                     return;
                 }
@@ -7406,10 +7405,10 @@ var Plottable;
                 var sectorValueAccessor = Plottable.Plot._scaledAccessor(this.sectorValue());
                 var dataset = this.datasets()[0];
                 var data = this._getDataToDraw().get(dataset);
-                var pie = d3.layout.pie().sort(null).value(function (d, i) { return sectorValueAccessor(d, i, dataset); })(data);
-                var factor = (this.endAngle() - this.startAngle()) / (2 * Math.PI);
-                this._startAngles = pie.map(function (slice) { return slice.startAngle * factor + _this.startAngle(); });
-                this._endAngles = pie.map(function (slice) { return slice.endAngle * factor + _this.startAngle(); });
+                var pie = d3.layout.pie().sort(null).startAngle(this._startAngle).endAngle(this._endAngle)
+                    .value(function (d, i) { return sectorValueAccessor(d, i, dataset); })(data);
+                this._startAngles = pie.map(function (slice) { return slice.startAngle; });
+                this._endAngles = pie.map(function (slice) { return slice.endAngle; });
             };
             Pie.prototype._getDataToDraw = function () {
                 var dataToDraw = _super.prototype._getDataToDraw.call(this);
@@ -7439,7 +7438,7 @@ var Plottable;
                     .value(function (d, i) {
                     var value = scaledValueAccessor(d, i, dataset);
                     return Pie._isValidData(value) ? value : 0;
-                })(dataset.data());
+                }).startAngle(this._startAngle).endAngle(this._endAngle)(dataset.data());
                 var startAngle = pie[index].startAngle;
                 var endAngle = pie[index].endAngle;
                 var avgAngle = (startAngle + endAngle) / 2;

--- a/quicktests/overlaying/tests/basic/half_pies.js
+++ b/quicktests/overlaying/tests/basic/half_pies.js
@@ -19,9 +19,8 @@ function run(svg, data, Plottable){
   topPie.addDataset(new Plottable.Dataset(data));
   topPie.sectorValue(function(d){ return d.value; })
         .innerRadius(0)
-        .outerRadius(100)
         .startAngle(0)
-        .endAngle(3 * Math.PI / 2)
+        .endAngle(Math.PI / 2)
         .attr("opacity", .5)
         .attr("fill", function(d){ return d.key; }, cs);
 
@@ -29,16 +28,13 @@ function run(svg, data, Plottable){
   bottomPie.addDataset(new Plottable.Dataset(data));
   bottomPie.sectorValue(function(d){ return d.value; })
           .innerRadius(0)
-          .outerRadius(100)
-          .startAngle(Math.PI / 4)
-          .endAngle(11 * Math.PI / 6)
+          .startAngle(3 * Math.PI / 4)
           .attr("fill", function(d){ return d.key; }, cs);
 
   var leftPie = new Plottable.Plots.Pie();
   leftPie.addDataset(new Plottable.Dataset(data));
   leftPie.sectorValue(function(d){ return d.value; })
         .innerRadius(0)
-        .outerRadius(100)
         .endAngle(Math.PI)
         .attr("opacity", .5)
         .attr("fill", function(d){ return d.key; }, cs);
@@ -47,7 +43,6 @@ function run(svg, data, Plottable){
   rightPie.addDataset(new Plottable.Dataset(data));
   rightPie.sectorValue(function(d){ return d.value; })
           .innerRadius(0)
-          .outerRadius(100)
           .startAngle(Math.PI)
           .attr("fill", function(d){ return d.key; }, cs);
 

--- a/quicktests/overlaying/tests/basic/half_pies.js
+++ b/quicktests/overlaying/tests/basic/half_pies.js
@@ -1,0 +1,71 @@
+function makeData() {
+  "use strict";
+  return [
+      {key: "banana", value: 4},
+      {key: "grape", value: 5},
+      {key: "raspberry", value: 9},
+      {key: "cherry", value: 2},
+      {key: "peach", value: 8},
+      {key: "apple", value: 6}
+  ];
+}
+
+function run(svg, data, Plottable){
+  "use strict";
+
+  var cs = new Plottable.Scales.Color();
+
+  var topPie = new Plottable.Plots.Pie();
+  topPie.addDataset(new Plottable.Dataset(data));
+  topPie.sectorValue(function(d){ return d.value; })
+        .innerRadius(0)
+        .outerRadius(100)
+        .vAlign("top")
+        .startAngle(Math.PI/2)
+        .endAngle(3 * Math.PI/2)
+        .attr("opacity", .5)
+        .attr("fill", function(d){ return d.key; }, cs);
+
+  var bottomPie = new Plottable.Plots.Pie();
+  bottomPie.addDataset(new Plottable.Dataset(data));
+  bottomPie.sectorValue(function(d){ return d.value; })
+          .innerRadius(0)
+          .outerRadius(100)
+          .startAngle(3 *  Math.PI / 2)
+          .endAngle(5 * Math.PI / 2)
+          .attr("fill", function(d){ return d.key; }, cs);
+
+  var leftPie = new Plottable.Plots.Pie();
+  leftPie.addDataset(new Plottable.Dataset(data));
+  leftPie.sectorValue(function(d){ return d.value; })
+        .innerRadius(0)
+        .outerRadius(100)
+        .hAlign("left")
+        .endAngle(Math.PI)
+        .attr("opacity", .5)
+        .attr("fill", function(d){ return d.key; }, cs);
+
+  var rightPie = new Plottable.Plots.Pie();
+  rightPie.addDataset(new Plottable.Dataset(data));
+  rightPie.sectorValue(function(d){ return d.value; })
+          .innerRadius(0)
+          .outerRadius(100)
+          .hAlign("right")
+          .startAngle(Math.PI)
+          .attr("fill", function(d){ return d.key; }, cs);
+
+  var pies = new Plottable.Components.Table([[topPie, rightPie], [leftPie, bottomPie]]);
+  pies.renderTo(svg);
+
+  new Plottable.Interactions.Pointer()
+  .onPointerMove(function(p){
+    topPie.entities().forEach(function(e){
+      e.selection.attr("opacity", .5);
+    });
+    var entity = topPie.entitiesAt(p)[0];
+    if(entity){
+      entity.selection.attr("opacity", 1);
+    }
+  })
+  .attachTo(topPie);
+}

--- a/quicktests/overlaying/tests/basic/half_pies.js
+++ b/quicktests/overlaying/tests/basic/half_pies.js
@@ -20,9 +20,8 @@ function run(svg, data, Plottable){
   topPie.sectorValue(function(d){ return d.value; })
         .innerRadius(0)
         .outerRadius(100)
-        .vAlign("top")
-        .startAngle(Math.PI/2)
-        .endAngle(3 * Math.PI/2)
+        .startAngle(0)
+        .endAngle(3 * Math.PI / 2)
         .attr("opacity", .5)
         .attr("fill", function(d){ return d.key; }, cs);
 
@@ -31,8 +30,8 @@ function run(svg, data, Plottable){
   bottomPie.sectorValue(function(d){ return d.value; })
           .innerRadius(0)
           .outerRadius(100)
-          .startAngle(3 *  Math.PI / 2)
-          .endAngle(5 * Math.PI / 2)
+          .startAngle(Math.PI / 4)
+          .endAngle(11 * Math.PI / 6)
           .attr("fill", function(d){ return d.key; }, cs);
 
   var leftPie = new Plottable.Plots.Pie();
@@ -40,7 +39,6 @@ function run(svg, data, Plottable){
   leftPie.sectorValue(function(d){ return d.value; })
         .innerRadius(0)
         .outerRadius(100)
-        .hAlign("left")
         .endAngle(Math.PI)
         .attr("opacity", .5)
         .attr("fill", function(d){ return d.key; }, cs);
@@ -50,22 +48,9 @@ function run(svg, data, Plottable){
   rightPie.sectorValue(function(d){ return d.value; })
           .innerRadius(0)
           .outerRadius(100)
-          .hAlign("right")
           .startAngle(Math.PI)
           .attr("fill", function(d){ return d.key; }, cs);
 
   var pies = new Plottable.Components.Table([[topPie, rightPie], [leftPie, bottomPie]]);
   pies.renderTo(svg);
-
-  new Plottable.Interactions.Pointer()
-  .onPointerMove(function(p){
-    topPie.entities().forEach(function(e){
-      e.selection.attr("opacity", .5);
-    });
-    var entity = topPie.entitiesAt(p)[0];
-    if(entity){
-      entity.selection.attr("opacity", 1);
-    }
-  })
-  .attachTo(topPie);
 }

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -229,7 +229,7 @@ namespace Plottable.Plots {
     }
 
     /**
-     * Gets whether slice labels are enabled.
+     * Gets the end angle of the Pie Plot.
      *
      * @returns {number} Returns the end angle
      */
@@ -374,10 +374,10 @@ namespace Plottable.Plots {
       let sectorValueAccessor = Plot._scaledAccessor(this.sectorValue());
       let dataset = this.datasets()[0];
       let data = this._getDataToDraw().get(dataset);
-      let pie = d3.layout.pie().sort(null).value((d, i) => sectorValueAccessor(d, i, dataset))(data);
-      let factor = (this.endAngle() - this.startAngle()) / (2 * Math.PI);
-      this._startAngles = pie.map((slice) => slice.startAngle * factor + this.startAngle());
-      this._endAngles = pie.map((slice) => slice.endAngle * factor + this.startAngle());
+      let pie = d3.layout.pie().sort(null).startAngle(this._startAngle).endAngle(this._endAngle)
+        .value((d, i) => sectorValueAccessor(d, i, dataset))(data);
+      this._startAngles = pie.map((slice) => slice.startAngle);
+      this._endAngles = pie.map((slice) => slice.endAngle);
     }
 
     protected _getDataToDraw() {
@@ -410,7 +410,7 @@ namespace Plottable.Plots {
                          .value((d: any, i: number) => {
                            let value = scaledValueAccessor(d, i, dataset);
                            return Pie._isValidData(value) ? value : 0;
-                         })(dataset.data());
+                         }).startAngle(this._startAngle).endAngle(this._endAngle)(dataset.data());
       let startAngle = pie[index].startAngle;
       let endAngle = pie[index].endAngle;
       let avgAngle = (startAngle + endAngle) / 2;

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -17,8 +17,11 @@ namespace Plottable.Plots {
      */
     constructor() {
       super();
-      this.innerRadius(0);
-      this.outerRadius(() => Math.min(this.width(), this.height()) / 2);
+      this.innerRadius(0)
+      this.outerRadius(() => {
+        let pieCenter = this._pieCenter();
+        return Math.min(Math.max(this.width() - pieCenter.x, pieCenter.x), Math.max(this.height() - pieCenter.y, pieCenter.y));
+      });
       this.addClass("pie-plot");
       this.attr("fill", (d, i) => String(i), new Scales.Color());
 
@@ -36,10 +39,7 @@ namespace Plottable.Plots {
       let pieCenter = this._pieCenter()
       this._renderArea.attr("transform", "translate(" + pieCenter.x + "," + pieCenter.y + ")");
       
-      let radiusLimit = Math.max(
-        Math.sqrt(Math.pow(pieCenter.x, 2) + Math.pow(pieCenter.y, 2)),
-        Math.sqrt(Math.pow(this.height() - pieCenter.y, 2) + Math.pow(this.width() - pieCenter.y, 2))
-      );
+      let radiusLimit = Math.min(Math.max(this.width() - pieCenter.x, pieCenter.x), Math.max(this.height() - pieCenter.y, pieCenter.y));
 
       if (this.innerRadius().scale != null) {
         this.innerRadius().scale.range([0, radiusLimit]);
@@ -348,10 +348,17 @@ namespace Plottable.Plots {
       let hBottom: number;
       let wRight: number;
       let wLeft: number;
+
+      /**
+       *  The center of the pie is computed using the sine and cosine of the start angle and the end angle
+       *  The sine indicates whether the start and end fall on the right half or the left half of the pie
+       *  The cosine indicates whether the start and end fall on the top or the bottom half of the pie
+       *  Different combinations provide the different heights and widths the pie needs from the center to the sides
+       */
       if (sinA >= 0 && sinB >= 0) {
-        if (cosA >= 0 && cosB >= 0) { hTop = cosA; hBottom = 0; wLeft = 0; wRight = Math.max(sinA, sinB); }
-        else if (cosA < 0 && cosB < 0) { hTop = 0; hBottom = Math.abs(Math.min(cosA, cosB)); wLeft = 0; wRight = Math.max(sinA, sinB); }
-        else if (cosA >= 0 && cosB < 0) { hTop = cosA; hBottom = -cosB; wLeft = 0; wRight = Math.max(sinA, sinB) }
+        if (cosA >= 0 && cosB >= 0) { hTop = cosA; hBottom = 0; wLeft = 0; wRight = sinB; }
+        else if (cosA < 0 && cosB < 0) { hTop = 0; hBottom = -cosB; wLeft = 0; wRight = sinA; }
+        else if (cosA >= 0 && cosB < 0) { hTop = cosA; hBottom = -cosB; wLeft = 0; wRight = sinA }
         else if (cosA < 0 && cosB >= 0) { hTop = 1; hBottom = 1; wLeft = 1; wRight = Math.max(sinA, sinB); }
       }
       else if (sinA >= 0 && sinB < 0) {

--- a/test/plots/piePlotTests.ts
+++ b/test/plots/piePlotTests.ts
@@ -142,6 +142,140 @@ describe("Plots", () => {
         svg.remove();
       });
 
+      it("can set startAngle()", () => {
+        let expectedStartAngle = Math.PI;
+        assert.strictEqual(piePlot.startAngle(expectedStartAngle), piePlot, "setter returns the calling pie plot");
+        let arcPaths = piePlot.content().selectAll(".arc.fill");
+        assert.strictEqual(arcPaths.size(), 2, "has two sectors");
+
+        let pathString0 = d3.select(arcPaths[0][0]).attr("d");
+        let decomposedPath0 = TestMethods.decomposePath(TestMethods.normalizePath(pathString0));
+
+        let moveCommand0 = decomposedPath0[0];
+        assert.closeTo(moveCommand0.arguments[0], 0, 1, "starts first arc at the bottom of the circle (x)");
+        assert.operator(moveCommand0.arguments[1], ">", 0, "starts first arc at the bottom of circle (y)");
+
+        let arcCommand0 = decomposedPath0[1];
+        assert.operator(arcCommand0.arguments[5], "<", 0, "arc ends on the left side of the circle (x)");
+        assert.operator(arcCommand0.arguments[6], ">", 0, "arc ends on the bottom side of the circle (y)");
+
+        let lineCommand0 = decomposedPath0[2];
+        assert.closeTo(lineCommand0.arguments[0], 0, 1, "draws line to origin (x)");
+        assert.closeTo(lineCommand0.arguments[1], 0, 1, "draws line to origin (y)");
+
+        let pathString1 = d3.select(arcPaths[0][1]).attr("d");
+        let decomposedPath1 = TestMethods.decomposePath(TestMethods.normalizePath(pathString1));
+
+        let moveCommand1 = decomposedPath1[0];
+        assert.operator(moveCommand1.arguments[0], "<", 0, "starts second arc at the end of the first arc");
+        assert.operator(moveCommand1.arguments[1], ">", 0, "starts secnond arc at the end of the first arc");
+
+        let arcCommand1 = decomposedPath1[1];
+        assert.closeTo(arcCommand1.arguments[5], 0, 1, "ends second arc at x origin");
+        assert.operator(arcCommand1.arguments[6], "<", 0, "ends second arc below 0");
+
+        let lineCommand1 = decomposedPath1[2];
+        assert.closeTo(lineCommand1.arguments[0], 0, 1, "draws line to origin (x)");
+        assert.closeTo(lineCommand1.arguments[1], 0, 1, "draws line to origin (y)");
+
+        svg.remove();
+      });
+
+      it("can set endAngle()", () => {
+        let expectedEndAngle = Math.PI;
+        assert.strictEqual(piePlot.endAngle(expectedEndAngle), piePlot, "setter returns the calling pie plot");
+        let arcPaths = piePlot.content().selectAll(".arc.fill");
+        assert.strictEqual(arcPaths.size(), 2, "has two sectors");
+
+        let pathString0 = d3.select(arcPaths[0][0]).attr("d");
+        let decomposedPath0 = TestMethods.decomposePath(TestMethods.normalizePath(pathString0));
+
+        let moveCommand0 = decomposedPath0[0];
+        assert.closeTo(moveCommand0.arguments[0], 0, 1, "starts first arc at the top of the circle (x)");
+        assert.operator(moveCommand0.arguments[1], "<", 0, "starts first arc at the top of circle (y)");
+
+        let arcCommand0 = decomposedPath0[1];
+        assert.operator(arcCommand0.arguments[5], ">", 0, "arc ends on the right side of the circle (x)");
+        assert.operator(arcCommand0.arguments[6], "<", 0, "arc ends on the right side of the circle (y)");
+
+        let lineCommand0 = decomposedPath0[2];
+        assert.closeTo(lineCommand0.arguments[0], 0, 1, "draws line to origin (x)");
+        assert.closeTo(lineCommand0.arguments[1], 0, 1, "draws line to origin (y)");
+
+        let pathString1 = d3.select(arcPaths[0][1]).attr("d");
+        let decomposedPath1 = TestMethods.decomposePath(TestMethods.normalizePath(pathString1));
+
+        let moveCommand1 = decomposedPath1[0];
+        assert.operator(moveCommand1.arguments[0], ">", 0, "starts second arc at the top right of the circle");
+        assert.operator(moveCommand1.arguments[1], "<", 0, "starts second arc at the top right of the circle");
+
+        let arcCommand1 = decomposedPath1[1];
+        assert.closeTo(arcCommand1.arguments[5], 0, 1, "ends second arc at the bottom of the circle (x origin)");
+        assert.operator(arcCommand1.arguments[6], ">", 0, "ends second arc at the bottom of the circle");
+
+        let lineCommand1 = decomposedPath1[2];
+        assert.closeTo(lineCommand1.arguments[0], 0, 1, "draws line to origin (x)");
+        assert.closeTo(lineCommand1.arguments[1], 0, 1, "draws line to origin (y)");
+
+        svg.remove();
+      });
+
+      it("can set hAlign() to left", () => {
+        let expectedHAlign = "left";
+        assert.strictEqual(piePlot.hAlign(expectedHAlign), piePlot, "setter returns the calling pie plot");
+        let arcPaths = piePlot.content().selectAll(".arc.fill");
+        assert.strictEqual(arcPaths.size(), 2, "has two sectors");
+
+        let renderArea = piePlot.computeLayout().content().selectAll(".render-area");
+        let vallll = d3.select(renderArea[0][0]).attr("transform");
+
+        assert.strictEqual(vallll, "translate(0,200)", "the center of the pie is at the center left");
+
+        svg.remove();
+      });
+
+      it("can set hAlign() to right", () => {
+        let expectedHAlign = "right";
+        assert.strictEqual(piePlot.hAlign(expectedHAlign), piePlot, "setter returns the calling pie plot");
+        let arcPaths = piePlot.content().selectAll(".arc.fill");
+        assert.strictEqual(arcPaths.size(), 2, "has two sectors");
+
+        let renderArea = piePlot.computeLayout().content().selectAll(".render-area");
+        let vallll = d3.select(renderArea[0][0]).attr("transform");
+
+        assert.strictEqual(vallll, "translate(400,200)", "the center of the pie is at the center right");
+
+        svg.remove();
+      });
+
+      it("can set vAlign() to top", () => {
+        let expectedVAlign = "top";
+        assert.strictEqual(piePlot.vAlign(expectedVAlign), piePlot, "setter returns the calling pie plot");
+        let arcPaths = piePlot.content().selectAll(".arc.fill");
+        assert.strictEqual(arcPaths.size(), 2, "has two sectors");
+
+        let renderArea = piePlot.computeLayout().content().selectAll(".render-area");
+        let vallll = d3.select(renderArea[0][0]).attr("transform");
+
+        assert.strictEqual(vallll, "translate(200,0)", "the center of the pie is at the top center");
+
+        svg.remove();
+      });
+
+      it("can set vAlign() to bottom", () => {
+        let expectedVAlign = "bottom";
+        assert.strictEqual(piePlot.vAlign(expectedVAlign), piePlot, "setter returns the calling pie plot");
+        let arcPaths = piePlot.content().selectAll(".arc.fill");
+        assert.strictEqual(arcPaths.size(), 2, "has two sectors");
+
+        let renderArea = piePlot.computeLayout().content().selectAll(".render-area");
+        let vallll = d3.select(renderArea[0][0]).attr("transform");
+
+        assert.strictEqual(vallll, "translate(200,400)", "the center of the pie is at the bottom center");
+
+        svg.remove();
+      });
+
       it("updates slices when data changes and render correctly w.r.t. scale changes", () => {
         const newDataset = new Plottable.Dataset([{ value: 500 }, { value: 600 }]);
         // reset database for this test's sake

--- a/test/plots/piePlotTests.ts
+++ b/test/plots/piePlotTests.ts
@@ -220,62 +220,6 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("can set hAlign() to left", () => {
-        let expectedHAlign = "left";
-        assert.strictEqual(piePlot.hAlign(expectedHAlign), piePlot, "setter returns the calling pie plot");
-        let arcPaths = piePlot.content().selectAll(".arc.fill");
-        assert.strictEqual(arcPaths.size(), 2, "has two sectors");
-
-        let renderArea = piePlot.computeLayout().content().selectAll(".render-area");
-        let vallll = d3.select(renderArea[0][0]).attr("transform");
-
-        assert.strictEqual(vallll, "translate(0,200)", "the center of the pie is at the center left");
-
-        svg.remove();
-      });
-
-      it("can set hAlign() to right", () => {
-        let expectedHAlign = "right";
-        assert.strictEqual(piePlot.hAlign(expectedHAlign), piePlot, "setter returns the calling pie plot");
-        let arcPaths = piePlot.content().selectAll(".arc.fill");
-        assert.strictEqual(arcPaths.size(), 2, "has two sectors");
-
-        let renderArea = piePlot.computeLayout().content().selectAll(".render-area");
-        let vallll = d3.select(renderArea[0][0]).attr("transform");
-
-        assert.strictEqual(vallll, "translate(400,200)", "the center of the pie is at the center right");
-
-        svg.remove();
-      });
-
-      it("can set vAlign() to top", () => {
-        let expectedVAlign = "top";
-        assert.strictEqual(piePlot.vAlign(expectedVAlign), piePlot, "setter returns the calling pie plot");
-        let arcPaths = piePlot.content().selectAll(".arc.fill");
-        assert.strictEqual(arcPaths.size(), 2, "has two sectors");
-
-        let renderArea = piePlot.computeLayout().content().selectAll(".render-area");
-        let vallll = d3.select(renderArea[0][0]).attr("transform");
-
-        assert.strictEqual(vallll, "translate(200,0)", "the center of the pie is at the top center");
-
-        svg.remove();
-      });
-
-      it("can set vAlign() to bottom", () => {
-        let expectedVAlign = "bottom";
-        assert.strictEqual(piePlot.vAlign(expectedVAlign), piePlot, "setter returns the calling pie plot");
-        let arcPaths = piePlot.content().selectAll(".arc.fill");
-        assert.strictEqual(arcPaths.size(), 2, "has two sectors");
-
-        let renderArea = piePlot.computeLayout().content().selectAll(".render-area");
-        let vallll = d3.select(renderArea[0][0]).attr("transform");
-
-        assert.strictEqual(vallll, "translate(200,400)", "the center of the pie is at the bottom center");
-
-        svg.remove();
-      });
-
       it("updates slices when data changes and render correctly w.r.t. scale changes", () => {
         const newDataset = new Plottable.Dataset([{ value: 500 }, { value: 600 }]);
         // reset database for this test's sake

--- a/test/plots/piePlotTests.ts
+++ b/test/plots/piePlotTests.ts
@@ -153,11 +153,11 @@ describe("Plots", () => {
 
         let moveCommand0 = decomposedPath0[0];
         assert.closeTo(moveCommand0.arguments[0], 0, 1, "starts first arc at the bottom of the circle (x)");
-        assert.operator(moveCommand0.arguments[1], ">", 0, "starts first arc at the bottom of circle (y)");
+        assert.isAbove(moveCommand0.arguments[1], 0, "starts first arc at the bottom of circle (y)");
 
         let arcCommand0 = decomposedPath0[1];
-        assert.operator(arcCommand0.arguments[5], "<", 0, "arc ends on the left side of the circle (x)");
-        assert.operator(arcCommand0.arguments[6], ">", 0, "arc ends on the bottom side of the circle (y)");
+        assert.isBelow(arcCommand0.arguments[5], 0, "arc ends on the left side of the circle (x)");
+        assert.isAbove(arcCommand0.arguments[6], 0, "arc ends on the bottom side of the circle (y)");
 
         let lineCommand0 = decomposedPath0[2];
         assert.closeTo(lineCommand0.arguments[0], 0, 1, "draws line to origin (x)");
@@ -167,12 +167,12 @@ describe("Plots", () => {
         let decomposedPath1 = TestMethods.decomposePath(TestMethods.normalizePath(pathString1));
 
         let moveCommand1 = decomposedPath1[0];
-        assert.operator(moveCommand1.arguments[0], "<", 0, "starts second arc at the end of the first arc");
-        assert.operator(moveCommand1.arguments[1], ">", 0, "starts secnond arc at the end of the first arc");
+        assert.isBelow(moveCommand1.arguments[0], 0, "starts second arc at the end of the first arc");
+        assert.isAbove(moveCommand1.arguments[1], 0, "starts secnond arc at the end of the first arc");
 
         let arcCommand1 = decomposedPath1[1];
         assert.closeTo(arcCommand1.arguments[5], 0, 1, "ends second arc at x origin");
-        assert.operator(arcCommand1.arguments[6], "<", 0, "ends second arc below 0");
+        assert.isBelow(arcCommand1.arguments[6], 0, "ends second arc below 0");
 
         let lineCommand1 = decomposedPath1[2];
         assert.closeTo(lineCommand1.arguments[0], 0, 1, "draws line to origin (x)");
@@ -192,11 +192,11 @@ describe("Plots", () => {
 
         let moveCommand0 = decomposedPath0[0];
         assert.closeTo(moveCommand0.arguments[0], 0, 1, "starts first arc at the top of the circle (x)");
-        assert.operator(moveCommand0.arguments[1], "<", 0, "starts first arc at the top of circle (y)");
+        assert.isBelow(moveCommand0.arguments[1], 0, "starts first arc at the top of circle (y)");
 
         let arcCommand0 = decomposedPath0[1];
-        assert.operator(arcCommand0.arguments[5], ">", 0, "arc ends on the right side of the circle (x)");
-        assert.operator(arcCommand0.arguments[6], "<", 0, "arc ends on the right side of the circle (y)");
+        assert.isAbove(arcCommand0.arguments[5], 0, "arc ends on the right side of the circle (x)");
+        assert.isBelow(arcCommand0.arguments[6], 0, "arc ends on the right side of the circle (y)");
 
         let lineCommand0 = decomposedPath0[2];
         assert.closeTo(lineCommand0.arguments[0], 0, 1, "draws line to origin (x)");
@@ -206,12 +206,12 @@ describe("Plots", () => {
         let decomposedPath1 = TestMethods.decomposePath(TestMethods.normalizePath(pathString1));
 
         let moveCommand1 = decomposedPath1[0];
-        assert.operator(moveCommand1.arguments[0], ">", 0, "starts second arc at the top right of the circle");
-        assert.operator(moveCommand1.arguments[1], "<", 0, "starts second arc at the top right of the circle");
+        assert.isAbove(moveCommand1.arguments[0], 0, "starts second arc at the top right of the circle");
+        assert.isBelow(moveCommand1.arguments[1], 0, "starts second arc at the top right of the circle");
 
         let arcCommand1 = decomposedPath1[1];
         assert.closeTo(arcCommand1.arguments[5], 0, 1, "ends second arc at the bottom of the circle (x origin)");
-        assert.operator(arcCommand1.arguments[6], ">", 0, "ends second arc at the bottom of the circle");
+        assert.isAbove(arcCommand1.arguments[6], 0, "ends second arc at the bottom of the circle");
 
         let lineCommand1 = decomposedPath1[2];
         assert.closeTo(lineCommand1.arguments[0], 0, 1, "draws line to origin (x)");


### PR DESCRIPTION
Addresses issue [#1041](https://github.com/palantir/plottable/issues/1041)

Adding to pie plot: 
- `startAngle(angle: number)`:  sets the start angle, so pies do not need to be a complete circle
- `endAngle(angle: number)` : sets the end angle, so pies do not need to be a complete circle
- `hAlign(alignment: string)`: the alignment is by default in the center of the render area. using `"left"` or `"right"` you can align the horizontal axis to the left or the right
- `vAlign(alignment: string)`: the alignment is by default in the center of the render area. using `"top"` or `"bottom"` you can align the vertical axis to the top or the bottom. 
