### PR TITLE
reduce memory leaks in barPlot

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -3510,13 +3510,13 @@ var Bar = (function (_super) {
         var tolerance = 0.5;
         var chartBounds = this.bounds();
         var closest;
-        this._getEntityStore().map(function (entity) {
+        this._getEntityStore().forEach(function (entity) {
             if (!_this._entityVisibleOnPlot(entity, chartBounds)) {
                 return;
             }
             var primaryDist = 0;
             var secondaryDist = 0;
-            var plotPt = entity.position;
+            var plotPt = _this._pixelPoint(entity.datum, entity.index, entity.dataset);
             // if we're inside a bar, distance in both directions should stay 0
             var barBBox = Utils.DOM.elementBBox(entity.drawer.selectionForIndex(entity.validDatumIndex));
             if (!Utils.DOM.intersectsBBox(queryPoint.x, queryPoint.y, barBBox, tolerance)) {
@@ -3542,7 +3542,12 @@ var Bar = (function (_super) {
                 minSecondaryDist = secondaryDist;
             }
         });
-        return this._lightweightPlotEntityToPlotEntity(closest);
+        if (closest !== undefined) {
+            return this._lightweightPlotEntityToPlotEntity(closest);
+        }
+        else {
+            return undefined;
+        }
     };
     Bar.prototype._entityVisibleOnPlot = function (entity, bounds) {
         var chartWidth = bounds.bottomRight.x - bounds.topLeft.x;
@@ -3583,10 +3588,12 @@ var Bar = (function (_super) {
         return this._entitiesIntersecting(dataXRange, dataYRange);
     };
     Bar.prototype._entitiesIntersecting = function (xValOrRange, yValOrRange) {
+        var _this = this;
         var intersected = [];
-        this.entities().forEach(function (entity) {
-            if (Utils.DOM.intersectsBBox(xValOrRange, yValOrRange, Utils.DOM.elementBBox(entity.selection))) {
-                intersected.push(entity);
+        this._getEntityStore().forEach(function (entity) {
+            var selection = entity.drawer.selectionForIndex(entity.validDatumIndex);
+            if (Utils.DOM.intersectsBBox(xValOrRange, yValOrRange, Utils.DOM.elementBBox(selection))) {
+                intersected.push(_this._lightweightPlotEntityToPlotEntity(entity));
             }
         });
         return intersected;
@@ -14789,6 +14796,9 @@ var EntityArray = (function () {
     };
     EntityArray.prototype.map = function (callback) {
         return this._entities.map(function (entity) { return callback(entity); });
+    };
+    EntityArray.prototype.forEach = function (callback) {
+        return this._entities.forEach(callback);
     };
     return EntityArray;
 }());

--- a/plottable.js
+++ b/plottable.js
@@ -3510,7 +3510,7 @@ var Bar = (function (_super) {
         var tolerance = 0.5;
         var chartBounds = this.bounds();
         var closest;
-        this.entities().forEach(function (entity) {
+        this._getEntityStore().map(function (entity) {
             if (!_this._entityVisibleOnPlot(entity, chartBounds)) {
                 return;
             }
@@ -3518,7 +3518,7 @@ var Bar = (function (_super) {
             var secondaryDist = 0;
             var plotPt = entity.position;
             // if we're inside a bar, distance in both directions should stay 0
-            var barBBox = Utils.DOM.elementBBox(entity.selection);
+            var barBBox = Utils.DOM.elementBBox(entity.drawer.selectionForIndex(entity.validDatumIndex));
             if (!Utils.DOM.intersectsBBox(queryPoint.x, queryPoint.y, barBBox, tolerance)) {
                 var plotPtPrimary = _this._isVertical ? plotPt.x : plotPt.y;
                 primaryDist = Math.abs(queryPtPrimary - plotPtPrimary);
@@ -3542,7 +3542,7 @@ var Bar = (function (_super) {
                 minSecondaryDist = secondaryDist;
             }
         });
-        return closest;
+        return this._lightweightPlotEntityToPlotEntity(closest);
     };
     Bar.prototype._entityVisibleOnPlot = function (entity, bounds) {
         var chartWidth = bounds.bottomRight.x - bounds.topLeft.x;

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -301,7 +301,7 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
       }
       let primaryDist = 0;
       let secondaryDist = 0;
-      let plotPt = entity.position;
+      let plotPt = this._pixelPoint(entity.datum, entity.index, entity.dataset);
       // if we're inside a bar, distance in both directions should stay 0
       let barBBox = Utils.DOM.elementBBox(entity.drawer.selectionForIndex(entity.validDatumIndex));
       if (!Utils.DOM.intersectsBBox(queryPoint.x, queryPoint.y, barBBox, tolerance)) {
@@ -329,7 +329,11 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
       }
     });
 
-    return this._lightweightPlotEntityToPlotEntity(closest);
+    if (closest !== undefined) {
+      return this._lightweightPlotEntityToPlotEntity(closest);
+    } else {
+      return undefined;
+    }
   }
 
   protected _entityVisibleOnPlot(entity: Plots.PlotEntity | Plots.LightweightPlotEntity, bounds: Bounds) {

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -17,6 +17,7 @@ import * as Plots from "./";
 import { PlotEntity } from "./";
 import { Plot } from "./plot";
 import { XYPlot } from "./xyPlot";
+import { LightweightPlotEntity } from "./commons";
 
 type LabelConfig = {
   labelArea: d3.Selection<void>;
@@ -293,8 +294,8 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
     let tolerance = 0.5;
 
     const chartBounds = this.bounds();
-    let closest: PlotEntity;
-    this.entities().forEach((entity) => {
+    let closest: LightweightPlotEntity;
+    this._getEntityStore().forEach((entity: LightweightPlotEntity) => {
       if (!this._entityVisibleOnPlot(entity, chartBounds)) {
         return;
       }
@@ -302,7 +303,7 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
       let secondaryDist = 0;
       let plotPt = entity.position;
       // if we're inside a bar, distance in both directions should stay 0
-      let barBBox = Utils.DOM.elementBBox(entity.selection);
+      let barBBox = Utils.DOM.elementBBox(entity.drawer.selectionForIndex(entity.validDatumIndex));
       if (!Utils.DOM.intersectsBBox(queryPoint.x, queryPoint.y, barBBox, tolerance)) {
         let plotPtPrimary = this._isVertical ? plotPt.x : plotPt.y;
         primaryDist = Math.abs(queryPtPrimary - plotPtPrimary);
@@ -328,10 +329,10 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
       }
     });
 
-    return closest;
+    return this._lightweightPlotEntityToPlotEntity(closest);
   }
 
-  protected _entityVisibleOnPlot(entity: Plots.PlotEntity, bounds: Bounds) {
+  protected _entityVisibleOnPlot(entity: Plots.PlotEntity | Plots.LightweightPlotEntity, bounds: Bounds) {
     const chartWidth = bounds.bottomRight.x - bounds.topLeft.x;
     const chartHeight = bounds.bottomRight.y - bounds.topLeft.y;
 
@@ -393,9 +394,10 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
 
   private _entitiesIntersecting(xValOrRange: number | Range, yValOrRange: number | Range): PlotEntity[] {
     let intersected: PlotEntity[] = [];
-    this.entities().forEach((entity) => {
-      if (Utils.DOM.intersectsBBox(xValOrRange, yValOrRange, Utils.DOM.elementBBox(entity.selection))) {
-        intersected.push(entity);
+    this._getEntityStore().forEach((entity) => {
+      const selection = entity.drawer.selectionForIndex(entity.validDatumIndex);
+      if (Utils.DOM.intersectsBBox(xValOrRange, yValOrRange, Utils.DOM.elementBBox(selection))) {
+        intersected.push(this._lightweightPlotEntityToPlotEntity(entity));
       }
     });
     return intersected;

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -517,7 +517,7 @@ export class Plot extends Component {
    * @param {Dataset[]} [datasets] - The datasets with which to construct the store. If no datasets
    * are specified all datasets will be used.
    */
-  private _getEntityStore(datasets?: Dataset[]): Utils.EntityStore<Plots.LightweightPlotEntity> {
+  protected _getEntityStore(datasets?: Dataset[]): Utils.EntityStore<Plots.LightweightPlotEntity> {
     if (datasets !== undefined) {
       const EntityStore = new Utils.EntityArray<Plots.LightweightPlotEntity>();
       this._buildLightweightPlotEntities(datasets).forEach((entity: Plots.LightweightPlotEntity) => {
@@ -535,7 +535,7 @@ export class Plot extends Component {
     return this._cachedEntityStore;
   }
 
-  private _lightweightPlotEntityToPlotEntity(entity: Plots.LightweightPlotEntity) {
+  protected _lightweightPlotEntityToPlotEntity(entity: Plots.LightweightPlotEntity) {
     let plotEntity: Plots.PlotEntity = {
       datum: entity.datum,
       position: this._pixelPoint(entity.datum, entity.index, entity.dataset),

--- a/src/utils/entityStore.ts
+++ b/src/utils/entityStore.ts
@@ -29,6 +29,13 @@ export interface EntityStore<T extends PositionedEntity> {
    * @returns {S[]} The aggregate result of each call to the transformation function
    */
   map<S>(callback: (value: T) => S): S[];
+
+  /**
+   * Iterator that loops through entities calls the callback on each iteration.
+   * @param {(value: T) => void} [callback] transformation function that is passed
+   * passed an entity {T}.
+   */
+  forEach(callback: (value: T) => void): void;
 }
 
 export interface PositionedEntity {
@@ -77,5 +84,9 @@ export class EntityArray<T extends PositionedEntity> implements EntityStore<T> {
 
   public map<S>(callback: (value: T) => S) {
     return this._entities.map<S>((entity: T) => callback(entity));
+  }
+
+  public forEach(callback: (value: T) => void) {
+    return this._entities.forEach(callback);
   }
 }


### PR DESCRIPTION
calling `Plot.entities()` creates new Plot.PlotEntity objects on each
invocation; repeated calls (e.g. in a mousemove callback) will quickly
accumulate memory and cause unnecessary GCs.

Address this problem in barPlot's entityNearest and entitiesIntersecting by avoiding this.entities().