### PR TITLE
remove measurer reset

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -908,9 +908,6 @@ var Component = (function () {
     /**
      * Causes the Component to re-layout and render.
      *
-     * This function should be called when a CSS change has occured that could
-     * influence the layout of the Component, such as changing the font size.
-     *
      * @returns {Component} The calling Component.
      */
     Component.prototype.redraw = function () {
@@ -923,6 +920,16 @@ var Component = (function () {
             }
         }
         return this;
+    };
+    /**
+     * Tell this component to invalidate any caching. This function should be
+     * called when a CSS change has occurred that could influence the layout
+     * of the Component, such as changing the font size.
+     *
+     * Subclasses should override.
+     */
+    Component.prototype.invalidateCache = function () {
+        // Core component has no caching.
     };
     /**
      * Renders the Component to a given <svg>.
@@ -3243,6 +3250,10 @@ var Axis = (function (_super) {
             }
         });
     };
+    Axis.prototype.invalidateCache = function () {
+        _super.prototype.invalidateCache.call(this);
+        this._annotationMeasurer.reset();
+    };
     /**
      * The css class applied to each end tick mark (the line on the end tick).
      */
@@ -4415,6 +4426,10 @@ var Time = (function (_super) {
             }
         });
     };
+    Time.prototype.invalidateCache = function () {
+        _super.prototype.invalidateCache.call(this);
+        this._measurer.reset();
+    };
     /**
      * The CSS class applied to each Time Axis tier
      */
@@ -4628,6 +4643,9 @@ var ComponentContainer = (function (_super) {
     ComponentContainer.prototype.destroy = function () {
         _super.prototype.destroy.call(this);
         this._forEach(function (c) { return c.destroy(); });
+    };
+    ComponentContainer.prototype.invalidateCache = function () {
+        this._forEach(function (c) { return c.invalidateCache(); });
     };
     return ComponentContainer;
 }(component_1.Component));
@@ -8270,6 +8288,10 @@ var Category = (function (_super) {
         }
         return this;
     };
+    Category.prototype.invalidateCache = function () {
+        _super.prototype.invalidateCache.call(this);
+        this._measurer.reset();
+    };
     /**
      * How many pixels to give labels at minimum before downsampling takes effect.
      */
@@ -8579,6 +8601,10 @@ var Numeric = (function (_super) {
             }
         }
         return true;
+    };
+    Numeric.prototype.invalidateCache = function () {
+        _super.prototype.invalidateCache.call(this);
+        this._measurer.reset();
     };
     return Numeric;
 }(axis_1.Axis));
@@ -9269,6 +9295,10 @@ var Label = (function (_super) {
         };
         this._writer.write(this._text, writeWidth, writeHeight, writeOptions);
         return this;
+    };
+    Label.prototype.invalidateCache = function () {
+        _super.prototype.invalidateCache.call(this);
+        this._measurer.reset();
     };
     return Label;
 }(component_1.Component));
@@ -13867,6 +13897,10 @@ var StackedBar = (function (_super) {
         var filter = this._filterForProperty(this._isVertical ? "y" : "x");
         this._stackingResult = Utils.Stacking.stack(datasets, keyAccessor, valueAccessor, this._stackingOrder);
         this._stackedExtent = Utils.Stacking.stackedExtent(this._stackingResult, keyAccessor, filter);
+    };
+    StackedBar.prototype.invalidateCache = function () {
+        _super.prototype.invalidateCache.call(this);
+        this._measurer.reset();
     };
     StackedBar._STACKED_BAR_LABEL_PADDING = 5;
     return StackedBar;

--- a/plottable.js
+++ b/plottable.js
@@ -8264,10 +8264,6 @@ var Category = (function (_super) {
         return this;
     };
     Category.prototype.computeLayout = function (origin, availableWidth, availableHeight) {
-        // When anyone calls redraw(), computeLayout() will be called
-        // on everyone, including this. Since CSS or something might have
-        // affected the size of the characters, clear the cache.
-        this._measurer.reset();
         _super.prototype.computeLayout.call(this, origin, availableWidth, availableHeight);
         if (!this.isHorizontal()) {
             this._scale.range([0, this.height()]);

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -819,5 +819,8 @@ export class Axis<D> extends Component {
     });
   }
 
-
+  public invalidateCache() {
+    super.invalidateCache();
+    (this._annotationMeasurer as SVGTypewriter.CacheMeasurer).reset();
+  }
 }

--- a/src/axes/categoryAxis.ts
+++ b/src/axes/categoryAxis.ts
@@ -411,10 +411,6 @@ export class Category extends Axis<string> {
   }
 
   public computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number) {
-    // When anyone calls redraw(), computeLayout() will be called
-    // on everyone, including this. Since CSS or something might have
-    // affected the size of the characters, clear the cache.
-    this._measurer.reset();
     super.computeLayout(origin, availableWidth, availableHeight);
     if (!this.isHorizontal()) {
       this._scale.range([0, this.height()]);

--- a/src/axes/categoryAxis.ts
+++ b/src/axes/categoryAxis.ts
@@ -417,4 +417,9 @@ export class Category extends Axis<string> {
     }
     return this;
   }
+
+  public invalidateCache() {
+    super.invalidateCache();
+    this._measurer.reset();
+  }
 }

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -355,4 +355,8 @@ export class Numeric extends Axis<number> {
     return true;
   }
 
+  public invalidateCache() {
+    super.invalidateCache();
+    (this._measurer as SVGTypewriter.CacheMeasurer).reset();
+  }
 }

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -644,4 +644,8 @@ export class Time extends Axis<Date> {
     });
   }
 
+  public invalidateCache() {
+    super.invalidateCache();
+    (this._measurer as SVGTypewriter.CacheMeasurer).reset();
+  }
 }

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -281,9 +281,6 @@ export class Component {
   /**
    * Causes the Component to re-layout and render.
    *
-   * This function should be called when a CSS change has occured that could
-   * influence the layout of the Component, such as changing the font size.
-   *
    * @returns {Component} The calling Component.
    */
   public redraw() {
@@ -295,6 +292,17 @@ export class Component {
       }
     }
     return this;
+  }
+
+  /**
+   * Tell this component to invalidate any caching. This function should be
+   * called when a CSS change has occurred that could influence the layout
+   * of the Component, such as changing the font size.
+   *
+   * Subclasses should override.
+   */
+  public invalidateCache() {
+    // Core component has no caching.
   }
 
   /**

--- a/src/components/componentContainer.ts
+++ b/src/components/componentContainer.ts
@@ -82,4 +82,8 @@ export class ComponentContainer extends Component {
     super.destroy();
     this._forEach((c: Component) => c.destroy());
   }
+
+  public invalidateCache() {
+    this._forEach((c: Component) => c.invalidateCache());
+  }
 }

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -13,7 +13,7 @@ export class Label extends Component {
   private _textContainer: d3.Selection<void>;
   private _text: string; // text assigned to the Label; may not be the actual text displayed due to truncation
   private _angle: number;
-  private _measurer: SVGTypewriter.Measurer;
+  private _measurer: SVGTypewriter.CacheMeasurer;
   private _wrapper: SVGTypewriter.Wrapper;
   private _writer: SVGTypewriter.Writer;
   private _padding: number;
@@ -160,6 +160,11 @@ export class Label extends Component {
     };
     this._writer.write(this._text, writeWidth, writeHeight, writeOptions);
     return this;
+  }
+
+  public invalidateCache() {
+    super.invalidateCache();
+    this._measurer.reset();
   }
 }
 

--- a/src/plots/stackedBarPlot.ts
+++ b/src/plots/stackedBarPlot.ts
@@ -17,7 +17,7 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
   protected static _STACKED_BAR_LABEL_PADDING = 5;
 
   private _labelArea: d3.Selection<void>;
-  private _measurer: SVGTypewriter.Measurer;
+  private _measurer: SVGTypewriter.CacheMeasurer;
   private _writer: SVGTypewriter.Writer;
   private _stackingOrder: Utils.Stacking.IStackingOrder;
   private _stackingResult: Utils.Stacking.StackingResult;
@@ -258,5 +258,10 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
 
     this._stackingResult = Utils.Stacking.stack(datasets, keyAccessor, valueAccessor, this._stackingOrder);
     this._stackedExtent = Utils.Stacking.stackedExtent(this._stackingResult, keyAccessor, filter);
+  }
+
+  public invalidateCache() {
+    super.invalidateCache();
+    this._measurer.reset();
   }
 }


### PR DESCRIPTION
Causes awful perf. The only "gain" was that Category Axis can auto-respond to e.g. dynamic changes in CSS (or font loading, for instance) but this is a tiny benefit whose cost is too great (poor performance on all bar/grid charts). Technically a breaking change since users who were relying on the live-css ability before will not be supported anymore (we should explore another way to tell Plottable "refresh the cache")