### PR TITLE
Interaction: LightweightEntity Caching

### DIFF
--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -2970,7 +2970,7 @@ declare namespace Plottable {
         /**
          * _cachedEntityStore is a cache of all the entities in the plot. It, at times
          * may be undefined and shouldn't be accessed directly. Instead, use _getEntityStore
-         * to access the entity index.
+         * to access the entity store.
          */
         private _cachedEntityStore;
         private _dataChanged;
@@ -3114,9 +3114,9 @@ declare namespace Plottable {
          */
         entities(datasets?: Dataset[]): Plots.PlotEntity[];
         /**
-         * _getEntityStore returns the index of all Entities associated with the specified dataset
+         * _getEntityStore returns the store of all Entities associated with the specified dataset
          *
-         * @param {Dataset[]} [datasets] - The datasets with which to construct the index. If no datasets
+         * @param {Dataset[]} [datasets] - The datasets with which to construct the store. If no datasets
          * are specified all datasets will be used.
          */
         private _getEntityStore(datasets?);

--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -1,10 +1,10 @@
 import * as d3 from "d3";
 declare namespace Plottable.Utils {
     /**
-     * EntityIndex stores entities and makes them searchable.
+     * EntityStore stores entities and makes them searchable.
      * Valid entities must be positioned in Cartesian space.
      */
-    interface EntityIndex<T extends PositionedEntity> {
+    interface EntityStore<T extends PositionedEntity> {
         /**
          * Adds an entity to the store
          * @param {T} [entity] Entity to add to the store. Entity must be positionable
@@ -32,9 +32,9 @@ declare namespace Plottable.Utils {
         position: Point;
     }
     /**
-     * Array-backed implementation of {EntityIndex}
+     * Array-backed implementation of {EntityStore}
      */
-    class EntityArray<T extends PositionedEntity> implements EntityIndex<T> {
+    class EntityArray<T extends PositionedEntity> implements EntityStore<T> {
         private _entities;
         constructor();
         add(entity: T): void;
@@ -750,7 +750,7 @@ declare namespace Plottable.Scales {
         /**
          * Returns value in *Transformation Space* for the provided *screen space*.
          */
-        invertTransformation(value: number): number;
+        invertedTransformation(value: number): number;
     }
     /**
      * Type guarded function to check if the scale implements the
@@ -957,7 +957,7 @@ declare namespace Plottable {
         zoom(magnifyAmount: number, centerValue: number): void;
         pan(translateAmount: number): void;
         scaleTransformation(value: number): number;
-        invertTransformation(value: number): number;
+        invertedTransformation(value: number): number;
         getTransformationDomain(): [number, number];
         protected _setDomain(values: D[]): void;
         /**
@@ -1000,7 +1000,7 @@ declare namespace Plottable.Scales {
         protected _expandSingleValueDomain(singleValueDomain: number[]): number[];
         scale(value: number): number;
         scaleTransformation(value: number): number;
-        invertTransformation(value: number): number;
+        invertedTransformation(value: number): number;
         getTransformationDomain(): [number, number];
         protected _getDomain(): number[];
         protected _backingScaleDomain(): number[];
@@ -1060,7 +1060,7 @@ declare namespace Plottable.Scales {
         scale(x: number): number;
         invert(x: number): number;
         scaleTransformation(value: number): number;
-        invertTransformation(value: number): number;
+        invertedTransformation(value: number): number;
         getTransformationDomain(): [number, number];
         protected _getDomain(): number[];
         protected _setDomain(values: number[]): void;
@@ -1188,7 +1188,7 @@ declare namespace Plottable.Scales {
         zoom(magnifyAmount: number, centerValue: number): void;
         pan(translateAmount: number): void;
         scaleTransformation(value: number): number;
-        invertTransformation(value: number): number;
+        invertedTransformation(value: number): number;
         getTransformationDomain(): [number, number];
         protected _getDomain(): string[];
         protected _backingScaleDomain(): string[];
@@ -1257,7 +1257,7 @@ declare namespace Plottable.Scales {
         protected _expandSingleValueDomain(singleValueDomain: Date[]): Date[];
         scale(value: Date): number;
         scaleTransformation(value: number): number;
-        invertTransformation(value: number): number;
+        invertedTransformation(value: number): number;
         getTransformationDomain(): [number, number];
         protected _getDomain(): Date[];
         protected _backingScaleDomain(): Date[];
@@ -2950,6 +2950,11 @@ declare namespace Plottable.Plots {
         accessor: Accessor<any>;
         scale?: Scale<D, R>;
     }
+    /**
+     * TransformableAccessorScaleBinding mapping from property accessor to
+     * TransformableScale. It is distinct from a plain AccessorScaleBinding
+     * in that the scale is guaranteed to be invertable.
+     */
     interface TransformableAccessorScaleBinding<D, R> {
         accessor: Accessor<any>;
         scale?: TransformableScale<D, R>;
@@ -2963,11 +2968,11 @@ declare namespace Plottable {
     class Plot extends Component {
         protected static _ANIMATION_MAX_DURATION: number;
         /**
-         * _cachedEntityIndex is a cache of all the entities in the plot. It, at times
-         * may be undefined and shouldn't be accessed directly. Instead, use _getEntityIndex
+         * _cachedEntityStore is a cache of all the entities in the plot. It, at times
+         * may be undefined and shouldn't be accessed directly. Instead, use _getEntityStore
          * to access the entity index.
          */
-        private _cachedEntityIndex;
+        private _cachedEntityStore;
         private _dataChanged;
         private _datasetToDrawer;
         protected _renderArea: d3.Selection<void>;
@@ -3109,12 +3114,12 @@ declare namespace Plottable {
          */
         entities(datasets?: Dataset[]): Plots.PlotEntity[];
         /**
-         * _getEntityIndex returns the index of all Entities associated with the specified dataset
+         * _getEntityStore returns the index of all Entities associated with the specified dataset
          *
          * @param {Dataset[]} [datasets] - The datasets with which to construct the index. If no datasets
          * are specified all datasets will be used.
          */
-        private _getEntityIndex(datasets?);
+        private _getEntityStore(datasets?);
         private _lightweightPlotEntityToPlotEntity(entity);
         /**
          * Gets the PlotEntities at a particular Point.
@@ -3133,10 +3138,14 @@ declare namespace Plottable {
          * or undefined if no {Plots.PlotEntity} can be found.
          *
          * @param {Point} queryPoint
-         * @param {bounds} Bounds The bounding box within which to search
+         * @param {bounds} Bounds The bounding box within which to search. By default, bounds is the bounds of
+         * the chart, relative to the parent.
          * @returns {Plots.PlotEntity} The nearest PlotEntity, or undefined if no {Plots.PlotEntity} can be found.
          */
-        entityNearest(queryPoint: Point, bounds?: Bounds): Plots.PlotEntity;
+        entityNearest(queryPoint: Point, bounds?: {
+            topLeft: Point;
+            bottomRight: Point;
+        }): Plots.PlotEntity;
         protected _entityVisibleOnPlot(entity: Plots.PlotEntity | Plots.LightweightPlotEntity, chartBounds: Bounds): boolean;
         protected _uninstallScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _installScaleForKey(scale: Scale<any, any>, key: string): void;

--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -3133,35 +3133,15 @@ declare namespace Plottable {
          * or undefined if no {Plots.PlotEntity} can be found.
          *
          * @param {Point} queryPoint
+         * @param {bounds} Bounds The bounding box within which to search
          * @returns {Plots.PlotEntity} The nearest PlotEntity, or undefined if no {Plots.PlotEntity} can be found.
          */
-        entityNearest(queryPoint: Point): Plots.PlotEntity;
+        entityNearest(queryPoint: Point, bounds?: Bounds): Plots.PlotEntity;
         protected _entityVisibleOnPlot(entity: Plots.PlotEntity | Plots.LightweightPlotEntity, chartBounds: Bounds): boolean;
         protected _uninstallScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _installScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _propertyProjectors(): AttributeToProjector;
         protected static _scaledAccessor<D, R>(binding: Plots.AccessorScaleBinding<D, R>): Accessor<any>;
-        /**
-         * _invertPixelPoint converts a point in pixel coordinates to a point in data coordinates
-         * @param {Point} point Representation of the point in pixel coordinates
-         * @return {Point} Returns the point represented in data coordinates
-         */
-        protected _invertPixelPoint(point: Point): Point;
-        /**
-         * Returns the bounds of the plot in the Data space ensures that the topLeft
-         * and bottomRight points represent the minima and maxima of the Data space, respectively
-         @returns {Bounds}
-         */
-        protected _invertedBounds(): {
-            topLeft: {
-                x: number;
-                y: number;
-            };
-            bottomRight: {
-                x: number;
-                y: number;
-            };
-        };
         protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point;
         protected _animateOnNextRender(): boolean;
     }
@@ -3309,6 +3289,7 @@ declare namespace Plottable {
          * @param {Scale} yScale The y scale to use.
          */
         constructor();
+        entityNearest(queryPoint: Point): Plots.PlotEntity;
         /**
          * Returns the whether or not the rendering is deferred for performance boost.
          * @return {boolean} The deferred rendering option
@@ -3396,7 +3377,19 @@ declare namespace Plottable {
         showAllData(): this;
         private _adjustYDomainOnChangeFromX();
         private _adjustXDomainOnChangeFromY();
+        protected _buildLightweightPlotEntities(datasets?: Dataset[]): Plots.LightweightPlotEntity[];
         protected _projectorsReady(): boolean;
+        /**
+         * Returns the bounds of the plot in the Data space ensures that the topLeft
+         * and bottomRight points represent the minima and maxima of the Data space, respectively
+         @returns {Bounds}
+         */
+        private _invertedBounds();
+        /**
+         * _invertPixelPoint converts a point in pixel coordinates to a point in data coordinates
+         * @param {Point} point Representation of the point in pixel coordinates
+         * @return {Point} Returns the point represented in data coordinates
+         */
         protected _invertPixelPoint(point: Point): Point;
         protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point;
         protected _getDataToDraw(): Utils.Map<Dataset, any[]>;

--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -1,4 +1,51 @@
 import * as d3 from "d3";
+declare namespace Plottable.Utils {
+    /**
+     * EntityIndex stores entities and makes them searchable.
+     * Valid entities must be positioned in Cartesian space.
+     */
+    interface EntityIndex<T extends PositionedEntity> {
+        /**
+         * Adds an entity to the store
+         * @param {T} [entity] Entity to add to the store. Entity must be positionable
+         */
+        add(entity: T): void;
+        /**
+         * Returns closest entity to a given {Point}
+         * @param {Point} [point] Point around which to search for a closest entity
+         * @param {(entity: T) => boolean} [filter] optional method that is called while
+         * searching for the entity nearest a point. If the filter returns false, the point
+         * is considered invalid and is not considered. If the filter returns true, the point
+         * is considered valid and will be considered.
+         * @returns {T} Will return the nearest entity or undefined if none are found
+         */
+        entityNearest(point: Point, filter?: (entity: T) => boolean): T;
+        /**
+         * Iterator that loops through entities and returns a transformed array
+         * @param {(value: T) => S} [callback] transformation function that is passed
+         * passed an entity {T} and returns an object {S}.
+         * @returns {S[]} The aggregate result of each call to the transformation function
+         */
+        map<S>(callback: (value: T) => S): S[];
+    }
+    interface PositionedEntity {
+        position: Point;
+    }
+    /**
+     * Array-backed implementation of {EntityIndex}
+     */
+    class EntityArray<T extends PositionedEntity> implements EntityIndex<T> {
+        private _entities;
+        constructor();
+        add(entity: T): void;
+        /**
+         * Iterates through array of of entities and computes the closest point using
+         * the standard Euclidean distance formula.
+         */
+        entityNearest(queryPoint: Point, filter?: (entity: T) => boolean): T;
+        map<S>(callback: (value: T) => S): S[];
+    }
+}
 declare namespace Plottable.Utils.Math {
     /**
      * Checks if x is between a and b.
@@ -700,6 +747,10 @@ declare namespace Plottable.Scales {
          * `scaleTransformation`.
          */
         getTransformationDomain(): [number, number];
+        /**
+         * Returns value in *Transformation Space* for the provided *screen space*.
+         */
+        invertTransformation(value: number): number;
     }
     /**
      * Type guarded function to check if the scale implements the
@@ -710,6 +761,7 @@ declare namespace Plottable.Scales {
     function isTransformable(scale: any): scale is TransformableScale;
 }
 declare namespace Plottable {
+    type TransformableScale<D, R> = Scale<D, R> & Plottable.Scales.TransformableScale;
     interface ScaleCallback<S extends Scale<any, any>> {
         (scale: S): any;
     }
@@ -905,6 +957,7 @@ declare namespace Plottable {
         zoom(magnifyAmount: number, centerValue: number): void;
         pan(translateAmount: number): void;
         scaleTransformation(value: number): number;
+        invertTransformation(value: number): number;
         getTransformationDomain(): [number, number];
         protected _setDomain(values: D[]): void;
         /**
@@ -947,6 +1000,7 @@ declare namespace Plottable.Scales {
         protected _expandSingleValueDomain(singleValueDomain: number[]): number[];
         scale(value: number): number;
         scaleTransformation(value: number): number;
+        invertTransformation(value: number): number;
         getTransformationDomain(): [number, number];
         protected _getDomain(): number[];
         protected _backingScaleDomain(): number[];
@@ -1006,6 +1060,7 @@ declare namespace Plottable.Scales {
         scale(x: number): number;
         invert(x: number): number;
         scaleTransformation(value: number): number;
+        invertTransformation(value: number): number;
         getTransformationDomain(): [number, number];
         protected _getDomain(): number[];
         protected _setDomain(values: number[]): void;
@@ -1133,6 +1188,7 @@ declare namespace Plottable.Scales {
         zoom(magnifyAmount: number, centerValue: number): void;
         pan(translateAmount: number): void;
         scaleTransformation(value: number): number;
+        invertTransformation(value: number): number;
         getTransformationDomain(): [number, number];
         protected _getDomain(): string[];
         protected _backingScaleDomain(): string[];
@@ -1201,6 +1257,7 @@ declare namespace Plottable.Scales {
         protected _expandSingleValueDomain(singleValueDomain: Date[]): Date[];
         scale(value: Date): number;
         scaleTransformation(value: number): number;
+        invertTransformation(value: number): number;
         getTransformationDomain(): [number, number];
         protected _getDomain(): Date[];
         protected _backingScaleDomain(): Date[];
@@ -1612,6 +1669,12 @@ declare namespace Plottable {
          * using the appropriate method on the ComponentContainer.
          */
         parent(parent: ComponentContainer): this;
+        /**
+         * @returns {Bounds} for the component in pixel space, where the topLeft
+         * represents the component's minimum x and y values and the bottomRight represents
+         * the component's maximum x and y values.
+         */
+        bounds(): Bounds;
         /**
          * Removes a Component from the DOM and disconnects all listeners.
          */
@@ -2862,6 +2925,21 @@ declare namespace Plottable.Components {
     }
 }
 declare namespace Plottable.Plots {
+    /**
+     * Computing the selection of an entity is an expensive operation. This object aims to
+     * reproduce the behavior of the Plots.PlotEntity, excluding the selection, but including
+     * drawer and validDatumIndex, which can be used to compute the selection.
+     */
+    interface LightweightPlotEntity {
+        datum: any;
+        dataset: Dataset;
+        datasetIndex: number;
+        position: Point;
+        index: number;
+        component: Plot;
+        drawer: Plottable.Drawer;
+        validDatumIndex: number;
+    }
     interface PlotEntity extends Entity<Plot> {
         dataset: Dataset;
         datasetIndex: number;
@@ -2872,6 +2950,10 @@ declare namespace Plottable.Plots {
         accessor: Accessor<any>;
         scale?: Scale<D, R>;
     }
+    interface TransformableAccessorScaleBinding<D, R> {
+        accessor: Accessor<any>;
+        scale?: TransformableScale<D, R>;
+    }
     namespace Animator {
         var MAIN: string;
         var RESET: string;
@@ -2880,6 +2962,12 @@ declare namespace Plottable.Plots {
 declare namespace Plottable {
     class Plot extends Component {
         protected static _ANIMATION_MAX_DURATION: number;
+        /**
+         * _cachedEntityIndex is a cache of all the entities in the plot. It, at times
+         * may be undefined and shouldn't be accessed directly. Instead, use _getEntityIndex
+         * to access the entity index.
+         */
+        private _cachedEntityIndex;
         private _dataChanged;
         private _datasetToDrawer;
         protected _renderArea: d3.Selection<void>;
@@ -2996,6 +3084,12 @@ declare namespace Plottable {
         protected _getDrawersInOrder(): Drawer[];
         protected _generateDrawSteps(): Drawers.DrawStep[];
         protected _additionalPaint(time: number): void;
+        /**
+         * _buildLightweightPlotEntities constucts {LightweightPlotEntity[]} from
+         * all the entities in the plot
+         * @param {Dataset[]} [datasets] - datasets comprising this plot
+         */
+        protected _buildLightweightPlotEntities(datasets: Dataset[]): Plots.LightweightPlotEntity[];
         protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
         private _paint();
         /**
@@ -3009,12 +3103,18 @@ declare namespace Plottable {
         /**
          * Gets the Entities associated with the specified Datasets.
          *
-         * @param {dataset[]} datasets The Datasets to retrieve the Entities for.
+         * @param {Dataset[]} datasets The Datasets to retrieve the Entities for.
          *   If not provided, returns defaults to all Datasets on the Plot.
          * @return {Plots.PlotEntity[]}
          */
         entities(datasets?: Dataset[]): Plots.PlotEntity[];
-        private _lightweightEntities(datasets?);
+        /**
+         * _getEntityIndex returns the index of all Entities associated with the specified dataset
+         *
+         * @param {Dataset[]} [datasets] - The datasets with which to construct the index. If no datasets
+         * are specified all datasets will be used.
+         */
+        private _getEntityIndex(datasets?);
         private _lightweightPlotEntityToPlotEntity(entity);
         /**
          * Gets the PlotEntities at a particular Point.
@@ -3029,17 +3129,39 @@ declare namespace Plottable {
          */
         entitiesAt(point: Point): Plots.PlotEntity[];
         /**
-         * Returns the PlotEntity nearest to the query point by the Euclidian norm, or undefined if no PlotEntity can be found.
+         * Returns the {Plots.PlotEntity} nearest to the query point,
+         * or undefined if no {Plots.PlotEntity} can be found.
          *
          * @param {Point} queryPoint
-         * @returns {Plots.PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
+         * @returns {Plots.PlotEntity} The nearest PlotEntity, or undefined if no {Plots.PlotEntity} can be found.
          */
         entityNearest(queryPoint: Point): Plots.PlotEntity;
-        protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;
+        protected _entityVisibleOnPlot(entity: Plots.PlotEntity | Plots.LightweightPlotEntity, chartBounds: Bounds): boolean;
         protected _uninstallScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _installScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _propertyProjectors(): AttributeToProjector;
         protected static _scaledAccessor<D, R>(binding: Plots.AccessorScaleBinding<D, R>): Accessor<any>;
+        /**
+         * _invertPixelPoint converts a point in pixel coordinates to a point in data coordinates
+         * @param {Point} point Representation of the point in pixel coordinates
+         * @return {Point} Returns the point represented in data coordinates
+         */
+        protected _invertPixelPoint(point: Point): Point;
+        /**
+         * Returns the bounds of the plot in the Data space ensures that the topLeft
+         * and bottomRight points represent the minima and maxima of the Data space, respectively
+         @returns {Bounds}
+         */
+        protected _invertedBounds(): {
+            topLeft: {
+                x: number;
+                y: number;
+            };
+            bottomRight: {
+                x: number;
+                y: number;
+            };
+        };
         protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point;
         protected _animateOnNextRender(): boolean;
     }
@@ -3203,9 +3325,9 @@ declare namespace Plottable {
          */
         deferredRendering(deferredRendering: boolean): this;
         /**
-         * Gets the AccessorScaleBinding for X.
+         * Gets the TransformableAccessorScaleBinding for X.
          */
-        x(): Plots.AccessorScaleBinding<X, number>;
+        x(): Plots.TransformableAccessorScaleBinding<X, number>;
         /**
          * Sets X to a constant number or the result of an Accessor<number>.
          *
@@ -3225,7 +3347,7 @@ declare namespace Plottable {
         /**
          * Gets the AccessorScaleBinding for Y.
          */
-        y(): Plots.AccessorScaleBinding<Y, number>;
+        y(): Plots.TransformableAccessorScaleBinding<Y, number>;
         /**
          * Sets Y to a constant number or the result of an Accessor<number>.
          *
@@ -3275,6 +3397,7 @@ declare namespace Plottable {
         private _adjustYDomainOnChangeFromX();
         private _adjustXDomainOnChangeFromY();
         protected _projectorsReady(): boolean;
+        protected _invertPixelPoint(point: Point): Point;
         protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point;
         protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
     }
@@ -3307,7 +3430,7 @@ declare namespace Plottable.Plots {
         /**
          * Gets the AccessorScaleBinding for X.
          */
-        x(): AccessorScaleBinding<X, number>;
+        x(): Plots.TransformableAccessorScaleBinding<X, number>;
         /**
          * Sets X to a constant number or the result of an Accessor<number>.
          *
@@ -3327,7 +3450,7 @@ declare namespace Plottable.Plots {
         /**
          * Gets the AccessorScaleBinding for X2.
          */
-        x2(): AccessorScaleBinding<X, number>;
+        x2(): Plots.TransformableAccessorScaleBinding<X, number>;
         /**
          * Sets X2 to a constant number or the result of an Accessor.
          * If a Scale has been set for X, it will also be used to scale X2.
@@ -3339,7 +3462,7 @@ declare namespace Plottable.Plots {
         /**
          * Gets the AccessorScaleBinding for Y.
          */
-        y(): AccessorScaleBinding<Y, number>;
+        y(): Plots.TransformableAccessorScaleBinding<Y, number>;
         /**
          * Sets Y to a constant number or the result of an Accessor<number>.
          *
@@ -3359,7 +3482,7 @@ declare namespace Plottable.Plots {
         /**
          * Gets the AccessorScaleBinding for Y2.
          */
-        y2(): AccessorScaleBinding<Y, number>;
+        y2(): Plots.TransformableAccessorScaleBinding<Y, number>;
         /**
          * Sets Y2 to a constant number or the result of an Accessor.
          * If a Scale has been set for Y, it will also be used to scale Y2.
@@ -3433,6 +3556,9 @@ declare namespace Plottable.Plots {
     }
 }
 declare namespace Plottable.Plots {
+    interface LightweightScatterPlotEntity extends LightweightPlotEntity {
+        diameter: Point;
+    }
     class Scatter<X, Y> extends XYPlot<X, Y> {
         private static _SIZE_KEY;
         private static _SYMBOL_KEY;
@@ -3442,12 +3568,13 @@ declare namespace Plottable.Plots {
          * @constructor
          */
         constructor();
+        protected _buildLightweightPlotEntities(datasets: Dataset[]): LightweightScatterPlotEntity[];
         protected _createDrawer(dataset: Dataset): Drawers.Symbol;
         /**
          * Gets the AccessorScaleBinding for the size property of the plot.
          * The size property corresponds to the area of the symbol.
          */
-        size<S>(): AccessorScaleBinding<S, number>;
+        size<S>(): TransformableAccessorScaleBinding<S, number>;
         /**
          * Sets the size property to a constant number or the result of an Accessor<number>.
          *
@@ -3477,7 +3604,7 @@ declare namespace Plottable.Plots {
          */
         symbol(symbol: Accessor<SymbolFactory>): this;
         protected _generateDrawSteps(): Drawers.DrawStep[];
-        protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;
+        protected _entityVisibleOnPlot(entity: LightweightScatterPlotEntity, bounds: Bounds): boolean;
         protected _propertyProjectors(): AttributeToProjector;
         /**
          * Gets the Entities that intersect the Bounds.
@@ -3501,6 +3628,15 @@ declare namespace Plottable.Plots {
          * @returns {PlotEntity[]}
          */
         entitiesAt(p: Point): PlotEntity[];
+        /**
+         * _invertedPixelSize returns the size of the object in data space
+         * @param {Point} [point] The size of the object in pixel space. X corresponds to
+         * the width of the object, and Y corresponds to the height of the object
+         * @return {Point} Returns the size of the object in data space. X corresponds to
+         * the width of the object in data space, and Y corresponds to the height of the
+         * object in data space.
+         */
+        private _invertedPixelSize(point);
     }
 }
 declare namespace Plottable.Plots {
@@ -3530,10 +3666,10 @@ declare namespace Plottable.Plots {
          * @param {string} [orientation="vertical"] One of "vertical"/"horizontal".
          */
         constructor(orientation?: string);
-        x(): Plots.AccessorScaleBinding<X, number>;
+        x(): Plots.TransformableAccessorScaleBinding<X, number>;
         x(x: number | Accessor<number>): this;
         x(x: X | Accessor<X>, xScale: Scale<X, number>): this;
-        y(): Plots.AccessorScaleBinding<Y, number>;
+        y(): Plots.TransformableAccessorScaleBinding<Y, number>;
         y(y: number | Accessor<number>): this;
         y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): this;
         /**
@@ -3603,7 +3739,7 @@ declare namespace Plottable.Plots {
          * @returns {PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
          */
         entityNearest(queryPoint: Point): PlotEntity;
-        protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;
+        protected _entityVisibleOnPlot(entity: Plots.PlotEntity, bounds: Bounds): boolean;
         /**
          * Gets the Entities at a particular Point.
          *
@@ -3666,10 +3802,10 @@ declare namespace Plottable.Plots {
          * @constructor
          */
         constructor();
-        x(): Plots.AccessorScaleBinding<X, number>;
+        x(): Plots.TransformableAccessorScaleBinding<X, number>;
         x(x: number | Accessor<number>): this;
         x(x: X | Accessor<X>, xScale: Scale<X, number>): this;
-        y(): Plots.AccessorScaleBinding<number, number>;
+        y(): Plots.TransformableAccessorScaleBinding<number, number>;
         y(y: number | Accessor<number>): this;
         y(y: number | Accessor<number>, yScale: Scale<number, number>): this;
         autorangeMode(): string;
@@ -3786,7 +3922,7 @@ declare namespace Plottable.Plots {
          */
         constructor();
         protected _setup(): void;
-        y(): Plots.AccessorScaleBinding<number, number>;
+        y(): Plots.TransformableAccessorScaleBinding<number, number>;
         y(y: number | Accessor<number>): this;
         y(y: number | Accessor<number>, yScale: QuantitativeScale<number>): this;
         /**
@@ -3852,10 +3988,10 @@ declare namespace Plottable.Plots {
         croppedRenderingEnabled(croppedRendering: boolean): this;
         protected _getAnimator(key: string): Animator;
         protected _setup(): void;
-        x(): Plots.AccessorScaleBinding<X, number>;
+        x(): Plots.TransformableAccessorScaleBinding<X, number>;
         x(x: number | Accessor<number>): this;
         x(x: X | Accessor<X>, xScale: Scale<X, number>): this;
-        y(): Plots.AccessorScaleBinding<number, number>;
+        y(): Plots.TransformableAccessorScaleBinding<number, number>;
         y(y: number | Accessor<number>): this;
         y(y: number | Accessor<number>, yScale: QuantitativeScale<number>): this;
         /**
@@ -3907,10 +4043,10 @@ declare namespace Plottable.Plots {
          * @param {string} [orientation="vertical"] One of "vertical"/"horizontal".
          */
         constructor(orientation?: string);
-        x(): Plots.AccessorScaleBinding<X, number>;
+        x(): Plots.TransformableAccessorScaleBinding<X, number>;
         x(x: number | Accessor<number>): this;
         x(x: X | Accessor<X>, xScale: Scale<X, number>): this;
-        y(): Plots.AccessorScaleBinding<Y, number>;
+        y(): Plots.TransformableAccessorScaleBinding<Y, number>;
         y(y: number | Accessor<number>): this;
         y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): this;
         protected _generateAttrToProjector(): {
@@ -3939,7 +4075,7 @@ declare namespace Plottable.Plots {
         /**
          * Gets the AccessorScaleBinding for X
          */
-        x(): AccessorScaleBinding<X, number>;
+        x(): TransformableAccessorScaleBinding<X, number>;
         /**
          * Sets X to a constant value or the result of an Accessor.
          *
@@ -3971,7 +4107,7 @@ declare namespace Plottable.Plots {
         /**
          * Gets the AccessorScaleBinding for Y
          */
-        y(): AccessorScaleBinding<Y, number>;
+        y(): TransformableAccessorScaleBinding<Y, number>;
         /**
          * Sets Y to a constant value or the result of an Accessor.
          *
@@ -4740,7 +4876,6 @@ declare namespace Plottable.Interactions {
      * `zoom` argument about the point defined by the `center` argument.
      */
     function zoomAt(value: number, zoom: number, center: number): number;
-    type TransformableScale = Plottable.Scale<any, number> & Plottable.Scales.TransformableScale;
     class PanZoom extends Interaction {
         /**
          * The number of pixels occupied in a line.
@@ -4771,7 +4906,7 @@ declare namespace Plottable.Interactions {
          * @param {TransformableScale} [xScale] The x-scale to update on panning/zooming.
          * @param {TransformableScale} [yScale] The y-scale to update on panning/zooming.
          */
-        constructor(xScale?: TransformableScale, yScale?: TransformableScale);
+        constructor(xScale?: TransformableScale<any, number>, yScale?: TransformableScale<any, number>);
         /**
          * Pans the chart by a specified amount
          *
@@ -4818,51 +4953,51 @@ declare namespace Plottable.Interactions {
         /**
          * Gets the x scales for this PanZoom Interaction.
          */
-        xScales(): TransformableScale[];
+        xScales(): TransformableScale<any, number>[];
         /**
          * Sets the x scales for this PanZoom Interaction.
          *
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        xScales(xScales: TransformableScale[]): this;
+        xScales(xScales: TransformableScale<any, number>[]): this;
         /**
          * Gets the y scales for this PanZoom Interaction.
          */
-        yScales(): TransformableScale[];
+        yScales(): TransformableScale<any, number>[];
         /**
          * Sets the y scales for this PanZoom Interaction.
          *
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        yScales(yScales: TransformableScale[]): this;
+        yScales(yScales: TransformableScale<any, number>[]): this;
         /**
          * Adds an x scale to this PanZoom Interaction
          *
          * @param {TransformableScale} An x scale to add
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        addXScale(xScale: TransformableScale): this;
+        addXScale(xScale: TransformableScale<any, number>): this;
         /**
          * Removes an x scale from this PanZoom Interaction
          *
          * @param {TransformableScale} An x scale to remove
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        removeXScale(xScale: TransformableScale): this;
+        removeXScale(xScale: TransformableScale<any, number>): this;
         /**
          * Adds a y scale to this PanZoom Interaction
          *
          * @param {TransformableScale} A y scale to add
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        addYScale(yScale: TransformableScale): this;
+        addYScale(yScale: TransformableScale<any, number>): this;
         /**
          * Removes a y scale from this PanZoom Interaction
          *
          * @param {TransformableScale} A y scale to remove
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        removeYScale(yScale: TransformableScale): this;
+        removeYScale(yScale: TransformableScale<any, number>): this;
         /**
          * Gets the minimum domain extent for the scale, specifying the minimum
          * allowable amount between the ends of the domain.
@@ -4873,7 +5008,7 @@ declare namespace Plottable.Interactions {
          * @param {TransformableScale} scale The scale to query
          * @returns {number} The minimum numerical domain extent for the scale.
          */
-        minDomainExtent(scale: TransformableScale): number;
+        minDomainExtent(scale: TransformableScale<any, number>): number;
         /**
          * Sets the minimum domain extent for the scale, specifying the minimum
          * allowable amount between the ends of the domain.
@@ -4886,7 +5021,7 @@ declare namespace Plottable.Interactions {
          * the scale.
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        minDomainExtent(scale: TransformableScale, minDomainExtent: number): this;
+        minDomainExtent(scale: TransformableScale<any, number>, minDomainExtent: number): this;
         /**
          * Gets the maximum domain extent for the scale, specifying the maximum
          * allowable amount between the ends of the domain.
@@ -4897,7 +5032,7 @@ declare namespace Plottable.Interactions {
          * @param {TransformableScale} scale The scale to query
          * @returns {number} The maximum numerical domain extent for the scale.
          */
-        maxDomainExtent(scale: TransformableScale): number;
+        maxDomainExtent(scale: TransformableScale<any, number>): number;
         /**
          * Sets the maximum domain extent for the scale, specifying the maximum
          * allowable amount between the ends of the domain.
@@ -4914,7 +5049,7 @@ declare namespace Plottable.Interactions {
          * the scale.
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        maxDomainExtent(scale: TransformableScale, maxDomainExtent: number): this;
+        maxDomainExtent(scale: TransformableScale<any, number>, maxDomainExtent: number): this;
         /**
          * Gets the minimum domain value for the scale, constraining the pan/zoom
          * interaction to a minimum value in the domain.
@@ -4929,7 +5064,7 @@ declare namespace Plottable.Interactions {
          * @param {TransformableScale} scale The scale to query
          * @returns {number} The minimum domain value for the scale.
          */
-        minDomainValue(scale: TransformableScale): number;
+        minDomainValue(scale: TransformableScale<any, number>): number;
         /**
          * Sets the minimum domain value for the scale, constraining the pan/zoom
          * interaction to a minimum value in the domain.
@@ -4945,7 +5080,7 @@ declare namespace Plottable.Interactions {
          * @param {number} minDomainExtent The minimum domain value for the scale.
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        minDomainValue(scale: TransformableScale, minDomainValue: number): this;
+        minDomainValue(scale: TransformableScale<any, number>, minDomainValue: number): this;
         /**
          * Gets the maximum domain value for the scale, constraining the pan/zoom
          * interaction to a maximum value in the domain.
@@ -4960,7 +5095,7 @@ declare namespace Plottable.Interactions {
          * @param {TransformableScale} scale The scale to query
          * @returns {number} The maximum domain value for the scale.
          */
-        maxDomainValue(scale: TransformableScale): number;
+        maxDomainValue(scale: TransformableScale<any, number>): number;
         /**
          * Sets the maximum domain value for the scale, constraining the pan/zoom
          * interaction to a maximum value in the domain.
@@ -4976,7 +5111,7 @@ declare namespace Plottable.Interactions {
          * @param {number} maxDomainExtent The maximum domain value for the scale.
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        maxDomainValue(scale: TransformableScale, maxDomainValue: number): this;
+        maxDomainValue(scale: TransformableScale<any, number>, maxDomainValue: number): this;
         /**
          * Uses the current domain of the scale to apply a minimum and maximum
          * domain value for that scale.
@@ -4984,7 +5119,7 @@ declare namespace Plottable.Interactions {
          * This constrains the pan/zoom interaction to show no more than the domain
          * of the scale.
          */
-        setMinMaxDomainValuesTo(scale: TransformableScale): void;
+        setMinMaxDomainValuesTo(scale: TransformableScale<any, number>): void;
         /**
          * Adds a callback to be called when panning ends.
          *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2969,7 +2969,7 @@ declare namespace Plottable {
         /**
          * _cachedEntityStore is a cache of all the entities in the plot. It, at times
          * may be undefined and shouldn't be accessed directly. Instead, use _getEntityStore
-         * to access the entity index.
+         * to access the entity store.
          */
         private _cachedEntityStore;
         private _dataChanged;
@@ -3113,9 +3113,9 @@ declare namespace Plottable {
          */
         entities(datasets?: Dataset[]): Plots.PlotEntity[];
         /**
-         * _getEntityStore returns the index of all Entities associated with the specified dataset
+         * _getEntityStore returns the store of all Entities associated with the specified dataset
          *
-         * @param {Dataset[]} [datasets] - The datasets with which to construct the index. If no datasets
+         * @param {Dataset[]} [datasets] - The datasets with which to construct the store. If no datasets
          * are specified all datasets will be used.
          */
         private _getEntityStore(datasets?);

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1,3 +1,50 @@
+declare namespace Plottable.Utils {
+    /**
+     * EntityIndex stores entities and makes them searchable.
+     * Valid entities must be positioned in Cartesian space.
+     */
+    interface EntityIndex<T extends PositionedEntity> {
+        /**
+         * Adds an entity to the store
+         * @param {T} [entity] Entity to add to the store. Entity must be positionable
+         */
+        add(entity: T): void;
+        /**
+         * Returns closest entity to a given {Point}
+         * @param {Point} [point] Point around which to search for a closest entity
+         * @param {(entity: T) => boolean} [filter] optional method that is called while
+         * searching for the entity nearest a point. If the filter returns false, the point
+         * is considered invalid and is not considered. If the filter returns true, the point
+         * is considered valid and will be considered.
+         * @returns {T} Will return the nearest entity or undefined if none are found
+         */
+        entityNearest(point: Point, filter?: (entity: T) => boolean): T;
+        /**
+         * Iterator that loops through entities and returns a transformed array
+         * @param {(value: T) => S} [callback] transformation function that is passed
+         * passed an entity {T} and returns an object {S}.
+         * @returns {S[]} The aggregate result of each call to the transformation function
+         */
+        map<S>(callback: (value: T) => S): S[];
+    }
+    interface PositionedEntity {
+        position: Point;
+    }
+    /**
+     * Array-backed implementation of {EntityIndex}
+     */
+    class EntityArray<T extends PositionedEntity> implements EntityIndex<T> {
+        private _entities;
+        constructor();
+        add(entity: T): void;
+        /**
+         * Iterates through array of of entities and computes the closest point using
+         * the standard Euclidean distance formula.
+         */
+        entityNearest(queryPoint: Point, filter?: (entity: T) => boolean): T;
+        map<S>(callback: (value: T) => S): S[];
+    }
+}
 declare namespace Plottable.Utils.Math {
     /**
      * Checks if x is between a and b.
@@ -699,6 +746,10 @@ declare namespace Plottable.Scales {
          * `scaleTransformation`.
          */
         getTransformationDomain(): [number, number];
+        /**
+         * Returns value in *Transformation Space* for the provided *screen space*.
+         */
+        invertTransformation(value: number): number;
     }
     /**
      * Type guarded function to check if the scale implements the
@@ -709,6 +760,7 @@ declare namespace Plottable.Scales {
     function isTransformable(scale: any): scale is TransformableScale;
 }
 declare namespace Plottable {
+    type TransformableScale<D, R> = Scale<D, R> & Plottable.Scales.TransformableScale;
     interface ScaleCallback<S extends Scale<any, any>> {
         (scale: S): any;
     }
@@ -904,6 +956,7 @@ declare namespace Plottable {
         zoom(magnifyAmount: number, centerValue: number): void;
         pan(translateAmount: number): void;
         scaleTransformation(value: number): number;
+        invertTransformation(value: number): number;
         getTransformationDomain(): [number, number];
         protected _setDomain(values: D[]): void;
         /**
@@ -946,6 +999,7 @@ declare namespace Plottable.Scales {
         protected _expandSingleValueDomain(singleValueDomain: number[]): number[];
         scale(value: number): number;
         scaleTransformation(value: number): number;
+        invertTransformation(value: number): number;
         getTransformationDomain(): [number, number];
         protected _getDomain(): number[];
         protected _backingScaleDomain(): number[];
@@ -1005,6 +1059,7 @@ declare namespace Plottable.Scales {
         scale(x: number): number;
         invert(x: number): number;
         scaleTransformation(value: number): number;
+        invertTransformation(value: number): number;
         getTransformationDomain(): [number, number];
         protected _getDomain(): number[];
         protected _setDomain(values: number[]): void;
@@ -1132,6 +1187,7 @@ declare namespace Plottable.Scales {
         zoom(magnifyAmount: number, centerValue: number): void;
         pan(translateAmount: number): void;
         scaleTransformation(value: number): number;
+        invertTransformation(value: number): number;
         getTransformationDomain(): [number, number];
         protected _getDomain(): string[];
         protected _backingScaleDomain(): string[];
@@ -1200,6 +1256,7 @@ declare namespace Plottable.Scales {
         protected _expandSingleValueDomain(singleValueDomain: Date[]): Date[];
         scale(value: Date): number;
         scaleTransformation(value: number): number;
+        invertTransformation(value: number): number;
         getTransformationDomain(): [number, number];
         protected _getDomain(): Date[];
         protected _backingScaleDomain(): Date[];
@@ -1611,6 +1668,12 @@ declare namespace Plottable {
          * using the appropriate method on the ComponentContainer.
          */
         parent(parent: ComponentContainer): this;
+        /**
+         * @returns {Bounds} for the component in pixel space, where the topLeft
+         * represents the component's minimum x and y values and the bottomRight represents
+         * the component's maximum x and y values.
+         */
+        bounds(): Bounds;
         /**
          * Removes a Component from the DOM and disconnects all listeners.
          */
@@ -2861,6 +2924,21 @@ declare namespace Plottable.Components {
     }
 }
 declare namespace Plottable.Plots {
+    /**
+     * Computing the selection of an entity is an expensive operation. This object aims to
+     * reproduce the behavior of the Plots.PlotEntity, excluding the selection, but including
+     * drawer and validDatumIndex, which can be used to compute the selection.
+     */
+    interface LightweightPlotEntity {
+        datum: any;
+        dataset: Dataset;
+        datasetIndex: number;
+        position: Point;
+        index: number;
+        component: Plot;
+        drawer: Plottable.Drawer;
+        validDatumIndex: number;
+    }
     interface PlotEntity extends Entity<Plot> {
         dataset: Dataset;
         datasetIndex: number;
@@ -2871,6 +2949,10 @@ declare namespace Plottable.Plots {
         accessor: Accessor<any>;
         scale?: Scale<D, R>;
     }
+    interface TransformableAccessorScaleBinding<D, R> {
+        accessor: Accessor<any>;
+        scale?: TransformableScale<D, R>;
+    }
     namespace Animator {
         var MAIN: string;
         var RESET: string;
@@ -2879,6 +2961,12 @@ declare namespace Plottable.Plots {
 declare namespace Plottable {
     class Plot extends Component {
         protected static _ANIMATION_MAX_DURATION: number;
+        /**
+         * _cachedEntityIndex is a cache of all the entities in the plot. It, at times
+         * may be undefined and shouldn't be accessed directly. Instead, use _getEntityIndex
+         * to access the entity index.
+         */
+        private _cachedEntityIndex;
         private _dataChanged;
         private _datasetToDrawer;
         protected _renderArea: d3.Selection<void>;
@@ -2995,6 +3083,12 @@ declare namespace Plottable {
         protected _getDrawersInOrder(): Drawer[];
         protected _generateDrawSteps(): Drawers.DrawStep[];
         protected _additionalPaint(time: number): void;
+        /**
+         * _buildLightweightPlotEntities constucts {LightweightPlotEntity[]} from
+         * all the entities in the plot
+         * @param {Dataset[]} [datasets] - datasets comprising this plot
+         */
+        protected _buildLightweightPlotEntities(datasets: Dataset[]): Plots.LightweightPlotEntity[];
         protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
         private _paint();
         /**
@@ -3008,12 +3102,18 @@ declare namespace Plottable {
         /**
          * Gets the Entities associated with the specified Datasets.
          *
-         * @param {dataset[]} datasets The Datasets to retrieve the Entities for.
+         * @param {Dataset[]} datasets The Datasets to retrieve the Entities for.
          *   If not provided, returns defaults to all Datasets on the Plot.
          * @return {Plots.PlotEntity[]}
          */
         entities(datasets?: Dataset[]): Plots.PlotEntity[];
-        private _lightweightEntities(datasets?);
+        /**
+         * _getEntityIndex returns the index of all Entities associated with the specified dataset
+         *
+         * @param {Dataset[]} [datasets] - The datasets with which to construct the index. If no datasets
+         * are specified all datasets will be used.
+         */
+        private _getEntityIndex(datasets?);
         private _lightweightPlotEntityToPlotEntity(entity);
         /**
          * Gets the PlotEntities at a particular Point.
@@ -3028,17 +3128,39 @@ declare namespace Plottable {
          */
         entitiesAt(point: Point): Plots.PlotEntity[];
         /**
-         * Returns the PlotEntity nearest to the query point by the Euclidian norm, or undefined if no PlotEntity can be found.
+         * Returns the {Plots.PlotEntity} nearest to the query point,
+         * or undefined if no {Plots.PlotEntity} can be found.
          *
          * @param {Point} queryPoint
-         * @returns {Plots.PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
+         * @returns {Plots.PlotEntity} The nearest PlotEntity, or undefined if no {Plots.PlotEntity} can be found.
          */
         entityNearest(queryPoint: Point): Plots.PlotEntity;
-        protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;
+        protected _entityVisibleOnPlot(entity: Plots.PlotEntity | Plots.LightweightPlotEntity, chartBounds: Bounds): boolean;
         protected _uninstallScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _installScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _propertyProjectors(): AttributeToProjector;
         protected static _scaledAccessor<D, R>(binding: Plots.AccessorScaleBinding<D, R>): Accessor<any>;
+        /**
+         * _invertPixelPoint converts a point in pixel coordinates to a point in data coordinates
+         * @param {Point} point Representation of the point in pixel coordinates
+         * @return {Point} Returns the point represented in data coordinates
+         */
+        protected _invertPixelPoint(point: Point): Point;
+        /**
+         * Returns the bounds of the plot in the Data space ensures that the topLeft
+         * and bottomRight points represent the minima and maxima of the Data space, respectively
+         @returns {Bounds}
+         */
+        protected _invertedBounds(): {
+            topLeft: {
+                x: number;
+                y: number;
+            };
+            bottomRight: {
+                x: number;
+                y: number;
+            };
+        };
         protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point;
         protected _animateOnNextRender(): boolean;
     }
@@ -3202,9 +3324,9 @@ declare namespace Plottable {
          */
         deferredRendering(deferredRendering: boolean): this;
         /**
-         * Gets the AccessorScaleBinding for X.
+         * Gets the TransformableAccessorScaleBinding for X.
          */
-        x(): Plots.AccessorScaleBinding<X, number>;
+        x(): Plots.TransformableAccessorScaleBinding<X, number>;
         /**
          * Sets X to a constant number or the result of an Accessor<number>.
          *
@@ -3224,7 +3346,7 @@ declare namespace Plottable {
         /**
          * Gets the AccessorScaleBinding for Y.
          */
-        y(): Plots.AccessorScaleBinding<Y, number>;
+        y(): Plots.TransformableAccessorScaleBinding<Y, number>;
         /**
          * Sets Y to a constant number or the result of an Accessor<number>.
          *
@@ -3274,6 +3396,7 @@ declare namespace Plottable {
         private _adjustYDomainOnChangeFromX();
         private _adjustXDomainOnChangeFromY();
         protected _projectorsReady(): boolean;
+        protected _invertPixelPoint(point: Point): Point;
         protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point;
         protected _getDataToDraw(): Utils.Map<Dataset, any[]>;
     }
@@ -3306,7 +3429,7 @@ declare namespace Plottable.Plots {
         /**
          * Gets the AccessorScaleBinding for X.
          */
-        x(): AccessorScaleBinding<X, number>;
+        x(): Plots.TransformableAccessorScaleBinding<X, number>;
         /**
          * Sets X to a constant number or the result of an Accessor<number>.
          *
@@ -3326,7 +3449,7 @@ declare namespace Plottable.Plots {
         /**
          * Gets the AccessorScaleBinding for X2.
          */
-        x2(): AccessorScaleBinding<X, number>;
+        x2(): Plots.TransformableAccessorScaleBinding<X, number>;
         /**
          * Sets X2 to a constant number or the result of an Accessor.
          * If a Scale has been set for X, it will also be used to scale X2.
@@ -3338,7 +3461,7 @@ declare namespace Plottable.Plots {
         /**
          * Gets the AccessorScaleBinding for Y.
          */
-        y(): AccessorScaleBinding<Y, number>;
+        y(): Plots.TransformableAccessorScaleBinding<Y, number>;
         /**
          * Sets Y to a constant number or the result of an Accessor<number>.
          *
@@ -3358,7 +3481,7 @@ declare namespace Plottable.Plots {
         /**
          * Gets the AccessorScaleBinding for Y2.
          */
-        y2(): AccessorScaleBinding<Y, number>;
+        y2(): Plots.TransformableAccessorScaleBinding<Y, number>;
         /**
          * Sets Y2 to a constant number or the result of an Accessor.
          * If a Scale has been set for Y, it will also be used to scale Y2.
@@ -3432,6 +3555,9 @@ declare namespace Plottable.Plots {
     }
 }
 declare namespace Plottable.Plots {
+    interface LightweightScatterPlotEntity extends LightweightPlotEntity {
+        diameter: Point;
+    }
     class Scatter<X, Y> extends XYPlot<X, Y> {
         private static _SIZE_KEY;
         private static _SYMBOL_KEY;
@@ -3441,12 +3567,13 @@ declare namespace Plottable.Plots {
          * @constructor
          */
         constructor();
+        protected _buildLightweightPlotEntities(datasets: Dataset[]): LightweightScatterPlotEntity[];
         protected _createDrawer(dataset: Dataset): Drawers.Symbol;
         /**
          * Gets the AccessorScaleBinding for the size property of the plot.
          * The size property corresponds to the area of the symbol.
          */
-        size<S>(): AccessorScaleBinding<S, number>;
+        size<S>(): TransformableAccessorScaleBinding<S, number>;
         /**
          * Sets the size property to a constant number or the result of an Accessor<number>.
          *
@@ -3476,7 +3603,7 @@ declare namespace Plottable.Plots {
          */
         symbol(symbol: Accessor<SymbolFactory>): this;
         protected _generateDrawSteps(): Drawers.DrawStep[];
-        protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;
+        protected _entityVisibleOnPlot(entity: LightweightScatterPlotEntity, bounds: Bounds): boolean;
         protected _propertyProjectors(): AttributeToProjector;
         /**
          * Gets the Entities that intersect the Bounds.
@@ -3500,6 +3627,15 @@ declare namespace Plottable.Plots {
          * @returns {PlotEntity[]}
          */
         entitiesAt(p: Point): PlotEntity[];
+        /**
+         * _invertedPixelSize returns the size of the object in data space
+         * @param {Point} [point] The size of the object in pixel space. X corresponds to
+         * the width of the object, and Y corresponds to the height of the object
+         * @return {Point} Returns the size of the object in data space. X corresponds to
+         * the width of the object in data space, and Y corresponds to the height of the
+         * object in data space.
+         */
+        private _invertedPixelSize(point);
     }
 }
 declare namespace Plottable.Plots {
@@ -3529,10 +3665,10 @@ declare namespace Plottable.Plots {
          * @param {string} [orientation="vertical"] One of "vertical"/"horizontal".
          */
         constructor(orientation?: string);
-        x(): Plots.AccessorScaleBinding<X, number>;
+        x(): Plots.TransformableAccessorScaleBinding<X, number>;
         x(x: number | Accessor<number>): this;
         x(x: X | Accessor<X>, xScale: Scale<X, number>): this;
-        y(): Plots.AccessorScaleBinding<Y, number>;
+        y(): Plots.TransformableAccessorScaleBinding<Y, number>;
         y(y: number | Accessor<number>): this;
         y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): this;
         /**
@@ -3602,7 +3738,7 @@ declare namespace Plottable.Plots {
          * @returns {PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
          */
         entityNearest(queryPoint: Point): PlotEntity;
-        protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset): boolean;
+        protected _entityVisibleOnPlot(entity: Plots.PlotEntity, bounds: Bounds): boolean;
         /**
          * Gets the Entities at a particular Point.
          *
@@ -3665,10 +3801,10 @@ declare namespace Plottable.Plots {
          * @constructor
          */
         constructor();
-        x(): Plots.AccessorScaleBinding<X, number>;
+        x(): Plots.TransformableAccessorScaleBinding<X, number>;
         x(x: number | Accessor<number>): this;
         x(x: X | Accessor<X>, xScale: Scale<X, number>): this;
-        y(): Plots.AccessorScaleBinding<number, number>;
+        y(): Plots.TransformableAccessorScaleBinding<number, number>;
         y(y: number | Accessor<number>): this;
         y(y: number | Accessor<number>, yScale: Scale<number, number>): this;
         autorangeMode(): string;
@@ -3785,7 +3921,7 @@ declare namespace Plottable.Plots {
          */
         constructor();
         protected _setup(): void;
-        y(): Plots.AccessorScaleBinding<number, number>;
+        y(): Plots.TransformableAccessorScaleBinding<number, number>;
         y(y: number | Accessor<number>): this;
         y(y: number | Accessor<number>, yScale: QuantitativeScale<number>): this;
         /**
@@ -3851,10 +3987,10 @@ declare namespace Plottable.Plots {
         croppedRenderingEnabled(croppedRendering: boolean): this;
         protected _getAnimator(key: string): Animator;
         protected _setup(): void;
-        x(): Plots.AccessorScaleBinding<X, number>;
+        x(): Plots.TransformableAccessorScaleBinding<X, number>;
         x(x: number | Accessor<number>): this;
         x(x: X | Accessor<X>, xScale: Scale<X, number>): this;
-        y(): Plots.AccessorScaleBinding<number, number>;
+        y(): Plots.TransformableAccessorScaleBinding<number, number>;
         y(y: number | Accessor<number>): this;
         y(y: number | Accessor<number>, yScale: QuantitativeScale<number>): this;
         /**
@@ -3906,10 +4042,10 @@ declare namespace Plottable.Plots {
          * @param {string} [orientation="vertical"] One of "vertical"/"horizontal".
          */
         constructor(orientation?: string);
-        x(): Plots.AccessorScaleBinding<X, number>;
+        x(): Plots.TransformableAccessorScaleBinding<X, number>;
         x(x: number | Accessor<number>): this;
         x(x: X | Accessor<X>, xScale: Scale<X, number>): this;
-        y(): Plots.AccessorScaleBinding<Y, number>;
+        y(): Plots.TransformableAccessorScaleBinding<Y, number>;
         y(y: number | Accessor<number>): this;
         y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): this;
         protected _generateAttrToProjector(): {
@@ -3938,7 +4074,7 @@ declare namespace Plottable.Plots {
         /**
          * Gets the AccessorScaleBinding for X
          */
-        x(): AccessorScaleBinding<X, number>;
+        x(): TransformableAccessorScaleBinding<X, number>;
         /**
          * Sets X to a constant value or the result of an Accessor.
          *
@@ -3970,7 +4106,7 @@ declare namespace Plottable.Plots {
         /**
          * Gets the AccessorScaleBinding for Y
          */
-        y(): AccessorScaleBinding<Y, number>;
+        y(): TransformableAccessorScaleBinding<Y, number>;
         /**
          * Sets Y to a constant value or the result of an Accessor.
          *
@@ -4739,7 +4875,6 @@ declare namespace Plottable.Interactions {
      * `zoom` argument about the point defined by the `center` argument.
      */
     function zoomAt(value: number, zoom: number, center: number): number;
-    type TransformableScale = Plottable.Scale<any, number> & Plottable.Scales.TransformableScale;
     class PanZoom extends Interaction {
         /**
          * The number of pixels occupied in a line.
@@ -4770,7 +4905,7 @@ declare namespace Plottable.Interactions {
          * @param {TransformableScale} [xScale] The x-scale to update on panning/zooming.
          * @param {TransformableScale} [yScale] The y-scale to update on panning/zooming.
          */
-        constructor(xScale?: TransformableScale, yScale?: TransformableScale);
+        constructor(xScale?: TransformableScale<any, number>, yScale?: TransformableScale<any, number>);
         /**
          * Pans the chart by a specified amount
          *
@@ -4817,51 +4952,51 @@ declare namespace Plottable.Interactions {
         /**
          * Gets the x scales for this PanZoom Interaction.
          */
-        xScales(): TransformableScale[];
+        xScales(): TransformableScale<any, number>[];
         /**
          * Sets the x scales for this PanZoom Interaction.
          *
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        xScales(xScales: TransformableScale[]): this;
+        xScales(xScales: TransformableScale<any, number>[]): this;
         /**
          * Gets the y scales for this PanZoom Interaction.
          */
-        yScales(): TransformableScale[];
+        yScales(): TransformableScale<any, number>[];
         /**
          * Sets the y scales for this PanZoom Interaction.
          *
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        yScales(yScales: TransformableScale[]): this;
+        yScales(yScales: TransformableScale<any, number>[]): this;
         /**
          * Adds an x scale to this PanZoom Interaction
          *
          * @param {TransformableScale} An x scale to add
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        addXScale(xScale: TransformableScale): this;
+        addXScale(xScale: TransformableScale<any, number>): this;
         /**
          * Removes an x scale from this PanZoom Interaction
          *
          * @param {TransformableScale} An x scale to remove
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        removeXScale(xScale: TransformableScale): this;
+        removeXScale(xScale: TransformableScale<any, number>): this;
         /**
          * Adds a y scale to this PanZoom Interaction
          *
          * @param {TransformableScale} A y scale to add
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        addYScale(yScale: TransformableScale): this;
+        addYScale(yScale: TransformableScale<any, number>): this;
         /**
          * Removes a y scale from this PanZoom Interaction
          *
          * @param {TransformableScale} A y scale to remove
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        removeYScale(yScale: TransformableScale): this;
+        removeYScale(yScale: TransformableScale<any, number>): this;
         /**
          * Gets the minimum domain extent for the scale, specifying the minimum
          * allowable amount between the ends of the domain.
@@ -4872,7 +5007,7 @@ declare namespace Plottable.Interactions {
          * @param {TransformableScale} scale The scale to query
          * @returns {number} The minimum numerical domain extent for the scale.
          */
-        minDomainExtent(scale: TransformableScale): number;
+        minDomainExtent(scale: TransformableScale<any, number>): number;
         /**
          * Sets the minimum domain extent for the scale, specifying the minimum
          * allowable amount between the ends of the domain.
@@ -4885,7 +5020,7 @@ declare namespace Plottable.Interactions {
          * the scale.
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        minDomainExtent(scale: TransformableScale, minDomainExtent: number): this;
+        minDomainExtent(scale: TransformableScale<any, number>, minDomainExtent: number): this;
         /**
          * Gets the maximum domain extent for the scale, specifying the maximum
          * allowable amount between the ends of the domain.
@@ -4896,7 +5031,7 @@ declare namespace Plottable.Interactions {
          * @param {TransformableScale} scale The scale to query
          * @returns {number} The maximum numerical domain extent for the scale.
          */
-        maxDomainExtent(scale: TransformableScale): number;
+        maxDomainExtent(scale: TransformableScale<any, number>): number;
         /**
          * Sets the maximum domain extent for the scale, specifying the maximum
          * allowable amount between the ends of the domain.
@@ -4913,7 +5048,7 @@ declare namespace Plottable.Interactions {
          * the scale.
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        maxDomainExtent(scale: TransformableScale, maxDomainExtent: number): this;
+        maxDomainExtent(scale: TransformableScale<any, number>, maxDomainExtent: number): this;
         /**
          * Gets the minimum domain value for the scale, constraining the pan/zoom
          * interaction to a minimum value in the domain.
@@ -4928,7 +5063,7 @@ declare namespace Plottable.Interactions {
          * @param {TransformableScale} scale The scale to query
          * @returns {number} The minimum domain value for the scale.
          */
-        minDomainValue(scale: TransformableScale): number;
+        minDomainValue(scale: TransformableScale<any, number>): number;
         /**
          * Sets the minimum domain value for the scale, constraining the pan/zoom
          * interaction to a minimum value in the domain.
@@ -4944,7 +5079,7 @@ declare namespace Plottable.Interactions {
          * @param {number} minDomainExtent The minimum domain value for the scale.
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        minDomainValue(scale: TransformableScale, minDomainValue: number): this;
+        minDomainValue(scale: TransformableScale<any, number>, minDomainValue: number): this;
         /**
          * Gets the maximum domain value for the scale, constraining the pan/zoom
          * interaction to a maximum value in the domain.
@@ -4959,7 +5094,7 @@ declare namespace Plottable.Interactions {
          * @param {TransformableScale} scale The scale to query
          * @returns {number} The maximum domain value for the scale.
          */
-        maxDomainValue(scale: TransformableScale): number;
+        maxDomainValue(scale: TransformableScale<any, number>): number;
         /**
          * Sets the maximum domain value for the scale, constraining the pan/zoom
          * interaction to a maximum value in the domain.
@@ -4975,7 +5110,7 @@ declare namespace Plottable.Interactions {
          * @param {number} maxDomainExtent The maximum domain value for the scale.
          * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
          */
-        maxDomainValue(scale: TransformableScale, maxDomainValue: number): this;
+        maxDomainValue(scale: TransformableScale<any, number>, maxDomainValue: number): this;
         /**
          * Uses the current domain of the scale to apply a minimum and maximum
          * domain value for that scale.
@@ -4983,7 +5118,7 @@ declare namespace Plottable.Interactions {
          * This constrains the pan/zoom interaction to show no more than the domain
          * of the scale.
          */
-        setMinMaxDomainValuesTo(scale: TransformableScale): void;
+        setMinMaxDomainValuesTo(scale: TransformableScale<any, number>): void;
         /**
          * Adds a callback to be called when panning ends.
          *

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -3132,35 +3132,15 @@ declare namespace Plottable {
          * or undefined if no {Plots.PlotEntity} can be found.
          *
          * @param {Point} queryPoint
+         * @param {bounds} Bounds The bounding box within which to search
          * @returns {Plots.PlotEntity} The nearest PlotEntity, or undefined if no {Plots.PlotEntity} can be found.
          */
-        entityNearest(queryPoint: Point): Plots.PlotEntity;
+        entityNearest(queryPoint: Point, bounds?: Bounds): Plots.PlotEntity;
         protected _entityVisibleOnPlot(entity: Plots.PlotEntity | Plots.LightweightPlotEntity, chartBounds: Bounds): boolean;
         protected _uninstallScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _installScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _propertyProjectors(): AttributeToProjector;
         protected static _scaledAccessor<D, R>(binding: Plots.AccessorScaleBinding<D, R>): Accessor<any>;
-        /**
-         * _invertPixelPoint converts a point in pixel coordinates to a point in data coordinates
-         * @param {Point} point Representation of the point in pixel coordinates
-         * @return {Point} Returns the point represented in data coordinates
-         */
-        protected _invertPixelPoint(point: Point): Point;
-        /**
-         * Returns the bounds of the plot in the Data space ensures that the topLeft
-         * and bottomRight points represent the minima and maxima of the Data space, respectively
-         @returns {Bounds}
-         */
-        protected _invertedBounds(): {
-            topLeft: {
-                x: number;
-                y: number;
-            };
-            bottomRight: {
-                x: number;
-                y: number;
-            };
-        };
         protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point;
         protected _animateOnNextRender(): boolean;
     }
@@ -3308,6 +3288,7 @@ declare namespace Plottable {
          * @param {Scale} yScale The y scale to use.
          */
         constructor();
+        entityNearest(queryPoint: Point): Plots.PlotEntity;
         /**
          * Returns the whether or not the rendering is deferred for performance boost.
          * @return {boolean} The deferred rendering option
@@ -3395,7 +3376,19 @@ declare namespace Plottable {
         showAllData(): this;
         private _adjustYDomainOnChangeFromX();
         private _adjustXDomainOnChangeFromY();
+        protected _buildLightweightPlotEntities(datasets?: Dataset[]): Plots.LightweightPlotEntity[];
         protected _projectorsReady(): boolean;
+        /**
+         * Returns the bounds of the plot in the Data space ensures that the topLeft
+         * and bottomRight points represent the minima and maxima of the Data space, respectively
+         @returns {Bounds}
+         */
+        private _invertedBounds();
+        /**
+         * _invertPixelPoint converts a point in pixel coordinates to a point in data coordinates
+         * @param {Point} point Representation of the point in pixel coordinates
+         * @return {Point} Returns the point represented in data coordinates
+         */
         protected _invertPixelPoint(point: Point): Point;
         protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point;
         protected _getDataToDraw(): Utils.Map<Dataset, any[]>;

--- a/plottable.js
+++ b/plottable.js
@@ -2707,6 +2707,7 @@ var Plottable;
         function Drawer(dataset) {
             this._cachedSelectionValid = false;
             this._dataset = dataset;
+            this._svgElementName = "path";
         }
         Drawer.prototype.renderArea = function (area) {
             if (area == null) {
@@ -7270,13 +7271,12 @@ var Plottable;
          */
         Plot.prototype.entities = function (datasets) {
             var _this = this;
-            if (datasets === void 0) { datasets = this.datasets(); }
             return this._getEntityStore(datasets).map(function (entity) { return _this._lightweightPlotEntityToPlotEntity(entity); });
         };
         /**
-         * _getEntityStore returns the index of all Entities associated with the specified dataset
+         * _getEntityStore returns the store of all Entities associated with the specified dataset
          *
-         * @param {Dataset[]} [datasets] - The datasets with which to construct the index. If no datasets
+         * @param {Dataset[]} [datasets] - The datasets with which to construct the store. If no datasets
          * are specified all datasets will be used.
          */
         Plot.prototype._getEntityStore = function (datasets) {

--- a/plottable.js
+++ b/plottable.js
@@ -7212,7 +7212,7 @@ var Plottable;
                     }
                     lightweightPlotEntities.push({
                         datum: datum,
-                        position: _this._invertPixelPoint(position),
+                        position: position,
                         index: datumIndex,
                         dataset: dataset,
                         datasetIndex: datasetIndex,
@@ -7327,17 +7327,16 @@ var Plottable;
          * or undefined if no {Plots.PlotEntity} can be found.
          *
          * @param {Point} queryPoint
+         * @param {bounds} Bounds The bounding box within which to search
          * @returns {Plots.PlotEntity} The nearest PlotEntity, or undefined if no {Plots.PlotEntity} can be found.
          */
-        Plot.prototype.entityNearest = function (queryPoint) {
+        Plot.prototype.entityNearest = function (queryPoint, bounds) {
             var _this = this;
-            // by default, the entity index stores position information in the data space
-            // the default impelentation of the entityNearest must convert the chart bounding
-            // box as well as the query point to the data space before it can make a comparison
-            var invertedChartBounds = this._invertedBounds();
-            var invertedQueryPoint = this._invertPixelPoint(queryPoint);
-            var nearest = this._getEntityIndex().entityNearest(invertedQueryPoint, function (entity) {
-                return _this._entityVisibleOnPlot(entity, invertedChartBounds);
+            if (bounds == null) {
+                bounds = this.bounds();
+            }
+            var nearest = this._getEntityIndex().entityNearest(queryPoint, function (entity) {
+                return _this._entityVisibleOnPlot(entity, bounds);
             });
             return nearest === undefined ? undefined : this._lightweightPlotEntityToPlotEntity(nearest);
         };
@@ -7360,39 +7359,6 @@ var Plottable;
             return binding.scale == null ?
                 binding.accessor :
                 function (d, i, ds) { return binding.scale.scale(binding.accessor(d, i, ds)); };
-        };
-        /**
-         * _invertPixelPoint converts a point in pixel coordinates to a point in data coordinates
-         * @param {Point} point Representation of the point in pixel coordinates
-         * @return {Point} Returns the point represented in data coordinates
-         */
-        Plot.prototype._invertPixelPoint = function (point) {
-            throw new Error("Subclasses should implement this method");
-        };
-        /**
-         * Returns the bounds of the plot in the Data space ensures that the topLeft
-         * and bottomRight points represent the minima and maxima of the Data space, respectively
-         @returns {Bounds}
-         */
-        Plot.prototype._invertedBounds = function () {
-            var bounds = this.bounds();
-            var maybeTopLeft = this._invertPixelPoint(bounds.topLeft);
-            var maybeBottomRight = this._invertPixelPoint(bounds.bottomRight);
-            // Scale domains can map from lowest to highest or highest to lowest (eg [0, 1] or [1, 0]).
-            // What we're interested in is a domain space equivalent to the concept of topLeft
-            // and bottomRight, not a true mapping from point to domain. This is in keeping
-            // with our definition of {Bounds}, where the topLeft coordinate is minimal
-            // and the bottomRight is maximal.
-            return {
-                topLeft: {
-                    x: Math.min(maybeTopLeft.x, maybeBottomRight.x),
-                    y: Math.min(maybeTopLeft.y, maybeBottomRight.y)
-                },
-                bottomRight: {
-                    x: Math.max(maybeBottomRight.x, maybeTopLeft.x),
-                    y: Math.max(maybeBottomRight.y, maybeTopLeft.y)
-                }
-            };
         };
         Plot.prototype._pixelPoint = function (datum, index, dataset) {
             return { x: 0, y: 0 };
@@ -7807,6 +7773,14 @@ var Plottable;
                 }
             };
         }
+        XYPlot.prototype.entityNearest = function (queryPoint) {
+            // by default, the entity index stores position information in the data space
+            // the default impelentation of the entityNearest must convert the chart bounding
+            // box as well as the query point to the data space before it can make a comparison
+            var invertedChartBounds = this._invertedBounds();
+            var invertedQueryPoint = this._invertPixelPoint(queryPoint);
+            return _super.prototype.entityNearest.call(this, invertedQueryPoint, invertedChartBounds);
+        };
         XYPlot.prototype.deferredRendering = function (deferredRendering) {
             if (deferredRendering == null) {
                 return this._deferredRendering;
@@ -7992,6 +7966,13 @@ var Plottable;
                 this._updateXExtentsAndAutodomain();
             }
         };
+        XYPlot.prototype._buildLightweightPlotEntities = function (datasets) {
+            var _this = this;
+            return _super.prototype._buildLightweightPlotEntities.call(this, datasets).map(function (lightweightPlotEntity) {
+                lightweightPlotEntity.position = _this._invertPixelPoint(lightweightPlotEntity.position);
+                return lightweightPlotEntity;
+            });
+        };
         XYPlot.prototype._projectorsReady = function () {
             var xBinding = this.x();
             var yBinding = this.y();
@@ -8000,6 +7981,36 @@ var Plottable;
                 yBinding != null &&
                 yBinding.accessor != null;
         };
+        /**
+         * Returns the bounds of the plot in the Data space ensures that the topLeft
+         * and bottomRight points represent the minima and maxima of the Data space, respectively
+         @returns {Bounds}
+         */
+        XYPlot.prototype._invertedBounds = function () {
+            var bounds = this.bounds();
+            var maybeTopLeft = this._invertPixelPoint(bounds.topLeft);
+            var maybeBottomRight = this._invertPixelPoint(bounds.bottomRight);
+            // Scale domains can map from lowest to highest or highest to lowest (eg [0, 1] or [1, 0]).
+            // What we're interested in is a domain space equivalent to the concept of topLeft
+            // and bottomRight, not a true mapping from point to domain. This is in keeping
+            // with our definition of {Bounds}, where the topLeft coordinate is minimal
+            // and the bottomRight is maximal.
+            return {
+                topLeft: {
+                    x: Math.min(maybeTopLeft.x, maybeBottomRight.x),
+                    y: Math.min(maybeTopLeft.y, maybeBottomRight.y)
+                },
+                bottomRight: {
+                    x: Math.max(maybeBottomRight.x, maybeTopLeft.x),
+                    y: Math.max(maybeBottomRight.y, maybeTopLeft.y)
+                }
+            };
+        };
+        /**
+         * _invertPixelPoint converts a point in pixel coordinates to a point in data coordinates
+         * @param {Point} point Representation of the point in pixel coordinates
+         * @return {Point} Returns the point represented in data coordinates
+         */
         XYPlot.prototype._invertPixelPoint = function (point) {
             var xScale = this.x();
             var yScale = this.y();

--- a/plottable.js
+++ b/plottable.js
@@ -8454,10 +8454,8 @@ var Plottable;
                 return drawSteps;
             };
             Scatter.prototype._entityVisibleOnPlot = function (entity, bounds) {
-                var chartWidth = bounds.bottomRight.x - bounds.topLeft.x;
-                var chartHeight = bounds.bottomRight.y - bounds.topLeft.y;
-                var xRange = { min: 0, max: chartWidth };
-                var yRange = { min: 0, max: chartHeight };
+                var xRange = { min: bounds.topLeft.x, max: bounds.bottomRight.x };
+                var yRange = { min: bounds.topLeft.y, max: bounds.bottomRight.y };
                 var translatedBbox = {
                     x: entity.position.x - entity.diameter.x,
                     y: entity.position.y - entity.diameter.y,

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -527,6 +527,23 @@ export class Component {
   }
 
   /**
+   * @returns {Bounds} for the component in pixel space, where the topLeft
+   * represents the component's minimum x and y values and the bottomRight represents
+   * the component's maximum x and y values.
+   */
+  public bounds(): Bounds {
+    const topLeft = this.origin();
+
+    return {
+      topLeft,
+      bottomRight: {
+        x: topLeft.x + this.width(),
+        y: topLeft.y + this.height()
+      },
+    }
+  }
+
+  /**
    * Removes a Component from the DOM and disconnects all listeners.
    */
   public destroy() {

--- a/src/drawers/drawer.ts
+++ b/src/drawers/drawer.ts
@@ -37,6 +37,7 @@ export class Drawer {
    */
   constructor(dataset: Dataset) {
     this._dataset = dataset;
+    this._svgElementName = "path";
   }
 
   /**

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -11,16 +11,14 @@ namespace Plottable.Interactions {
     return center - (center - value) * zoom;
   }
 
-  export type TransformableScale = Plottable.Scale<any, number> & Plottable.Scales.TransformableScale;
-
   export class PanZoom extends Interaction {
     /**
      * The number of pixels occupied in a line.
      */
     private static _PIXELS_PER_LINE = 120;
 
-    private _xScales: Utils.Set<TransformableScale>;
-    private _yScales: Utils.Set<TransformableScale>;
+    private _xScales: Utils.Set<TransformableScale<any, number>>;
+    private _yScales: Utils.Set<TransformableScale<any, number>>;
     private _dragInteraction: Interactions.Drag;
     private _mouseDispatcher: Dispatchers.Mouse;
     private _touchDispatcher: Dispatchers.Touch;
@@ -33,11 +31,11 @@ namespace Plottable.Interactions {
     private _touchEndCallback = (ids: number[], idToPoint: Point[], e: TouchEvent) => this._handleTouchEnd(ids, idToPoint, e);
     private _touchCancelCallback = (ids: number[], idToPoint: Point[], e: TouchEvent) => this._handleTouchEnd(ids, idToPoint, e);
 
-    private _minDomainExtents: Utils.Map<TransformableScale, any>;
-    private _maxDomainExtents: Utils.Map<TransformableScale, any>;
+    private _minDomainExtents: Utils.Map<TransformableScale<any, number>, any>;
+    private _maxDomainExtents: Utils.Map<TransformableScale<any, number>, any>;
 
-    private _minDomainValues: Utils.Map<TransformableScale, any>;
-    private _maxDomainValues: Utils.Map<TransformableScale, any>;
+    private _minDomainValues: Utils.Map<TransformableScale<any, number>, any>;
+    private _maxDomainValues: Utils.Map<TransformableScale<any, number>, any>;
 
     private _panEndCallbacks = new Utils.CallbackSet<PanCallback>();
     private _zoomEndCallbacks = new Utils.CallbackSet<ZoomCallback>();
@@ -50,17 +48,17 @@ namespace Plottable.Interactions {
      * @param {TransformableScale} [xScale] The x-scale to update on panning/zooming.
      * @param {TransformableScale} [yScale] The y-scale to update on panning/zooming.
      */
-    constructor(xScale?: TransformableScale, yScale?: TransformableScale) {
+    constructor(xScale?: TransformableScale<any, number>, yScale?: TransformableScale<any, number>) {
       super();
-      this._xScales = new Utils.Set<TransformableScale>();
-      this._yScales = new Utils.Set<TransformableScale>();
+      this._xScales = new Utils.Set<TransformableScale<any, number>>();
+      this._yScales = new Utils.Set<TransformableScale<any, number>>();
       this._dragInteraction = new Interactions.Drag();
       this._setupDragInteraction();
       this._touchIds = d3.map<Point>();
-      this._minDomainExtents = new Utils.Map<TransformableScale, number>();
-      this._maxDomainExtents = new Utils.Map<TransformableScale, number>();
-      this._minDomainValues = new Utils.Map<TransformableScale, any>();
-      this._maxDomainValues = new Utils.Map<TransformableScale, any>();
+      this._minDomainExtents = new Utils.Map<TransformableScale<any, number>, number>();
+      this._maxDomainExtents = new Utils.Map<TransformableScale<any, number>, number>();
+      this._minDomainValues = new Utils.Map<TransformableScale<any, number>, any>();
+      this._maxDomainValues = new Utils.Map<TransformableScale<any, number>, any>();
       if (xScale != null) {
         this.addXScale(xScale);
       }
@@ -271,12 +269,12 @@ namespace Plottable.Interactions {
       }
     }
 
-    private _constrainedZoom(scale: TransformableScale, zoomAmount: number, centerPoint: number) {
+    private _constrainedZoom(scale: TransformableScale<any, number>, zoomAmount: number, centerPoint: number) {
       zoomAmount = this._constrainZoomExtents(scale, zoomAmount);
       return this._constrainZoomValues(scale, zoomAmount, centerPoint);
     }
 
-    private _constrainZoomExtents(scale: TransformableScale, zoomAmount: number) {
+    private _constrainZoomExtents(scale: TransformableScale<any, number>, zoomAmount: number) {
       let extentIncreasing = zoomAmount > 1;
 
       let boundingDomainExtent = extentIncreasing ? this.maxDomainExtent(scale) : this.minDomainExtent(scale);
@@ -288,7 +286,7 @@ namespace Plottable.Interactions {
       return compareF(zoomAmount, boundingDomainExtent / domainExtent);
     }
 
-    private _constrainZoomValues(scale: TransformableScale, zoomAmount: number, centerPoint: number) {
+    private _constrainZoomValues(scale: TransformableScale<any, number>, zoomAmount: number, centerPoint: number) {
       // when zooming in, we don't have to worry about overflowing domain
       if (zoomAmount <= 1) {
         return { centerPoint, zoomAmount };
@@ -392,7 +390,7 @@ namespace Plottable.Interactions {
      * Returns a new translation value that respects domain min/max value
      * constraints.
      */
-    private _constrainedTranslation(scale: TransformableScale, translation: number) {
+    private _constrainedTranslation(scale: TransformableScale<any, number>, translation: number) {
       const [ scaleDomainMin, scaleDomainMax ] = scale.getTransformationDomain();
       if (translation > 0) {
         const bound = this.maxDomainValue(scale);
@@ -412,7 +410,7 @@ namespace Plottable.Interactions {
       return translation;
     }
 
-    private _nonLinearScaleWithExtents(scale: TransformableScale) {
+    private _nonLinearScaleWithExtents(scale: TransformableScale<any, number>) {
       return this.minDomainExtent(scale) != null && this.maxDomainExtent(scale) != null &&
              !(scale instanceof Scales.Linear) && !(scale instanceof Scales.Time);
     }
@@ -420,22 +418,22 @@ namespace Plottable.Interactions {
     /**
      * Gets the x scales for this PanZoom Interaction.
      */
-    public xScales(): TransformableScale[];
+    public xScales(): TransformableScale<any, number>[];
     /**
      * Sets the x scales for this PanZoom Interaction.
      *
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
-    public xScales(xScales: TransformableScale[]): this;
-    public xScales(xScales?: TransformableScale[]): any {
+    public xScales(xScales: TransformableScale<any, number>[]): this;
+    public xScales(xScales?: TransformableScale<any, number>[]): any {
       if (xScales == null) {
-        let scales: TransformableScale[] = [];
+        let scales: TransformableScale<any, number>[] = [];
         this._xScales.forEach((xScale) => {
           scales.push(xScale);
         });
         return scales;
       }
-      this._xScales = new Utils.Set<TransformableScale>();
+      this._xScales = new Utils.Set<TransformableScale<any, number>>();
       xScales.forEach((xScale) => {
         this.addXScale(xScale);
       });
@@ -445,22 +443,22 @@ namespace Plottable.Interactions {
     /**
      * Gets the y scales for this PanZoom Interaction.
      */
-    public yScales(): TransformableScale[];
+    public yScales(): TransformableScale<any, number>[];
     /**
      * Sets the y scales for this PanZoom Interaction.
      *
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
-    public yScales(yScales: TransformableScale[]): this;
-    public yScales(yScales?: TransformableScale[]): any {
+    public yScales(yScales: TransformableScale<any, number>[]): this;
+    public yScales(yScales?: TransformableScale<any, number>[]): any {
       if (yScales == null) {
-        let scales: TransformableScale[] = [];
+        let scales: TransformableScale<any, number>[] = [];
         this._yScales.forEach((yScale) => {
           scales.push(yScale);
         });
         return scales;
       }
-      this._yScales = new Utils.Set<TransformableScale>();
+      this._yScales = new Utils.Set<TransformableScale<any, number>>();
       yScales.forEach((yScale) => {
         this.addYScale(yScale);
       });
@@ -473,7 +471,7 @@ namespace Plottable.Interactions {
      * @param {TransformableScale} An x scale to add
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
-    public addXScale(xScale: TransformableScale) {
+    public addXScale(xScale: TransformableScale<any, number>) {
       this._xScales.add(xScale);
       return this;
     }
@@ -484,7 +482,7 @@ namespace Plottable.Interactions {
      * @param {TransformableScale} An x scale to remove
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
-    public removeXScale(xScale: TransformableScale) {
+    public removeXScale(xScale: TransformableScale<any, number>) {
       this._xScales.delete(xScale);
       this._minDomainExtents.delete(xScale);
       this._maxDomainExtents.delete(xScale);
@@ -499,7 +497,7 @@ namespace Plottable.Interactions {
      * @param {TransformableScale} A y scale to add
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
-    public addYScale(yScale: TransformableScale) {
+    public addYScale(yScale: TransformableScale<any, number>) {
       this._yScales.add(yScale);
       return this;
     }
@@ -510,7 +508,7 @@ namespace Plottable.Interactions {
      * @param {TransformableScale} A y scale to remove
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
-    public removeYScale(yScale: TransformableScale) {
+    public removeYScale(yScale: TransformableScale<any, number>) {
       this._yScales.delete(yScale);
       this._minDomainExtents.delete(yScale);
       this._maxDomainExtents.delete(yScale);
@@ -529,7 +527,7 @@ namespace Plottable.Interactions {
      * @param {TransformableScale} scale The scale to query
      * @returns {number} The minimum numerical domain extent for the scale.
      */
-    public minDomainExtent(scale: TransformableScale): number;
+    public minDomainExtent(scale: TransformableScale<any, number>): number;
     /**
      * Sets the minimum domain extent for the scale, specifying the minimum
      * allowable amount between the ends of the domain.
@@ -542,8 +540,8 @@ namespace Plottable.Interactions {
      * the scale.
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
-    public minDomainExtent(scale: TransformableScale, minDomainExtent: number): this;
-    public minDomainExtent(scale: TransformableScale, minDomainExtent?: number): number | this {
+    public minDomainExtent(scale: TransformableScale<any, number>, minDomainExtent: number): this;
+    public minDomainExtent(scale: TransformableScale<any, number>, minDomainExtent?: number): number | this {
       if (minDomainExtent == null) {
         return this._minDomainExtents.get(scale);
       }
@@ -571,7 +569,7 @@ namespace Plottable.Interactions {
      * @param {TransformableScale} scale The scale to query
      * @returns {number} The maximum numerical domain extent for the scale.
      */
-    public maxDomainExtent(scale: TransformableScale): number;
+    public maxDomainExtent(scale: TransformableScale<any, number>): number;
     /**
      * Sets the maximum domain extent for the scale, specifying the maximum
      * allowable amount between the ends of the domain.
@@ -588,8 +586,8 @@ namespace Plottable.Interactions {
      * the scale.
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
-    public maxDomainExtent(scale: TransformableScale, maxDomainExtent: number): this;
-    public maxDomainExtent(scale: TransformableScale, maxDomainExtent?: number): number | this {
+    public maxDomainExtent(scale: TransformableScale<any, number>, maxDomainExtent: number): this;
+    public maxDomainExtent(scale: TransformableScale<any, number>, maxDomainExtent?: number): number | this {
       if (maxDomainExtent == null) {
         return this._maxDomainExtents.get(scale);
       }
@@ -621,7 +619,7 @@ namespace Plottable.Interactions {
      * @param {TransformableScale} scale The scale to query
      * @returns {number} The minimum domain value for the scale.
      */
-    public minDomainValue(scale: TransformableScale): number;
+    public minDomainValue(scale: TransformableScale<any, number>): number;
     /**
      * Sets the minimum domain value for the scale, constraining the pan/zoom
      * interaction to a minimum value in the domain.
@@ -637,8 +635,8 @@ namespace Plottable.Interactions {
      * @param {number} minDomainExtent The minimum domain value for the scale.
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
-    public minDomainValue(scale: TransformableScale, minDomainValue: number): this;
-    public minDomainValue(scale: TransformableScale, minDomainValue?: number): number | this {
+    public minDomainValue(scale: TransformableScale<any, number>, minDomainValue: number): this;
+    public minDomainValue(scale: TransformableScale<any, number>, minDomainValue?: number): number | this {
       if (minDomainValue == null) {
         return this._minDomainValues.get(scale);
       }
@@ -664,7 +662,7 @@ namespace Plottable.Interactions {
      * @param {TransformableScale} scale The scale to query
      * @returns {number} The maximum domain value for the scale.
      */
-    public maxDomainValue(scale: TransformableScale): number;
+    public maxDomainValue(scale: TransformableScale<any, number>): number;
     /**
      * Sets the maximum domain value for the scale, constraining the pan/zoom
      * interaction to a maximum value in the domain.
@@ -680,8 +678,8 @@ namespace Plottable.Interactions {
      * @param {number} maxDomainExtent The maximum domain value for the scale.
      * @returns {Interactions.PanZoom} The calling PanZoom Interaction.
      */
-    public maxDomainValue(scale: TransformableScale, maxDomainValue: number): this;
-    public maxDomainValue(scale: TransformableScale, maxDomainValue?: number): number | this {
+    public maxDomainValue(scale: TransformableScale<any, number>, maxDomainValue: number): this;
+    public maxDomainValue(scale: TransformableScale<any, number>, maxDomainValue?: number): number | this {
       if (maxDomainValue == null) {
         return this._maxDomainValues.get(scale);
       }
@@ -700,7 +698,7 @@ namespace Plottable.Interactions {
      * This constrains the pan/zoom interaction to show no more than the domain
      * of the scale.
      */
-    public setMinMaxDomainValuesTo(scale: TransformableScale) {
+    public setMinMaxDomainValuesTo(scale: TransformableScale<any, number>) {
       this._minDomainValues.delete(scale);
       this._maxDomainValues.delete(scale);
       const [ domainMin, domainMax ] = scale.getTransformationDomain();

--- a/src/plots/areaPlot.ts
+++ b/src/plots/areaPlot.ts
@@ -24,7 +24,7 @@ namespace Plottable.Plots {
       this._lineDrawers.forEach((d) => d.renderArea(this._renderArea.append("g")));
     }
 
-    public y(): Plots.AccessorScaleBinding<number, number>;
+    public y(): Plots.TransformableAccessorScaleBinding<number, number>;
     public y(y: number | Accessor<number>): this;
     public y(y: number | Accessor<number>, yScale: QuantitativeScale<number>): this;
     public y(y?: number | Accessor<number>, yScale?: QuantitativeScale<number>): any {

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -47,7 +47,7 @@ namespace Plottable.Plots {
       this._updateBarPixelWidthCallback = () => this._updateBarPixelWidth();
     }
 
-    public x(): Plots.AccessorScaleBinding<X, number>;
+    public x(): Plots.TransformableAccessorScaleBinding<X, number>;
     public x(x: number | Accessor<number>): this;
     public x(x: X | Accessor<X>, xScale: Scale<X, number>): this;
     public x(x?: number | Accessor<number> | X | Accessor<X>, xScale?: Scale<X, number>): any {
@@ -66,7 +66,7 @@ namespace Plottable.Plots {
       return this;
     }
 
-    public y(): Plots.AccessorScaleBinding<Y, number>;
+    public y(): Plots.TransformableAccessorScaleBinding<Y, number>;
     public y(y: number | Accessor<number>): this;
     public y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): this;
     public y(y?: number | Accessor<number> | Y | Accessor<Y>, yScale?: Scale<Y, number>): any {
@@ -272,9 +272,10 @@ namespace Plottable.Plots {
       // mouse events) usually have pixel accuracy. We add a tolerance of 0.5 pixels.
       let tolerance = 0.5;
 
+      const chartBounds = this.bounds();
       let closest: PlotEntity;
       this.entities().forEach((entity) => {
-        if (!this._entityVisibleOnPlot(entity.position, entity.datum, entity.index, entity.dataset)) {
+        if (!this._entityVisibleOnPlot(entity, chartBounds)) {
           return;
         }
         let primaryDist = 0;
@@ -310,11 +311,16 @@ namespace Plottable.Plots {
       return closest;
     }
 
-    protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset) {
-      let xRange = { min: 0, max: this.width() };
-      let yRange = { min: 0, max: this.height() };
+    protected _entityVisibleOnPlot(entity: Plots.PlotEntity, bounds: Bounds) {
+      const chartWidth = bounds.bottomRight.x - bounds.topLeft.x;
+      const chartHeight = bounds.bottomRight.y - bounds.topLeft.y;
+
+      let xRange = { min: 0, max: chartWidth };
+      let yRange = { min: 0, max: chartHeight };
 
       let attrToProjector = this._generateAttrToProjector();
+
+      const { datum, index, dataset } = entity;
 
       let barBBox = {
         x: attrToProjector["x"](datum, index, dataset),

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -31,7 +31,7 @@ namespace Plottable.Plots {
       this.attr("stroke-width", "2px");
     }
 
-    public x(): Plots.AccessorScaleBinding<X, number>;
+    public x(): Plots.TransformableAccessorScaleBinding<X, number>;
     public x(x: number | Accessor<number>): this;
     public x(x: X | Accessor<X>, xScale: Scale<X, number>): this;
     public x(x?: number | Accessor<number> | X | Accessor<X>, xScale?: Scale<X, number>): any {
@@ -48,7 +48,7 @@ namespace Plottable.Plots {
       }
     }
 
-    public y(): Plots.AccessorScaleBinding<number, number>;
+    public y(): Plots.TransformableAccessorScaleBinding<number, number>;
     public y(y: number | Accessor<number>): this;
     public y(y: number | Accessor<number>, yScale: Scale<number, number>): this;
     public y(y?: number | Accessor<number>, yScale?: Scale<number, number>): any {
@@ -395,8 +395,10 @@ namespace Plottable.Plots {
       let minXDist = Infinity;
       let minYDist = Infinity;
       let closest: PlotEntity;
+
+      const chartBounds = this.bounds();
       this.entities().forEach((entity) => {
-        if (!this._entityVisibleOnPlot(entity.position, entity.datum, entity.index, entity.dataset)) {
+        if (!this._entityVisibleOnPlot(entity, chartBounds)) {
           return;
         }
         let xDist = Math.abs(queryPoint.x - entity.position.x);

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -53,7 +53,7 @@ export class Plot extends Component {
   /**
    * _cachedEntityStore is a cache of all the entities in the plot. It, at times
    * may be undefined and shouldn't be accessed directly. Instead, use _getEntityStore
-   * to access the entity index.
+   * to access the entity store.
    */
   private _cachedEntityStore: Plottable.Utils.EntityStore<Plots.LightweightPlotEntity>;
   private _dataChanged = false;
@@ -537,14 +537,14 @@ export class Plot extends Component {
    *   If not provided, returns defaults to all Datasets on the Plot.
    * @return {Plots.PlotEntity[]}
    */
-  public entities(datasets = this.datasets()): Plots.PlotEntity[] {
+  public entities(datasets?: Dataset[]): Plots.PlotEntity[] {
     return this._getEntityStore(datasets).map((entity) => this._lightweightPlotEntityToPlotEntity(entity));
   }
 
   /**
-   * _getEntityStore returns the index of all Entities associated with the specified dataset
+   * _getEntityStore returns the store of all Entities associated with the specified dataset
    *
-   * @param {Dataset[]} [datasets] - The datasets with which to construct the index. If no datasets
+   * @param {Dataset[]} [datasets] - The datasets with which to construct the store. If no datasets
    * are specified all datasets will be used.
    */
   private _getEntityStore(datasets?: Dataset[]): Plottable.Utils.EntityStore<Plots.LightweightPlotEntity> {

--- a/src/plots/rectanglePlot.ts
+++ b/src/plots/rectanglePlot.ts
@@ -90,7 +90,7 @@ namespace Plottable.Plots {
     /**
      * Gets the AccessorScaleBinding for X.
      */
-    public x(): AccessorScaleBinding<X, number>;
+    public x(): Plots.TransformableAccessorScaleBinding<X, number>;
     /**
      * Sets X to a constant number or the result of an Accessor<number>.
      *
@@ -137,7 +137,7 @@ namespace Plottable.Plots {
     /**
      * Gets the AccessorScaleBinding for X2.
      */
-    public x2(): AccessorScaleBinding<X, number>;
+    public x2(): Plots.TransformableAccessorScaleBinding<X, number>;
     /**
      * Sets X2 to a constant number or the result of an Accessor.
      * If a Scale has been set for X, it will also be used to scale X2.
@@ -162,7 +162,7 @@ namespace Plottable.Plots {
     /**
      * Gets the AccessorScaleBinding for Y.
      */
-    public y(): AccessorScaleBinding<Y, number>;
+    public y(): Plots.TransformableAccessorScaleBinding<Y, number>;
     /**
      * Sets Y to a constant number or the result of an Accessor<number>.
      *
@@ -209,7 +209,7 @@ namespace Plottable.Plots {
     /**
      * Gets the AccessorScaleBinding for Y2.
      */
-    public y2(): AccessorScaleBinding<Y, number>;
+    public y2(): Plots.TransformableAccessorScaleBinding<Y, number>;
     /**
      * Sets Y2 to a constant number or the result of an Accessor.
      * If a Scale has been set for Y, it will also be used to scale Y2.

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -1,4 +1,9 @@
 namespace Plottable.Plots {
+
+  export interface LightweightScatterPlotEntity extends LightweightPlotEntity {
+    diameter: Point;
+  }
+
   export class Scatter<X, Y> extends XYPlot<X, Y> {
     private static _SIZE_KEY = "size";
     private static _SYMBOL_KEY = "symbol";
@@ -23,6 +28,21 @@ namespace Plottable.Plots {
       this.symbol(() => circleSymbolFactory);
     }
 
+    protected _buildLightweightPlotEntities(datasets: Dataset[]) {
+        const lightweightPlotEntities = super._buildLightweightPlotEntities(datasets);
+
+        return lightweightPlotEntities.map((lightweightPlotEntity: LightweightScatterPlotEntity) => {
+          const diameter = Plot._scaledAccessor(this.size())(
+            lightweightPlotEntity.datum,
+            lightweightPlotEntity.index,
+            lightweightPlotEntity.dataset);
+
+          // convert diameter into data space to be on the same scale as the scatter point position
+          lightweightPlotEntity.diameter = this._invertedPixelSize({ x: diameter, y: diameter });
+          return lightweightPlotEntity;
+        });
+    }
+
     protected _createDrawer(dataset: Dataset) {
       return new Plottable.Drawers.Symbol(dataset);
     }
@@ -31,7 +51,7 @@ namespace Plottable.Plots {
      * Gets the AccessorScaleBinding for the size property of the plot.
      * The size property corresponds to the area of the symbol.
      */
-    public size<S>(): AccessorScaleBinding<S, number>;
+    public size<S>(): TransformableAccessorScaleBinding<S, number>;
     /**
      * Sets the size property to a constant number or the result of an Accessor<number>.
      *
@@ -92,16 +112,18 @@ namespace Plottable.Plots {
       return drawSteps;
     }
 
-    protected _entityVisibleOnPlot(pixelPoint: Point, datum: any, index: number, dataset: Dataset) {
-      let xRange = { min: 0, max: this.width() };
-      let yRange = { min: 0, max: this.height() };
+    protected _entityVisibleOnPlot(entity: LightweightScatterPlotEntity, bounds: Bounds) {
+      const chartWidth = bounds.bottomRight.x - bounds.topLeft.x;
+      const chartHeight = bounds.bottomRight.y - bounds.topLeft.y;
 
-      let diameter = Plot._scaledAccessor(this.size())(datum, index, dataset);
+      let xRange = { min: 0, max: chartWidth };
+      let yRange = { min: 0, max: chartHeight };
+
       let translatedBbox = {
-        x: pixelPoint.x - diameter,
-        y: pixelPoint.y - diameter,
-        width: diameter,
-        height: diameter,
+        x: entity.position.x - entity.diameter.x,
+        y: entity.position.y - entity.diameter.y,
+        width: entity.diameter.x,
+        height: entity.diameter.y,
       };
 
       return Utils.DOM.intersectsBBox(xRange, yRange, translatedBbox);
@@ -182,6 +204,24 @@ namespace Plottable.Plots {
         let size = sizeProjector(datum, index, dataset);
         return x - size / 2  <= p.x && p.x <= x + size / 2 && y - size / 2 <= p.y && p.y <= y + size / 2;
       });
+    }
+
+    /**
+     * _invertedPixelSize returns the size of the object in data space
+     * @param {Point} [point] The size of the object in pixel space. X corresponds to
+     * the width of the object, and Y corresponds to the height of the object
+     * @return {Point} Returns the size of the object in data space. X corresponds to
+     * the width of the object in data space, and Y corresponds to the height of the
+     * object in data space.
+     */
+    private _invertedPixelSize(point: Point) {
+      const invertedOrigin = this._invertPixelPoint(this.origin());
+      const invertedSize = this._invertPixelPoint({ x: point.x, y: point.y });
+
+      return {
+        x: Math.abs(invertedSize.x - invertedOrigin.x),
+        y: Math.abs(invertedSize.y - invertedOrigin.y)
+      };
     }
   }
 }

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -113,13 +113,10 @@ namespace Plottable.Plots {
     }
 
     protected _entityVisibleOnPlot(entity: LightweightScatterPlotEntity, bounds: Bounds) {
-      const chartWidth = bounds.bottomRight.x - bounds.topLeft.x;
-      const chartHeight = bounds.bottomRight.y - bounds.topLeft.y;
+      const xRange = { min: bounds.topLeft.x, max: bounds.bottomRight.x };
+      const yRange = { min: bounds.topLeft.y, max: bounds.bottomRight.y };
 
-      let xRange = { min: 0, max: chartWidth };
-      let yRange = { min: 0, max: chartHeight };
-
-      let translatedBbox = {
+      const translatedBbox = {
         x: entity.position.x - entity.diameter.x,
         y: entity.position.y - entity.diameter.y,
         width: entity.diameter.x,

--- a/src/plots/segmentPlot.ts
+++ b/src/plots/segmentPlot.ts
@@ -44,7 +44,7 @@ namespace Plottable.Plots {
     /**
      * Gets the AccessorScaleBinding for X
      */
-    public x(): AccessorScaleBinding<X, number>;
+    public x(): TransformableAccessorScaleBinding<X, number>;
     /**
      * Sets X to a constant value or the result of an Accessor.
      *
@@ -104,7 +104,7 @@ namespace Plottable.Plots {
     /**
      * Gets the AccessorScaleBinding for Y
      */
-    public y(): AccessorScaleBinding<Y, number>;
+    public y(): TransformableAccessorScaleBinding<Y, number>;
     /**
      * Sets Y to a constant value or the result of an Accessor.
      *

--- a/src/plots/stackedAreaPlot.ts
+++ b/src/plots/stackedAreaPlot.ts
@@ -45,7 +45,7 @@ namespace Plottable.Plots {
       this._baseline = this._renderArea.append("line").classed("baseline", true);
     }
 
-    public x(): Plots.AccessorScaleBinding<X, number>;
+    public x(): Plots.TransformableAccessorScaleBinding<X, number>;
     public x(x: number | Accessor<number>): this;
     public x(x: X | Accessor<X>, xScale: Scale<X, number>): this;
     public x(x?: number | Accessor<number> | X | Accessor<X>, xScale?: Scale<X, number>): any {
@@ -63,7 +63,7 @@ namespace Plottable.Plots {
       return this;
     }
 
-    public y(): Plots.AccessorScaleBinding<number, number>;
+    public y(): Plots.TransformableAccessorScaleBinding<number, number>;
     public y(y: number | Accessor<number>): this;
     public y(y: number | Accessor<number>, yScale: QuantitativeScale<number>): this;
     public y(y?: number | Accessor<number>, yScale?: QuantitativeScale<number>): any {

--- a/src/plots/stackedBarPlot.ts
+++ b/src/plots/stackedBarPlot.ts
@@ -20,7 +20,7 @@ namespace Plottable.Plots {
       this._stackedExtent = [];
     }
 
-    public x(): Plots.AccessorScaleBinding<X, number>;
+    public x(): Plots.TransformableAccessorScaleBinding<X, number>;
     public x(x: number | Accessor<number>): this;
     public x(x: X | Accessor<X>, xScale: Scale<X, number>): this;
     public x(x?: number | Accessor<number> | X | Accessor<X>, xScale?: Scale<X, number>): any {
@@ -37,7 +37,7 @@ namespace Plottable.Plots {
       return this;
     }
 
-    public y(): Plots.AccessorScaleBinding<Y, number>;
+    public y(): Plots.TransformableAccessorScaleBinding<Y, number>;
     public y(y: number | Accessor<number>): this;
     public y(y: Y | Accessor<Y>, yScale: Scale<Y, number>): this;
     public y(y?: number | Accessor<number> | Y | Accessor<Y>, yScale?: Scale<Y, number>): any {

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -2,6 +2,7 @@ namespace Plottable {
 export class XYPlot<X, Y> extends Plot {
   protected static _X_KEY = "x";
   protected static _Y_KEY = "y";
+
   private _autoAdjustXScaleDomain = false;
   private _autoAdjustYScaleDomain = false;
   private _adjustYDomainOnChangeFromXCallback: ScaleCallback<Scale<any, any>>;
@@ -123,9 +124,9 @@ export class XYPlot<X, Y> extends Plot {
   }
 
   /**
-   * Gets the AccessorScaleBinding for X.
+   * Gets the TransformableAccessorScaleBinding for X.
    */
-  public x(): Plots.AccessorScaleBinding<X, number>;
+  public x(): Plots.TransformableAccessorScaleBinding<X, number>;
   /**
    * Sets X to a constant number or the result of an Accessor<number>.
    *
@@ -164,7 +165,7 @@ export class XYPlot<X, Y> extends Plot {
   /**
    * Gets the AccessorScaleBinding for Y.
    */
-  public y(): Plots.AccessorScaleBinding<Y, number>;
+  public y(): Plots.TransformableAccessorScaleBinding<Y, number>;
   /**
    * Sets Y to a constant number or the result of an Accessor<number>.
    *
@@ -352,6 +353,7 @@ export class XYPlot<X, Y> extends Plot {
       this._updateYExtentsAndAutodomain();
     }
   }
+
   private _adjustXDomainOnChangeFromY() {
     if (!this._projectorsReady()) { return; }
     if (this._autoAdjustXScaleDomain) {
@@ -366,6 +368,13 @@ export class XYPlot<X, Y> extends Plot {
         xBinding.accessor != null &&
         yBinding != null &&
         yBinding.accessor != null;
+  }
+
+  protected _invertPixelPoint(point: Point): Point {
+    const xScale = this.x();
+    const yScale = this.y();
+
+    return { x: xScale.scale.invertTransformation(point.x), y: yScale.scale.invertTransformation(point.y) };
   }
 
   protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point {

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -422,7 +422,7 @@ export class XYPlot<X, Y> extends Plot {
     const xScale = this.x();
     const yScale = this.y();
 
-    return { x: xScale.scale.invertTransformation(point.x), y: yScale.scale.invertTransformation(point.y) };
+    return { x: xScale.scale.invertedTransformation(point.x), y: yScale.scale.invertedTransformation(point.y) };
   }
 
   protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point {

--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -180,7 +180,7 @@ namespace Plottable.Scales {
       return this._d3TransformationScale(value);
     }
 
-    public invertTransformation(value: number) {
+    public invertedTransformation(value: number) {
       return this._d3TransformationScale.invert(value);
     }
 

--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -180,6 +180,10 @@ namespace Plottable.Scales {
       return this._d3TransformationScale(value);
     }
 
+    public invertTransformation(value: number) {
+      return this._d3TransformationScale.invert(value);
+    }
+
     public getTransformationDomain() {
       return this._d3TransformationScale.domain() as [number, number];
     }

--- a/src/scales/linearScale.ts
+++ b/src/scales/linearScale.ts
@@ -29,6 +29,10 @@ namespace Plottable.Scales {
       return this.scale(value);
     }
 
+    public invertTransformation(value: number) {
+      return this.invert(value);
+    }
+
     public getTransformationDomain() {
       return this.domain() as [number, number];
     }

--- a/src/scales/linearScale.ts
+++ b/src/scales/linearScale.ts
@@ -29,7 +29,7 @@ namespace Plottable.Scales {
       return this.scale(value);
     }
 
-    public invertTransformation(value: number) {
+    public invertedTransformation(value: number) {
       return this.invert(value);
     }
 

--- a/src/scales/modifiedLogScale.ts
+++ b/src/scales/modifiedLogScale.ts
@@ -92,6 +92,10 @@ namespace Plottable.Scales {
       return this.scale(value);
     }
 
+    public invertTransformation(value: number) {
+      return this.invert(value);
+    }
+
     public getTransformationDomain() {
       return this.domain() as [number, number];
     }

--- a/src/scales/modifiedLogScale.ts
+++ b/src/scales/modifiedLogScale.ts
@@ -92,7 +92,7 @@ namespace Plottable.Scales {
       return this.scale(value);
     }
 
-    public invertTransformation(value: number) {
+    public invertedTransformation(value: number) {
       return this.invert(value);
     }
 

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -271,8 +271,8 @@ export class QuantitativeScale<D> extends Scale<D, number> implements Plottable.
     throw new Error("Subclasses should override scaleTransformation");
   }
 
-  public invertTransformation(value: number): number {
-    throw new Error("Subclasses should override invertTransformation");
+  public invertedTransformation(value: number): number {
+    throw new Error("Subclasses should override invertedTransformation");
   }
 
   public getTransformationDomain(): [number, number] {

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -271,6 +271,10 @@ export class QuantitativeScale<D> extends Scale<D, number> implements Plottable.
     throw new Error("Subclasses should override scaleTransformation");
   }
 
+  public invertTransformation(value: number): number {
+    throw new Error("Subclasses should override invertTransformation");
+  }
+
   public getTransformationDomain(): [number, number] {
     throw new Error("Subclasses should override getTransformationDomain");
   }

--- a/src/scales/scale.ts
+++ b/src/scales/scale.ts
@@ -61,6 +61,11 @@ namespace Plottable.Scales {
      * `scaleTransformation`.
      */
     getTransformationDomain(): [number, number];
+
+    /**
+     * Returns value in *Transformation Space* for the provided *screen space*.
+     */
+    invertTransformation(value: number): number;
   }
 
   /**
@@ -76,6 +81,8 @@ namespace Plottable.Scales {
 }
 
 namespace Plottable {
+
+export type TransformableScale<D, R> = Scale<D, R> & Plottable.Scales.TransformableScale;
 
 export interface ScaleCallback<S extends Scale<any, any>> {
   (scale: S): any;

--- a/src/scales/scale.ts
+++ b/src/scales/scale.ts
@@ -65,7 +65,7 @@ namespace Plottable.Scales {
     /**
      * Returns value in *Transformation Space* for the provided *screen space*.
      */
-    invertTransformation(value: number): number;
+    invertedTransformation(value: number): number;
   }
 
   /**

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -60,6 +60,10 @@ namespace Plottable.Scales {
       return this.scale(new Date(value));
     }
 
+    public invertTransformation(value: number) {
+      return this.invert(value).getTime();
+    }
+
     public getTransformationDomain() {
       let dates = this.domain();
       return [dates[0].valueOf(), dates[1].valueOf()] as [number, number];

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -60,7 +60,7 @@ namespace Plottable.Scales {
       return this.scale(new Date(value));
     }
 
-    public invertTransformation(value: number) {
+    public invertedTransformation(value: number) {
       return this.invert(value).getTime();
     }
 

--- a/src/utils/entityIndex.ts
+++ b/src/utils/entityIndex.ts
@@ -1,0 +1,80 @@
+namespace Plottable.Utils {
+
+  /**
+   * EntityIndex stores entities and makes them searchable.
+   * Valid entities must be positioned in Cartesian space.
+   */
+  export interface EntityIndex<T extends PositionedEntity> {
+    /**
+     * Adds an entity to the store
+     * @param {T} [entity] Entity to add to the store. Entity must be positionable
+     */
+    add(entity: T): void;
+    /**
+     * Returns closest entity to a given {Point}
+     * @param {Point} [point] Point around which to search for a closest entity
+     * @param {(entity: T) => boolean} [filter] optional method that is called while
+     * searching for the entity nearest a point. If the filter returns false, the point
+     * is considered invalid and is not considered. If the filter returns true, the point
+     * is considered valid and will be considered.
+     * @returns {T} Will return the nearest entity or undefined if none are found
+     */
+    entityNearest(point: Point, filter?: (entity: T) => boolean): T;
+    /**
+     * Iterator that loops through entities and returns a transformed array
+     * @param {(value: T) => S} [callback] transformation function that is passed
+     * passed an entity {T} and returns an object {S}.
+     * @returns {S[]} The aggregate result of each call to the transformation function
+     */
+    map<S>(callback: (value: T) => S): S[];
+  }
+
+  export interface PositionedEntity {
+    position: Point;
+  }
+
+  /**
+   * Array-backed implementation of {EntityIndex}
+   */
+  export class EntityArray<T extends PositionedEntity> implements EntityIndex<T> {
+    private _entities: T[];
+
+    constructor() {
+      this._entities = [];
+    }
+
+    public add(entity: T) {
+      this._entities.push(entity);
+    }
+
+    /**
+     * Iterates through array of of entities and computes the closest point using
+     * the standard Euclidean distance formula.
+     */
+    public entityNearest(queryPoint: Point, filter?: (entity: T) => boolean) {
+      let closestDistanceSquared = Infinity;
+      let closestPointEntity: T;
+      this._entities.forEach((entity) => {
+        if (filter !== undefined && filter(entity) === false) {
+          return;
+        }
+
+        let distanceSquared = Utils.Math.distanceSquared(entity.position, queryPoint);
+        if (distanceSquared < closestDistanceSquared) {
+          closestDistanceSquared = distanceSquared;
+          closestPointEntity = entity;
+        }
+      });
+
+      if (closestPointEntity === undefined) {
+        return undefined;
+      }
+
+      return closestPointEntity;
+    }
+
+    public map<S>(callback: (value: T) => S) {
+      return this._entities.map<S>((entity: T) => callback(entity));
+    }
+  }
+}

--- a/src/utils/entityStore.ts
+++ b/src/utils/entityStore.ts
@@ -1,10 +1,10 @@
 namespace Plottable.Utils {
 
   /**
-   * EntityIndex stores entities and makes them searchable.
+   * EntityStore stores entities and makes them searchable.
    * Valid entities must be positioned in Cartesian space.
    */
-  export interface EntityIndex<T extends PositionedEntity> {
+  export interface EntityStore<T extends PositionedEntity> {
     /**
      * Adds an entity to the store
      * @param {T} [entity] Entity to add to the store. Entity must be positionable
@@ -34,9 +34,9 @@ namespace Plottable.Utils {
   }
 
   /**
-   * Array-backed implementation of {EntityIndex}
+   * Array-backed implementation of {EntityStore}
    */
-  export class EntityArray<T extends PositionedEntity> implements EntityIndex<T> {
+  export class EntityArray<T extends PositionedEntity> implements EntityStore<T> {
     private _entities: T[];
 
     constructor() {

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -812,6 +812,27 @@ describe("Component", () => {
     });
   });
 
+  describe("calculating the bounds", () => {
+    let c: Plottable.Component;
+    let svg: d3.Selection<void>;
+
+    beforeEach(() => {
+      c = new Plottable.Component();
+      svg = TestMethods.generateSVG(SVG_WIDTH, SVG_HEIGHT);
+      c.anchor(svg);
+      c.computeLayout();
+    });
+
+    it("calculates the bounds relative to the origin", () => {
+      assert.deepEqual(c.bounds(), {
+        topLeft: c.origin(),
+        bottomRight: { x: SVG_WIDTH, y: SVG_HEIGHT }
+      });
+      c.destroy();
+      svg.remove();
+    });
+  });
+
   describe("restricting rendering through clipPath", () => {
 
     let clippedComponent: Plottable.Component;

--- a/test/coverage.html
+++ b/test/coverage.html
@@ -14,6 +14,15 @@
     <script src="../bower_components/svg-typewriter/svgtypewriter.js" charset="utf-8"></script>
     <script src="../node_modules/chai/chai.js"></script>
     <script src="../node_modules/mocha/mocha.js"></script>
+    <!-- sinon imports -->
+    <script src="../node_modules/sinon/lib/sinon.js"></script>
+    <script src="../node_modules/sinon/lib/sinon/util/core.js"></script>
+    <script src="../node_modules/sinon/lib/sinon/call.js"></script>
+    <script src="../node_modules/sinon/lib/sinon/extend.js"></script>
+    <script src="../node_modules/sinon/lib/sinon/times_in_words.js"></script>
+    <script src="../node_modules/sinon/lib/sinon/format.js"></script>
+    <script src="../node_modules/sinon/lib/sinon/spy.js"></script>
+    <!--  --> 
     <script src="../node_modules/jquery/dist/jquery.js"></script>
     <script src="../node_modules/jquery-simulate-ext/libs/jquery.simulate.js"></script>
     <script src="blanket_mocha.js"></script>

--- a/test/plots/plotTests.ts
+++ b/test/plots/plotTests.ts
@@ -7,6 +7,95 @@ describe("Plots", () => {
       assert.isTrue(plot.hasClass("plot"), "plot class added by default");
     });
 
+    describe("managing entities", () => {
+      let plot: Plottable.Plot;
+      let svg: any;
+
+      beforeEach(() => {
+        plot = new Plottable.Plot();
+        svg = TestMethods.generateSVG();
+        plot.renderTo(svg);
+      });
+
+      afterEach(() => {
+        svg.remove();
+      });
+
+      it("first call to entities builds a new store", () => {
+        const data = [5, -5, 10];
+        const dataset = new Plottable.Dataset(data);
+        plot.addDataset(dataset);
+
+        const lightweightPlotEntitySpy = sinon.spy(plot, "_buildLightweightPlotEntities");
+        const entities = plot.entities();
+        const entities1 = plot.entities();
+        assert.deepEqual(entities, entities1);
+        assert.isTrue(lightweightPlotEntitySpy.calledOnce);
+      });
+
+      it("new store is built each time entities is called with data", () => {
+        const data = [5, -5, 10];
+        const dataset = new Plottable.Dataset(data);
+        plot.addDataset(dataset);
+
+        const lightweightPlotEntitySpy = sinon.spy(plot, "_buildLightweightPlotEntities");
+        const entities = plot.entities([dataset]);
+        const entities1 = plot.entities([dataset]);
+        assert.deepEqual(entities, entities1);
+        assert.isTrue(lightweightPlotEntitySpy.calledTwice);
+      });
+
+      it("rebuilds the store when the datasets change", () => {
+        const dataset = new Plottable.Dataset([5, -5, 10]);
+        const dataset1 = new Plottable.Dataset([1, -2, 3]);
+
+        plot.addDataset(dataset);
+
+        const lightweightPlotEntitySpy = sinon.spy(plot, "_buildLightweightPlotEntities");
+        const entities = plot.entities();
+        assert.strictEqual(entities.length, 3);
+
+        plot.datasets([dataset1]);
+
+        const entities1 = plot.entities();
+        assert.isTrue(lightweightPlotEntitySpy.calledTwice);
+        assert.strictEqual(entities1.length, 3);
+
+        plot.addDataset(dataset);
+        const entities2 = plot.entities();
+        assert.isTrue(lightweightPlotEntitySpy.calledThrice);
+        assert.strictEqual(entities2.length, 6);
+
+        plot.removeDataset(dataset);
+        const entities3 = plot.entities();
+        assert.deepEqual(entities3, entities1);
+        assert.strictEqual(lightweightPlotEntitySpy.callCount, 4);
+      });
+    });
+
+    describe("entityNearest", () => {
+      let plot: Plottable.Plot;
+      let svg: any;
+
+      beforeEach(() => {
+        plot = new Plottable.Plot();
+        svg = TestMethods.generateSVG();
+        plot.renderTo(svg);
+      });
+
+      afterEach(() => {
+        svg.remove();
+      });
+
+      it("builds entityStore if entity store is undefined", () => {
+        const dataset = new Plottable.Dataset([5, -5, 10]);
+        plot.addDataset(dataset);
+        const lightweightPlotEntitySpy = sinon.spy(plot, "_buildLightweightPlotEntities");
+        plot.entityNearest({ x: 5, y: 0 });
+        assert.isTrue(lightweightPlotEntitySpy.calledOnce);
+      });
+    });
+
     describe("managing datasets", () => {
       let plot: Plottable.Plot;
 

--- a/test/tests.html
+++ b/test/tests.html
@@ -14,6 +14,15 @@
     <script src="../bower_components/svg-typewriter/svgtypewriter.js" charset="utf-8"></script>
     <script src="../node_modules/chai/chai.js"></script>
     <script src="../node_modules/mocha/mocha.js"></script>
+    <!-- sinon imports -->
+    <script src="../node_modules/sinon/lib/sinon.js"></script>
+    <script src="../node_modules/sinon/lib/sinon/util/core.js"></script>
+    <script src="../node_modules/sinon/lib/sinon/call.js"></script>
+    <script src="../node_modules/sinon/lib/sinon/extend.js"></script>
+    <script src="../node_modules/sinon/lib/sinon/times_in_words.js"></script>
+    <script src="../node_modules/sinon/lib/sinon/format.js"></script>
+    <script src="../node_modules/sinon/lib/sinon/spy.js"></script>
+    <!--  -->
     <script src="../node_modules/jquery/dist/jquery.js"></script>
     <script src="../node_modules/jquery-simulate-ext/libs/jquery.simulate.js"></script>
     <script src="../plottable.js"></script>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
       "typings/d3/d3.d.ts",
       "bower_components/svg-typewriter/svgtypewriter.d.ts",
 
+      "src/utils/entityIndex.ts",
       "src/utils/mathUtils.ts",
       "src/utils/map.ts",
       "src/utils/set.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
       "typings/d3/d3.d.ts",
       "bower_components/svg-typewriter/svgtypewriter.d.ts",
 
-      "src/utils/entityIndex.ts",
+      "src/utils/entityStore.ts",
       "src/utils/mathUtils.ts",
       "src/utils/map.ts",
       "src/utils/set.ts",


### PR DESCRIPTION
Implements LightweightEntity caching in base plot in
order to speed up various chart interactions. The entity
cache is invalidated whenever underlying data changes. The
cache is constructed lazily on the first new call to `entities()`
from the time of invalidate (or initialization).

Entity positioning is stored as Points in the Data space, rather
than the screen space in order to avoid having to rebuild the
cache on each pan/zoom interaction. Comparison is done on chart
and cursor positions which are all converted to data space first.

-- notable changes

* Base plot now implements entity caching.
* `LightweightPlotEntity` is now exported publicly.
* Adds `TransformableAccessorScaleBinding`.
* Moves `TransformableScale` from PanZoomInteraction
  to `Plottable.TransformableScale` namespace.
* Quantitative Scales accessors x(), y(), x1(), y1() now
  return an instance of `TransformableScale` instead of
  simply `Scale`
* Adds `utils/entityIndex.ts`, which defines
  and implements a simple entity storage API
* New public method `bounds` on component returns
  the {Bounds} of the component
* Adds `invertTransformation` method to `TransformableScale`
  which maps pixel coordinates to Transformation Space