### PR TITLE
Bar Labels: Remove Italics

### DIFF
--- a/plottable.css
+++ b/plottable.css
@@ -63,7 +63,6 @@ svg.plottable {
 .plottable .bar-label-text-area text {
   font-family: "Helvetica Neue", sans-serif;
   font-size: 12px;
-  font-style: italic;
 }
 
 .plottable .label-area text {


### PR DESCRIPTION
Resolves issue in IE 9+ where IE incorrectly measures
width of italic text