### PR TITLE
Routable Quicktests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "env": {
+    "es6": true,
     "browser": true,
     "jquery": true
   },

--- a/quicktests/dev/dev.js
+++ b/quicktests/dev/dev.js
@@ -1,5 +1,4 @@
 
-
 class Router {
     constructor() {
         this.routes = {};
@@ -72,7 +71,7 @@ function renderRouteList(routes) {
         `);
     });
 
-    d3.select("#app").html(links.join('\n'));
+    d3.select("#app").html(links.join("\n"));
 }
 
 function loadQuickTest(path){

--- a/quicktests/dev/dev.js
+++ b/quicktests/dev/dev.js
@@ -1,0 +1,114 @@
+
+
+class Router {
+    constructor() {
+        this.routes = {};
+    }
+
+    start() {
+        window.addEventListener("hashchange", this.route.bind(this));
+        window.addEventListener("load", this.route.bind(this));
+        this.route();
+    }
+
+    register(route) {
+        this.routes[route.route] = route;
+    }
+
+    route() {
+        this.el = this.el || document.getElementById("app");
+        const hashRoute = location.hash.slice(1) || "default";
+        const route = this.routes[hashRoute];
+
+        if (this.el && route && route != this.currentRoute) {
+            this.currentRoute = route;
+            this.el.innerHTML = "";
+            route.render(this.el);
+        } else {
+            this.currentRoute = null;
+        }
+    }
+}
+
+const PATH_PREFIX = "quicktests/overlaying/tests/";
+const PATH_SPLIT_REGEX = /(^.*?)\/([^\/]*$)/;
+const ROUTER = new Router()
+
+function loadTests() {
+  d3.json("../overlaying/list_of_quicktests.json", (data) => {
+    const routes = data.map((test) => test.path.replace(PATH_PREFIX, "").replace(/.js$/, ""));
+
+    routes.forEach((path) => {
+        ROUTER.register({
+            route: path,
+            render: () => loadQuickTest(path)
+        });
+    });
+
+    ROUTER.register({
+        route: "default",
+        render: () => renderRouteList(routes)
+    });
+
+    ROUTER.start();
+  });
+}
+
+function renderRouteList(routes) {
+    routes = routes.slice();
+    routes.sort();
+    const links = [];
+    let lastFolder = "";
+
+    routes.forEach((route) => {
+        const folder = route.replace(PATH_SPLIT_REGEX, "$1");
+        if (folder !== lastFolder) {
+            links.push(`<h2>${folder}</h2>`);
+            lastFolder = folder;
+        }
+
+        links.push(`
+            <a href="#${route}"><div class="test-link">${route}</div></a>
+        `);
+    });
+
+    d3.select("#app").html(links.join('\n'));
+}
+
+function loadQuickTest(path){
+    // clear app
+    d3.select("#app").html("");
+
+    d3.text(`../../${PATH_PREFIX}${path}.js`, (error, text) => {
+        if (error !== null) {
+            throw new Error("Error loading test: " + error);
+        }
+
+        const name = path.replace(PATH_SPLIT_REGEX, "$2");
+
+        const closure = eval(`
+            (function(){
+                ${text}
+                return { makeData, run };
+            })();
+        `);
+
+        d3.select("#app").html(`
+            <a href="#"><div>&#x3008; quicktests</div></a><br/>
+            <div class="quicktest">
+                <h2>${name}</h2>
+                <svg width=600 height=400>
+            </div>
+        `)
+
+        const svg = d3.select("#app svg");
+
+        try {
+            closure.run(svg, closure.makeData(), Plottable);
+        } catch (err) {
+            setTimeout(function(){ throw err; }, 0);
+        }
+    });
+}
+
+loadTests();

--- a/quicktests/dev/index.html
+++ b/quicktests/dev/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html> <meta charset="utf-8">
+<html>
+<head>
+    <title>Plottable Quicktests</title>
+    <style>
+        body {
+            background-color: #EEEEF0;
+            color: #433;
+            font-family: sans-serif;
+            padding: 40px 40px;
+            margin: 0 0 0 0;
+        }
+
+        a .test-link {
+            background-color: white;
+            border-radius: 5px;
+            padding: 10px 40px;
+            margin-bottom: 10px;
+            width: 400px;
+            font-size: 15px;
+        }
+
+        a .test-link:hover {
+            background-color: #F8F8FD;
+        }
+
+        a {
+            color: #433;
+            text-decoration: none;
+        }
+
+        .quicktest {
+            display: inline-block;
+            background-color: white;
+            border-radius: 5px;
+            padding: 20px 20px;
+        }
+    </style>
+    <script src="../../node_modules/jquery/dist/jquery.js" charset="utf-8"></script>
+    <script src="../../node_modules/d3/d3.js" charset="utf-8"></script>
+    <script src="../../plottable.js"></script>
+    <script src="../exampleUtil.js"></script>
+    <link rel="stylesheet" type="text/css" href="../../plottable.css">
+    <script src="dev.js" defer> </script>
+    <title>All Plottable QuickTests</title>
+</head>
+<body>
+    <div id="app"><div class="floating">Loading Tests...</div></div>
+</body>
+</html>

--- a/quicktests/index.html
+++ b/quicktests/index.html
@@ -32,6 +32,7 @@
 </head>
 <body>
     <h1>Plottable Quicktests</h1>
+    <a href="dev/index.html"><div>Dev</div></a>
     <a href="color/index.html"><div>Colors</div></a>
     <a href="overlaying/index.html"><div>Overlaying</div></a>
     <a href="maxLabelWidth.html"><div>Max Label Width</div></a>

--- a/quicktests/overlaying/tests/interactions/pan_zoom_reverse.js
+++ b/quicktests/overlaying/tests/interactions/pan_zoom_reverse.js
@@ -1,0 +1,35 @@
+function makeData() {
+  "use strict";
+  return makeRandomData(20);
+}
+
+function run(svg, data, Plottable) {
+  "use strict";
+
+  var xScale = new Plottable.Scales.Linear();
+  var yScale = new Plottable.Scales.Linear();
+
+  // set reverse domains
+  xScale.domain([2, 0]);
+  yScale.domain([2, 0]);
+
+  var scatterPlot = new Plottable.Plots.Scatter()
+    .addDataset(new Plottable.Dataset(data))
+    .x((d) => d.x, xScale)
+    .y((d) => d.y, yScale);
+
+  // layout components
+  var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
+  var yAxis = new Plottable.Axes.Numeric(yScale, "left");
+  var gridlines = new Plottable.Components.Gridlines(xScale, yScale);
+  var renderGroup = new Plottable.Components.Group([scatterPlot, gridlines]);
+  new Plottable.Components.Table([
+    [yAxis, renderGroup],
+    [null,  xAxis]
+  ]).renderTo(svg);
+
+  var interaction = new Plottable.Interactions.PanZoom(xScale, yScale);
+  interaction.attachTo(renderGroup);
+  interaction.setMinMaxDomainValuesTo(xScale);
+  interaction.setMinMaxDomainValuesTo(yScale);
+}


### PR DESCRIPTION
The "overlaying" quicktests can't be individual linked to.

Moreover livereload resets your view so you have to re-select
the tests you were working on every time.

This commit adds a simple list of tests that can be linked
to with hashroutes so livereload updates will maintain
your place and you can work with tests one at a time.