### PR TITLE
Add max for time axis tick precision.

### DIFF
--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -2107,6 +2107,7 @@ declare namespace Plottable.Axes {
          * The CSS class applied to each Time Axis tier
          */
         static TIME_AXIS_TIER_CLASS: string;
+        private static _SORTED_TIME_INTERVAL_INDEX;
         private static _DEFAULT_TIME_AXIS_CONFIGURATIONS;
         private _tierLabelContainers;
         private _tierMarkContainers;
@@ -2115,6 +2116,7 @@ declare namespace Plottable.Axes {
         private _possibleTimeAxisConfigurations;
         private _numTiers;
         private _measurer;
+        private _maxTimeIntervalPrecision;
         private _mostPreciseConfigIndex;
         private _tierLabelPositions;
         private static _LONG_DATE;
@@ -2141,6 +2143,30 @@ declare namespace Plottable.Axes {
          */
         tierLabelPositions(newPositions: string[]): this;
         /**
+         * Gets the maximum TimeInterval precision
+         */
+        maxTimeIntervalPrecision(): string;
+        /**
+         * Sets the maximum TimeInterval precision. This limits the display to not
+         * show time intervals above this precision. For example, if this is set to
+         * `TimeInterval.day` then no hours or minute ticks will be displayed in the
+         * axis.
+         *
+         * @param {TimeInterval} newPositions The positions for each tier. "bottom" and "center" are the only supported values.
+         * @returns {Axes.Time} The calling Time Axis.
+         */
+        maxTimeIntervalPrecision(newPrecision: string): this;
+        /**
+         * Returns the current `TimeAxisConfiguration` used to render the axes.
+         *
+         * Note that this is only valid after the axis had been rendered and the
+         * most precise valid configuration is determined from the available space
+         * and maximum precision constraints.
+         *
+         * @returns {TimeAxisConfiguration} The currently used `TimeAxisConfiguration` or `undefined`.
+         */
+        currentAxisConfiguration(): TimeAxisConfiguration;
+        /**
          * Gets the possible TimeAxisConfigurations.
          */
         axisConfigurations(): TimeAxisConfiguration[];
@@ -2162,9 +2188,10 @@ declare namespace Plottable.Axes {
         private _getIntervalLength(config);
         private _maxWidthForInterval(config);
         /**
-         * Check if tier configuration fits in the current width.
+         * Check if tier configuration fits in the current width and satisfied the
+         * max TimeInterval precision limit.
          */
-        private _checkTimeAxisTierConfigurationWidth(config);
+        private _checkTimeAxisTierConfiguration(config);
         protected _sizeFromOffer(availableWidth: number, availableHeight: number): {
             width: number;
             height: number;

--- a/plottable-npm.js
+++ b/plottable-npm.js
@@ -4391,6 +4391,7 @@ var Plottable;
              */
             function Time(scale, orientation) {
                 _super.call(this, scale, orientation);
+                this._maxTimeIntervalPrecision = null;
                 this._tierLabelPositions = [];
                 this.addClass("time-axis");
                 this.tickLabelPadding(5);
@@ -4409,6 +4410,28 @@ var Plottable;
                     this.redraw();
                     return this;
                 }
+            };
+            Time.prototype.maxTimeIntervalPrecision = function (newPrecision) {
+                if (newPrecision == null) {
+                    return this._maxTimeIntervalPrecision;
+                }
+                else {
+                    this._maxTimeIntervalPrecision = newPrecision;
+                    this.redraw();
+                    return this;
+                }
+            };
+            /**
+             * Returns the current `TimeAxisConfiguration` used to render the axes.
+             *
+             * Note that this is only valid after the axis had been rendered and the
+             * most precise valid configuration is determined from the available space
+             * and maximum precision constraints.
+             *
+             * @returns {TimeAxisConfiguration} The currently used `TimeAxisConfiguration` or `undefined`.
+             */
+            Time.prototype.currentAxisConfiguration = function () {
+                return this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex];
             };
             Time.prototype.axisConfigurations = function (configurations) {
                 if (configurations == null) {
@@ -4436,7 +4459,7 @@ var Plottable;
                 var mostPreciseIndex = this._possibleTimeAxisConfigurations.length;
                 this._possibleTimeAxisConfigurations.forEach(function (interval, index) {
                     if (index < mostPreciseIndex && interval.every(function (tier) {
-                        return _this._checkTimeAxisTierConfigurationWidth(tier);
+                        return _this._checkTimeAxisTierConfiguration(tier);
                     })) {
                         mostPreciseIndex = index;
                     }
@@ -4478,9 +4501,20 @@ var Plottable;
                 return this._measurer.measure(config.formatter(Time._LONG_DATE)).width;
             };
             /**
-             * Check if tier configuration fits in the current width.
+             * Check if tier configuration fits in the current width and satisfied the
+             * max TimeInterval precision limit.
              */
-            Time.prototype._checkTimeAxisTierConfigurationWidth = function (config) {
+            Time.prototype._checkTimeAxisTierConfiguration = function (config) {
+                // Use the sorted index to determine if the teir configuration contains a
+                // time interval that is too precise for the maxTimeIntervalPrecision
+                // setting (if set).
+                if (this._maxTimeIntervalPrecision != null) {
+                    var precisionLimit = Time._SORTED_TIME_INTERVAL_INDEX[this._maxTimeIntervalPrecision];
+                    var configPrecision = Time._SORTED_TIME_INTERVAL_INDEX[config.interval];
+                    if (precisionLimit != null && configPrecision != null && configPrecision < precisionLimit) {
+                        return false;
+                    }
+                }
                 var worstWidth = this._maxWidthForInterval(config) + 2 * this.tickLabelPadding();
                 return Math.min(this._getIntervalLength(config), this.width()) >= worstWidth;
             };
@@ -4720,6 +4754,16 @@ var Plottable;
              * The CSS class applied to each Time Axis tier
              */
             Time.TIME_AXIS_TIER_CLASS = "time-axis-tier";
+            Time._SORTED_TIME_INTERVAL_INDEX = (_a = {},
+                _a[Plottable.TimeInterval.second] = 0,
+                _a[Plottable.TimeInterval.minute] = 1,
+                _a[Plottable.TimeInterval.hour] = 2,
+                _a[Plottable.TimeInterval.day] = 3,
+                _a[Plottable.TimeInterval.week] = 4,
+                _a[Plottable.TimeInterval.month] = 5,
+                _a[Plottable.TimeInterval.year] = 6,
+                _a
+            );
             Time._DEFAULT_TIME_AXIS_CONFIGURATIONS = [
                 [
                     { interval: Plottable.TimeInterval.second, step: 1, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
@@ -4831,6 +4875,7 @@ var Plottable;
             ];
             Time._LONG_DATE = new Date(9999, 8, 29, 12, 59, 9999);
             return Time;
+            var _a;
         }(Plottable.Axis));
         Axes.Time = Time;
     })(Axes = Plottable.Axes || (Plottable.Axes = {}));

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -2106,6 +2106,7 @@ declare namespace Plottable.Axes {
          * The CSS class applied to each Time Axis tier
          */
         static TIME_AXIS_TIER_CLASS: string;
+        private static _SORTED_TIME_INTERVAL_INDEX;
         private static _DEFAULT_TIME_AXIS_CONFIGURATIONS;
         private _tierLabelContainers;
         private _tierMarkContainers;
@@ -2114,6 +2115,7 @@ declare namespace Plottable.Axes {
         private _possibleTimeAxisConfigurations;
         private _numTiers;
         private _measurer;
+        private _maxTimeIntervalPrecision;
         private _mostPreciseConfigIndex;
         private _tierLabelPositions;
         private static _LONG_DATE;
@@ -2140,6 +2142,30 @@ declare namespace Plottable.Axes {
          */
         tierLabelPositions(newPositions: string[]): this;
         /**
+         * Gets the maximum TimeInterval precision
+         */
+        maxTimeIntervalPrecision(): string;
+        /**
+         * Sets the maximum TimeInterval precision. This limits the display to not
+         * show time intervals above this precision. For example, if this is set to
+         * `TimeInterval.day` then no hours or minute ticks will be displayed in the
+         * axis.
+         *
+         * @param {TimeInterval} newPositions The positions for each tier. "bottom" and "center" are the only supported values.
+         * @returns {Axes.Time} The calling Time Axis.
+         */
+        maxTimeIntervalPrecision(newPrecision: string): this;
+        /**
+         * Returns the current `TimeAxisConfiguration` used to render the axes.
+         *
+         * Note that this is only valid after the axis had been rendered and the
+         * most precise valid configuration is determined from the available space
+         * and maximum precision constraints.
+         *
+         * @returns {TimeAxisConfiguration} The currently used `TimeAxisConfiguration` or `undefined`.
+         */
+        currentAxisConfiguration(): TimeAxisConfiguration;
+        /**
          * Gets the possible TimeAxisConfigurations.
          */
         axisConfigurations(): TimeAxisConfiguration[];
@@ -2161,9 +2187,10 @@ declare namespace Plottable.Axes {
         private _getIntervalLength(config);
         private _maxWidthForInterval(config);
         /**
-         * Check if tier configuration fits in the current width.
+         * Check if tier configuration fits in the current width and satisfied the
+         * max TimeInterval precision limit.
          */
-        private _checkTimeAxisTierConfigurationWidth(config);
+        private _checkTimeAxisTierConfiguration(config);
         protected _sizeFromOffer(availableWidth: number, availableHeight: number): {
             width: number;
             height: number;

--- a/plottable.js
+++ b/plottable.js
@@ -4391,6 +4391,7 @@ var Plottable;
              */
             function Time(scale, orientation) {
                 _super.call(this, scale, orientation);
+                this._maxTimeIntervalPrecision = null;
                 this._tierLabelPositions = [];
                 this.addClass("time-axis");
                 this.tickLabelPadding(5);
@@ -4409,6 +4410,28 @@ var Plottable;
                     this.redraw();
                     return this;
                 }
+            };
+            Time.prototype.maxTimeIntervalPrecision = function (newPrecision) {
+                if (newPrecision == null) {
+                    return this._maxTimeIntervalPrecision;
+                }
+                else {
+                    this._maxTimeIntervalPrecision = newPrecision;
+                    this.redraw();
+                    return this;
+                }
+            };
+            /**
+             * Returns the current `TimeAxisConfiguration` used to render the axes.
+             *
+             * Note that this is only valid after the axis had been rendered and the
+             * most precise valid configuration is determined from the available space
+             * and maximum precision constraints.
+             *
+             * @returns {TimeAxisConfiguration} The currently used `TimeAxisConfiguration` or `undefined`.
+             */
+            Time.prototype.currentAxisConfiguration = function () {
+                return this._possibleTimeAxisConfigurations[this._mostPreciseConfigIndex];
             };
             Time.prototype.axisConfigurations = function (configurations) {
                 if (configurations == null) {
@@ -4436,7 +4459,7 @@ var Plottable;
                 var mostPreciseIndex = this._possibleTimeAxisConfigurations.length;
                 this._possibleTimeAxisConfigurations.forEach(function (interval, index) {
                     if (index < mostPreciseIndex && interval.every(function (tier) {
-                        return _this._checkTimeAxisTierConfigurationWidth(tier);
+                        return _this._checkTimeAxisTierConfiguration(tier);
                     })) {
                         mostPreciseIndex = index;
                     }
@@ -4478,9 +4501,20 @@ var Plottable;
                 return this._measurer.measure(config.formatter(Time._LONG_DATE)).width;
             };
             /**
-             * Check if tier configuration fits in the current width.
+             * Check if tier configuration fits in the current width and satisfied the
+             * max TimeInterval precision limit.
              */
-            Time.prototype._checkTimeAxisTierConfigurationWidth = function (config) {
+            Time.prototype._checkTimeAxisTierConfiguration = function (config) {
+                // Use the sorted index to determine if the teir configuration contains a
+                // time interval that is too precise for the maxTimeIntervalPrecision
+                // setting (if set).
+                if (this._maxTimeIntervalPrecision != null) {
+                    var precisionLimit = Time._SORTED_TIME_INTERVAL_INDEX[this._maxTimeIntervalPrecision];
+                    var configPrecision = Time._SORTED_TIME_INTERVAL_INDEX[config.interval];
+                    if (precisionLimit != null && configPrecision != null && configPrecision < precisionLimit) {
+                        return false;
+                    }
+                }
                 var worstWidth = this._maxWidthForInterval(config) + 2 * this.tickLabelPadding();
                 return Math.min(this._getIntervalLength(config), this.width()) >= worstWidth;
             };
@@ -4720,6 +4754,16 @@ var Plottable;
              * The CSS class applied to each Time Axis tier
              */
             Time.TIME_AXIS_TIER_CLASS = "time-axis-tier";
+            Time._SORTED_TIME_INTERVAL_INDEX = (_a = {},
+                _a[Plottable.TimeInterval.second] = 0,
+                _a[Plottable.TimeInterval.minute] = 1,
+                _a[Plottable.TimeInterval.hour] = 2,
+                _a[Plottable.TimeInterval.day] = 3,
+                _a[Plottable.TimeInterval.week] = 4,
+                _a[Plottable.TimeInterval.month] = 5,
+                _a[Plottable.TimeInterval.year] = 6,
+                _a
+            );
             Time._DEFAULT_TIME_AXIS_CONFIGURATIONS = [
                 [
                     { interval: Plottable.TimeInterval.second, step: 1, formatter: Plottable.Formatters.time("%I:%M:%S %p") },
@@ -4831,6 +4875,7 @@ var Plottable;
             ];
             Time._LONG_DATE = new Date(9999, 8, 29, 12, 59, 9999);
             return Time;
+            var _a;
         }(Plottable.Axis));
         Axes.Time = Time;
     })(Axes = Plottable.Axes || (Plottable.Axes = {}));

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -228,10 +228,10 @@ namespace Plottable.Axes {
     /**
      * Sets the maximum TimeInterval precision. This limits the display to not
      * show time intervals above this precision. For example, if this is set to
-     * `TimeInterval.day` then no hours or minute ticks will be displayed in the
-     * axis.
+     * `TimeInterval.day` or `"day"` then no hours or minute ticks will be
+     * displayed in the axis.
      *
-     * @param {TimeInterval} newPositions The positions for each tier. "bottom" and "center" are the only supported values.
+     * @param {TimeInterval} newPrecision The new maximum precision.
      * @returns {Axes.Time} The calling Time Axis.
      */
     public maxTimeIntervalPrecision(newPrecision: string): this;

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -383,4 +383,51 @@ describe("TimeAxis", () => {
       svg.remove();
     });
   });
+
+  describe("limiting timeinterval precision", () => {
+    it("uses default axis config when maxTimeIntervalPrecision not set", () => {
+      let svg = TestMethods.generateSVG();
+      let axis = new Plottable.Axes.Time(new Plottable.Scales.Time(), "bottom");
+
+      axis.renderTo(svg);
+      let config = axis.currentAxisConfiguration();
+      assert.strictEqual(config.length, 2, "2 tiers");
+      assert.strictEqual(config[0].interval, "hour");
+      assert.strictEqual(config[1].interval, "day");
+
+      axis.destroy();
+      svg.remove();
+    });
+
+    it("still works when maxTimeIntervalPrecision is set high", () => {
+      let svg = TestMethods.generateSVG();
+      let axis = new Plottable.Axes.Time(new Plottable.Scales.Time(), "bottom");
+
+      axis.maxTimeIntervalPrecision("minute")
+      axis.renderTo(svg);
+      let config = axis.currentAxisConfiguration();
+      assert.strictEqual(config.length, 2, "2 tiers");
+      assert.strictEqual(config[0].interval, "hour");
+      assert.strictEqual(config[1].interval, "day");
+
+      axis.destroy();
+      svg.remove();
+    });
+
+    it("limits axis config when maxTimeIntervalPrecision is set", () => {
+      let svg = TestMethods.generateSVG();
+      let axis = new Plottable.Axes.Time(new Plottable.Scales.Time(), "bottom");
+
+      axis.maxTimeIntervalPrecision("day")
+      axis.renderTo(svg);
+      let config = axis.currentAxisConfiguration();
+      // day/month is most precise valid config after hour/day
+      assert.strictEqual(config.length, 2, "2 tiers");
+      assert.strictEqual(config[0].interval, "day");
+      assert.strictEqual(config[1].interval, "month");
+
+      axis.destroy();
+      svg.remove();
+    });
+  });
 });


### PR DESCRIPTION
Adds new property to time axes to limit how precise the
tick labels will go.

For example, setting the value of maxTimeIntervalPrecision
to "day" will prevent hours and minutes from showing
even if you are zoomed all the way in.

By default, not max is set.