### PR TITLE
Fix pan-zoom interaction for reversed domains and ranges

### DIFF
--- a/plottable-npm.d.ts
+++ b/plottable-npm.d.ts
@@ -5103,6 +5103,12 @@ declare namespace Plottable.Interactions {
         private static _pointDistance(point1, point2);
         private _handleTouchEnd(ids, idToPoint, e);
         private _handleWheelEvent(p, e);
+        /**
+         * When scale ranges are reversed (i.e. range[1] < range[0]), we must alter the
+         * the calculations we do in screen space to constrain pan and zoom. This method
+         * returns `true` if the scale is reversed.
+         */
+        private _isRangeReversed(scale);
         private _constrainedZoom(scale, zoomAmount, centerPoint);
         private _constrainZoomExtents(scale, zoomAmount);
         private _constrainZoomValues(scale, zoomAmount, centerPoint);
@@ -5288,7 +5294,7 @@ declare namespace Plottable.Interactions {
          * This constrains the pan/zoom interaction to show no more than the domain
          * of the scale.
          */
-        setMinMaxDomainValuesTo(scale: TransformableScale<any, number>): void;
+        setMinMaxDomainValuesTo(scale: TransformableScale<any, number>): this;
         /**
          * Adds a callback to be called when panning ends.
          *

--- a/plottable-npm.js
+++ b/plottable-npm.js
@@ -12427,6 +12427,15 @@ var Plottable;
                     this._zoomEndCallbacks.callCallbacks();
                 }
             };
+            /**
+             * When scale ranges are reversed (i.e. range[1] < range[0]), we must alter the
+             * the calculations we do in screen space to constrain pan and zoom. This method
+             * returns `true` if the scale is reversed.
+             */
+            PanZoom.prototype._isRangeReversed = function (scale) {
+                var range = scale.range();
+                return range[1] < range[0];
+            };
             PanZoom.prototype._constrainedZoom = function (scale, zoomAmount, centerPoint) {
                 zoomAmount = this._constrainZoomExtents(scale, zoomAmount);
                 return this._constrainZoomValues(scale, zoomAmount, centerPoint);
@@ -12447,6 +12456,7 @@ var Plottable;
                 if (zoomAmount <= 1) {
                     return { centerPoint: centerPoint, zoomAmount: zoomAmount };
                 }
+                var reversed = this._isRangeReversed(scale);
                 var minDomain = this.minDomainValue(scale);
                 var maxDomain = this.maxDomainValue(scale);
                 // if no constraints set, we're done
@@ -12460,7 +12470,7 @@ var Plottable;
                     var currentMaxRange = scale.scaleTransformation(scaleDomainMax);
                     var testMaxRange = zoomAt(currentMaxRange, zoomAmount, centerPoint);
                     // move the center point to prevent max overflow, if necessary
-                    if (testMaxRange > maxRange) {
+                    if (testMaxRange > maxRange != reversed) {
                         centerPoint = this._getZoomCenterForTarget(currentMaxRange, zoomAmount, maxRange);
                     }
                 }
@@ -12470,7 +12480,7 @@ var Plottable;
                     var currentMinRange = scale.scaleTransformation(scaleDomainMin);
                     var testMinRange = zoomAt(currentMinRange, zoomAmount, centerPoint);
                     // move the center point to prevent min overflow, if necessary
-                    if (testMinRange < minRange) {
+                    if (testMinRange < minRange != reversed) {
                         centerPoint = this._getZoomCenterForTarget(currentMinRange, zoomAmount, minRange);
                     }
                 }
@@ -12485,7 +12495,7 @@ var Plottable;
                     // If we overflow both, use some algebra to solve for centerPoint and
                     // zoomAmount that will make the domain match the min/max exactly.
                     // Algebra brought to you by Wolfram Alpha.
-                    if (testMaxRange > maxRange || testMinRange < minRange) {
+                    if (testMaxRange > maxRange != reversed || testMinRange < minRange != reversed) {
                         var denominator = (currentMaxRange - currentMinRange + minRange - maxRange);
                         if (denominator === 0) {
                             // In this case the domains already match, so just return no-op values.
@@ -12532,12 +12542,13 @@ var Plottable;
              */
             PanZoom.prototype._constrainedTranslation = function (scale, translation) {
                 var _a = scale.getTransformationDomain(), scaleDomainMin = _a[0], scaleDomainMax = _a[1];
-                if (translation > 0) {
+                var reversed = this._isRangeReversed(scale);
+                if (translation > 0 !== reversed) {
                     var bound = this.maxDomainValue(scale);
                     if (bound != null) {
                         var currentMaxRange = scale.scaleTransformation(scaleDomainMax);
                         var maxRange = scale.scaleTransformation(bound);
-                        translation = Math.min(currentMaxRange + translation, maxRange) - currentMaxRange;
+                        translation = (reversed ? Math.max : Math.min)(currentMaxRange + translation, maxRange) - currentMaxRange;
                     }
                 }
                 else {
@@ -12545,7 +12556,7 @@ var Plottable;
                     if (bound != null) {
                         var currentMinRange = scale.scaleTransformation(scaleDomainMin);
                         var minRange = scale.scaleTransformation(bound);
-                        translation = Math.max(currentMinRange + translation, minRange) - currentMinRange;
+                        translation = (reversed ? Math.min : Math.max)(currentMinRange + translation, minRange) - currentMinRange;
                     }
                 }
                 return translation;
@@ -12670,20 +12681,12 @@ var Plottable;
                 if (minDomainValue == null) {
                     return this._minDomainValues.get(scale);
                 }
-                var maxValueForScale = this.maxDomainValue(scale);
-                if (maxValueForScale != null && maxValueForScale.valueOf() <= minDomainValue.valueOf()) {
-                    throw new Error("minDomainValue must be smaller than maxDomainValue for the same Scale");
-                }
                 this._minDomainValues.set(scale, minDomainValue);
                 return this;
             };
             PanZoom.prototype.maxDomainValue = function (scale, maxDomainValue) {
                 if (maxDomainValue == null) {
                     return this._maxDomainValues.get(scale);
-                }
-                var minValueForScale = this.minDomainValue(scale);
-                if (minValueForScale != null && maxDomainValue <= minValueForScale) {
-                    throw new Error("maxDomainValue must be larger than minDomainValue for the same Scale");
                 }
                 this._maxDomainValues.set(scale, maxDomainValue);
                 return this;
@@ -12701,6 +12704,7 @@ var Plottable;
                 var _a = scale.getTransformationDomain(), domainMin = _a[0], domainMax = _a[1];
                 this.minDomainValue(scale, domainMin);
                 this.maxDomainValue(scale, domainMax);
+                return this;
             };
             /**
              * Adds a callback to be called when panning ends.

--- a/plottable.d.ts
+++ b/plottable.d.ts
@@ -5102,6 +5102,12 @@ declare namespace Plottable.Interactions {
         private static _pointDistance(point1, point2);
         private _handleTouchEnd(ids, idToPoint, e);
         private _handleWheelEvent(p, e);
+        /**
+         * When scale ranges are reversed (i.e. range[1] < range[0]), we must alter the
+         * the calculations we do in screen space to constrain pan and zoom. This method
+         * returns `true` if the scale is reversed.
+         */
+        private _isRangeReversed(scale);
         private _constrainedZoom(scale, zoomAmount, centerPoint);
         private _constrainZoomExtents(scale, zoomAmount);
         private _constrainZoomValues(scale, zoomAmount, centerPoint);
@@ -5287,7 +5293,7 @@ declare namespace Plottable.Interactions {
          * This constrains the pan/zoom interaction to show no more than the domain
          * of the scale.
          */
-        setMinMaxDomainValuesTo(scale: TransformableScale<any, number>): void;
+        setMinMaxDomainValuesTo(scale: TransformableScale<any, number>): this;
         /**
          * Adds a callback to be called when panning ends.
          *

--- a/plottable.js
+++ b/plottable.js
@@ -12427,6 +12427,15 @@ var Plottable;
                     this._zoomEndCallbacks.callCallbacks();
                 }
             };
+            /**
+             * When scale ranges are reversed (i.e. range[1] < range[0]), we must alter the
+             * the calculations we do in screen space to constrain pan and zoom. This method
+             * returns `true` if the scale is reversed.
+             */
+            PanZoom.prototype._isRangeReversed = function (scale) {
+                var range = scale.range();
+                return range[1] < range[0];
+            };
             PanZoom.prototype._constrainedZoom = function (scale, zoomAmount, centerPoint) {
                 zoomAmount = this._constrainZoomExtents(scale, zoomAmount);
                 return this._constrainZoomValues(scale, zoomAmount, centerPoint);
@@ -12447,6 +12456,7 @@ var Plottable;
                 if (zoomAmount <= 1) {
                     return { centerPoint: centerPoint, zoomAmount: zoomAmount };
                 }
+                var reversed = this._isRangeReversed(scale);
                 var minDomain = this.minDomainValue(scale);
                 var maxDomain = this.maxDomainValue(scale);
                 // if no constraints set, we're done
@@ -12460,7 +12470,7 @@ var Plottable;
                     var currentMaxRange = scale.scaleTransformation(scaleDomainMax);
                     var testMaxRange = zoomAt(currentMaxRange, zoomAmount, centerPoint);
                     // move the center point to prevent max overflow, if necessary
-                    if (testMaxRange > maxRange) {
+                    if (testMaxRange > maxRange != reversed) {
                         centerPoint = this._getZoomCenterForTarget(currentMaxRange, zoomAmount, maxRange);
                     }
                 }
@@ -12470,7 +12480,7 @@ var Plottable;
                     var currentMinRange = scale.scaleTransformation(scaleDomainMin);
                     var testMinRange = zoomAt(currentMinRange, zoomAmount, centerPoint);
                     // move the center point to prevent min overflow, if necessary
-                    if (testMinRange < minRange) {
+                    if (testMinRange < minRange != reversed) {
                         centerPoint = this._getZoomCenterForTarget(currentMinRange, zoomAmount, minRange);
                     }
                 }
@@ -12485,7 +12495,7 @@ var Plottable;
                     // If we overflow both, use some algebra to solve for centerPoint and
                     // zoomAmount that will make the domain match the min/max exactly.
                     // Algebra brought to you by Wolfram Alpha.
-                    if (testMaxRange > maxRange || testMinRange < minRange) {
+                    if (testMaxRange > maxRange != reversed || testMinRange < minRange != reversed) {
                         var denominator = (currentMaxRange - currentMinRange + minRange - maxRange);
                         if (denominator === 0) {
                             // In this case the domains already match, so just return no-op values.
@@ -12532,12 +12542,13 @@ var Plottable;
              */
             PanZoom.prototype._constrainedTranslation = function (scale, translation) {
                 var _a = scale.getTransformationDomain(), scaleDomainMin = _a[0], scaleDomainMax = _a[1];
-                if (translation > 0) {
+                var reversed = this._isRangeReversed(scale);
+                if (translation > 0 !== reversed) {
                     var bound = this.maxDomainValue(scale);
                     if (bound != null) {
                         var currentMaxRange = scale.scaleTransformation(scaleDomainMax);
                         var maxRange = scale.scaleTransformation(bound);
-                        translation = Math.min(currentMaxRange + translation, maxRange) - currentMaxRange;
+                        translation = (reversed ? Math.max : Math.min)(currentMaxRange + translation, maxRange) - currentMaxRange;
                     }
                 }
                 else {
@@ -12545,7 +12556,7 @@ var Plottable;
                     if (bound != null) {
                         var currentMinRange = scale.scaleTransformation(scaleDomainMin);
                         var minRange = scale.scaleTransformation(bound);
-                        translation = Math.max(currentMinRange + translation, minRange) - currentMinRange;
+                        translation = (reversed ? Math.min : Math.max)(currentMinRange + translation, minRange) - currentMinRange;
                     }
                 }
                 return translation;
@@ -12670,20 +12681,12 @@ var Plottable;
                 if (minDomainValue == null) {
                     return this._minDomainValues.get(scale);
                 }
-                var maxValueForScale = this.maxDomainValue(scale);
-                if (maxValueForScale != null && maxValueForScale.valueOf() <= minDomainValue.valueOf()) {
-                    throw new Error("minDomainValue must be smaller than maxDomainValue for the same Scale");
-                }
                 this._minDomainValues.set(scale, minDomainValue);
                 return this;
             };
             PanZoom.prototype.maxDomainValue = function (scale, maxDomainValue) {
                 if (maxDomainValue == null) {
                     return this._maxDomainValues.get(scale);
-                }
-                var minValueForScale = this.minDomainValue(scale);
-                if (minValueForScale != null && maxDomainValue <= minValueForScale) {
-                    throw new Error("maxDomainValue must be larger than minDomainValue for the same Scale");
                 }
                 this._maxDomainValues.set(scale, maxDomainValue);
                 return this;
@@ -12701,6 +12704,7 @@ var Plottable;
                 var _a = scale.getTransformationDomain(), domainMin = _a[0], domainMax = _a[1];
                 this.minDomainValue(scale, domainMin);
                 this.maxDomainValue(scale, domainMax);
+                return this;
             };
             /**
              * Adds a callback to be called when panning ends.

--- a/quicktests/overlaying/tests/interactions/pan_zoom_reverse.js
+++ b/quicktests/overlaying/tests/interactions/pan_zoom_reverse.js
@@ -6,30 +6,34 @@ function makeData() {
 function run(svg, data, Plottable) {
   "use strict";
 
-  var xScale = new Plottable.Scales.Linear();
-  var yScale = new Plottable.Scales.Linear();
+  function makePlot(xDomain, yDomain) {
+    const xScale = new Plottable.Scales.Linear().domain(xDomain);
+    const yScale = new Plottable.Scales.Linear().domain(yDomain);
+    const scatterPlot = new Plottable.Plots.Scatter()
+      .addDataset(new Plottable.Dataset(data))
+      .x((d) => d.x, xScale)
+      .y((d) => d.y, yScale);
 
-  // set reverse domains
-  xScale.domain([2, 0]);
-  yScale.domain([2, 0]);
+    // layout components
+    const xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
+    const yAxis = new Plottable.Axes.Numeric(yScale, "left");
+    const gridlines = new Plottable.Components.Gridlines(xScale, yScale);
+    const renderGroup = new Plottable.Components.Group([scatterPlot, gridlines]);
+    const table = new Plottable.Components.Table([
+      [yAxis, renderGroup],
+      [null,  xAxis],
+    ]);
 
-  var scatterPlot = new Plottable.Plots.Scatter()
-    .addDataset(new Plottable.Dataset(data))
-    .x((d) => d.x, xScale)
-    .y((d) => d.y, yScale);
+    new Plottable.Interactions.PanZoom(xScale, yScale)
+      .attachTo(renderGroup)
+      .setMinMaxDomainValuesTo(xScale)
+      .setMinMaxDomainValuesTo(yScale);
 
-  // layout components
-  var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
-  var yAxis = new Plottable.Axes.Numeric(yScale, "left");
-  var gridlines = new Plottable.Components.Gridlines(xScale, yScale);
-  var renderGroup = new Plottable.Components.Group([scatterPlot, gridlines]);
+    return table;
+  }
+
   new Plottable.Components.Table([
-    [yAxis, renderGroup],
-    [null,  xAxis]
+    [makePlot([3, -1], [3, -1]), makePlot([-1, 3], [3, -1])],
+    [makePlot([3, -1], [-1, 3]), makePlot([-1, 3], [-1, 3])],
   ]).renderTo(svg);
-
-  var interaction = new Plottable.Interactions.PanZoom(xScale, yScale);
-  interaction.attachTo(renderGroup);
-  interaction.setMinMaxDomainValuesTo(xScale);
-  interaction.setMinMaxDomainValuesTo(yScale);
 }

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -81,6 +81,7 @@ namespace Plottable.Interactions {
         yScale.pan(this._constrainedTranslation(yScale, translateAmount.y));
       });
     }
+
     /**
      * Zooms the chart by a specified amount around a specific point
      *
@@ -269,6 +270,16 @@ namespace Plottable.Interactions {
       }
     }
 
+    /**
+     * When scale ranges are reversed (i.e. range[1] < range[0]), we must alter the
+     * the calculations we do in screen space to constrain pan and zoom. This method
+     * returns `true` if the scale is reversed.
+     */
+    private _isRangeReversed(scale: TransformableScale<any, number>): boolean {
+      const range = scale.range();
+      return range[1] < range[0];
+    }
+
     private _constrainedZoom(scale: TransformableScale<any, number>, zoomAmount: number, centerPoint: number) {
       zoomAmount = this._constrainZoomExtents(scale, zoomAmount);
       return this._constrainZoomValues(scale, zoomAmount, centerPoint);
@@ -292,6 +303,7 @@ namespace Plottable.Interactions {
         return { centerPoint, zoomAmount };
       }
 
+      const reversed = this._isRangeReversed(scale);
       const minDomain = this.minDomainValue(scale);
       const maxDomain = this.maxDomainValue(scale);
 
@@ -309,7 +321,7 @@ namespace Plottable.Interactions {
         const testMaxRange = zoomAt(currentMaxRange, zoomAmount, centerPoint);
 
         // move the center point to prevent max overflow, if necessary
-        if (testMaxRange > maxRange) {
+        if (testMaxRange > maxRange != reversed) {
           centerPoint = this._getZoomCenterForTarget(currentMaxRange, zoomAmount, maxRange);
         }
       }
@@ -321,7 +333,7 @@ namespace Plottable.Interactions {
         const testMinRange = zoomAt(currentMinRange, zoomAmount, centerPoint);
 
         // move the center point to prevent min overflow, if necessary
-        if (testMinRange < minRange) {
+        if (testMinRange < minRange != reversed) {
           centerPoint = this._getZoomCenterForTarget(currentMinRange, zoomAmount, minRange);
         }
       }
@@ -339,7 +351,7 @@ namespace Plottable.Interactions {
         // If we overflow both, use some algebra to solve for centerPoint and
         // zoomAmount that will make the domain match the min/max exactly.
         // Algebra brought to you by Wolfram Alpha.
-        if (testMaxRange > maxRange || testMinRange < minRange) {
+        if (testMaxRange > maxRange != reversed || testMinRange < minRange != reversed) {
           const denominator = (currentMaxRange - currentMinRange + minRange - maxRange);
           if (denominator === 0) {
             // In this case the domains already match, so just return no-op values.
@@ -392,21 +404,24 @@ namespace Plottable.Interactions {
      */
     private _constrainedTranslation(scale: TransformableScale<any, number>, translation: number) {
       const [ scaleDomainMin, scaleDomainMax ] = scale.getTransformationDomain();
-      if (translation > 0) {
+      const reversed = this._isRangeReversed(scale);
+
+      if (translation > 0 !== reversed) {
         const bound = this.maxDomainValue(scale);
         if (bound != null) {
           const currentMaxRange = scale.scaleTransformation(scaleDomainMax);
           const maxRange = scale.scaleTransformation(bound);
-          translation = Math.min(currentMaxRange + translation, maxRange) - currentMaxRange;
+          translation = (reversed ? Math.max : Math.min)(currentMaxRange + translation, maxRange) - currentMaxRange;
         }
       } else {
         const bound = this.minDomainValue(scale);
         if (bound != null) {
           const currentMinRange = scale.scaleTransformation(scaleDomainMin);
           const minRange = scale.scaleTransformation(bound);
-          translation = Math.max(currentMinRange + translation, minRange) - currentMinRange;
+          translation = (reversed ? Math.min : Math.max)(currentMinRange + translation, minRange) - currentMinRange;
         }
       }
+
       return translation;
     }
 
@@ -640,10 +655,6 @@ namespace Plottable.Interactions {
       if (minDomainValue == null) {
         return this._minDomainValues.get(scale);
       }
-      let maxValueForScale = this.maxDomainValue(scale);
-      if (maxValueForScale != null && maxValueForScale.valueOf() <= minDomainValue.valueOf()) {
-        throw new Error("minDomainValue must be smaller than maxDomainValue for the same Scale");
-      }
       this._minDomainValues.set(scale, minDomainValue);
       return this;
     }
@@ -683,10 +694,6 @@ namespace Plottable.Interactions {
       if (maxDomainValue == null) {
         return this._maxDomainValues.get(scale);
       }
-      let minValueForScale = this.minDomainValue(scale);
-      if (minValueForScale != null && maxDomainValue <= minValueForScale) {
-        throw new Error("maxDomainValue must be larger than minDomainValue for the same Scale");
-      }
       this._maxDomainValues.set(scale, maxDomainValue);
       return this;
     }
@@ -704,6 +711,7 @@ namespace Plottable.Interactions {
       const [ domainMin, domainMax ] = scale.getTransformationDomain();
       this.minDomainValue(scale, domainMin);
       this.maxDomainValue(scale, domainMax);
+      return this;
     }
 
     /**

--- a/test/interactions/panZoomInteractionTests.ts
+++ b/test/interactions/panZoomInteractionTests.ts
@@ -616,17 +616,6 @@ describe("Interactions", () => {
           "returns the correct minDomainValue");
       });
 
-      it("can't set minDomainValue() be larger than maxDomainValue() for the same Scale", () => {
-        let domainValue = SVG_WIDTH / 2;
-        panZoomInteraction.maxDomainValue(xScale, domainValue);
-
-        let tooBigValue = domainValue * 2;
-        // HACKHACK #2661: Cannot assert errors being thrown with description
-        (<any> assert).throws(() => panZoomInteraction.minDomainValue(xScale, tooBigValue), Error,
-          "minDomainValue must be smaller than maxDomainValue for the same Scale",
-          "cannot have minDomainValue larger than maxDomainValue");
-      });
-
       it("cannot go beyond the specified minDomainValue (mousewheel)", () => {
         // HACKHACK PhantomJS doesn't implement fake creation of WheelEvents
         // https://github.com/ariya/phantomjs/issues/11289
@@ -709,17 +698,6 @@ describe("Interactions", () => {
         panZoomInteraction.maxDomainValue(xScale, domainValue);
         assert.strictEqual(panZoomInteraction.maxDomainValue(xScale), domainValue,
           "returns the correct minDomainValue");
-      });
-
-      it("can't set maxDomainValue() be smaller than maxDomainValue() for the same Scale", () => {
-        let domainValue = SVG_WIDTH / 2;
-        panZoomInteraction.minDomainValue(xScale, domainValue);
-
-        let tooSmallValue = domainValue / 2;
-        // HACKHACK #2661: Cannot assert errors being thrown with description
-        (<any> assert).throws(() => panZoomInteraction.maxDomainValue(xScale, tooSmallValue), Error,
-          "maxDomainValue must be larger than minDomainValue for the same Scale",
-          "cannot have minDomainValue larger than maxDomainValue");
       });
 
       it("cannot go beyond the specified maxDomainValue (mousewheel)", () => {


### PR DESCRIPTION
Domains with max < min (like [-10, 0]) work just fine
with the pan-zoom interaction, but we had explicit tests
disabling this. The commit removes those conditions and
removes the unit tests that confirmed this.

However, there was an issue with reversed ranges since
all pan-zoom constraint calculations happen in range space.
This commit includes fixes for those calculations and
adds a quicktest that has every combination of x/y reversing
in scatter plots.