### PR TITLE
Legend: maxWidth and maxLinesPerEntry

### DIFF
--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -2166,10 +2166,10 @@ declare namespace Plottable.Axes {
         /**
          * Sets the maximum TimeInterval precision. This limits the display to not
          * show time intervals above this precision. For example, if this is set to
-         * `TimeInterval.day` then no hours or minute ticks will be displayed in the
-         * axis.
+         * `TimeInterval.day` or `"day"` then no hours or minute ticks will be
+         * displayed in the axis.
          *
-         * @param {TimeInterval} newPositions The positions for each tier. "bottom" and "center" are the only supported values.
+         * @param {TimeInterval} newPrecision The new maximum precision.
          * @returns {Axes.Time} The calling Time Axis.
          */
         maxTimeIntervalPrecision(newPrecision: string): this;

--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -100,6 +100,13 @@ declare namespace Plottable.Utils.Math {
      */
     function distanceSquared(p1: Point, p2: Point): number;
     function degreesToRadians(degree: number): number;
+    /**
+     * Returns if the point is within the bounds. Points along
+     * the bounds are considered "within" as well.
+     * @param {Point} p Point in considerations.
+     * @param {Bounds} bounds Bounds within which to check for inclusion.
+     */
+    function within(p: Point, bounds: Bounds): boolean;
 }
 declare namespace Plottable.Utils {
     /**
@@ -2554,7 +2561,7 @@ declare namespace Plottable.Components {
          */
         maxLinesPerEntry(maxLinesPerEntry: number): this;
         /**
-         * Gets teh maximum width of the legend in pixels.
+         * Gets the maximum width of the legend in pixels.
          * @returns {number}
          */
         maxWidth(): number;
@@ -3270,10 +3277,7 @@ declare namespace Plottable {
          * the chart, relative to the parent.
          * @returns {Plots.PlotEntity} The nearest PlotEntity, or undefined if no {Plots.PlotEntity} can be found.
          */
-        entityNearest(queryPoint: Point, bounds?: {
-            topLeft: Point;
-            bottomRight: Point;
-        }): Plots.PlotEntity;
+        entityNearest(queryPoint: Point, bounds?: Bounds): Plots.PlotEntity;
         protected _entityVisibleOnPlot(entity: Plots.PlotEntity | Plots.LightweightPlotEntity, chartBounds: Bounds): boolean;
         protected _uninstallScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _installScaleForKey(scale: Scale<any, any>, key: string): void;

--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -2491,9 +2491,12 @@ declare namespace Plottable.Components {
          */
         static LEGEND_SYMBOL_CLASS: string;
         private _padding;
+        private _rowBottomPadding;
         private _colorScale;
         private _formatter;
         private _maxEntriesPerRow;
+        private _maxLinesPerEntry;
+        private _maxWidth;
         private _comparator;
         private _measurer;
         private _wrapper;
@@ -2527,12 +2530,40 @@ declare namespace Plottable.Components {
          */
         maxEntriesPerRow(): number;
         /**
-         * Sets the maximum number of entries perrow.
+         * Sets the maximum number of entries per row.
          *
          * @param {number} maxEntriesPerRow
          * @returns {Legend} The calling Legend.
          */
         maxEntriesPerRow(maxEntriesPerRow: number): this;
+        /**
+         * Gets the maximum lines per row.
+         *
+         * @returns {number}
+         */
+        maxLinesPerEntry(): number;
+        /**
+         * Sets the maximum number of lines per entry. This is distinct from
+         * maxEntriesPerRow in that, maxEntriesPerRow determines the maximum allowable
+         * number of series labels that may be displayed per row whereas maxLinesPerEntry
+         * specifies the maximum number of times a single entry may be broken into new
+         * lines before being truncated.
+         *
+         * @param {number} maxLinesPerEntry
+         * @returns {Legend} The calling Legend.
+         */
+        maxLinesPerEntry(maxLinesPerEntry: number): this;
+        /**
+         * Gets teh maximum width of the legend in pixels.
+         * @returns {number}
+         */
+        maxWidth(): number;
+        /**
+         * Sets the maximum width of the legend in pixels.
+         * @param {number} maxWidth The maximum width in pixels.
+         * @returns {Legend}
+         */
+        maxWidth(maxWidth: number): this;
         /**
          * Gets the current comparator for the Legend's entries.
          *
@@ -2561,9 +2592,8 @@ declare namespace Plottable.Components {
          */
         colorScale(colorScale: Scales.Color): this;
         destroy(): void;
-        private _calculateLayoutInfo(availableWidth, availableHeight);
+        private _buildLegendTable(width, height);
         requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
-        private _packRows(availableWidth, entries, entryLengths);
         /**
          * Gets the Entities (representing Legend entries) at a particular point.
          * Returns an empty array if no Entities are present at that location.

--- a/plottable-npm.js
+++ b/plottable-npm.js
@@ -6119,6 +6119,7 @@ var Plottable;
                     };
                     self._writer.write(self._formatter(column.data.name), column.width, self.height(), writeOptions);
                 });
+                entries.exit().remove();
                 return this;
             };
             Legend.prototype.symbol = function (symbol) {

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -99,6 +99,13 @@ declare namespace Plottable.Utils.Math {
      */
     function distanceSquared(p1: Point, p2: Point): number;
     function degreesToRadians(degree: number): number;
+    /**
+     * Returns if the point is within the bounds. Points along
+     * the bounds are considered "within" as well.
+     * @param {Point} p Point in considerations.
+     * @param {Bounds} bounds Bounds within which to check for inclusion.
+     */
+    function within(p: Point, bounds: Bounds): boolean;
 }
 declare namespace Plottable.Utils {
     /**
@@ -2553,7 +2560,7 @@ declare namespace Plottable.Components {
          */
         maxLinesPerEntry(maxLinesPerEntry: number): this;
         /**
-         * Gets teh maximum width of the legend in pixels.
+         * Gets the maximum width of the legend in pixels.
          * @returns {number}
          */
         maxWidth(): number;
@@ -3269,10 +3276,7 @@ declare namespace Plottable {
          * the chart, relative to the parent.
          * @returns {Plots.PlotEntity} The nearest PlotEntity, or undefined if no {Plots.PlotEntity} can be found.
          */
-        entityNearest(queryPoint: Point, bounds?: {
-            topLeft: Point;
-            bottomRight: Point;
-        }): Plots.PlotEntity;
+        entityNearest(queryPoint: Point, bounds?: Bounds): Plots.PlotEntity;
         protected _entityVisibleOnPlot(entity: Plots.PlotEntity | Plots.LightweightPlotEntity, chartBounds: Bounds): boolean;
         protected _uninstallScaleForKey(scale: Scale<any, any>, key: string): void;
         protected _installScaleForKey(scale: Scale<any, any>, key: string): void;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2165,10 +2165,10 @@ declare namespace Plottable.Axes {
         /**
          * Sets the maximum TimeInterval precision. This limits the display to not
          * show time intervals above this precision. For example, if this is set to
-         * `TimeInterval.day` then no hours or minute ticks will be displayed in the
-         * axis.
+         * `TimeInterval.day` or `"day"` then no hours or minute ticks will be
+         * displayed in the axis.
          *
-         * @param {TimeInterval} newPositions The positions for each tier. "bottom" and "center" are the only supported values.
+         * @param {TimeInterval} newPrecision The new maximum precision.
          * @returns {Axes.Time} The calling Time Axis.
          */
         maxTimeIntervalPrecision(newPrecision: string): this;

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2490,9 +2490,12 @@ declare namespace Plottable.Components {
          */
         static LEGEND_SYMBOL_CLASS: string;
         private _padding;
+        private _rowBottomPadding;
         private _colorScale;
         private _formatter;
         private _maxEntriesPerRow;
+        private _maxLinesPerEntry;
+        private _maxWidth;
         private _comparator;
         private _measurer;
         private _wrapper;
@@ -2526,12 +2529,40 @@ declare namespace Plottable.Components {
          */
         maxEntriesPerRow(): number;
         /**
-         * Sets the maximum number of entries perrow.
+         * Sets the maximum number of entries per row.
          *
          * @param {number} maxEntriesPerRow
          * @returns {Legend} The calling Legend.
          */
         maxEntriesPerRow(maxEntriesPerRow: number): this;
+        /**
+         * Gets the maximum lines per row.
+         *
+         * @returns {number}
+         */
+        maxLinesPerEntry(): number;
+        /**
+         * Sets the maximum number of lines per entry. This is distinct from
+         * maxEntriesPerRow in that, maxEntriesPerRow determines the maximum allowable
+         * number of series labels that may be displayed per row whereas maxLinesPerEntry
+         * specifies the maximum number of times a single entry may be broken into new
+         * lines before being truncated.
+         *
+         * @param {number} maxLinesPerEntry
+         * @returns {Legend} The calling Legend.
+         */
+        maxLinesPerEntry(maxLinesPerEntry: number): this;
+        /**
+         * Gets teh maximum width of the legend in pixels.
+         * @returns {number}
+         */
+        maxWidth(): number;
+        /**
+         * Sets the maximum width of the legend in pixels.
+         * @param {number} maxWidth The maximum width in pixels.
+         * @returns {Legend}
+         */
+        maxWidth(maxWidth: number): this;
         /**
          * Gets the current comparator for the Legend's entries.
          *
@@ -2560,9 +2591,8 @@ declare namespace Plottable.Components {
          */
         colorScale(colorScale: Scales.Color): this;
         destroy(): void;
-        private _calculateLayoutInfo(availableWidth, availableHeight);
+        private _buildLegendTable(width, height);
         requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest;
-        private _packRows(availableWidth, entries, entryLengths);
         /**
          * Gets the Entities (representing Legend entries) at a particular point.
          * Returns an empty array if no Entities are present at that location.

--- a/plottable.js
+++ b/plottable.js
@@ -6119,6 +6119,7 @@ var Plottable;
                     };
                     self._writer.write(self._formatter(column.data.name), column.width, self.height(), writeOptions);
                 });
+                entries.exit().remove();
                 return this;
             };
             Legend.prototype.symbol = function (symbol) {

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -290,9 +290,9 @@ namespace Plottable.Components {
       super._setup();
       let fakeLegendRow = this.content().append("g").classed(Legend.LEGEND_ROW_CLASS, true);
       let fakeLegendEntry = fakeLegendRow.append("g").classed(Legend.LEGEND_ENTRY_CLASS, true);
-      fakeLegendEntry.append("text");
+      fakeLegendEntry.append("text"); 
       this._measurer = new SVGTypewriter.Measurer(fakeLegendRow);
-      this._wrapper = new SVGTypewriter.Wrappers.Wrapper().maxLines(this.maxLinesPerEntry());
+      this._wrapper = new SVGTypewriter.Wrapper().maxLines(this.maxLinesPerEntry());
       this._writer = new SVGTypewriter.Writer(this._measurer, this._wrapper).addTitleElement(Configs.ADD_TITLE_ELEMENTS);
     }
 
@@ -494,7 +494,10 @@ namespace Plottable.Components {
     public requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest {
       // if max width is set, the table is guaranteed to be at most maxWidth wide.
       // if max width is not set, the table will be as wide as the longest untruncated row
-      const table = this._buildLegendTable(Utils.Math.min([this.maxWidth(), Infinity], Infinity), offeredHeight);
+      const table = this._buildLegendTable(
+        Utils.Math.min([this.maxWidth(), offeredWidth], offeredWidth),
+        offeredHeight
+      );
 
       return {
         minHeight: table.getHeight(),

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -1,4 +1,233 @@
 namespace Plottable.Components {
+  /**
+   * The Legend's column representation. Stores position information
+   * as well as data
+   */
+  class LegendColumn<T> {
+    constructor(private _width = 0, private _height = 0, private _data: T) {}
+
+    /**
+     * @return {T} data Returns any data stored in the column
+     */
+    public getData() {
+      return this._data;
+    }
+
+    /**
+     * @return {number} height The height of the column.
+     */
+    public getHeight() {
+      return this._height;
+    }
+
+    /**
+     * @return {number} width The width of the column.
+     */
+    public getWidth() {
+      return this._width;
+    }
+
+    /**
+     * @param {number} width Sets the width of the column
+     */
+    public setWidth(width: number) {
+      return this._width = width;
+    }
+  }
+
+  /**
+   * The Legend's row representations. Stores positioning information
+   * and column data.
+   */
+  class LegendRow {
+    constructor(
+        private _columns: LegendColumn<any>[] = [],
+        private _bottomPadding = 0,
+        private _maxWidth = Infinity) {}
+
+    public addColumn(column: LegendColumn<any>) {
+      const desiredColumnWidth = column.getWidth();
+      // choose the smaller of 1) remaining space, 2) desired width
+      const widthRemaining = this.getWidthAvailable();
+      column.setWidth(Math.min(widthRemaining, desiredColumnWidth));
+      this._columns.push(column);
+    }
+
+    public forEach(callback: (column: LegendColumn<any>, index?: number) => void) {
+      this._columns.forEach(callback);
+    }
+
+    public reduce<U>(callbackfn: (
+      previousValue: U,
+      currentValue: LegendColumn<any>,
+      currentIndex: number,
+      array: LegendColumn<any>[]) => U, initialValue: U): U {
+      return this._columns.reduce(callbackfn, initialValue);
+    }
+
+    /**
+     * Returns the bounds the column, relative to the row.
+     * @param {LegendColumn<any>} column The column in question
+     * @returns {Bounds} bounds
+     */
+    public getBounds(column: LegendColumn<any>) {
+      const indexOfColumn = this._columns.indexOf(column);
+      const columnXOffset = this._columns.slice(0, indexOfColumn)
+        .reduce((sum, column) => sum + column.getWidth(), 0);
+
+      return {
+        topLeft: { x: columnXOffset, y: 0 },
+        bottomRight: {
+          x: columnXOffset + column.getWidth(),
+          y: column.getHeight(),
+        }
+      };
+    }
+
+    public getColumns() {
+      return this._columns;
+    }
+
+    /**
+     * Returns the height of the row, including the bottomPadding.
+     * @return {number} height
+     */
+    public getHeight() {
+      return Utils.Math.max(this._columns.map((column) => column.getHeight()), 0)
+        + this._bottomPadding;
+    }
+
+    /**
+     * Padding applied below the row. Affects the spacing between rows. Defaults to 0.
+     * @param {bottomPadding} number
+     */
+    public setBottomPadding(bottomPadding: number) {
+      this._bottomPadding = bottomPadding;
+    }
+
+    /**
+     * Sets the maximum allowable width of this column.
+     * @param {number} maxWidth
+     */
+    public setMaxWidth(maxWidth: number) {
+      this._maxWidth = maxWidth;
+    }
+
+    /**
+     * Returns the current width of the row constrained by maxWidth, if set.
+     * @returns {number} width
+     */
+    public getWidth() {
+      return Math.min(
+        this._columns.reduce((sum, column) => sum + column.getWidth(), 0),
+        this._maxWidth
+      );
+    }
+
+    /**
+     * Returns the remaining width available in the row based on the maximum
+     * width of this row.
+     * @returns {number} widthRemaining
+     */
+    public getWidthAvailable() {
+      const widthConsumed = this.getWidth();
+      return Math.max(this._maxWidth - widthConsumed, 0);
+    }
+  }
+
+  /**
+   * Stores LegendRows. Useful for calculating and maintaining
+   * positioning information about the Legend.
+   */
+  class LegendTable {
+    constructor(
+        private _maxWidth = Infinity,
+        private _maxHeight = Infinity,
+        private _padding = 0,
+        private _rows: LegendRow[] = []) {}
+
+    public addRow(row: LegendRow) {
+      row.setMaxWidth(this._maxWidth - this._padding * 2);
+      this._rows.push(row);
+    }
+
+    public forEach(callback: (row: LegendRow, index?: number) => void) {
+      this._rows.forEach(callback);
+    }
+
+    /**
+     * Returns the bounds relative to the parent and siblings of the row or
+     * column. If column is not specified, bounds will be calculate for the row only.
+     * If the column is specified, the bounds will be calculate for the column only.
+     *
+     * @param {LegendRow} row The row to calculate bounds
+     * @param {LegendColumn} column The column to calculate bounds.
+     * @returns {Bounds}
+     */
+    public getBounds(row: LegendRow, column?: LegendColumn<any>) {
+      const indexOfRow = this._rows.indexOf(row);
+      const rowYOffset = this._rows.slice(0, indexOfRow)
+        .reduce((sum, row) => sum + row.getHeight(), this._padding);
+      const rowXOffset = this._padding;
+
+      const rowBounds = {
+        topLeft: { x: rowXOffset, y: rowYOffset },
+        bottomRight: {
+          x: rowXOffset + row.getWidth(),
+          y: rowYOffset + row.getHeight(),
+        }
+      };
+
+      if (column !== undefined) {
+        const columnBounds = row.getBounds(column);
+        columnBounds.topLeft.x += rowBounds.topLeft.x;
+        columnBounds.bottomRight.x += rowBounds.topLeft.x;
+
+        columnBounds.topLeft.y += rowBounds.topLeft.y;
+        columnBounds.bottomRight.y += rowBounds.topLeft.y;
+        return columnBounds;
+      }
+
+      return rowBounds;
+    }
+
+    public getRows() {
+      return this._rows;
+    }
+
+    /**
+     * Returns the height of the Table, constrained by a maximum height, if set.
+     * The height includes the padding, if set.
+     * @returns {number} height
+     */
+    public getHeight() {
+      return Math.min(
+        this._rows.reduce((sum, row) => sum + row.getHeight(), 0) + this._padding * 2,
+        this._maxHeight
+      );
+    }
+
+    /**
+     * Returns the width of the table, constrained by the maximum width, if set.
+     * The width includes the padding, if set.
+     * @returns {number} width
+     */
+    public getWidth() {
+      return Math.min(
+        Utils.Math.max(this._rows.map((row) => row.getWidth()), 0) + this._padding * 2,
+        this._maxWidth
+      );
+    }
+
+    public reduce<U>(callbackfn: (
+      previousValue: U,
+      currentValue: LegendRow,
+      currentIndex: number,
+      array: LegendRow[]) => U, initialValue: U): U {
+      return this._rows.reduce(callbackfn, initialValue);
+    }
+  }
+
   export class Legend extends Component {
     /**
      * The css class applied to each legend row
@@ -14,9 +243,12 @@ namespace Plottable.Components {
     public static LEGEND_SYMBOL_CLASS = "legend-symbol";
 
     private _padding = 5;
+    private _rowBottomPadding = 3;
     private _colorScale: Scales.Color;
     private _formatter: Formatter;
     private _maxEntriesPerRow: number;
+    private _maxLinesPerEntry: number;
+    private _maxWidth: number;
     private _comparator: (a: string, b: string) => number;
     private _measurer: SVGTypewriter.Measurer;
     private _wrapper: SVGTypewriter.Wrapper;
@@ -44,6 +276,7 @@ namespace Plottable.Components {
       this._redrawCallback = (scale) => this.redraw();
       this._colorScale.onUpdate(this._redrawCallback);
       this._formatter = Formatters.identity();
+      this.maxLinesPerEntry(1);
       this.xAlignment("right").yAlignment("top");
       this.comparator((a: string, b: string) => {
         let formattedText = this._colorScale.domain().slice().map((d: string) => this._formatter(d));
@@ -59,7 +292,7 @@ namespace Plottable.Components {
       let fakeLegendEntry = fakeLegendRow.append("g").classed(Legend.LEGEND_ENTRY_CLASS, true);
       fakeLegendEntry.append("text");
       this._measurer = new SVGTypewriter.Measurer(fakeLegendRow);
-      this._wrapper = new SVGTypewriter.Wrapper().maxLines(1);
+      this._wrapper = new SVGTypewriter.Wrappers.Wrapper().maxLines(this.maxLinesPerEntry());
       this._writer = new SVGTypewriter.Writer(this._measurer, this._wrapper).addTitleElement(Configs.ADD_TITLE_ELEMENTS);
     }
 
@@ -89,7 +322,7 @@ namespace Plottable.Components {
      */
     public maxEntriesPerRow(): number;
     /**
-     * Sets the maximum number of entries perrow.
+     * Sets the maximum number of entries per row.
      *
      * @param {number} maxEntriesPerRow
      * @returns {Legend} The calling Legend.
@@ -104,7 +337,53 @@ namespace Plottable.Components {
         return this;
       }
     }
+    /**
+     * Gets the maximum lines per row.
+     *
+     * @returns {number}
+     */
+    public maxLinesPerEntry(): number;
+    /**
+     * Sets the maximum number of lines per entry. This is distinct from
+     * maxEntriesPerRow in that, maxEntriesPerRow determines the maximum allowable
+     * number of series labels that may be displayed per row whereas maxLinesPerEntry
+     * specifies the maximum number of times a single entry may be broken into new
+     * lines before being truncated.
+     *
+     * @param {number} maxLinesPerEntry
+     * @returns {Legend} The calling Legend.
+     */
+    public maxLinesPerEntry(maxLinesPerEntry: number): this;
+    public maxLinesPerEntry(maxLinesPerEntry?: number): any {
+      if (maxLinesPerEntry == null) {
+        return this._maxLinesPerEntry;
+      } else {
+        this._maxLinesPerEntry = maxLinesPerEntry;
+        this.redraw();
+        return this;
+      }
+    }
 
+    /**
+     * Gets teh maximum width of the legend in pixels.
+     * @returns {number}
+     */
+    public maxWidth(): number;
+    /**
+     * Sets the maximum width of the legend in pixels.
+     * @param {number} maxWidth The maximum width in pixels.
+     * @returns {Legend}
+     */
+    public maxWidth(maxWidth: number): this;
+    public maxWidth(maxWidth?: number): any {
+      if (maxWidth == null) {
+        return this._maxWidth;
+      } else {
+        this._maxWidth = maxWidth;
+        this.redraw();
+        return this;
+      }
+    }
     /**
      * Gets the current comparator for the Legend's entries.
      *
@@ -159,70 +438,68 @@ namespace Plottable.Components {
       this._colorScale.offUpdate(this._redrawCallback);
     }
 
-    private _calculateLayoutInfo(availableWidth: number, availableHeight: number) {
+    private _buildLegendTable(width: number, height: number) {
       let textHeight = this._measurer.measure().height;
 
-      let availableWidthForEntries = Math.max(0, (availableWidth - this._padding));
+      const table = new LegendTable(width, height, this._padding);
+      const entryNames = this._colorScale.domain().slice().sort((a, b) => this._comparator(this._formatter(a), this._formatter(b)));
 
-      let entryNames = this._colorScale.domain().slice().sort((a, b) => this._comparator(this._formatter(a), this._formatter(b)));
-      let entryLengths: d3.Map<number> = d3.map<number>();
-      let untruncatedEntryLengths: d3.Map<number> = d3.map<number>();
-      entryNames.forEach((entryName) => {
-        let untruncatedEntryLength = textHeight + this._measurer.measure(this._formatter(entryName)).width + this._padding;
-        let entryLength = Math.min(untruncatedEntryLength, availableWidthForEntries);
-        entryLengths.set(entryName, entryLength);
-        untruncatedEntryLengths.set(entryName, untruncatedEntryLength);
+      let row: LegendRow = new LegendRow();
+      table.addRow(row);
+      entryNames.forEach((entryName, index) => {
+        if (row.getColumns().length / 2 === this.maxEntriesPerRow()) {
+          // we add two columns per entry, a symbol column and a name column
+          // if the current row is full, according to the number of entries
+          // we're allowed to have per row, we need to allocate new space
+          row = new LegendRow();
+          row.setBottomPadding(this._rowBottomPadding);
+          table.addRow(row);
+        }
+
+        let availableWidth = row.getWidthAvailable();
+        const formattedName = this._formatter(entryName);
+        // this is the width of the series name without any line wrapping
+        // it is the most optimal presentation of the name
+        const unwrappedNameWidth = this._measurer.measure(formattedName).width;
+        const willBeSquished = (availableWidth - textHeight - unwrappedNameWidth) < 0;
+
+        if (willBeSquished && row.getColumns().length > 1) {
+          // adding the entry to this row will squish this
+          // entry. The row already contains entries so create
+          // a new row to add this entry to for optimal display
+          row = new LegendRow();
+          row.setBottomPadding(this._rowBottomPadding);
+          table.addRow(row);
+        }
+
+        const symbolColumn = new LegendColumn(textHeight, textHeight, entryName);
+        row.addColumn(symbolColumn);
+
+        // the space consumed by the name field is the minimum of the space available in the table
+        // and the actual width consumed by the name
+        availableWidth = row.getWidthAvailable();
+        const usedNameWidth = Math.min(availableWidth, unwrappedNameWidth);
+
+        this._wrapper.maxLines(this.maxLinesPerEntry());
+        let numberOfRows = this._wrapper.wrap(formattedName, this._measurer, usedNameWidth).noLines;
+
+        let nameColumnHeight = numberOfRows * textHeight;
+        const nameColumn = new LegendColumn(usedNameWidth, nameColumnHeight, entryName);
+        row.addColumn(nameColumn);
       });
 
-      let rows = this._packRows(availableWidthForEntries, entryNames, entryLengths);
-
-      let rowsAvailable = Math.floor((availableHeight - 2 * this._padding) / textHeight);
-      if (rowsAvailable !== rowsAvailable) { // rowsAvailable can be NaN if this.textHeight = 0
-        rowsAvailable = 0;
-      }
-
-      return {
-        textHeight: textHeight,
-        entryLengths: entryLengths,
-        untruncatedEntryLengths: untruncatedEntryLengths,
-        rows: rows,
-        numRowsToDraw: Math.max(Math.min(rowsAvailable, rows.length), 0),
-      };
+      return table;
     }
 
     public requestedSpace(offeredWidth: number, offeredHeight: number): SpaceRequest {
-      let estimatedLayout = this._calculateLayoutInfo(offeredWidth, offeredHeight);
-
-      let untruncatedRowLengths = estimatedLayout.rows.map((row) => {
-        return d3.sum(row, (entry) => estimatedLayout.untruncatedEntryLengths.get(entry));
-      });
-      let longestUntruncatedRowLength = Utils.Math.max(untruncatedRowLengths, 0);
+      // if max width is set, the table is guaranteed to be at most maxWidth wide.
+      // if max width is not set, the table will be as wide as the longest untruncated row
+      const table = this._buildLegendTable(Utils.Math.min([this.maxWidth(), Infinity], Infinity), offeredHeight);
 
       return {
-        minWidth: this._padding + longestUntruncatedRowLength,
-        minHeight: estimatedLayout.rows.length * estimatedLayout.textHeight + 2 * this._padding,
+        minHeight: table.getHeight(),
+        minWidth: table.getWidth()
       };
-    }
-
-    private _packRows(availableWidth: number, entries: string[], entryLengths: d3.Map<number>) {
-      let rows: string[][] = [];
-      let currentRow: string[] = [];
-      let spaceLeft = availableWidth;
-      entries.forEach((e: string) => {
-        let entryLength = entryLengths.get(e);
-        if (entryLength > spaceLeft || currentRow.length === this._maxEntriesPerRow) {
-          rows.push(currentRow);
-          currentRow = [];
-          spaceLeft = availableWidth;
-        }
-        currentRow.push(e);
-        spaceLeft -= entryLength;
-      });
-
-      if (currentRow.length !== 0) {
-        rows.push(currentRow);
-      }
-      return rows;
     }
 
     /**
@@ -237,88 +514,107 @@ namespace Plottable.Components {
         return [];
       }
 
-      let entities: Entity<Legend>[] = [];
-      let layout = this._calculateLayoutInfo(this.width(), this.height());
-      let legendPadding = this._padding;
-      let legend = this;
-      this.content().selectAll("g." + Legend.LEGEND_ROW_CLASS).each(function(d: any, i: number) {
-        let lowY = i * layout.textHeight + legendPadding;
-        let highY = (i + 1) * layout.textHeight + legendPadding;
-        let symbolY = (lowY + highY) / 2;
-        let lowX = legendPadding;
-        let highX = legendPadding;
-        d3.select(this).selectAll("g." + Legend.LEGEND_ENTRY_CLASS).each(function(value: string) {
-          highX += layout.entryLengths.get(value);
-          let symbolX = lowX + layout.textHeight / 2;
-          if (highX >= p.x && lowX <= p.x &&
-              highY >= p.y && lowY <= p.y) {
-            let entrySelection = d3.select(this);
-            let datum = entrySelection.datum();
-            entities.push({
-              datum: datum,
-              position: { x: symbolX, y: symbolY },
-              selection: entrySelection,
-              component: legend,
-            });
-          }
-          lowX += layout.entryLengths.get(value);
-        });
-      });
+      function within(p: Point, bounds: Bounds) {
+        return bounds.topLeft.x <= p.x
+          && bounds.bottomRight.x >= p.x
+          && bounds.topLeft.y <= p.y
+          && bounds.bottomRight.y >= p.y;
+      };
 
-      return entities;
+      const table = this._buildLegendTable(this.width(), this.height());
+      return table.reduce((entity: Entity<Legend>[], row: LegendRow, rowIndex: number) => {
+        if (entity.length !== 0) {
+          // we've already found the nearest entity; just return it.
+          return entity;
+        }
+
+        const rowBounds = table.getBounds(row);
+        const withinRow = within(p, rowBounds);
+
+        if (!withinRow) {
+          // the nearest entity isn't within this row, continue;
+          return entity;
+        }
+
+        return row.reduce((entity: Entity<Legend>[], column: LegendColumn<string>, columnIndex: number) => {
+          const columnBounds = table.getBounds(row, column);
+          const withinColumn = within(p, columnBounds);
+
+          if (withinColumn) {
+            const rowElement = this.content().selectAll(`.${Legend.LEGEND_ROW_CLASS}`)[0][rowIndex];
+            // HACKHACK The 2.x API chooses the symbol element as the "selection" to return, regardless of what
+            // was actually selected
+            const entryElement = d3.select(rowElement)
+              .selectAll(`.${Legend.LEGEND_ENTRY_CLASS}`)[0][Math.floor(columnIndex / 2)];
+             const symbolElement = d3.select(entryElement).select(`.${Legend.LEGEND_SYMBOL_CLASS}`);
+
+            // HACKHACK The 2.x API returns the center {x, y} of the symbol as the position.
+            const rowTranslate = d3.transform(d3.select(rowElement).attr("transform")).translate;
+            const symbolTranslate = d3.transform(symbolElement.attr("transform")).translate;
+
+            return [{
+              datum: column.getData(),
+              position: { x: rowTranslate[0] + symbolTranslate[0], y: rowTranslate[1] + symbolTranslate[1] },
+              selection: d3.select(entryElement),
+              component: this,
+            }];
+          }
+
+          return entity;
+        }, entity);
+
+      }, [] as Entity<Legend>[])
     }
 
     public renderImmediately() {
       super.renderImmediately();
+      const table = this._buildLegendTable(this.width(), this.height());
+      const entryNames = this._colorScale.domain().slice().sort((a, b) => this._comparator(this._formatter(a), this._formatter(b)));
 
-      let layout = this._calculateLayoutInfo(this.width(), this.height());
+      // clear content from previous renders
+      this.content().selectAll("*").remove();
+      const tableRoot = this.content();
 
-      let rowsToDraw = layout.rows.slice(0, layout.numRowsToDraw);
-      let rows = this.content().selectAll("g." + Legend.LEGEND_ROW_CLASS).data(rowsToDraw);
-      rows.enter().append("g").classed(Legend.LEGEND_ROW_CLASS, true);
-      rows.exit().remove();
+      table.forEach((row: LegendRow, rowIndex: number) => {
+        const rowBounds = table.getBounds(row);
+        const rowRoot = tableRoot.append("g").classed(Legend.LEGEND_ROW_CLASS, true)
+          .attr("transform", `translate(${rowBounds.topLeft.x}, ${rowBounds.topLeft.y})`);
 
-      rows.attr("transform", (d: any, i: number) => "translate(0, " + (i * layout.textHeight + this._padding) + ")");
+        let rowEntry: d3.Selection<any>;
+        const rowElement = row.forEach((column: LegendColumn<string>, index: number) => {
+          const columnBounds = table.getBounds(row, column);
 
-      let entries = rows.selectAll("g." + Legend.LEGEND_ENTRY_CLASS).data((d) => d);
-      let entriesEnter = entries.enter().append("g").classed(Legend.LEGEND_ENTRY_CLASS, true);
-      entriesEnter.append("path");
-      entriesEnter.append("g").classed("text-container", true);
-      entries.exit().remove();
+          if (index % 2  === 0) {
+            // symbols are at even indices in the rows of our table
 
-      let legendPadding = this._padding;
-      rows.each(function (values: string[]) {
-        let xShift = legendPadding;
-        let entriesInRow = d3.select(this).selectAll("g." + Legend.LEGEND_ENTRY_CLASS);
-        entriesInRow.attr("transform", (value: string, i: number) => {
-          let translateString = "translate(" + xShift + ", 0)";
-          xShift += layout.entryLengths.get(value);
-          return translateString;
+            // HACKHACK need a legend entry element to maintain back compat with 2.x
+            rowEntry = rowRoot.append("g").classed(Legend.LEGEND_ENTRY_CLASS, true);
+            rowEntry.append("path")
+              .attr("d", this.symbol()(column.getData(), rowIndex)(column.getHeight() * 0.6))
+              .attr("transform", `translate(${columnBounds.topLeft.x + column.getWidth() / 2}, ${column.getHeight() / 2})`)
+              .attr("fill", this._colorScale.scale(column.getData()))
+              .attr("opacity", this.symbolOpacity()(column.getData(), rowIndex))
+              .classed(Legend.LEGEND_SYMBOL_CLASS, true);
+          } else {
+            // series names are at odd indicies in the rows of our table
+
+            // HACKHACK add data to element to maintain backcompat with 2.x
+            rowEntry.data(() => [column.getData()]);
+
+            const textContainer = rowEntry.append("g").classed("text-container", true)
+              .attr("transform", "translate(" + columnBounds.topLeft.x + ", 0)");
+
+            const writeOptions = {
+              selection: textContainer,
+              xAlign: "left",
+              yAlign: "top",
+              textRotation: 0,
+            };
+            this._writer.write(this._formatter(column.getData()), column.getWidth(), this.height(), writeOptions);
+          }
         });
       });
 
-      entries.select("path").attr("d", (d: any, i: number, j: number) => this.symbol()(d, j)(layout.textHeight * 0.6))
-                            .attr("transform", "translate(" + (layout.textHeight / 2) + "," + layout.textHeight / 2 + ")")
-                            .attr("fill", (value: string) => this._colorScale.scale(value))
-                            .attr("opacity", (d: any, i: number, j: number) => this.symbolOpacity()(d, j))
-                            .classed(Legend.LEGEND_SYMBOL_CLASS, true);
-
-      let padding = this._padding;
-      let textContainers = entries.select("g.text-container");
-      textContainers.text(""); // clear out previous results
-      let self = this;
-      textContainers.attr("transform", "translate(" + layout.textHeight + ", 0)")
-                    .each(function(value: string) {
-                      let container = d3.select(this);
-                      let maxTextLength = layout.entryLengths.get(value) - layout.textHeight - padding;
-                      let writeOptions = {
-                        selection: container,
-                        xAlign: "left",
-                        yAlign: "top",
-                        textRotation: 0,
-                      };
-                      self._writer.write(self._formatter(value), maxTextLength, self.height(), writeOptions);
-                    });
       return this;
     }
 

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -586,6 +586,8 @@ namespace Plottable.Components {
           self._writer.write(self._formatter(column.data.name), column.width, self.height(), writeOptions)
         });
 
+      entries.exit().remove();
+
       return this;
     }
 

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -103,4 +103,17 @@ namespace Plottable.Utils.Math {
   export function degreesToRadians(degree: number) {
     return degree / 360 * nativeMath.PI * 2;
   }
+
+  /**
+   * Returns if the point is within the bounds. Points along
+   * the bounds are considered "within" as well.
+   * @param {Point} p Point in considerations.
+   * @param {Bounds} bounds Bounds within which to check for inclusion.
+   */
+  export function within(p: Point, bounds: Bounds) {
+    return bounds.topLeft.x <= p.x
+      && bounds.bottomRight.x >= p.x
+      && bounds.topLeft.y <= p.y
+      && bounds.bottomRight.y >= p.y;
+  }
 }

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -154,7 +154,7 @@ describe("Legend", () => {
       legend.maxWidth(100);
       legend.maxLinesPerEntry(2);
       assert.strictEqual(2, legend.content().selectAll(`${ROW_SELECTOR} ${TEXT_LINE_SELECTOR}`).size());
-      legend.maxLinesPerEntry(10);
+      legend.maxLinesPerEntry(4);
       assert.strictEqual(4, legend.content().selectAll(`${ROW_SELECTOR} ${TEXT_LINE_SELECTOR}`).size());
       svg.remove();
     });

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -24,12 +24,13 @@ describe("Legend", () => {
       assert.strictEqual(rows.size(), color.domain().length, "one entry is created for each item in the domain");
 
       rows.each(function(d: any, i: number) {
-        assert.strictEqual(d, color.domain()[i], "the data is set properly");
+        const name = d[0].data.name;
+        assert.strictEqual(name, color.domain()[i], "the data is set properly");
         let row = d3.select(this);
         let text = row.select("text").text();
-        assert.strictEqual(text, d, "the text node has correct text");
+        assert.strictEqual(text, name, "the text node has correct text");
         let symbol = row.select(SYMBOL_SELECTOR);
-        assert.strictEqual(symbol.attr("fill"), color.scale(d), "the symbol's fill is set properly");
+        assert.strictEqual(symbol.attr("fill"), color.scale(name), "the symbol's fill is set properly");
         assert.strictEqual(symbol.attr("opacity"), "1", "the symbol's opacity is set by default to 1");
       });
       svg.remove();
@@ -97,11 +98,12 @@ describe("Legend", () => {
       color.domain(newDomain);
 
       legend.content().selectAll(ENTRY_SELECTOR).each(function(d: any, i: number) {
-        assert.strictEqual(d, newDomain[i], "the data is set correctly");
+        const name = d[0].data.name;
+        assert.strictEqual(name, newDomain[i], "the data is set correctly");
         const text = d3.select(this).select("text").text();
-        assert.strictEqual(text, d, "the text was set properly");
+        assert.strictEqual(text, name, "the text was set properly");
         const fill = d3.select(this).select(SYMBOL_SELECTOR).attr("fill");
-        assert.strictEqual(fill, color.scale(d), "the fill was set properly");
+        assert.strictEqual(fill, color.scale(name), "the fill was set properly");
       });
       assert.strictEqual(legend.content().selectAll(ENTRY_SELECTOR).size(), 5, "there are the right number of legend elements");
       svg.remove();
@@ -117,11 +119,12 @@ describe("Legend", () => {
       legend.colorScale(newColorScale);
 
       legend.content().selectAll(ENTRY_SELECTOR).each(function(d: any, i: number) {
-        assert.strictEqual(d, newDomain[i], "the data is set correctly");
+        const name = d[0].data.name;
+        assert.strictEqual(name, newDomain[i], "the data is set correctly");
         let text = d3.select(this).select("text").text();
-        assert.strictEqual(text, d, "the text was set properly");
+        assert.strictEqual(text, name, "the text was set properly");
         let fill = d3.select(this).select(SYMBOL_SELECTOR).attr("fill");
-        assert.strictEqual(fill, newColorScale.scale(d), "the fill was set properly");
+        assert.strictEqual(fill, newColorScale.scale(name), "the fill was set properly");
       });
 
       svg.remove();
@@ -139,11 +142,12 @@ describe("Legend", () => {
       const newDomain = ["a", "foo", "d"];
       newColorScale.domain(newDomain);
       legend.content().selectAll(ENTRY_SELECTOR).each(function(d: any, i: number) {
-        assert.strictEqual(d, newDomain[i], "the data is set correctly");
+        const name = d[0].data.name;
+        assert.strictEqual(name, newDomain[i], "the data is set correctly");
         const text = d3.select(this).select("text").text();
-        assert.strictEqual(text, d, "the text was set properly");
+        assert.strictEqual(text, name, "the text was set properly");
         const fill = d3.select(this).select(SYMBOL_SELECTOR).attr("fill");
-        assert.strictEqual(fill, newColorScale.scale(d), "the fill was set properly");
+        assert.strictEqual(fill, newColorScale.scale(name), "the fill was set properly");
       });
       svg.remove();
     });
@@ -206,19 +210,6 @@ describe("Legend", () => {
       svg.remove();
     });
 
-    it("requests more width if entries would be truncated", () => {
-      color.domain(["George Waaaaaashington", "John Adaaaams", "Thomaaaaas Jefferson"]);
-
-      legend.renderTo(svg); // have to be in DOM to measure
-
-      const idealSpaceRequest = legend.requestedSpace(Infinity, Infinity);
-      const constrainedRequest = legend.requestedSpace(idealSpaceRequest.minWidth * 0.9, Infinity);
-
-      assert.strictEqual(idealSpaceRequest.minWidth, constrainedRequest.minWidth,
-        "won't settle for less width if entries would be truncated");
-      svg.remove();
-    });
-
     it("truncates and hides entries if space is constrained for a horizontal legend", () => {
       svg.remove();
       svg = TestMethods.generateSVG(70, 400);
@@ -277,9 +268,10 @@ describe("Legend", () => {
       rows = legend.content().selectAll(ENTRY_SELECTOR);
 
       rows.each(function(d: any, i: number) {
+        const name = d[0].data.name;
         const row = d3.select(this);
         const symbol = row.select(SYMBOL_SELECTOR);
-        assert.strictEqual(symbol.attr("opacity"), String(opacityFunction(d, i)), "the symbol's opacity follows the provided function.");
+        assert.strictEqual(symbol.attr("opacity"), String(opacityFunction(name, i)), "the symbol's opacity follows the provided function.");
       });
       svg.remove();
     });
@@ -442,7 +434,7 @@ describe("Legend", () => {
       const colorDomain = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"];
       color.domain(colorDomain);
       legend.renderTo(svg);
-      const entryTexts = legend.content().selectAll(ENTRY_SELECTOR).data();
+      const entryTexts = legend.content().selectAll(ENTRY_SELECTOR).data().map((datum) => datum[0].data.name);
       assert.deepEqual(colorDomain, entryTexts, "displayed texts should have the same order as the legend domain");
       svg.remove();
     });

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -3,6 +3,7 @@
 describe("Legend", () => {
   const ENTRY_SELECTOR = "." + Plottable.Components.Legend.LEGEND_ENTRY_CLASS;
   const SYMBOL_SELECTOR = "." + Plottable.Components.Legend.LEGEND_SYMBOL_CLASS;
+  const TEXT_LINE_SELECTOR = ".text-line";
   const ROW_SELECTOR = "." + Plottable.Components.Legend.LEGEND_ROW_CLASS;
 
   describe("Basic Usage", () => {
@@ -147,7 +148,28 @@ describe("Legend", () => {
       svg.remove();
     });
 
-    it("can set maximun number of entries per row", () => {
+    it("can set maximum number of lines per entry", () => {
+      color.domain(["this is a very very very very very very very long"]);
+      legend.renderTo(svg);
+      legend.maxWidth(100);
+      legend.maxLinesPerEntry(2);
+      assert.strictEqual(2, legend.content().selectAll(`${ROW_SELECTOR} ${TEXT_LINE_SELECTOR}`).size());
+      legend.maxLinesPerEntry(10);
+      assert.strictEqual(4, legend.content().selectAll(`${ROW_SELECTOR} ${TEXT_LINE_SELECTOR}`).size());
+      svg.remove();
+    });
+
+   it("can set maximum width of legend", () => {
+      color.domain(["this is a very very very very very very very long"]);
+      legend.renderTo(svg);
+      legend.maxWidth(100);
+      assert.strictEqual(100, (legend.background()[0][0] as SVGElement).getBoundingClientRect().width);
+      legend.maxWidth(0);
+      assert.strictEqual(0, (legend.background()[0][0] as SVGElement).getBoundingClientRect().width);
+      svg.remove();
+    });
+
+    it("can set maximum number of entries per row", () => {
       color.domain(["AA", "BB", "CC", "DD", "EE", "FF"]);
       legend.renderTo(svg);
 
@@ -425,7 +447,7 @@ describe("Legend", () => {
       const entryTexts = legend.content().selectAll(ENTRY_SELECTOR).data();
       assert.deepEqual(colorDomain, entryTexts, "displayed texts should have the same order as the legend domain");
       svg.remove();
-      });
+    });
 
     it("sorts entries by comparator", () => {
       const newDomain = ["F", "E", "D", "C", "B", "A"];

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -163,9 +163,7 @@ describe("Legend", () => {
       color.domain(["this is a very very very very very very very long"]);
       legend.renderTo(svg);
       legend.maxWidth(100);
-      assert.strictEqual(100, (legend.background()[0][0] as SVGElement).getBoundingClientRect().width);
-      legend.maxWidth(0);
-      assert.strictEqual(0, (legend.background()[0][0] as SVGElement).getBoundingClientRect().width);
+      assert.isTrue((legend.content()[0][0] as SVGElement).getBoundingClientRect().width <= 100);
       svg.remove();
     });
 


### PR DESCRIPTION
Adds `maxWidth` property to legend
 - When defined, maxWidth restricts legend growth to at most `maxWidth` pixels.

Adds `maxLinesPerEntry` property to legend
- When defined, `maxLinesPerEntry` specifies number of times a single entry may wrap before being truncated

Refactors legend to include `LegendTable` to aid with layout calculation.