### PR TITLE
Add downsampling for number of category axis tick labels shown

### DIFF
--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -1825,6 +1825,10 @@ declare namespace Plottable {
         computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): this;
         protected _setup(): void;
         protected _getTickValues(): D[];
+        /**
+         * Render tick marks, baseline, and annotations. Should be super called by subclasses and then overridden to draw
+         * other relevant aspects of this Axis.
+         */
         renderImmediately(): this;
         /**
          * Gets the annotated ticks.
@@ -2172,6 +2176,10 @@ declare namespace Plottable.Axes {
 }
 declare namespace Plottable.Axes {
     class Category extends Axis<string> {
+        /**
+         * How many pixels to give labels at minimum before downsampling takes effect.
+         */
+        static MINIMUM_WIDTH_PER_LABEL: number;
         private _tickLabelAngle;
         /**
          * Maximum allowable px width of tick labels.
@@ -2219,6 +2227,13 @@ declare namespace Plottable.Axes {
         protected _coreSize(): number;
         protected _getTickValues(): string[];
         /**
+         * Take the scale and drop ticks at regular intervals such that the resultant ticks are all a reasonable minimum
+         * distance apart. Return the resultant ticks to render, as well as the new stepWidth between them.
+         *
+         * @return [downsampled domain, new stepWidth]
+         */
+        getDownsampleInfo(scale?: Scales.Category): [string[], number];
+        /**
          * Gets the tick label angle in degrees.
          */
         tickLabelAngle(): number;
@@ -2244,7 +2259,7 @@ declare namespace Plottable.Axes {
          * @param {Plottable.Scales.Category} scale The scale this axis is representing.
          * @param {d3.Selection} ticks The tick elements to write.
          */
-        private _drawTicks(scale, ticks);
+        private _drawTicks(stepWidth, ticks);
         /**
          * Measures the size of the tick labels without making any (permanent) DOM changes.
          *
@@ -2253,7 +2268,7 @@ declare namespace Plottable.Axes {
          * @param {Plottable.Scales.Category} scale The scale this axis is representing.
          * @param {string[]} ticks The strings that will be printed on the ticks.
          */
-        private _measureTickLabels(axisWidth, axisHeight, scale, ticks);
+        private _measureTickLabels(axisWidth, axisHeight);
         renderImmediately(): this;
         computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): this;
     }

--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -2175,11 +2175,15 @@ declare namespace Plottable.Axes {
     }
 }
 declare namespace Plottable.Axes {
+    interface DownsampleInfo {
+        domain: string[];
+        stepWidth: number;
+    }
     class Category extends Axis<string> {
         /**
          * How many pixels to give labels at minimum before downsampling takes effect.
          */
-        static MINIMUM_WIDTH_PER_LABEL: number;
+        private static _MINIMUM_WIDTH_PER_LABEL_PX;
         private _tickLabelAngle;
         /**
          * Maximum allowable px width of tick labels.
@@ -2230,9 +2234,10 @@ declare namespace Plottable.Axes {
          * Take the scale and drop ticks at regular intervals such that the resultant ticks are all a reasonable minimum
          * distance apart. Return the resultant ticks to render, as well as the new stepWidth between them.
          *
-         * @return [downsampled domain, new stepWidth]
+         * @param scale the scale being downsampled. Defaults to this Axis' scale.
+         * @return {DownsampleInfo} an object holding the resultant domain and new stepWidth.
          */
-        getDownsampleInfo(scale?: Scales.Category): [string[], number];
+        getDownsampleInfo(scale?: Scales.Category): DownsampleInfo;
         /**
          * Gets the tick label angle in degrees.
          */

--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -2234,7 +2234,7 @@ declare namespace Plottable.Axes {
          * Take the scale and drop ticks at regular intervals such that the resultant ticks are all a reasonable minimum
          * distance apart. Return the resultant ticks to render, as well as the new stepWidth between them.
          *
-         * @param scale the scale being downsampled. Defaults to this Axis' scale.
+         * @param {Scales.Category} scale - The scale being downsampled. Defaults to this Axis' scale.
          * @return {DownsampleInfo} an object holding the resultant domain and new stepWidth.
          */
         getDownsampleInfo(scale?: Scales.Category): DownsampleInfo;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2233,7 +2233,7 @@ declare namespace Plottable.Axes {
          * Take the scale and drop ticks at regular intervals such that the resultant ticks are all a reasonable minimum
          * distance apart. Return the resultant ticks to render, as well as the new stepWidth between them.
          *
-         * @param scale the scale being downsampled. Defaults to this Axis' scale.
+         * @param {Scales.Category} scale - The scale being downsampled. Defaults to this Axis' scale.
          * @return {DownsampleInfo} an object holding the resultant domain and new stepWidth.
          */
         getDownsampleInfo(scale?: Scales.Category): DownsampleInfo;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -1824,6 +1824,10 @@ declare namespace Plottable {
         computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): this;
         protected _setup(): void;
         protected _getTickValues(): D[];
+        /**
+         * Render tick marks, baseline, and annotations. Should be super called by subclasses and then overridden to draw
+         * other relevant aspects of this Axis.
+         */
         renderImmediately(): this;
         /**
          * Gets the annotated ticks.
@@ -2171,6 +2175,10 @@ declare namespace Plottable.Axes {
 }
 declare namespace Plottable.Axes {
     class Category extends Axis<string> {
+        /**
+         * How many pixels to give labels at minimum before downsampling takes effect.
+         */
+        static MINIMUM_WIDTH_PER_LABEL: number;
         private _tickLabelAngle;
         /**
          * Maximum allowable px width of tick labels.
@@ -2218,6 +2226,13 @@ declare namespace Plottable.Axes {
         protected _coreSize(): number;
         protected _getTickValues(): string[];
         /**
+         * Take the scale and drop ticks at regular intervals such that the resultant ticks are all a reasonable minimum
+         * distance apart. Return the resultant ticks to render, as well as the new stepWidth between them.
+         *
+         * @return [downsampled domain, new stepWidth]
+         */
+        getDownsampleInfo(scale?: Scales.Category): [string[], number];
+        /**
          * Gets the tick label angle in degrees.
          */
         tickLabelAngle(): number;
@@ -2243,7 +2258,7 @@ declare namespace Plottable.Axes {
          * @param {Plottable.Scales.Category} scale The scale this axis is representing.
          * @param {d3.Selection} ticks The tick elements to write.
          */
-        private _drawTicks(scale, ticks);
+        private _drawTicks(stepWidth, ticks);
         /**
          * Measures the size of the tick labels without making any (permanent) DOM changes.
          *
@@ -2252,7 +2267,7 @@ declare namespace Plottable.Axes {
          * @param {Plottable.Scales.Category} scale The scale this axis is representing.
          * @param {string[]} ticks The strings that will be printed on the ticks.
          */
-        private _measureTickLabels(axisWidth, axisHeight, scale, ticks);
+        private _measureTickLabels(axisWidth, axisHeight);
         renderImmediately(): this;
         computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number): this;
     }

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2174,11 +2174,15 @@ declare namespace Plottable.Axes {
     }
 }
 declare namespace Plottable.Axes {
+    interface DownsampleInfo {
+        domain: string[];
+        stepWidth: number;
+    }
     class Category extends Axis<string> {
         /**
          * How many pixels to give labels at minimum before downsampling takes effect.
          */
-        static MINIMUM_WIDTH_PER_LABEL: number;
+        private static _MINIMUM_WIDTH_PER_LABEL_PX;
         private _tickLabelAngle;
         /**
          * Maximum allowable px width of tick labels.
@@ -2229,9 +2233,10 @@ declare namespace Plottable.Axes {
          * Take the scale and drop ticks at regular intervals such that the resultant ticks are all a reasonable minimum
          * distance apart. Return the resultant ticks to render, as well as the new stepWidth between them.
          *
-         * @return [downsampled domain, new stepWidth]
+         * @param scale the scale being downsampled. Defaults to this Axis' scale.
+         * @return {DownsampleInfo} an object holding the resultant domain and new stepWidth.
          */
-        getDownsampleInfo(scale?: Scales.Category): [string[], number];
+        getDownsampleInfo(scale?: Scales.Category): DownsampleInfo;
         /**
          * Gets the tick label angle in degrees.
          */

--- a/plottable.js
+++ b/plottable.js
@@ -5123,7 +5123,7 @@ var Plottable;
              * Take the scale and drop ticks at regular intervals such that the resultant ticks are all a reasonable minimum
              * distance apart. Return the resultant ticks to render, as well as the new stepWidth between them.
              *
-             * @param scale the scale being downsampled. Defaults to this Axis' scale.
+             * @param {Scales.Category} scale - The scale being downsampled. Defaults to this Axis' scale.
              * @return {DownsampleInfo} an object holding the resultant domain and new stepWidth.
              */
             Category.prototype.getDownsampleInfo = function (scale) {

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -173,6 +173,10 @@ export class Axis<D> extends Component {
     return [];
   }
 
+  /**
+   * Render tick marks, baseline, and annotations. Should be super called by subclasses and then overridden to draw
+   * other relevant aspects of this Axis.
+   */
   public renderImmediately() {
     let tickMarkValues = this._getTickValues();
     let tickMarks = this._tickMarkContainer.selectAll("." + Axis.TICK_MARK_CLASS).data(tickMarkValues);

--- a/src/axes/categoryAxis.ts
+++ b/src/axes/categoryAxis.ts
@@ -1,5 +1,10 @@
 namespace Plottable.Axes {
   export class Category extends Axis<string> {
+    /**
+     * How many pixels to give labels at minimum before downsampling takes effect.
+     */
+    public static MINIMUM_WIDTH_PER_LABEL = 15;
+
     private _tickLabelAngle = 0;
 
     /**
@@ -88,8 +93,7 @@ namespace Plottable.Axes {
         }
       }
 
-      let categoryScale = <Scales.Category> this._scale;
-      let measureResult = this._measureTickLabels(offeredWidth, offeredHeight, categoryScale, categoryScale.domain());
+      let measureResult = this._measureTickLabels(offeredWidth, offeredHeight);
 
       return {
         minWidth: measureResult.usedWidth + widthRequiredByTicks,
@@ -108,7 +112,18 @@ namespace Plottable.Axes {
     }
 
     protected _getTickValues() {
-      return this._scale.domain();
+      return this.getDownsampleInfo()[0];
+    }
+
+    /**
+     * Take the scale and drop ticks at regular intervals such that the resultant ticks are all a reasonable minimum
+     * distance apart. Return the resultant ticks to render, as well as the new stepWidth between them.
+     *
+     * @return [downsampled domain, new stepWidth]
+     */
+    public getDownsampleInfo(scale = <Scales.Category> this._scale): [string[], number] {
+      const downsampleRatio = Math.ceil(Category.MINIMUM_WIDTH_PER_LABEL / scale.stepWidth());
+      return [scale.domain().filter((d, i) => i % downsampleRatio === 0), downsampleRatio * scale.stepWidth()];
     }
 
     /**
@@ -192,7 +207,7 @@ namespace Plottable.Axes {
      * @param {Plottable.Scales.Category} scale The scale this axis is representing.
      * @param {d3.Selection} ticks The tick elements to write.
      */
-    private _drawTicks(scale: Scales.Category, ticks: d3.Selection<string>) {
+    private _drawTicks(stepWidth: number, ticks: d3.Selection<string>) {
       let self = this;
       let xAlign: {[s: string]: string};
       let yAlign: {[s: string]: string};
@@ -211,9 +226,8 @@ namespace Plottable.Axes {
           break;
       }
       ticks.each(function (this: SVGElement, d: string) {
-        let bandWidth = scale.stepWidth();
-        let width = self._isHorizontal() ? bandWidth : self.width() - self._tickSpaceRequired();
-        let height = self._isHorizontal() ? self.height() - self._tickSpaceRequired() : bandWidth;
+        let width = self._isHorizontal() ? stepWidth : self.width() - self._tickSpaceRequired();
+        let height = self._isHorizontal() ? self.height() - self._tickSpaceRequired() : stepWidth;
         let writeOptions = {
           selection: d3.select(this),
           xAlign: xAlign[self.orientation()],
@@ -242,40 +256,47 @@ namespace Plottable.Axes {
      * @param {Plottable.Scales.Category} scale The scale this axis is representing.
      * @param {string[]} ticks The strings that will be printed on the ticks.
      */
-    private _measureTickLabels(axisWidth: number, axisHeight: number, scale: Scales.Category, ticks: string[]) {
-      let axisSpace = this._isHorizontal() ? axisWidth : axisHeight;
-      let totalOuterPaddingRatio = 2 * scale.outerPadding();
-      let totalInnerPaddingRatio = (ticks.length - 1) * scale.innerPadding();
-      let expectedRangeBand = axisSpace / (totalOuterPaddingRatio + totalInnerPaddingRatio + ticks.length);
-      let stepWidth = expectedRangeBand * (1 + scale.innerPadding());
+    private _measureTickLabels(axisWidth: number, axisHeight: number) {
+      const thisScale = <Scales.Category> this._scale;
+
+      // set up a test scale to simulate rendering ticks with the given width and height.
+      const scale = new Scales.Category()
+        .domain(thisScale.domain())
+        .innerPadding(thisScale.innerPadding())
+        .outerPadding(thisScale.outerPadding())
+        .range([0, this._isHorizontal() ? axisWidth : axisHeight]);
+
+      const [ticks, stepWidth] = this.getDownsampleInfo(scale);
+
+      // HACKHACK: https://github.com/palantir/svg-typewriter/issues/25
+      // the width (x-axis specific) available to a single tick label.
+      let width = axisWidth - this._tickSpaceRequired(); // default for left/right
+      if (this._isHorizontal()) { // case for top/bottom
+        width = stepWidth; // defaults to the band width
+        if (this._tickLabelAngle !== 0) { // rotated label
+          width = axisHeight - this._tickSpaceRequired(); // use the axis height
+        }
+        // HACKHACK: Wrapper fails under negative circumstances
+        width = Math.max(width, 0);
+      }
+
+      // HACKHACK: https://github.com/palantir/svg-typewriter/issues/25
+      // the height (y-axis specific) available to a single tick label.
+      let height = stepWidth; // default for left/right
+      if (this._isHorizontal()) { // case for top/bottom
+        height = axisHeight - this._tickSpaceRequired();
+        if (this._tickLabelAngle !== 0) { // rotated label
+          height = axisWidth - this._tickSpaceRequired();
+        }
+        // HACKHACK: Wrapper fails under negative circumstances
+        height = Math.max(height, 0);
+      }
+
+      if (this._tickLabelMaxWidth != null) {
+        width = Math.min(width, this._tickLabelMaxWidth);
+      }
 
       let wrappingResults = ticks.map((s: string) => {
-
-        // HACKHACK: https://github.com/palantir/svg-typewriter/issues/25
-        let width = axisWidth - this._tickSpaceRequired(); // default for left/right
-        if (this._isHorizontal()) { // case for top/bottom
-          width = stepWidth; // defaults to the band width
-          if (this._tickLabelAngle !== 0) { // rotated label
-            width = axisHeight - this._tickSpaceRequired(); // use the axis height
-          }
-          // HACKHACK: Wrapper fails under negative circumstances
-          width = Math.max(width, 0);
-        }
-
-        // HACKHACK: https://github.com/palantir/svg-typewriter/issues/25
-        let height = stepWidth; // default for left/right
-        if (this._isHorizontal()) { // case for top/bottom
-          height = axisHeight - this._tickSpaceRequired();
-          if (this._tickLabelAngle !== 0) { // rotated label
-            height = axisWidth - this._tickSpaceRequired();
-          }
-          // HACKHACK: Wrapper fails under negative circumstances
-          height = Math.max(height, 0);
-        }
-
-        if (this._tickLabelMaxWidth != null) {
-          width = Math.min(width, this._tickLabelMaxWidth);
-        }
         return this._wrapper.wrap(this.formatter()(s), this._measurer, width, height);
       });
 
@@ -303,20 +324,20 @@ namespace Plottable.Axes {
     public renderImmediately() {
       super.renderImmediately();
       let catScale = <Scales.Category> this._scale;
-      let tickLabels = this._tickLabelContainer.selectAll("." + Axis.TICK_LABEL_CLASS).data(this._scale.domain(), (d) => d);
+      const [downsampledDomain, stepWidth] = this.getDownsampleInfo();
+      let tickLabels = this._tickLabelContainer.selectAll("." + Axis.TICK_LABEL_CLASS).data(downsampledDomain, (d) => d);
+      // Give each tick a stepWidth of space which will partition the entire axis evenly
+      let availableTextWidth = stepWidth;
+      if (this._isHorizontal() && this._tickLabelMaxWidth != null) {
+        availableTextWidth = Math.min(availableTextWidth, this._tickLabelMaxWidth);
+      }
 
       let getTickLabelTransform = (d: string, i: number) => {
-        // Give each tick a stepWidth of space which will partition the entire axis evenly
-        let availableTextWidth = catScale.stepWidth();
-        if (this._isHorizontal() && this._tickLabelMaxWidth != null) {
-          availableTextWidth = Math.min(availableTextWidth, this._tickLabelMaxWidth);
-        }
-
-        // scale(d) will give the center of the band, so subtract half of the text width so that the tick label will be
-        // centered with the band
-        let scaledValue = catScale.scale(d) - availableTextWidth / 2;
-        let x = this._isHorizontal() ? scaledValue : 0;
-        let y = this._isHorizontal() ? 0 : scaledValue;
+        // scale(d) will give the center of the band, so subtract half of the text width to get the left (top-most)
+        // coordinate that the tick label should be transformed to.
+        let tickLabelEdge = catScale.scale(d) - availableTextWidth / 2;
+        let x = this._isHorizontal() ? tickLabelEdge : 0;
+        let y = this._isHorizontal() ? 0 : tickLabelEdge;
         return "translate(" + x + "," + y + ")";
       };
       tickLabels.enter().append("g").classed(Axis.TICK_LABEL_CLASS, true);
@@ -324,7 +345,7 @@ namespace Plottable.Axes {
       tickLabels.attr("transform", getTickLabelTransform);
       // erase all text first, then rewrite
       tickLabels.text("");
-      this._drawTicks(catScale, tickLabels);
+      this._drawTicks(availableTextWidth, tickLabels);
 
       let xTranslate = this.orientation() === "right" ? this._tickSpaceRequired() : 0;
       let yTranslate = this.orientation() === "bottom" ? this._tickSpaceRequired() : 0;

--- a/src/axes/categoryAxis.ts
+++ b/src/axes/categoryAxis.ts
@@ -124,7 +124,7 @@ namespace Plottable.Axes {
      * Take the scale and drop ticks at regular intervals such that the resultant ticks are all a reasonable minimum
      * distance apart. Return the resultant ticks to render, as well as the new stepWidth between them.
      *
-     * @param scale the scale being downsampled. Defaults to this Axis' scale.
+     * @param {Scales.Category} scale - The scale being downsampled. Defaults to this Axis' scale.
      * @return {DownsampleInfo} an object holding the resultant domain and new stepWidth.
      */
     public getDownsampleInfo(scale = <Scales.Category> this._scale): DownsampleInfo {

--- a/test/axes/categoryAxisTests.ts
+++ b/test/axes/categoryAxisTests.ts
@@ -99,9 +99,6 @@ describe("Category Axes", () => {
 
       const tickLabels = axis.content().selectAll(".tick-label");
       assert.strictEqual(tickLabels.size(), 2, "renders downsampled labels");
-      const [oneLabel, fiveLabel] = tickLabels[0];
-      assert.strictEqual(d3.select(oneLabel).text(), "one", "first label is correct");
-      assert.strictEqual(d3.select(fiveLabel).text(), "five", "second label is correct");
 
       svg.remove();
     });

--- a/test/axes/categoryAxisTests.ts
+++ b/test/axes/categoryAxisTests.ts
@@ -58,7 +58,7 @@ describe("Category Axes", () => {
       let axis = new Plottable.Axes.Category(scale, "left");
       const TICK_LABEL_MAX_WIDTH = 60;
       axis.tickLabelMaxWidth(TICK_LABEL_MAX_WIDTH);
-      axis.renderTo("svg");
+      axis.renderTo(svg);
 
       let tickLabelContainer = axis.content().select(".tick-label-container").node() as SVGGElement;
       // add 8px padding to account for https://github.com/palantir/svg-typewriter/issues/40
@@ -74,7 +74,7 @@ describe("Category Axes", () => {
       const axis = new Plottable.Axes.Category(scale, "left");
       axis.tickLabelMaxWidth(60);
       axis.tickLabelMaxLines(2);
-      axis.renderTo("svg");
+      axis.renderTo(svg);
 
       const tickLabels = axis.content().selectAll(".tick-label");
       assert.strictEqual(tickLabels.size(), 2, "only renders two labels");
@@ -91,7 +91,7 @@ describe("Category Axes", () => {
       const domain = ["one", "two", "three", "four", "five", "six", "seven"];
       const scale = new Plottable.Scales.Category().domain(domain);
       const axis = new Plottable.Axes.Category(scale, "left");
-      axis.renderTo("svg");
+      axis.renderTo(svg);
 
       const [downsampledDomain, stepWidth] = axis.getDownsampleInfo();
       assert.strictEqual(stepWidth, 4 * scale.stepWidth(), "computes new stepWidth correctly");

--- a/test/axes/categoryAxisTests.ts
+++ b/test/axes/categoryAxisTests.ts
@@ -93,7 +93,7 @@ describe("Category Axes", () => {
       const axis = new Plottable.Axes.Category(scale, "left");
       axis.renderTo(svg);
 
-      const [downsampledDomain, stepWidth] = axis.getDownsampleInfo();
+      const { domain: downsampledDomain, stepWidth } = axis.getDownsampleInfo();
       assert.strictEqual(stepWidth, 4 * scale.stepWidth(), "computes new stepWidth correctly");
       assert.deepEqual(downsampledDomain, ["one", "five"], "downsamples domain correctly");
 

--- a/test/axes/categoryAxisTests.ts
+++ b/test/axes/categoryAxisTests.ts
@@ -85,6 +85,27 @@ describe("Category Axes", () => {
       svg.remove();
     });
 
+    it("downsamples the domain if there are too many ticks to fit", () => {
+      const height = 30;
+      const svg = TestMethods.generateSVG(400, height);
+      const domain = ["one", "two", "three", "four", "five", "six", "seven"];
+      const scale = new Plottable.Scales.Category().domain(domain);
+      const axis = new Plottable.Axes.Category(scale, "left");
+      axis.renderTo("svg");
+
+      const [downsampledDomain, stepWidth] = axis.getDownsampleInfo();
+      assert.strictEqual(stepWidth, 4 * scale.stepWidth(), "computes new stepWidth correctly");
+      assert.deepEqual(downsampledDomain, ["one", "five"], "downsamples domain correctly");
+
+      const tickLabels = axis.content().selectAll(".tick-label");
+      assert.strictEqual(tickLabels.size(), 2, "renders downsampled labels");
+      const [oneLabel, fiveLabel] = tickLabels[0];
+      assert.strictEqual(d3.select(oneLabel).text(), "one", "first label is correct");
+      assert.strictEqual(d3.select(fiveLabel).text(), "five", "second label is correct");
+
+      svg.remove();
+    });
+
     it("re-renders with the new domain when the category scale's domain changes", () => {
       let svg = TestMethods.generateSVG();
       let domain = ["foo", "bar", "baz"];


### PR DESCRIPTION
![downsampling](https://cloud.githubusercontent.com/assets/1079495/22003192/a9073608-dc1f-11e6-83ab-1781aede8e80.gif)


Category axes with too many labels compared to the space its given would
previously degenerate into rendering all "..."s or no text at all.

We now drop ticks at regular intervals when rendering the ticks would
otherwise be too tight (set at 15px per tick). This allows at least
some labels to be drawn - a strict improvement over the previous
behavior.

Fixes #3160 