### PR TITLE
add license header to source files

### DIFF
--- a/license_header.txt
+++ b/license_header.txt
@@ -1,5 +1,5 @@
 /*!
 Plottable @VERSION (https://github.com/palantir/plottable)
-Copyright 2014-2017 Palantir Technologies
+Copyright 2014-present Palantir Technologies
 Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
 */

--- a/plottable.js
+++ b/plottable.js
@@ -87,6 +87,10 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -121,6 +125,10 @@ module.exports = __WEBPACK_EXTERNAL_MODULE_1__;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -154,6 +162,10 @@ exports.isTransformable = isTransformable;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -671,6 +683,10 @@ __export(__webpack_require__(111));
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var d3 = __webpack_require__(1);
 var RenderController = __webpack_require__(24);
@@ -1223,6 +1239,10 @@ exports.Component = Component;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -1236,6 +1256,10 @@ __export(__webpack_require__(50));
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var d3 = __webpack_require__(1);
 var Utils = __webpack_require__(0);
@@ -1377,6 +1401,10 @@ exports.Drawer = Drawer;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var d3 = __webpack_require__(1);
 /**
@@ -1617,6 +1645,10 @@ function verifyPrecision(precision) {
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -1635,6 +1667,10 @@ __export(__webpack_require__(71));
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -1901,6 +1937,10 @@ exports.QuantitativeScale = QuantitativeScale;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -1915,6 +1955,10 @@ __export(__webpack_require__(64));
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var Interaction = (function () {
     function Interaction() {
@@ -2034,6 +2078,10 @@ __export(__webpack_require__(108));
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -2051,6 +2099,10 @@ __export(__webpack_require__(76));
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -2412,6 +2464,10 @@ exports.XYPlot = XYPlot;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -2435,6 +2491,10 @@ __export(__webpack_require__(84));
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var Utils = __webpack_require__(0);
 var Scale = (function () {
@@ -2588,6 +2648,10 @@ exports.Scale = Scale;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -3219,6 +3283,10 @@ exports.Axis = Axis;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 /**
  * Specifies if Plottable should show warnings.
@@ -3235,6 +3303,10 @@ exports.ADD_TITLE_ELEMENTS = true;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var Utils = __webpack_require__(0);
 var Dispatcher = (function () {
@@ -3306,6 +3378,10 @@ exports.Dispatcher = Dispatcher;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -3934,6 +4010,10 @@ exports.Bar = Bar;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -4464,6 +4544,10 @@ exports.Time = Time;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -4549,6 +4633,10 @@ exports.ComponentContainer = ComponentContainer;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var Utils = __webpack_require__(0);
 var RenderPolicies = __webpack_require__(30);
@@ -4679,6 +4767,10 @@ exports.flush = flush;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var d3 = __webpack_require__(1);
 function circle() {
@@ -4712,6 +4804,10 @@ exports.triangleDown = triangleDown;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -5091,6 +5187,10 @@ exports.DragBoxLayer = DragBoxLayer;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var d3 = __webpack_require__(1);
 var nativeMath = window.Math;
@@ -5295,6 +5395,10 @@ exports.BaseAnimator = BaseAnimator;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -5330,6 +5434,10 @@ exports.Alignment = Alignment;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var Utils = __webpack_require__(0);
 var RenderController = __webpack_require__(24);
@@ -5381,6 +5489,10 @@ exports.Timeout = Timeout;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -5503,6 +5615,10 @@ exports.Key = Key;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -5603,6 +5719,10 @@ exports.Group = Group;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -5755,6 +5875,10 @@ exports.GuideLineLayer = GuideLineLayer;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -5980,6 +6104,10 @@ exports.SelectionBoxLayer = SelectionBoxLayer;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -6168,6 +6296,10 @@ exports.Area = Area;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var Animator;
 (function (Animator) {
@@ -6181,6 +6313,10 @@ var Animator;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -6628,6 +6764,10 @@ exports.Line = Line;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -6784,6 +6924,10 @@ exports.Category = Category;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var d3 = __webpack_require__(1);
 var nativeMath = window.Math;
@@ -6986,6 +7130,10 @@ function _parseStyleValue(style, property) {
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 /**
  * Shim for ES6 set.
@@ -7493,6 +7641,10 @@ exports.Wrapper = Wrapper;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -7507,6 +7659,10 @@ __export(__webpack_require__(22));
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var Utils = __webpack_require__(0);
 var Dataset = (function () {
@@ -7575,6 +7731,10 @@ exports.Dataset = Dataset;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 exports.version = "2.9.0";
 
@@ -7584,6 +7744,10 @@ exports.version = "2.9.0";
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 /**
  * An Animator with easing and configurable durations and delays.
@@ -7699,6 +7863,10 @@ exports.Easing = Easing;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 /**
  * An animator implementation with no animation. The attributes are
@@ -7723,6 +7891,10 @@ exports.Null = Null;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -8068,6 +8240,10 @@ exports.Category = Category;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -8370,6 +8546,10 @@ exports.Numeric = Numeric;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -8555,6 +8735,10 @@ exports.DragLineLayer = DragLineLayer;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -8661,6 +8845,10 @@ exports.Gridlines = Gridlines;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -8916,6 +9104,10 @@ exports.InterpolatedColorLegend = InterpolatedColorLegend;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -9074,6 +9266,10 @@ exports.AxisLabel = AxisLabel;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -9570,6 +9766,10 @@ exports.Legend = Legend;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -9623,6 +9823,10 @@ exports.PlotGroup = PlotGroup;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -10018,6 +10222,10 @@ exports.Table = Table;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -10080,6 +10288,10 @@ exports.XDragBoxLayer = XDragBoxLayer;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -10142,6 +10354,10 @@ exports.YDragBoxLayer = YDragBoxLayer;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -10234,6 +10450,10 @@ exports.Key = Key;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -10430,6 +10650,10 @@ exports.Mouse = Mouse;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -10602,6 +10826,10 @@ exports.Touch = Touch;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -10630,6 +10858,10 @@ exports.Arc = Arc;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -10658,6 +10890,10 @@ exports.ArcOutline = ArcOutline;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -10690,6 +10926,10 @@ exports.Area = Area;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -10722,6 +10962,10 @@ exports.Line = Line;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -10745,6 +10989,10 @@ exports.Rectangle = Rectangle;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -10768,6 +11016,10 @@ exports.Segment = Segment;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -10792,6 +11044,10 @@ exports.Symbol = Symbol;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -10877,6 +11133,10 @@ exports.Click = Click;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -10992,6 +11252,10 @@ exports.DoubleClick = DoubleClick;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -11153,6 +11417,10 @@ exports.Drag = Drag;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -11707,6 +11975,10 @@ exports.PanZoom = PanZoom;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -11834,6 +12106,10 @@ exports.Pointer = Pointer;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -11903,6 +12179,10 @@ exports.ClusteredBar = ClusteredBar;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -12395,6 +12675,10 @@ exports.Pie = Pie;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -12757,6 +13041,10 @@ exports.Rectangle = Rectangle;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -12931,6 +13219,10 @@ exports.Scatter = Scatter;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -13125,6 +13417,10 @@ exports.Segment = Segment;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -13324,6 +13620,10 @@ exports.StackedArea = StackedArea;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -13528,6 +13828,10 @@ exports.StackedBar = StackedBar;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -13735,6 +14039,10 @@ exports.Waterfall = Waterfall;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -13862,6 +14170,10 @@ exports.Color = Color;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -14024,6 +14336,10 @@ exports.InterpolatedColor = InterpolatedColor;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -14099,6 +14415,10 @@ exports.Linear = Linear;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -14319,6 +14639,10 @@ exports.ModifiedLog = ModifiedLog;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var Utils = __webpack_require__(0);
 /**
@@ -14365,6 +14689,10 @@ exports.integerTickGenerator = integerTickGenerator;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -14496,6 +14824,10 @@ exports.Time = Time;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var d3 = __webpack_require__(1);
 var nativeArray = window.Array;
@@ -14562,6 +14894,10 @@ exports.createFilledArray = createFilledArray;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -14600,6 +14936,10 @@ exports.CallbackSet = CallbackSet;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var DOM = __webpack_require__(39);
 var ClientToSVGTranslator = (function () {
@@ -14674,6 +15014,10 @@ exports.ClientToSVGTranslator = ClientToSVGTranslator;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var d3 = __webpack_require__(1);
 var nativeMath = window.Math;
@@ -14753,6 +15097,10 @@ function luminance(color) {
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var Math = __webpack_require__(27);
 /**
@@ -14800,6 +15148,10 @@ exports.EntityArray = EntityArray;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var Math = __webpack_require__(27);
 /**
@@ -14887,6 +15239,10 @@ exports.Map = Map;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var d3 = __webpack_require__(1);
 var Utils = __webpack_require__(0);
@@ -15007,6 +15363,10 @@ exports.normalizeKey = normalizeKey;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
 
 var Configs = __webpack_require__(19);
 /**

--- a/src/animators/animator.ts
+++ b/src/animators/animator.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/animators/animator.ts
+++ b/src/animators/animator.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { AttributeToAppliedProjector } from "../core/interfaces";

--- a/src/animators/easingAnimator.ts
+++ b/src/animators/easingAnimator.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/animators/easingAnimator.ts
+++ b/src/animators/easingAnimator.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Animator } from "./animator";

--- a/src/animators/index.ts
+++ b/src/animators/index.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 export * from "./easingAnimator";
 export * from "./nullAnimator";
 

--- a/src/animators/index.ts
+++ b/src/animators/index.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 export * from "./easingAnimator";
 export * from "./nullAnimator";

--- a/src/animators/nullAnimator.ts
+++ b/src/animators/nullAnimator.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/animators/nullAnimator.ts
+++ b/src/animators/nullAnimator.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Animator } from "./animator";

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 
 import * as d3 from "d3";

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 
 import * as d3 from "d3";
 import * as SVGTypewriter from "svg-typewriter";

--- a/src/axes/categoryAxis.ts
+++ b/src/axes/categoryAxis.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 import * as SVGTypewriter from "svg-typewriter";

--- a/src/axes/categoryAxis.ts
+++ b/src/axes/categoryAxis.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 import * as SVGTypewriter from "svg-typewriter";
 

--- a/src/axes/index.ts
+++ b/src/axes/index.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 export * from "./categoryAxis";
 export * from "./numericAxis";

--- a/src/axes/index.ts
+++ b/src/axes/index.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 export * from "./categoryAxis";
 export * from "./numericAxis";
 export * from "./timeAxis";

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 import * as SVGTypewriter from "svg-typewriter";

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 import * as SVGTypewriter from "svg-typewriter";
 

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 import * as SVGTypewriter from "svg-typewriter";

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 import * as SVGTypewriter from "svg-typewriter";
 

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Point, SpaceRequest, Bounds } from "../core/interfaces";

--- a/src/components/componentContainer.ts
+++ b/src/components/componentContainer.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/components/componentContainer.ts
+++ b/src/components/componentContainer.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Component, ComponentCallback } from "./component";

--- a/src/components/dragBoxLayer.ts
+++ b/src/components/dragBoxLayer.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/components/dragBoxLayer.ts
+++ b/src/components/dragBoxLayer.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Bounds, Point } from "../core/interfaces";

--- a/src/components/dragLineLayer.ts
+++ b/src/components/dragLineLayer.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { GuideLineLayer } from "../components/guideLineLayer";
 import { Point } from "../core/interfaces";

--- a/src/components/dragLineLayer.ts
+++ b/src/components/dragLineLayer.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { GuideLineLayer } from "../components/guideLineLayer";
 import { Point } from "../core/interfaces";
 import * as Interactions from "../interactions";

--- a/src/components/gridlines.ts
+++ b/src/components/gridlines.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 
 import * as d3 from "d3";

--- a/src/components/gridlines.ts
+++ b/src/components/gridlines.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 
 import * as d3 from "d3";
 

--- a/src/components/group.ts
+++ b/src/components/group.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { SpaceRequest, Point } from "../core/interfaces";
 import * as Utils from "../utils";

--- a/src/components/group.ts
+++ b/src/components/group.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { SpaceRequest, Point } from "../core/interfaces";
 import * as Utils from "../utils";
 

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Point } from "../core/interfaces";
 import { QuantitativeScale } from "../scales/quantitativeScale";

--- a/src/components/guideLineLayer.ts
+++ b/src/components/guideLineLayer.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Point } from "../core/interfaces";
 import { QuantitativeScale } from "../scales/quantitativeScale";
 import { ScaleCallback } from "../scales/scale";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 export * from "./dragBoxLayer";
 export * from "./dragLineLayer";
 export * from "./gridlines";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 export * from "./dragBoxLayer";
 export * from "./dragLineLayer";

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as SVGTypewriter from "svg-typewriter";
 
 import * as Configs from "../core/config";

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as SVGTypewriter from "svg-typewriter";
 

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as SVGTypewriter from "svg-typewriter";
 
 import { SpaceRequest } from "../core/interfaces";

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as SVGTypewriter from "svg-typewriter";
 

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 import * as SVGTypewriter from "svg-typewriter";

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 import * as SVGTypewriter from "svg-typewriter";
 

--- a/src/components/plotGroup.ts
+++ b/src/components/plotGroup.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Point } from "../core/interfaces";
 import * as Plots from "../plots";

--- a/src/components/plotGroup.ts
+++ b/src/components/plotGroup.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Point } from "../core/interfaces";
 import * as Plots from "../plots";
 import { Plot } from "../plots/plot";

--- a/src/components/selectionBoxLayer.ts
+++ b/src/components/selectionBoxLayer.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/components/selectionBoxLayer.ts
+++ b/src/components/selectionBoxLayer.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Bounds, Point } from "../core/interfaces";

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Point, SpaceRequest } from "../core/interfaces";

--- a/src/components/xDragBoxLayer.ts
+++ b/src/components/xDragBoxLayer.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Point, Bounds } from "../core/interfaces";
 import { QuantitativeScale } from "../scales/quantitativeScale";

--- a/src/components/xDragBoxLayer.ts
+++ b/src/components/xDragBoxLayer.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Point, Bounds } from "../core/interfaces";
 import { QuantitativeScale } from "../scales/quantitativeScale";
 

--- a/src/components/yDragBoxLayer.ts
+++ b/src/components/yDragBoxLayer.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Point, Bounds } from "../core/interfaces";
 import { QuantitativeScale } from "../scales/quantitativeScale";

--- a/src/components/yDragBoxLayer.ts
+++ b/src/components/yDragBoxLayer.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Point, Bounds } from "../core/interfaces";
 import { QuantitativeScale } from "../scales/quantitativeScale";
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 /**
  * Specifies if Plottable should show warnings.
  */

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 /**
  * Specifies if Plottable should show warnings.

--- a/src/core/dataset.ts
+++ b/src/core/dataset.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as Utils from "../utils";
 

--- a/src/core/dataset.ts
+++ b/src/core/dataset.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as Utils from "../utils";
 
 export type DatasetCallback = (dataset: Dataset) => void;

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 export type Formatter = (d: any) => string;

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Dataset } from "./dataset";

--- a/src/core/renderController.ts
+++ b/src/core/renderController.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Component } from "../components/component";
 import * as Utils from "../utils";
 

--- a/src/core/renderController.ts
+++ b/src/core/renderController.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Component } from "../components/component";
 import * as Utils from "../utils";

--- a/src/core/renderPolicy.ts
+++ b/src/core/renderPolicy.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as Utils from "../utils";
 

--- a/src/core/renderPolicy.ts
+++ b/src/core/renderPolicy.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as Utils from "../utils";
 
 import * as RenderController from "./renderController";

--- a/src/core/symbolFactories.ts
+++ b/src/core/symbolFactories.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/core/symbolFactories.ts
+++ b/src/core/symbolFactories.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 /**

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,1 +1,6 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 export var version = "@VERSION";

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,6 +1,6 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 export var version = "@VERSION";

--- a/src/dispatchers/dispatcher.ts
+++ b/src/dispatchers/dispatcher.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as Utils from "../utils";
 

--- a/src/dispatchers/dispatcher.ts
+++ b/src/dispatchers/dispatcher.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as Utils from "../utils";
 
 export class Dispatcher {

--- a/src/dispatchers/index.ts
+++ b/src/dispatchers/index.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 export * from "./keyDispatcher";
 export * from "./mouseDispatcher";

--- a/src/dispatchers/index.ts
+++ b/src/dispatchers/index.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 export * from "./keyDispatcher";
 export * from "./mouseDispatcher";
 export * from "./touchDispatcher";

--- a/src/dispatchers/keyDispatcher.ts
+++ b/src/dispatchers/keyDispatcher.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Dispatcher } from "./dispatcher";
 import * as Dispatchers from "./";
 

--- a/src/dispatchers/keyDispatcher.ts
+++ b/src/dispatchers/keyDispatcher.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Dispatcher } from "./dispatcher";
 import * as Dispatchers from "./";

--- a/src/dispatchers/mouseDispatcher.ts
+++ b/src/dispatchers/mouseDispatcher.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Point } from "../core/interfaces";
 import * as Utils from "../utils";
 

--- a/src/dispatchers/mouseDispatcher.ts
+++ b/src/dispatchers/mouseDispatcher.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Point } from "../core/interfaces";
 import * as Utils from "../utils";

--- a/src/dispatchers/touchDispatcher.ts
+++ b/src/dispatchers/touchDispatcher.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Point } from "../core/interfaces";
 import * as Utils from "../utils";
 

--- a/src/dispatchers/touchDispatcher.ts
+++ b/src/dispatchers/touchDispatcher.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Point } from "../core/interfaces";
 import * as Utils from "../utils";

--- a/src/drawers/arcDrawer.ts
+++ b/src/drawers/arcDrawer.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/drawers/arcDrawer.ts
+++ b/src/drawers/arcDrawer.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Dataset } from "../core/dataset";

--- a/src/drawers/arcOutlineDrawer.ts
+++ b/src/drawers/arcOutlineDrawer.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/drawers/arcOutlineDrawer.ts
+++ b/src/drawers/arcOutlineDrawer.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Dataset } from "../core/dataset";

--- a/src/drawers/areaDrawer.ts
+++ b/src/drawers/areaDrawer.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/drawers/areaDrawer.ts
+++ b/src/drawers/areaDrawer.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Dataset } from "../core/dataset";

--- a/src/drawers/drawer.ts
+++ b/src/drawers/drawer.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 import * as Utils from "../utils";

--- a/src/drawers/drawer.ts
+++ b/src/drawers/drawer.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 import * as Utils from "../utils";
 

--- a/src/drawers/index.ts
+++ b/src/drawers/index.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Animator } from "../animators/animator";
 import { AttributeToProjector, AttributeToAppliedProjector } from "../core/interfaces";

--- a/src/drawers/index.ts
+++ b/src/drawers/index.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Animator } from "../animators/animator";
 import { AttributeToProjector, AttributeToAppliedProjector } from "../core/interfaces";
 

--- a/src/drawers/lineDrawer.ts
+++ b/src/drawers/lineDrawer.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/drawers/lineDrawer.ts
+++ b/src/drawers/lineDrawer.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Dataset } from "../core/dataset";

--- a/src/drawers/rectangleDrawer.ts
+++ b/src/drawers/rectangleDrawer.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Dataset } from "../core/dataset";
 

--- a/src/drawers/rectangleDrawer.ts
+++ b/src/drawers/rectangleDrawer.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Dataset } from "../core/dataset";
 
 import { Drawer } from "./drawer";

--- a/src/drawers/segmentDrawer.ts
+++ b/src/drawers/segmentDrawer.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Dataset } from "../core/dataset";
 

--- a/src/drawers/segmentDrawer.ts
+++ b/src/drawers/segmentDrawer.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Dataset } from "../core/dataset";
 
 import { Drawer } from "./drawer";

--- a/src/drawers/symbolDrawer.ts
+++ b/src/drawers/symbolDrawer.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Dataset } from "../core/dataset";
 

--- a/src/drawers/symbolDrawer.ts
+++ b/src/drawers/symbolDrawer.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Dataset } from "../core/dataset";
 
 import { Drawer } from "./drawer";

--- a/src/interactions/clickInteraction.ts
+++ b/src/interactions/clickInteraction.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Component } from "../components/component";
 import { Point } from "../core/interfaces";

--- a/src/interactions/clickInteraction.ts
+++ b/src/interactions/clickInteraction.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Component } from "../components/component";
 import { Point } from "../core/interfaces";
 import * as Dispatchers from "../dispatchers";

--- a/src/interactions/doubleClickInteraction.ts
+++ b/src/interactions/doubleClickInteraction.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Component } from "../components/component";
 import { Point } from "../core/interfaces";

--- a/src/interactions/doubleClickInteraction.ts
+++ b/src/interactions/doubleClickInteraction.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Component } from "../components/component";
 import { Point } from "../core/interfaces";
 import * as Dispatchers from "../dispatchers";

--- a/src/interactions/dragInteraction.ts
+++ b/src/interactions/dragInteraction.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Component } from "../components/component";
 import { Point } from "../core/interfaces";

--- a/src/interactions/dragInteraction.ts
+++ b/src/interactions/dragInteraction.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Component } from "../components/component";
 import { Point } from "../core/interfaces";
 import * as Dispatchers from "../dispatchers";

--- a/src/interactions/index.ts
+++ b/src/interactions/index.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 export * from "./clickInteraction";
 export * from "./doubleClickInteraction";

--- a/src/interactions/index.ts
+++ b/src/interactions/index.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 export * from "./clickInteraction";
 export * from "./doubleClickInteraction";
 export * from "./dragInteraction";

--- a/src/interactions/interaction.ts
+++ b/src/interactions/interaction.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Component } from "../components/component";
 import { Point } from "../core/interfaces";

--- a/src/interactions/interaction.ts
+++ b/src/interactions/interaction.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Component } from "../components/component";
 import { Point } from "../core/interfaces";
 

--- a/src/interactions/keyInteraction.ts
+++ b/src/interactions/keyInteraction.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Component } from "../components/component";
 import { Point } from "../core/interfaces";

--- a/src/interactions/keyInteraction.ts
+++ b/src/interactions/keyInteraction.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Component } from "../components/component";
 import { Point } from "../core/interfaces";
 import * as Dispatchers from "../dispatchers";

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Component } from "../components/component";

--- a/src/interactions/pointerInteraction.ts
+++ b/src/interactions/pointerInteraction.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Component } from "../components/component";
 import { Point } from "../core/interfaces";

--- a/src/interactions/pointerInteraction.ts
+++ b/src/interactions/pointerInteraction.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Component } from "../components/component";
 import { Point } from "../core/interfaces";
 import * as Dispatchers from "../dispatchers";

--- a/src/plots/areaPlot.ts
+++ b/src/plots/areaPlot.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/plots/areaPlot.ts
+++ b/src/plots/areaPlot.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Accessor, AttributeToProjector, Projector } from "../core/interfaces";

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 import * as SVGTypewriter from "svg-typewriter";

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 import * as SVGTypewriter from "svg-typewriter";
 

--- a/src/plots/clusteredBarPlot.ts
+++ b/src/plots/clusteredBarPlot.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Dataset } from "../core/dataset";
 import * as Scales from "../scales";

--- a/src/plots/clusteredBarPlot.ts
+++ b/src/plots/clusteredBarPlot.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Dataset } from "../core/dataset";
 import * as Scales from "../scales";
 import * as Utils from "../utils";

--- a/src/plots/commons.ts
+++ b/src/plots/commons.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Dataset } from "../core/dataset";
 import { Point, Entity, Accessor } from "../core/interfaces";
 import { Drawer } from "../drawers/drawer";

--- a/src/plots/commons.ts
+++ b/src/plots/commons.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Dataset } from "../core/dataset";
 import { Point, Entity, Accessor } from "../core/interfaces";

--- a/src/plots/index.ts
+++ b/src/plots/index.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 export * from "./areaPlot";
 export * from "./barPlot";
 export * from "./commons";

--- a/src/plots/index.ts
+++ b/src/plots/index.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 export * from "./areaPlot";
 export * from "./barPlot";

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import * as Animators from "../animators";

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 import * as SVGTypewriter from "svg-typewriter";

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 import * as SVGTypewriter from "svg-typewriter";
 

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import * as Animators from "../animators";

--- a/src/plots/rectanglePlot.ts
+++ b/src/plots/rectanglePlot.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 import * as SVGTypewriter from "svg-typewriter";

--- a/src/plots/rectanglePlot.ts
+++ b/src/plots/rectanglePlot.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 import * as SVGTypewriter from "svg-typewriter";
 

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as Animators from "../animators";
 import { Accessor, Point, Bounds, Range, AttributeToProjector } from "../core/interfaces";

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as Animators from "../animators";
 import { Accessor, Point, Bounds, Range, AttributeToProjector } from "../core/interfaces";
 import { Dataset } from "../core/dataset";

--- a/src/plots/segmentPlot.ts
+++ b/src/plots/segmentPlot.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as Animators from "../animators";
 import { Accessor, Point, Bounds, Range, AttributeToProjector } from "../core/interfaces";

--- a/src/plots/segmentPlot.ts
+++ b/src/plots/segmentPlot.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as Animators from "../animators";
 import { Accessor, Point, Bounds, Range, AttributeToProjector } from "../core/interfaces";
 import { Dataset } from "../core/dataset";

--- a/src/plots/stackedAreaPlot.ts
+++ b/src/plots/stackedAreaPlot.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/plots/stackedAreaPlot.ts
+++ b/src/plots/stackedAreaPlot.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import * as Animators from "../animators";

--- a/src/plots/stackedBarPlot.ts
+++ b/src/plots/stackedBarPlot.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as SVGTypewriter from "svg-typewriter";
 
 import { Accessor, Point } from "../core/interfaces";

--- a/src/plots/stackedBarPlot.ts
+++ b/src/plots/stackedBarPlot.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as SVGTypewriter from "svg-typewriter";
 

--- a/src/plots/waterfallPlot.ts
+++ b/src/plots/waterfallPlot.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Accessor, Point, Bounds, Range, AttributeToProjector } from "../core/interfaces";
 import { Dataset } from "../core/dataset";

--- a/src/plots/waterfallPlot.ts
+++ b/src/plots/waterfallPlot.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Accessor, Point, Bounds, Range, AttributeToProjector } from "../core/interfaces";
 import { Dataset } from "../core/dataset";
 import { Drawer } from "../drawers/drawer";

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Accessor, Point } from "../core/interfaces";
 import { Dataset } from "../core/dataset";
 import * as Scales from "../scales";

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Accessor, Point } from "../core/interfaces";
 import { Dataset } from "../core/dataset";

--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import * as Interactions from "../interactions";

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import * as Utils from "../utils";

--- a/src/scales/colorScale.ts
+++ b/src/scales/colorScale.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/scales/index.ts
+++ b/src/scales/index.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as TickGenerators from "./tickGenerators";
 

--- a/src/scales/index.ts
+++ b/src/scales/index.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as TickGenerators from "./tickGenerators";
 
 export {

--- a/src/scales/interpolatedColorScale.ts
+++ b/src/scales/interpolatedColorScale.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import * as Utils from "../utils";

--- a/src/scales/interpolatedColorScale.ts
+++ b/src/scales/interpolatedColorScale.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/scales/linearScale.ts
+++ b/src/scales/linearScale.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { QuantitativeScale } from "./quantitativeScale";

--- a/src/scales/linearScale.ts
+++ b/src/scales/linearScale.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/scales/modifiedLogScale.ts
+++ b/src/scales/modifiedLogScale.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import * as Utils from "../utils";

--- a/src/scales/modifiedLogScale.ts
+++ b/src/scales/modifiedLogScale.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import * as Interactions from "../interactions";

--- a/src/scales/scale.ts
+++ b/src/scales/scale.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 
 import * as Utils from "../utils";
 import * as Scales from "./";

--- a/src/scales/scale.ts
+++ b/src/scales/scale.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 
 import * as Utils from "../utils";

--- a/src/scales/tickGenerators.ts
+++ b/src/scales/tickGenerators.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { QuantitativeScale } from "../scales/quantitativeScale";
 import * as Utils from "../utils";

--- a/src/scales/tickGenerators.ts
+++ b/src/scales/tickGenerators.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { QuantitativeScale } from "../scales/quantitativeScale";
 import * as Utils from "../utils";
 

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { TimeInterval } from "../axes/timeAxis";

--- a/src/utils/arrayUtils.ts
+++ b/src/utils/arrayUtils.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 let nativeArray = (<any>window).Array;

--- a/src/utils/arrayUtils.ts
+++ b/src/utils/arrayUtils.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/utils/callbackSet.ts
+++ b/src/utils/callbackSet.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Set } from "./set";
 

--- a/src/utils/callbackSet.ts
+++ b/src/utils/callbackSet.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Set } from "./set";
 
 /**

--- a/src/utils/clientToSVGTranslator.ts
+++ b/src/utils/clientToSVGTranslator.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Point } from "../core/interfaces";
 
 import * as DOM from "./domUtils";

--- a/src/utils/clientToSVGTranslator.ts
+++ b/src/utils/clientToSVGTranslator.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Point } from "../core/interfaces";
 

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 let nativeMath: Math = (<any>window).Math;

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Range } from "../core/interfaces";

--- a/src/utils/entityStore.ts
+++ b/src/utils/entityStore.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import { Point } from "../core/interfaces";
 
 import * as Math from "./mathUtils";

--- a/src/utils/entityStore.ts
+++ b/src/utils/entityStore.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import { Point } from "../core/interfaces";
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as Array from "./arrayUtils";
 import * as Color from "./colorUtils";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as Array from "./arrayUtils";
 import * as Color from "./colorUtils";
 import * as DOM from "./domUtils";

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as Math from "./mathUtils";
 /**
  * Shim for ES6 map.

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as Math from "./mathUtils";
 /**

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Bounds, Point } from "../core/interfaces";

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 /**
  * Shim for ES6 set.
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 /**
  * Shim for ES6 set.

--- a/src/utils/stackingUtils.ts
+++ b/src/utils/stackingUtils.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as d3 from "d3";
 

--- a/src/utils/stackingUtils.ts
+++ b/src/utils/stackingUtils.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as d3 from "d3";
 
 import { Dataset } from "../core/dataset";

--- a/src/utils/windowUtils.ts
+++ b/src/utils/windowUtils.ts
@@ -1,3 +1,8 @@
+/*
+Copyright 2014-present Palantir Technologies
+Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
+*/
+
 import * as Configs from "../core/config";
 
 /**

--- a/src/utils/windowUtils.ts
+++ b/src/utils/windowUtils.ts
@@ -1,7 +1,7 @@
-/*
-Copyright 2014-present Palantir Technologies
-Licensed under MIT (https://github.com/palantir/plottable/blob/master/LICENSE)
-*/
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 import * as Configs from "../core/config";
 


### PR DESCRIPTION
now that we release modules, all source files (that get compiled into
the /build folder) should have license headers.