### PR TITLE
Nearest entity data / pixel space option

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -590,13 +590,15 @@ var Plot = (function (_super) {
         if (bounds === void 0) { bounds = this.bounds(); }
         if (transformPoint === void 0) { transformPoint = function (point) { return point; }; }
         var nearest = this._getEntityStore().entityNearest(queryPoint, transformPoint, function (entity) {
-            return _this._entityVisibleOnPlot(entity, bounds);
+            return _this._entityVisibleOnPlot(entity, bounds, transformPoint);
         });
         return nearest === undefined ? undefined : this._lightweightPlotEntityToPlotEntity(nearest);
     };
-    Plot.prototype._entityVisibleOnPlot = function (entity, chartBounds) {
-        return !(entity.position.x < chartBounds.topLeft.x || entity.position.y < chartBounds.topLeft.y ||
-            entity.position.x > chartBounds.bottomRight.x || entity.position.y > chartBounds.bottomRight.y);
+    Plot.prototype._entityVisibleOnPlot = function (entity, chartBounds, transformPoint) {
+        if (transformPoint === void 0) { transformPoint = function (point) { return point; }; }
+        var _a = transformPoint(entity.position), x = _a.x, y = _a.y;
+        return !(x < chartBounds.topLeft.x || y < chartBounds.topLeft.y ||
+            x > chartBounds.bottomRight.x || y > chartBounds.bottomRight.y);
     };
     Plot.prototype._uninstallScaleForKey = function (scale, key) {
         scale.offUpdate(this._renderCallback);
@@ -13558,12 +13560,14 @@ var Scatter = (function (_super) {
         });
         return drawSteps;
     };
-    Scatter.prototype._entityVisibleOnPlot = function (entity, bounds) {
+    Scatter.prototype._entityVisibleOnPlot = function (entity, bounds, transformPoint) {
+        if (transformPoint === void 0) { transformPoint = function (point) { return point; }; }
+        var _a = transformPoint(entity.position), x = _a.x, y = _a.y;
         var xRange = { min: bounds.topLeft.x, max: bounds.bottomRight.x };
         var yRange = { min: bounds.topLeft.y, max: bounds.bottomRight.y };
         var translatedBbox = {
-            x: entity.position.x - entity.diameter.x,
-            y: entity.position.y - entity.diameter.y,
+            x: x - entity.diameter.x,
+            y: y - entity.diameter.y,
             width: entity.diameter.x,
             height: entity.diameter.y,
         };

--- a/plottable.js
+++ b/plottable.js
@@ -2256,15 +2256,20 @@ var XYPlot = (function (_super) {
         var _this = this;
         if (dataspace === void 0) { dataspace = false; }
         if (dataspace) {
-            // convert the chart bounding box and query point to the data space
-            // for comparison
+            /**
+             * Convert the chart bounding box and query point to the data space
+             * for comparison
+             */
             var invertedChartBounds = this._invertedBounds();
             var invertedQueryPoint = this._invertPixelPoint(queryPoint);
             return _super.prototype.entityNearest.call(this, invertedQueryPoint, dataspace, invertedChartBounds);
         }
         else {
-            // convert the position in the entities store back to screen space
-            // for comparison
+            /**
+             * Convert the position in the entities store back to screen space
+             * for comparison. We do this here because entities store points in data space
+             * for pan & zoom interactions (#3159).
+             */
             return _super.prototype.entityNearest.call(this, queryPoint, dataspace, this.bounds(), function (point) {
                 return {
                     x: _this.x().scale.scaleTransformation(point.x),

--- a/plottable.js
+++ b/plottable.js
@@ -580,13 +580,16 @@ var Plot = (function (_super) {
      * or undefined if no {Plots.PlotEntity} can be found.
      *
      * @param {Point} queryPoint
-     * @param {bounds} Bounds The bounding box within which to search. By default, bounds is the bounds of
+     * @param {boolean} dataspace Whether to find the nearest point in pixel space or data space.
+     * @param {Bounds} bounds The bounding box within which to search. By default, bounds is the bounds of
      * the chart, relative to the parent.
+     * @param {Function} transformPoint Function to transform entity position from data space to pixel space if
+     * dataspace is set to false.
      * @returns {Plots.PlotEntity} The nearest PlotEntity, or undefined if no {Plots.PlotEntity} can be found.
      */
-    Plot.prototype.entityNearest = function (queryPoint, dataSpace, bounds, transformPoint) {
+    Plot.prototype.entityNearest = function (queryPoint, dataspace, bounds, transformPoint) {
         var _this = this;
-        if (dataSpace === void 0) { dataSpace = false; }
+        if (dataspace === void 0) { dataspace = false; }
         if (bounds === void 0) { bounds = this.bounds(); }
         if (transformPoint === void 0) { transformPoint = function (point) { return point; }; }
         var nearest = this._getEntityStore().entityNearest(queryPoint, transformPoint, function (entity) {
@@ -15569,14 +15572,14 @@ var EntityArray = (function () {
      * Iterates through array of of entities and computes the closest point using
      * the standard Euclidean distance formula.
      */
-    EntityArray.prototype.entityNearest = function (queryPoint, pointTransform, filter) {
+    EntityArray.prototype.entityNearest = function (queryPoint, transformPoint, filter) {
         var closestDistanceSquared = Infinity;
         var closestPointEntity;
         this._entities.forEach(function (entity) {
             if (filter !== undefined && filter(entity) === false) {
                 return;
             }
-            var distanceSquared = Math.distanceSquared(pointTransform(entity.position), queryPoint);
+            var distanceSquared = Math.distanceSquared(transformPoint(entity.position), queryPoint);
             if (distanceSquared < closestDistanceSquared) {
                 closestDistanceSquared = distanceSquared;
                 closestPointEntity = entity;

--- a/plottable.js
+++ b/plottable.js
@@ -98,9 +98,9 @@ var Array = __webpack_require__(93);
 exports.Array = Array;
 var Color = __webpack_require__(96);
 exports.Color = Color;
-var DOM = __webpack_require__(40);
+var DOM = __webpack_require__(39);
 exports.DOM = DOM;
-var Math = __webpack_require__(28);
+var Math = __webpack_require__(40);
 exports.Math = Math;
 var Stacking = __webpack_require__(99);
 exports.Stacking = Stacking;
@@ -125,22 +125,22 @@ module.exports = __WEBPACK_EXTERNAL_MODULE_1__;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-/**
- * Copyright 2014-present Palantir Technologies
- * @license MIT
- */
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 var d3 = __webpack_require__(1);
 var Animators = __webpack_require__(6);
 var component_1 = __webpack_require__(5);
 var drawer_1 = __webpack_require__(7);
 var Utils = __webpack_require__(0);
-var Plots = __webpack_require__(37);
+var Plots = __webpack_require__(36);
 var coerceD3_1 = __webpack_require__(11);
 var Plot = (function (_super) {
     __extends(Plot, _super);
@@ -577,7 +577,8 @@ var Plot = (function (_super) {
     };
     /**
      * Returns the {Plots.PlotEntity} nearest to the query point,
-     * or undefined if no {Plots.PlotEntity} can be found.
+     * or undefined if no {Plots.PlotEntity} can be found. The closest point is computed using
+     * the standard Euclidean distance formula. Note that this is done in pixel space.
      *
      * @param {Point} queryPoint
      * @param {Bounds} bounds The bounding box within which to search. By default, bounds is the bounds of
@@ -587,11 +588,24 @@ var Plot = (function (_super) {
     Plot.prototype.entityNearest = function (queryPoint, bounds) {
         var _this = this;
         if (bounds === void 0) { bounds = this.bounds(); }
-        var nearest = this._getEntityStore().entityNearest(queryPoint, function (point) { return _this._dataPointToPixelPoint(point); }, function (entity) { return _this._entityVisibleOnPlot(entity, bounds); });
-        return nearest === undefined ? undefined : this._lightweightPlotEntityToPlotEntity(nearest);
+        var closestDistanceSquared = Infinity;
+        var closestPointEntity;
+        this._getEntityStore().forEach(function (entity) {
+            if (_this._entityVisibleOnPlot(entity, bounds) !== false) {
+                var entityPoint = _this._pixelPoint(entity.datum, entity.index, entity.dataset);
+                var distanceSquared = Utils.Math.distanceSquared(entityPoint, queryPoint);
+                if (distanceSquared < closestDistanceSquared) {
+                    closestDistanceSquared = distanceSquared;
+                    closestPointEntity = entity;
+                }
+            }
+        });
+        return closestPointEntity === undefined
+            ? undefined
+            : this._lightweightPlotEntityToPlotEntity(closestPointEntity);
     };
     Plot.prototype._entityVisibleOnPlot = function (entity, chartBounds) {
-        var _a = this._dataPointToPixelPoint(entity.position), x = _a.x, y = _a.y;
+        var _a = this._pixelPoint(entity.datum, entity.index, entity.dataset), x = _a.x, y = _a.y;
         return !(x < chartBounds.topLeft.x || y < chartBounds.topLeft.y ||
             x > chartBounds.bottomRight.x || y > chartBounds.bottomRight.y);
     };
@@ -610,14 +624,6 @@ var Plot = (function (_super) {
         return binding.scale == null ?
             binding.accessor :
             function (d, i, ds) { return binding.scale.scale(binding.accessor(d, i, ds)); };
-    };
-    /**
-     * Convert the position in the entities store back to screen space
-     * for comparison. We do this here because entities store points in data space
-     * for pan & zoom interactions (#3159).
-     */
-    Plot.prototype._dataPointToPixelPoint = function (point) {
-        throw new Error("plots must implement data point to pixel point");
     };
     Plot.prototype._pixelPoint = function (datum, index, dataset) {
         return { x: 0, y: 0 };
@@ -646,14 +652,14 @@ function __export(m) {
 }
 var TickGenerators = __webpack_require__(91);
 exports.TickGenerators = TickGenerators;
-__export(__webpack_require__(39));
+__export(__webpack_require__(38));
 __export(__webpack_require__(87));
 __export(__webpack_require__(88));
 __export(__webpack_require__(89));
 __export(__webpack_require__(90));
 __export(__webpack_require__(92));
 // ---------------------------------------------------------
-var categoryScale_2 = __webpack_require__(39);
+var categoryScale_2 = __webpack_require__(38);
 var quantitativeScale_1 = __webpack_require__(10);
 /**
  * Type guarded function to check if the scale implements the
@@ -2156,7 +2162,7 @@ function __export(m) {
 __export(__webpack_require__(74));
 __export(__webpack_require__(75));
 __export(__webpack_require__(76));
-__export(__webpack_require__(32));
+__export(__webpack_require__(31));
 __export(__webpack_require__(77));
 __export(__webpack_require__(78));
 
@@ -2483,17 +2489,6 @@ var XYPlot = (function (_super) {
         };
     };
     /**
-     * _dataPointToPixelPoint converts a point in data coordinates to a point in pixel coordinates
-     * @param {Point} point Representation of the point in data coordinates
-     * @return {Point} Returns the point represented in pixel coordinates
-     */
-    XYPlot.prototype._dataPointToPixelPoint = function (point) {
-        return {
-            x: this.x().scale.scaleTransformation(point.x),
-            y: this.y().scale.scaleTransformation(point.y),
-        };
-    };
-    /**
      * _invertPixelPoint converts a point in pixel coordinates to a point in data coordinates
      * @param {Point} point Representation of the point in pixel coordinates
      * @return {Point} Returns the point represented in data coordinates
@@ -2542,11 +2537,11 @@ exports.XYPlot = XYPlot;
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
-__export(__webpack_require__(36));
+__export(__webpack_require__(35));
 __export(__webpack_require__(22));
-__export(__webpack_require__(37));
+__export(__webpack_require__(36));
 __export(__webpack_require__(79));
-__export(__webpack_require__(38));
+__export(__webpack_require__(37));
 __export(__webpack_require__(80));
 __export(__webpack_require__(81));
 __export(__webpack_require__(82));
@@ -4748,7 +4743,7 @@ exports.ComponentContainer = ComponentContainer;
  */
 
 var Utils = __webpack_require__(0);
-var RenderPolicies = __webpack_require__(31);
+var RenderPolicies = __webpack_require__(30);
 /**
  * The RenderController is responsible for enqueueing and synchronizing
  * layout and render calls for Components.
@@ -4933,8 +4928,8 @@ var __extends = (this && this.__extends) || function (d, b) {
 };
 var Interactions = __webpack_require__(15);
 var Utils = __webpack_require__(0);
-var _1 = __webpack_require__(30);
-var selectionBoxLayer_1 = __webpack_require__(35);
+var _1 = __webpack_require__(29);
+var selectionBoxLayer_1 = __webpack_require__(34);
 var coerceD3_1 = __webpack_require__(11);
 var DragBoxLayer = (function (_super) {
     __extends(DragBoxLayer, _super);
@@ -5307,122 +5302,6 @@ exports.DragBoxLayer = DragBoxLayer;
 
 "use strict";
 /**
- * Copyright 2014-present Palantir Technologies
- * @license MIT
- */
-
-var d3 = __webpack_require__(1);
-var nativeMath = window.Math;
-/**
- * Checks if x is between a and b.
- *
- * @param {number} x The value to test if in range
- * @param {number} a The beginning of the (inclusive) range
- * @param {number} b The ending of the (inclusive) range
- * @return {boolean} Whether x is in [a, b]
- */
-function inRange(x, a, b) {
-    return (nativeMath.min(a, b) <= x && x <= nativeMath.max(a, b));
-}
-exports.inRange = inRange;
-/**
- * Clamps x to the range [min, max].
- *
- * @param {number} x The value to be clamped.
- * @param {number} min The minimum value.
- * @param {number} max The maximum value.
- * @return {number} A clamped value in the range [min, max].
- */
-function clamp(x, min, max) {
-    return nativeMath.min(nativeMath.max(min, x), max);
-}
-exports.clamp = clamp;
-function max(array, firstArg, secondArg) {
-    var accessor = typeof (firstArg) === "function" ? firstArg : null;
-    var defaultValue = accessor == null ? firstArg : secondArg;
-    /* tslint:disable:ban */
-    var maxValue = accessor == null ? d3.max(array) : d3.max(array, accessor);
-    /* tslint:enable:ban */
-    return maxValue !== undefined ? maxValue : defaultValue;
-}
-exports.max = max;
-function min(array, firstArg, secondArg) {
-    var accessor = typeof (firstArg) === "function" ? firstArg : null;
-    var defaultValue = accessor == null ? firstArg : secondArg;
-    /* tslint:disable:ban */
-    var minValue = accessor == null ? d3.min(array) : d3.min(array, accessor);
-    /* tslint:enable:ban */
-    return minValue !== undefined ? minValue : defaultValue;
-}
-exports.min = min;
-/**
- * Returns true **only** if x is NaN
- */
-function isNaN(n) {
-    return n !== n;
-}
-exports.isNaN = isNaN;
-/**
- * Returns true if the argument is a number, which is not NaN
- * Numbers represented as strings do not pass this function
- */
-function isValidNumber(n) {
-    return typeof n === "number" && !isNaN(n) && isFinite(n);
-}
-exports.isValidNumber = isValidNumber;
-/**
- * Generates an array of consecutive, strictly increasing numbers
- * in the range [start, stop) separeted by step
- */
-function range(start, stop, step) {
-    if (step === void 0) { step = 1; }
-    if (step === 0) {
-        throw new Error("step cannot be 0");
-    }
-    var length = nativeMath.max(nativeMath.ceil((stop - start) / step), 0);
-    var range = [];
-    for (var i = 0; i < length; ++i) {
-        range[i] = start + step * i;
-    }
-    return range;
-}
-exports.range = range;
-/**
- * Returns the square of the distance between two points
- *
- * @param {Point} p1
- * @param {Point} p2
- * @return {number} dist(p1, p2)^2
- */
-function distanceSquared(p1, p2) {
-    return nativeMath.pow(p2.y - p1.y, 2) + nativeMath.pow(p2.x - p1.x, 2);
-}
-exports.distanceSquared = distanceSquared;
-function degreesToRadians(degree) {
-    return degree / 360 * nativeMath.PI * 2;
-}
-exports.degreesToRadians = degreesToRadians;
-/**
- * Returns if the point is within the bounds. Points along
- * the bounds are considered "within" as well.
- * @param {Point} p Point in considerations.
- * @param {Bounds} bounds Bounds within which to check for inclusion.
- */
-function within(p, bounds) {
-    return bounds.topLeft.x <= p.x
-        && bounds.bottomRight.x >= p.x
-        && bounds.topLeft.y <= p.y
-        && bounds.bottomRight.y >= p.y;
-}
-exports.within = within;
-
-
-/***/ }),
-/* 29 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/**
  * Copyright 2017-present Palantir Technologies, Inc. All rights reserved.
  * Licensed under the MIT License (the "License"); you may obtain a copy of the
  * license at https://github.com/palantir/svg-typewriter/blob/develop/LICENSE
@@ -5510,7 +5389,7 @@ exports.BaseAnimator = BaseAnimator;
 //# sourceMappingURL=baseAnimator.js.map
 
 /***/ }),
-/* 30 */
+/* 29 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -5525,13 +5404,13 @@ function __export(m) {
 __export(__webpack_require__(27));
 __export(__webpack_require__(55));
 __export(__webpack_require__(56));
+__export(__webpack_require__(32));
 __export(__webpack_require__(33));
-__export(__webpack_require__(34));
 __export(__webpack_require__(57));
 __export(__webpack_require__(58));
 __export(__webpack_require__(59));
 __export(__webpack_require__(60));
-__export(__webpack_require__(35));
+__export(__webpack_require__(34));
 __export(__webpack_require__(61));
 __export(__webpack_require__(62));
 __export(__webpack_require__(63));
@@ -5549,7 +5428,7 @@ exports.Alignment = Alignment;
 
 
 /***/ }),
-/* 31 */
+/* 30 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -5604,7 +5483,7 @@ exports.Timeout = Timeout;
 
 
 /***/ }),
-/* 32 */
+/* 31 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -5730,7 +5609,7 @@ exports.Key = Key;
 
 
 /***/ }),
-/* 33 */
+/* 32 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -5834,7 +5713,7 @@ exports.Group = Group;
 
 
 /***/ }),
-/* 34 */
+/* 33 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -5990,7 +5869,7 @@ exports.GuideLineLayer = GuideLineLayer;
 
 
 /***/ }),
-/* 35 */
+/* 34 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -6219,7 +6098,7 @@ exports.SelectionBoxLayer = SelectionBoxLayer;
 
 
 /***/ }),
-/* 36 */
+/* 35 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -6238,7 +6117,7 @@ var Drawers = __webpack_require__(9);
 var Scales = __webpack_require__(3);
 var Utils = __webpack_require__(0);
 var Plots = __webpack_require__(17);
-var linePlot_1 = __webpack_require__(38);
+var linePlot_1 = __webpack_require__(37);
 var plot_1 = __webpack_require__(2);
 var Area = (function (_super) {
     __extends(Area, _super);
@@ -6413,7 +6292,7 @@ exports.Area = Area;
 
 
 /***/ }),
-/* 37 */
+/* 36 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -6430,7 +6309,7 @@ var Animator;
 
 
 /***/ }),
-/* 38 */
+/* 37 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -6912,7 +6791,7 @@ exports.Line = Line;
 
 
 /***/ }),
-/* 39 */
+/* 38 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -7106,7 +6985,7 @@ exports.Category = Category;
 
 
 /***/ }),
-/* 40 */
+/* 39 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -7358,6 +7237,122 @@ function _parseStyleValue(style, property) {
     var parsedValue = parseFloat(value);
     return parsedValue || 0;
 }
+
+
+/***/ }),
+/* 40 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
+
+var d3 = __webpack_require__(1);
+var nativeMath = window.Math;
+/**
+ * Checks if x is between a and b.
+ *
+ * @param {number} x The value to test if in range
+ * @param {number} a The beginning of the (inclusive) range
+ * @param {number} b The ending of the (inclusive) range
+ * @return {boolean} Whether x is in [a, b]
+ */
+function inRange(x, a, b) {
+    return (nativeMath.min(a, b) <= x && x <= nativeMath.max(a, b));
+}
+exports.inRange = inRange;
+/**
+ * Clamps x to the range [min, max].
+ *
+ * @param {number} x The value to be clamped.
+ * @param {number} min The minimum value.
+ * @param {number} max The maximum value.
+ * @return {number} A clamped value in the range [min, max].
+ */
+function clamp(x, min, max) {
+    return nativeMath.min(nativeMath.max(min, x), max);
+}
+exports.clamp = clamp;
+function max(array, firstArg, secondArg) {
+    var accessor = typeof (firstArg) === "function" ? firstArg : null;
+    var defaultValue = accessor == null ? firstArg : secondArg;
+    /* tslint:disable:ban */
+    var maxValue = accessor == null ? d3.max(array) : d3.max(array, accessor);
+    /* tslint:enable:ban */
+    return maxValue !== undefined ? maxValue : defaultValue;
+}
+exports.max = max;
+function min(array, firstArg, secondArg) {
+    var accessor = typeof (firstArg) === "function" ? firstArg : null;
+    var defaultValue = accessor == null ? firstArg : secondArg;
+    /* tslint:disable:ban */
+    var minValue = accessor == null ? d3.min(array) : d3.min(array, accessor);
+    /* tslint:enable:ban */
+    return minValue !== undefined ? minValue : defaultValue;
+}
+exports.min = min;
+/**
+ * Returns true **only** if x is NaN
+ */
+function isNaN(n) {
+    return n !== n;
+}
+exports.isNaN = isNaN;
+/**
+ * Returns true if the argument is a number, which is not NaN
+ * Numbers represented as strings do not pass this function
+ */
+function isValidNumber(n) {
+    return typeof n === "number" && !isNaN(n) && isFinite(n);
+}
+exports.isValidNumber = isValidNumber;
+/**
+ * Generates an array of consecutive, strictly increasing numbers
+ * in the range [start, stop) separeted by step
+ */
+function range(start, stop, step) {
+    if (step === void 0) { step = 1; }
+    if (step === 0) {
+        throw new Error("step cannot be 0");
+    }
+    var length = nativeMath.max(nativeMath.ceil((stop - start) / step), 0);
+    var range = [];
+    for (var i = 0; i < length; ++i) {
+        range[i] = start + step * i;
+    }
+    return range;
+}
+exports.range = range;
+/**
+ * Returns the square of the distance between two points
+ *
+ * @param {Point} p1
+ * @param {Point} p2
+ * @return {number} dist(p1, p2)^2
+ */
+function distanceSquared(p1, p2) {
+    return nativeMath.pow(p2.y - p1.y, 2) + nativeMath.pow(p2.x - p1.x, 2);
+}
+exports.distanceSquared = distanceSquared;
+function degreesToRadians(degree) {
+    return degree / 360 * nativeMath.PI * 2;
+}
+exports.degreesToRadians = degreesToRadians;
+/**
+ * Returns if the point is within the bounds. Points along
+ * the bounds are considered "within" as well.
+ * @param {Point} p Point in considerations.
+ * @param {Bounds} bounds Bounds within which to check for inclusion.
+ */
+function within(p, bounds) {
+    return bounds.topLeft.x <= p.x
+        && bounds.bottomRight.x >= p.x
+        && bounds.topLeft.y <= p.y
+        && bounds.bottomRight.y >= p.y;
+}
+exports.within = within;
 
 
 /***/ }),
@@ -8963,7 +8958,7 @@ var __extends = (this && this.__extends) || function (d, b) {
     function __() { this.constructor = d; }
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
-var guideLineLayer_1 = __webpack_require__(34);
+var guideLineLayer_1 = __webpack_require__(33);
 var Interactions = __webpack_require__(15);
 var Utils = __webpack_require__(0);
 var DragLineLayer = (function (_super) {
@@ -10202,7 +10197,7 @@ var __extends = (this && this.__extends) || function (d, b) {
 };
 var plot_1 = __webpack_require__(2);
 var Utils = __webpack_require__(0);
-var group_1 = __webpack_require__(33);
+var group_1 = __webpack_require__(32);
 var PlotGroup = (function (_super) {
     __extends(PlotGroup, _super);
     function PlotGroup() {
@@ -13549,7 +13544,7 @@ var Scatter = (function (_super) {
         return drawSteps;
     };
     Scatter.prototype._entityVisibleOnPlot = function (entity, bounds) {
-        var _a = this._dataPointToPixelPoint(entity.position), x = _a.x, y = _a.y;
+        var _a = this._pixelPoint(entity.datum, entity.index, entity.dataset), x = _a.x, y = _a.y;
         var xRange = { min: bounds.topLeft.x, max: bounds.bottomRight.x };
         var yRange = { min: bounds.topLeft.y, max: bounds.bottomRight.y };
         var translatedBbox = {
@@ -13856,7 +13851,7 @@ var __extends = (this && this.__extends) || function (d, b) {
 var d3 = __webpack_require__(1);
 var Animators = __webpack_require__(6);
 var Utils = __webpack_require__(0);
-var areaPlot_1 = __webpack_require__(36);
+var areaPlot_1 = __webpack_require__(35);
 var plot_1 = __webpack_require__(2);
 var StackedArea = (function (_super) {
     __extends(StackedArea, _super);
@@ -15379,7 +15374,7 @@ exports.CallbackSet = CallbackSet;
  * @license MIT
  */
 
-var DOM = __webpack_require__(40);
+var DOM = __webpack_require__(39);
 var ClientToSVGTranslator = (function () {
     function ClientToSVGTranslator(svg) {
         this._svg = svg;
@@ -15541,7 +15536,6 @@ function luminance(color) {
  * @license MIT
  */
 
-var Math = __webpack_require__(28);
 /**
  * Array-backed implementation of {EntityStore}
  */
@@ -15551,29 +15545,6 @@ var EntityArray = (function () {
     }
     EntityArray.prototype.add = function (entity) {
         this._entities.push(entity);
-    };
-    /**
-     * TODO: remove this logic from EntityStore (plots should own it internally since we do a position conversion)
-     * Iterates through array of of entities and computes the closest point using
-     * the standard Euclidean distance formula.
-     */
-    EntityArray.prototype.entityNearest = function (queryPoint, transformPoint, filter) {
-        var closestDistanceSquared = Infinity;
-        var closestPointEntity;
-        this._entities.forEach(function (entity) {
-            if (filter !== undefined && filter(entity) === false) {
-                return;
-            }
-            var distanceSquared = Math.distanceSquared(transformPoint(entity.position), queryPoint);
-            if (distanceSquared < closestDistanceSquared) {
-                closestDistanceSquared = distanceSquared;
-                closestPointEntity = entity;
-            }
-        });
-        if (closestPointEntity === undefined) {
-            return undefined;
-        }
-        return closestPointEntity;
     };
     EntityArray.prototype.map = function (callback) {
         return this._entities.map(function (entity) { return callback(entity); });
@@ -15596,7 +15567,7 @@ exports.EntityArray = EntityArray;
  * @license MIT
  */
 
-var Math = __webpack_require__(28);
+var Math = __webpack_require__(40);
 /**
  * Shim for ES6 map.
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
@@ -16261,7 +16232,7 @@ function sinInOut(t) {
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
-__export(__webpack_require__(29));
+__export(__webpack_require__(28));
 __export(__webpack_require__(113));
 __export(__webpack_require__(114));
 //# sourceMappingURL=index.js.map
@@ -16282,7 +16253,7 @@ var __extends = (this && this.__extends) || function (d, b) {
     function __() { this.constructor = d; }
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
-var baseAnimator_1 = __webpack_require__(29);
+var baseAnimator_1 = __webpack_require__(28);
 var OpacityAnimator = (function (_super) {
     __extends(OpacityAnimator, _super);
     function OpacityAnimator() {
@@ -16319,7 +16290,7 @@ var __extends = (this && this.__extends) || function (d, b) {
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var Utils = __webpack_require__(12);
-var baseAnimator_1 = __webpack_require__(29);
+var baseAnimator_1 = __webpack_require__(28);
 var UnveilAnimator = (function (_super) {
     __extends(UnveilAnimator, _super);
     function UnveilAnimator() {
@@ -16957,7 +16928,7 @@ var Animators = __webpack_require__(6);
 exports.Animators = Animators;
 var Axes = __webpack_require__(47);
 exports.Axes = Axes;
-var Components = __webpack_require__(30);
+var Components = __webpack_require__(29);
 exports.Components = Components;
 var Configs = __webpack_require__(20);
 exports.Configs = Configs;
@@ -16965,7 +16936,7 @@ var Formatters = __webpack_require__(8);
 exports.Formatters = Formatters;
 var RenderController = __webpack_require__(25);
 exports.RenderController = RenderController;
-var RenderPolicies = __webpack_require__(31);
+var RenderPolicies = __webpack_require__(30);
 exports.RenderPolicies = RenderPolicies;
 var SymbolFactories = __webpack_require__(26);
 exports.SymbolFactories = SymbolFactories;
@@ -16992,7 +16963,7 @@ exports.version = version_1.version;
 __export(__webpack_require__(21));
 __export(__webpack_require__(7));
 __export(__webpack_require__(14));
-__export(__webpack_require__(32));
+__export(__webpack_require__(31));
 __export(__webpack_require__(16));
 __export(__webpack_require__(2));
 __export(__webpack_require__(10));

--- a/plottable.js
+++ b/plottable.js
@@ -125,23 +125,23 @@ module.exports = __WEBPACK_EXTERNAL_MODULE_1__;
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
 
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
-/**
- * Copyright 2014-present Palantir Technologies
- * @license MIT
- */
 var d3 = __webpack_require__(1);
 var Animators = __webpack_require__(6);
 var component_1 = __webpack_require__(5);
 var drawer_1 = __webpack_require__(7);
 var Utils = __webpack_require__(0);
-var Plots = __webpack_require__(36);
 var coerceD3_1 = __webpack_require__(11);
+var Plots = __webpack_require__(36);
 var Plot = (function (_super) {
     __extends(Plot, _super);
     /**

--- a/quicktests/overlaying/tests/functional/nearestEntity.js
+++ b/quicktests/overlaying/tests/functional/nearestEntity.js
@@ -30,14 +30,10 @@ function makeData() {
     ];
 }
 
-
-// area, bar, clustered, line, pie, rectangle, scatter, segment, stackedarea,
-// stackedbar, waterfall
 function run(svg, data, Plottable) {
     "use strict";
 
     // TODO: fix entityNearest for pie charts, createPie(data[0])
-
     var chart = new Plottable.Components.Table([
         [createPlot(new Plottable.Plots.Line(), data[0]), createClusteredBar(data[1])],
         [createPlot(new Plottable.Plots.Scatter(), data[0]), createSegmentPlot()],

--- a/quicktests/overlaying/tests/functional/nearestEntity.js
+++ b/quicktests/overlaying/tests/functional/nearestEntity.js
@@ -1,0 +1,131 @@
+function makeData() {
+    "use strict";
+    return [
+        // single data set
+        [
+            {x: "Amazon", y: 0.1},
+            {x: "Apple", y: 0.30},
+            {x: "Facebook", y: 0.9},
+            {x: "Google", y: 0.30},
+            {x: "Intel", y: 0.94},
+            {x: "Microsoft", y: 0.29},
+            {x: "Twitter", y: 0.30},
+        ],
+        // multiple data set
+        [
+            [{name: "jon", y: 1, type: "q1"}, {name: "dan", y: 2, type: "q1"}, {name: "zoo", y: 1, type: "q1"}],
+            [{name: "jon", y: 2, type: "q2"}, {name: "dan", y: 4, type: "q2"}, {name: "zoo", y: 2, type: "q2"}],
+            [{name: "jon", y: 4, type: "q3"}, {name: "dan", y: 15, type: "q3"}, {name: "zoo", y: 15, type: "q3"}],
+        ]
+    ];
+}
+
+
+// area, bar, clustered, line, pie, rectangle, scatter, segment, stackedarea,
+// stackedbar, waterfall
+function run(svg, data, Plottable) {
+    "use strict";
+
+    var chart = new Plottable.Components.Table([
+        [createPlot(new Plottable.Plots.Line(), data[0]), createClusteredBar(data[1])],
+        [createPlot(new Plottable.Plots.Scatter(), data[0]), createPie(data[0])],
+        [createPlot(new Plottable.Plots.Bar(), data[0])],
+    ]);
+
+    chart.renderTo(svg);
+}
+
+function createPlot(plot, data) {
+    var xScale = new Plottable.Scales.Category();
+    var yScale = new Plottable.Scales.Linear();
+
+    plot.addDataset(new Plottable.Dataset(data))
+        .x(function (d) { return d.x; }, xScale)
+        .y(function(d) { return d.y; }, yScale);
+
+    var xAxis = new Plottable.Axes.Category(xScale, "bottom");
+    var yAxis = new Plottable.Axes.Numeric(yScale, "left");
+
+    var defaultTitleText = "Closest entity";
+    var title = new Plottable.Components.TitleLabel(defaultTitleText);
+
+    var pointer = new Plottable.Interactions.Pointer();
+    pointer.onPointerMove(function(p) {
+        if (plot.entityNearest(p)) {
+        title.text(plot.entityNearest(p).datum.x + ", " + plot.entityNearest(p).datum.y);
+        }
+    });
+    pointer.attachTo(plot);
+
+    return new Plottable.Components.Table([
+        [yAxis, plot],
+        [null, xAxis],
+        [null, title],
+    ]);
+}
+
+function createClusteredBar(data) {
+    var xScale = new Plottable.Scales.Category();
+    var xAxis = new Plottable.Axes.Category(xScale, "bottom");
+
+    var yScale = new Plottable.Scales.Linear();
+    var yAxis = new Plottable.Axes.Numeric(yScale, "left");
+
+    var barPlot = new Plottable.Plots.ClusteredBar()
+        .addDataset(new Plottable.Dataset(data[0]))
+        .addDataset(new Plottable.Dataset(data[1]))
+        .addDataset(new Plottable.Dataset(data[2]))
+        .x(function(d) { return d.name; }, xScale)
+        .y(function(d) { return d.y; }, yScale);
+
+    var defaultTitleText = "Closest entity";
+    var title = new Plottable.Components.TitleLabel(defaultTitleText);
+
+    var pointer = new Plottable.Interactions.Pointer();
+    pointer.onPointerMove(function(p) {
+        if (barPlot.entityNearest(p)) {
+        title.text(
+            barPlot.entityNearest(p).datum.name + ", " +
+            barPlot.entityNearest(p).datum.y + ", " +
+            barPlot.entityNearest(p).datum.type);
+        }
+    });
+    pointer.attachTo(barPlot);
+
+    return new Plottable.Components.Table([
+        [yAxis, barPlot],
+        [null,  xAxis],
+        [null, title],
+    ]);
+}
+
+function createPie(data) {
+    var cs = new Plottable.Scales.Color();
+    var pie = new Plottable.Plots.Pie();
+    pie.addDataset(new Plottable.Dataset(data));
+    pie.sectorValue(function(d){ return d.y; })
+        .outerRadius(200)
+        .labelsEnabled(true)
+        .labelFormatter(function(d){return "Value: " + d; })
+          .attr("fill", function(d){ return d.y; }, cs);
+
+    var defaultTitleText = "Closest entity";
+    var title = new Plottable.Components.TitleLabel(defaultTitleText);
+
+    var pointer = new Plottable.Interactions.Pointer();
+    pointer.onPointerMove(function(p) {
+        if (pie.entityNearest(p)) {
+            title.text(
+                pie.entityNearest(p).datum);
+                // pie.entityNearest(p).datum.name + ", " +
+                // pie.entityNearest(p).datum.y + ", " +
+                // pie.entityNearest(p).datum.type);
+        }
+    });
+    pointer.attachTo(pie);
+
+    return new Plottable.Components.Table([
+        [pie],
+        [title],
+    ]);
+}

--- a/quicktests/overlaying/tests/functional/nearestEntity.js
+++ b/quicktests/overlaying/tests/functional/nearestEntity.js
@@ -16,7 +16,17 @@ function makeData() {
             [{name: "jon", y: 1, type: "q1"}, {name: "dan", y: 2, type: "q1"}, {name: "zoo", y: 1, type: "q1"}],
             [{name: "jon", y: 2, type: "q2"}, {name: "dan", y: 4, type: "q2"}, {name: "zoo", y: 2, type: "q2"}],
             [{name: "jon", y: 4, type: "q3"}, {name: "dan", y: 15, type: "q3"}, {name: "zoo", y: 15, type: "q3"}],
-        ]
+        ],
+        // numerical scatter
+        [
+            {x: 10, y: 0.1},
+            {x: 90, y: 0.30},
+            {x: 12, y: 0.9},
+            {x: 1, y: 0.30},
+            {x: 100, y: 0.94},
+            {x: 90, y: 0.29},
+            {x: 80, y: 0.30},
+        ],
     ];
 }
 
@@ -26,10 +36,12 @@ function makeData() {
 function run(svg, data, Plottable) {
     "use strict";
 
+    // TODO: fix entityNearest for pie charts, createPie(data[0])
+
     var chart = new Plottable.Components.Table([
         [createPlot(new Plottable.Plots.Line(), data[0]), createClusteredBar(data[1])],
-        [createPlot(new Plottable.Plots.Scatter(), data[0]), createPie(data[0])],
-        [createPlot(new Plottable.Plots.Bar(), data[0])],
+        [createPlot(new Plottable.Plots.Scatter(), data[0]), createSegmentPlot()],
+        [createPlot(new Plottable.Plots.Bar(), data[0]), createNumericalScatter(data[2])],
     ]);
 
     chart.renderTo(svg);
@@ -95,6 +107,76 @@ function createClusteredBar(data) {
     return new Plottable.Components.Table([
         [yAxis, barPlot],
         [null,  xAxis],
+        [null, title],
+    ]);
+}
+
+function createSegmentPlot() {
+    const plot = new Plottable.Plots.Segment();
+    const xScale = new Plottable.Scales.Linear();
+    const yScale = new Plottable.Scales.Linear();
+    var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
+    var yAxis = new Plottable.Axes.Numeric(yScale, "left");
+
+    const data = [
+        { x: 1, y: 1, x2: 4, y2: 4 },
+        { x: 2, y: 2, x2: 3, y2: 5 },
+        { x: 3, y: 3, x2: 5, y2: 2 },
+    ];
+    plot.addDataset(new Plottable.Dataset(data));
+    plot.x((d) => d.x, xScale);
+    plot.y((d) => d.y, yScale);
+    plot.x2((d) => d.x2);
+    plot.y2((d) => d.y2);
+
+    const defaultTitleText = "Closest entity";
+    const title = new Plottable.Components.TitleLabel(defaultTitleText);
+
+    const pointer = new Plottable.Interactions.Pointer();
+    pointer.onPointerMove(function(p) {
+        if (plot.entityNearest(p)) {
+            title.text(
+                plot.entityNearest(p).datum.x + ", " +
+                plot.entityNearest(p).datum.y + ", " +
+                plot.entityNearest(p).datum.x2 + ", " +
+                plot.entityNearest(p).datum.y2);
+        }
+    });
+    pointer.attachTo(plot);
+
+    return new Plottable.Components.Table([
+        [yAxis, plot],
+        [null,  xAxis],
+        [null, title],
+    ]);
+}
+
+function createNumericalScatter(data) {
+    var plot = new Plottable.Plots.Scatter()
+    var xScale = new Plottable.Scales.Linear();
+    var yScale = new Plottable.Scales.Linear();
+
+    plot.addDataset(new Plottable.Dataset(data))
+        .x(function (d) { return d.x; }, xScale)
+        .y(function(d) { return d.y; }, yScale);
+
+    var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
+    var yAxis = new Plottable.Axes.Numeric(yScale, "left");
+
+    var defaultTitleText = "Closest entity";
+    var title = new Plottable.Components.TitleLabel(defaultTitleText);
+
+    var pointer = new Plottable.Interactions.Pointer();
+    pointer.onPointerMove(function(p) {
+        if (plot.entityNearest(p)) {
+        title.text(plot.entityNearest(p).datum.x + ", " + plot.entityNearest(p).datum.y);
+        }
+    });
+    pointer.attachTo(plot);
+
+    return new Plottable.Components.Table([
+        [yAxis, plot],
+        [null, xAxis],
         [null, title],
     ]);
 }

--- a/quicktests/overlaying/tests/functional/nearestEntity.js
+++ b/quicktests/overlaying/tests/functional/nearestEntity.js
@@ -116,10 +116,8 @@ function createPie(data) {
     pointer.onPointerMove(function(p) {
         if (pie.entityNearest(p)) {
             title.text(
-                pie.entityNearest(p).datum);
-                // pie.entityNearest(p).datum.name + ", " +
-                // pie.entityNearest(p).datum.y + ", " +
-                // pie.entityNearest(p).datum.type);
+                pie.entityNearest(p).datum.x + ", " +
+                pie.entityNearest(p).datum.y);
         }
     });
     pointer.attachTo(pie);

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -1,4 +1,3 @@
-import { LightweightPlotEntity } from "./commons";
 /**
  * Copyright 2014-present Palantir Technologies
  * @license MIT
@@ -9,16 +8,15 @@ import * as d3 from "d3";
 import * as Animators from "../animators";
 import { Animator } from "../animators/animator";
 import { Component } from "../components/component";
-import { Accessor, Point, AttributeToProjector, Bounds, SimpleSelection } from "../core/interfaces";
 import { Dataset, DatasetCallback } from "../core/dataset";
+import { Accessor, AttributeToProjector, Bounds, Point, SimpleSelection } from "../core/interfaces";
 import * as Drawers from "../drawers";
 import { Drawer } from "../drawers/drawer";
 import * as Scales from "../scales";
 import { Scale, ScaleCallback } from "../scales/scale";
 import * as Utils from "../utils";
-
-import * as Plots from "./commons";
 import { coerceExternalD3 } from "../utils/coerceD3";
+import * as Plots from "./commons";
 
 export class Plot extends Component {
   protected static _ANIMATION_MAX_DURATION = 600;

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -581,8 +581,12 @@ export class Plot extends Component {
    * the chart, relative to the parent.
    * @returns {Plots.PlotEntity} The nearest PlotEntity, or undefined if no {Plots.PlotEntity} can be found.
    */
-  public entityNearest(queryPoint: Point, bounds = this.bounds()): Plots.PlotEntity {
-    const nearest = this._getEntityStore().entityNearest(queryPoint, (entity: Plots.LightweightPlotEntity) => {
+  public entityNearest(
+        queryPoint: Point,
+        dataSpace = false,
+        bounds = this.bounds(),
+        transformPoint = (point: Point) => point): Plots.PlotEntity {
+    const nearest = this._getEntityStore().entityNearest(queryPoint, transformPoint, (entity: Plots.LightweightPlotEntity) => {
       return this._entityVisibleOnPlot(entity, bounds);
     });
 

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -577,13 +577,16 @@ export class Plot extends Component {
    * or undefined if no {Plots.PlotEntity} can be found.
    *
    * @param {Point} queryPoint
-   * @param {bounds} Bounds The bounding box within which to search. By default, bounds is the bounds of
+   * @param {boolean} dataspace Whether to find the nearest point in pixel space or data space.
+   * @param {Bounds} bounds The bounding box within which to search. By default, bounds is the bounds of
    * the chart, relative to the parent.
+   * @param {Function} transformPoint Function to transform entity position from data space to pixel space if
+   * dataspace is set to false.
    * @returns {Plots.PlotEntity} The nearest PlotEntity, or undefined if no {Plots.PlotEntity} can be found.
    */
   public entityNearest(
         queryPoint: Point,
-        dataSpace = false,
+        dataspace = false,
         bounds = this.bounds(),
         transformPoint = (point: Point) => point): Plots.PlotEntity {
     const nearest = this._getEntityStore().entityNearest(queryPoint, transformPoint, (entity: Plots.LightweightPlotEntity) => {

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -587,15 +587,20 @@ export class Plot extends Component {
         bounds = this.bounds(),
         transformPoint = (point: Point) => point): Plots.PlotEntity {
     const nearest = this._getEntityStore().entityNearest(queryPoint, transformPoint, (entity: Plots.LightweightPlotEntity) => {
-      return this._entityVisibleOnPlot(entity, bounds);
+      return this._entityVisibleOnPlot(entity, bounds, transformPoint);
     });
 
     return nearest === undefined ? undefined : this._lightweightPlotEntityToPlotEntity(nearest);
   }
 
-  protected _entityVisibleOnPlot(entity: Plots.PlotEntity | Plots.LightweightPlotEntity, chartBounds: Bounds) {
-    return !(entity.position.x < chartBounds.topLeft.x || entity.position.y < chartBounds.topLeft.y ||
-    entity.position.x > chartBounds.bottomRight.x || entity.position.y > chartBounds.bottomRight.y);
+  protected _entityVisibleOnPlot(
+      entity: Plots.PlotEntity | Plots.LightweightPlotEntity,
+      chartBounds: Bounds,
+      transformPoint = (point: Point) => point) {
+    const { x, y } = transformPoint(entity.position);
+
+    return !(x < chartBounds.topLeft.x || y < chartBounds.topLeft.y ||
+    x > chartBounds.bottomRight.x || y > chartBounds.bottomRight.y);
   }
 
   protected _uninstallScaleForKey(scale: Scale<any, any>, key: string) {

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -134,7 +134,7 @@ export class Scatter<X, Y> extends XYPlot<X, Y> {
   }
 
   protected _entityVisibleOnPlot(entity: LightweightScatterPlotEntity, bounds: Bounds) {
-    const { x, y } = this._dataPointToPixelPoint(entity.position);
+    const { x, y } = this._pixelPoint(entity.datum, entity.index, entity.dataset);
 
     const xRange = { min: bounds.topLeft.x, max: bounds.bottomRight.x };
     const yRange = { min: bounds.topLeft.y, max: bounds.bottomRight.y };

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -133,13 +133,15 @@ export class Scatter<X, Y> extends XYPlot<X, Y> {
     return drawSteps;
   }
 
-  protected _entityVisibleOnPlot(entity: LightweightScatterPlotEntity, bounds: Bounds) {
+  protected _entityVisibleOnPlot(entity: LightweightScatterPlotEntity, bounds: Bounds, transformPoint = (point: Point) => point) {
+    const { x, y } = transformPoint(entity.position);
+
     const xRange = { min: bounds.topLeft.x, max: bounds.bottomRight.x };
     const yRange = { min: bounds.topLeft.y, max: bounds.bottomRight.y };
 
     const translatedBbox = {
-      x: entity.position.x - entity.diameter.x,
-      y: entity.position.y - entity.diameter.y,
+      x: x - entity.diameter.x,
+      y: y - entity.diameter.y,
       width: entity.diameter.x,
       height: entity.diameter.y,
     };

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -133,8 +133,8 @@ export class Scatter<X, Y> extends XYPlot<X, Y> {
     return drawSteps;
   }
 
-  protected _entityVisibleOnPlot(entity: LightweightScatterPlotEntity, bounds: Bounds, transformPoint = (point: Point) => point) {
-    const { x, y } = transformPoint(entity.position);
+  protected _entityVisibleOnPlot(entity: LightweightScatterPlotEntity, bounds: Bounds) {
+    const { x, y } = this._dataPointToPixelPoint(entity.position);
 
     const xRange = { min: bounds.topLeft.x, max: bounds.bottomRight.x };
     const yRange = { min: bounds.topLeft.y, max: bounds.bottomRight.y };

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -5,10 +5,10 @@
 
 import { Dataset } from "../core/dataset";
 import { Accessor, Point } from "../core/interfaces";
-import { Scale, ScaleCallback } from "../scales/scale";
 import * as Scales from "../scales";
+import { Scale, ScaleCallback } from "../scales/scale";
 import * as Utils from "../utils";
-import { LightweightPlotEntity, PlotEntity, TransformableAccessorScaleBinding } from "./commons";
+import { LightweightPlotEntity, TransformableAccessorScaleBinding } from "./commons";
 import { Plot } from "./plot";
 
 export class XYPlot<X, Y> extends Plot {

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -102,30 +102,6 @@ export class XYPlot<X, Y> extends Plot {
     };
   }
 
-  public entityNearest(queryPoint: Point, dataspace = false): PlotEntity {
-    if (dataspace) {
-      /**
-       * Convert the chart bounding box and query point to the data space
-       * for comparison
-       */
-      const invertedChartBounds = this._invertedBounds();
-      const invertedQueryPoint = this._invertPixelPoint(queryPoint);
-      return super.entityNearest(invertedQueryPoint, dataspace, invertedChartBounds);
-    } else {
-      /**
-       * Convert the position in the entities store back to screen space
-       * for comparison. We do this here because entities store points in data space
-       * for pan & zoom interactions (#3159).
-       */
-      return super.entityNearest(queryPoint, dataspace, this.bounds(), (point) => {
-        return {
-          x: this.x().scale.scaleTransformation(point.x),
-          y: this.y().scale.scaleTransformation(point.y),
-        };
-      });
-    }
-  }
-
   /**
    * Returns the whether or not the rendering is deferred for performance boost.
    * @return {boolean} The deferred rendering option
@@ -441,6 +417,18 @@ export class XYPlot<X, Y> extends Plot {
         x: Math.max(maybeBottomRight.x, maybeTopLeft.x),
         y: Math.max(maybeBottomRight.y, maybeTopLeft.y)
       }
+    };
+  }
+
+  /**
+   * _dataPointToPixelPoint converts a point in data coordinates to a point in pixel coordinates
+   * @param {Point} point Representation of the point in data coordinates
+   * @return {Point} Returns the point represented in pixel coordinates
+   */
+  protected _dataPointToPixelPoint(point: Point): Point {
+    return {
+      x: this.x().scale.scaleTransformation(point.x),
+      y: this.y().scale.scaleTransformation(point.y),
     };
   }
 

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -104,14 +104,19 @@ export class XYPlot<X, Y> extends Plot {
 
   public entityNearest(queryPoint: Point, dataspace = false): PlotEntity {
     if (dataspace) {
-      // convert the chart bounding box and query point to the data space
-      // for comparison
+      /**
+       * Convert the chart bounding box and query point to the data space
+       * for comparison
+       */
       const invertedChartBounds = this._invertedBounds();
       const invertedQueryPoint = this._invertPixelPoint(queryPoint);
       return super.entityNearest(invertedQueryPoint, dataspace, invertedChartBounds);
     } else {
-      // convert the position in the entities store back to screen space
-      // for comparison
+      /**
+       * Convert the position in the entities store back to screen space
+       * for comparison. We do this here because entities store points in data space
+       * for pan & zoom interactions (#3159).
+       */
       return super.entityNearest(queryPoint, dataspace, this.bounds(), (point) => {
         return {
           x: this.x().scale.scaleTransformation(point.x),

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -421,18 +421,6 @@ export class XYPlot<X, Y> extends Plot {
   }
 
   /**
-   * _dataPointToPixelPoint converts a point in data coordinates to a point in pixel coordinates
-   * @param {Point} point Representation of the point in data coordinates
-   * @return {Point} Returns the point represented in pixel coordinates
-   */
-  protected _dataPointToPixelPoint(point: Point): Point {
-    return {
-      x: this.x().scale.scaleTransformation(point.x),
-      y: this.y().scale.scaleTransformation(point.y),
-    };
-  }
-
-  /**
    * _invertPixelPoint converts a point in pixel coordinates to a point in data coordinates
    * @param {Point} point Representation of the point in pixel coordinates
    * @return {Point} Returns the point represented in data coordinates

--- a/src/utils/entityStore.ts
+++ b/src/utils/entityStore.ts
@@ -18,18 +18,6 @@ export interface EntityStore<T extends PositionedEntity> {
    */
   add(entity: T): void;
   /**
-   * Returns closest entity to a given {Point}
-   * @param {Point} [point] Point around which to search for a closest entity
-   * @param {(point: Point) => Point} [transformPoint] method to transform an entity's
-   * position when calculating the distance. Should default to the identify function.
-   * @param {(entity: T) => boolean} [filter] optional method that is called while
-   * searching for the entity nearest a point. If the filter returns false, the point
-   * is considered invalid and is not considered. If the filter returns true, the point
-   * is considered valid and will be considered.
-   * @returns {T} Will return the nearest entity or undefined if none are found
-   */
-  entityNearest(point: Point, transformPoint: (point: Point) => Point, filter?: (entity: T) => boolean): T;
-  /**
    * Iterator that loops through entities and returns a transformed array
    * @param {(value: T) => S} [callback] transformation function that is passed
    * passed an entity {T} and returns an object {S}.
@@ -61,33 +49,6 @@ export class EntityArray<T extends PositionedEntity> implements EntityStore<T> {
 
   public add(entity: T) {
     this._entities.push(entity);
-  }
-
-  /**
-   * TODO: remove this logic from EntityStore (plots should own it internally since we do a position conversion)
-   * Iterates through array of of entities and computes the closest point using
-   * the standard Euclidean distance formula.
-   */
-  public entityNearest(queryPoint: Point, transformPoint: (point: Point) => Point, filter?: (entity: T) => boolean) {
-    let closestDistanceSquared = Infinity;
-    let closestPointEntity: T;
-    this._entities.forEach((entity) => {
-      if (filter !== undefined && filter(entity) === false) {
-        return;
-      }
-
-      let distanceSquared = Math.distanceSquared(transformPoint(entity.position), queryPoint);
-      if (distanceSquared < closestDistanceSquared) {
-        closestDistanceSquared = distanceSquared;
-        closestPointEntity = entity;
-      }
-    });
-
-    if (closestPointEntity === undefined) {
-      return undefined;
-    }
-
-    return closestPointEntity;
   }
 
   public map<S>(callback: (value: T) => S) {

--- a/src/utils/entityStore.ts
+++ b/src/utils/entityStore.ts
@@ -20,8 +20,8 @@ export interface EntityStore<T extends PositionedEntity> {
   /**
    * Returns closest entity to a given {Point}
    * @param {Point} [point] Point around which to search for a closest entity
-   * @param {(entity: T) => Point} [transformEntityPosition] method that transforms an entity's
-   * position when calculating the distance. Returns the position property by default.
+   * @param {(point: Point) => Point} [pointTransform] method to transform an entity's
+   * position when calculating the distance. Should default to the identify function.
    * @param {(entity: T) => boolean} [filter] optional method that is called while
    * searching for the entity nearest a point. If the filter returns false, the point
    * is considered invalid and is not considered. If the filter returns true, the point

--- a/src/utils/entityStore.ts
+++ b/src/utils/entityStore.ts
@@ -20,7 +20,7 @@ export interface EntityStore<T extends PositionedEntity> {
   /**
    * Returns closest entity to a given {Point}
    * @param {Point} [point] Point around which to search for a closest entity
-   * @param {(point: Point) => Point} [pointTransform] method to transform an entity's
+   * @param {(point: Point) => Point} [transformPoint] method to transform an entity's
    * position when calculating the distance. Should default to the identify function.
    * @param {(entity: T) => boolean} [filter] optional method that is called while
    * searching for the entity nearest a point. If the filter returns false, the point
@@ -28,7 +28,7 @@ export interface EntityStore<T extends PositionedEntity> {
    * is considered valid and will be considered.
    * @returns {T} Will return the nearest entity or undefined if none are found
    */
-  entityNearest(point: Point, pointTransform: (point: Point) => Point, filter?: (entity: T) => boolean): T;
+  entityNearest(point: Point, transformPoint: (point: Point) => Point, filter?: (entity: T) => boolean): T;
   /**
    * Iterator that loops through entities and returns a transformed array
    * @param {(value: T) => S} [callback] transformation function that is passed
@@ -67,7 +67,7 @@ export class EntityArray<T extends PositionedEntity> implements EntityStore<T> {
    * Iterates through array of of entities and computes the closest point using
    * the standard Euclidean distance formula.
    */
-  public entityNearest(queryPoint: Point, pointTransform: (point: Point) => Point, filter?: (entity: T) => boolean) {
+  public entityNearest(queryPoint: Point, transformPoint: (point: Point) => Point, filter?: (entity: T) => boolean) {
     let closestDistanceSquared = Infinity;
     let closestPointEntity: T;
     this._entities.forEach((entity) => {
@@ -75,7 +75,7 @@ export class EntityArray<T extends PositionedEntity> implements EntityStore<T> {
         return;
       }
 
-      let distanceSquared = Math.distanceSquared(pointTransform(entity.position), queryPoint);
+      let distanceSquared = Math.distanceSquared(transformPoint(entity.position), queryPoint);
       if (distanceSquared < closestDistanceSquared) {
         closestDistanceSquared = distanceSquared;
         closestPointEntity = entity;

--- a/src/utils/entityStore.ts
+++ b/src/utils/entityStore.ts
@@ -64,6 +64,7 @@ export class EntityArray<T extends PositionedEntity> implements EntityStore<T> {
   }
 
   /**
+   * TODO: remove this logic from EntityStore (plots should own it internally since we do a position conversion)
    * Iterates through array of of entities and computes the closest point using
    * the standard Euclidean distance formula.
    */

--- a/src/utils/entityStore.ts
+++ b/src/utils/entityStore.ts
@@ -20,13 +20,15 @@ export interface EntityStore<T extends PositionedEntity> {
   /**
    * Returns closest entity to a given {Point}
    * @param {Point} [point] Point around which to search for a closest entity
+   * @param {(entity: T) => Point} [transformEntityPosition] method that transforms an entity's
+   * position when calculating the distance. Returns the position property by default.
    * @param {(entity: T) => boolean} [filter] optional method that is called while
    * searching for the entity nearest a point. If the filter returns false, the point
    * is considered invalid and is not considered. If the filter returns true, the point
    * is considered valid and will be considered.
    * @returns {T} Will return the nearest entity or undefined if none are found
    */
-  entityNearest(point: Point, filter?: (entity: T) => boolean): T;
+  entityNearest(point: Point, pointTransform: (point: Point) => Point, filter?: (entity: T) => boolean): T;
   /**
    * Iterator that loops through entities and returns a transformed array
    * @param {(value: T) => S} [callback] transformation function that is passed
@@ -65,7 +67,7 @@ export class EntityArray<T extends PositionedEntity> implements EntityStore<T> {
    * Iterates through array of of entities and computes the closest point using
    * the standard Euclidean distance formula.
    */
-  public entityNearest(queryPoint: Point, filter?: (entity: T) => boolean) {
+  public entityNearest(queryPoint: Point, pointTransform: (point: Point) => Point, filter?: (entity: T) => boolean) {
     let closestDistanceSquared = Infinity;
     let closestPointEntity: T;
     this._entities.forEach((entity) => {
@@ -73,7 +75,7 @@ export class EntityArray<T extends PositionedEntity> implements EntityStore<T> {
         return;
       }
 
-      let distanceSquared = Math.distanceSquared(entity.position, queryPoint);
+      let distanceSquared = Math.distanceSquared(pointTransform(entity.position), queryPoint);
       if (distanceSquared < closestDistanceSquared) {
         closestDistanceSquared = distanceSquared;
         closestPointEntity = entity;

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -395,7 +395,7 @@ describe("Plots", () => {
       });
     });
 
-    describe("finding the nearest entity", () => {
+    describe("nearest entity", () => {
       let svg: SimpleSelection<void>;
       let plot: Plottable.XYPlot<number, number>;
       let xAccessor = (d: any) => d.x;
@@ -409,7 +409,7 @@ describe("Plots", () => {
         svg.remove();
       });
 
-      it("in point space", () => {
+      it("finds the nearest entity in point space", () => {
         const xScale = new Plottable.Scales.Linear();
         const yScale = new Plottable.Scales.Linear();
 
@@ -431,7 +431,7 @@ describe("Plots", () => {
         assert.equal(plot.entityNearest(point).datum, dataset.data()[0]);
       });
 
-      it("in data space", () => {
+      it("independent of axes scales", () => {
         const xScale = new Plottable.Scales.Linear();
         const yScale = new Plottable.Scales.ModifiedLog();
 

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -429,7 +429,6 @@ describe("Plots", () => {
         };
 
         assert.equal(plot.entityNearest(point).datum, dataset.data()[0]);
-        assert.equal(plot.entityNearest(point, true).datum, dataset.data()[0]);
       });
 
       it("in data space", () => {
@@ -452,7 +451,6 @@ describe("Plots", () => {
         };
 
         assert.equal(plot.entityNearest(point).datum, dataset.data()[1]);
-        assert.equal(plot.entityNearest(point, true).datum, dataset.data()[0]);
       });
     });
   });

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -395,7 +395,7 @@ describe("Plots", () => {
       });
     });
 
-    describe("finding the neatest entity", () => {
+    describe("finding the nearest entity", () => {
       let svg: SimpleSelection<void>;
       let plot: Plottable.XYPlot<number, number>;
       let xAccessor = (d: any) => d.x;


### PR DESCRIPTION
As per the threads in #3241 
- There should just be a flag of which "space" to use to find the nearest entity instead of trying to second guess what the consumer wants.
- Because of the reasoning for changes in #3159 for pan/zoom interaction, we're constrained in entities only having their datum and not their pixel position anymore.
- There are a bunch of places where we were actually comparing pixel `Points` or data `Points` in calculations eg. in `_entityVisibleOnPlot` - passing around `transformPoint` fixes it up (and just defaults to an identity function)

EDIT: instead of pushing transform functions through to do what we want, I've made a couple of changes
- plots own the transform and take care of the closest entity math, keeping the `entityStore` a generic
- use `_pixelPoint` which we should be overwriting in extended classes