### PR TITLE
Remove unused touch code in double click interaction

### DIFF
--- a/src/interactions/doubleClickInteraction.ts
+++ b/src/interactions/doubleClickInteraction.ts
@@ -11,87 +11,30 @@ import * as Utils from "../utils";
 import { Interaction } from "./interaction";
 import { ClickCallback } from "./";
 
-enum ClickState {NotClicked, SingleClicked, DoubleClicked}
-
 export class DoubleClick extends Interaction {
 
   private _mouseDispatcher: Dispatchers.Mouse;
-  private _touchDispatcher: Dispatchers.Touch;
-  private _clickState = ClickState.NotClicked;
-  private _clickedDown = false;
-  private _clickedPoint: Point;
 
   private _onDoubleClickCallbacks = new Utils.CallbackSet<ClickCallback>();
 
-  private _mouseDownCallback = (p: Point) => this._handleClickDown(p);
-  private _mouseUpCallback = (p: Point) => this._handleClickUp(p);
-  private _dblClickCallback = (p: Point) => this._handleDblClick();
-  private _touchStartCallback = (ids: number[], idToPoint: Point[]) => this._handleClickDown(idToPoint[ids[0]]);
-  private _touchEndCallback = (ids: number[], idToPoint: Point[]) => this._handleClickUp(idToPoint[ids[0]]);
-  private _touchCancelCallback = (ids: number[], idToPoint: Point[]) => this._handleClickCancel();
+  private _dblClickCallback = (p: Point, event: MouseEvent) => this._handleDblClick(p, event);
 
   protected _anchor(component: Component) {
     super._anchor(component);
 
     this._mouseDispatcher = Dispatchers.Mouse.getDispatcher(<SVGElement> component.content().node());
-    this._mouseDispatcher.onMouseDown(this._mouseDownCallback);
-    this._mouseDispatcher.onMouseUp(this._mouseUpCallback);
     this._mouseDispatcher.onDblClick(this._dblClickCallback);
-
-    this._touchDispatcher = Dispatchers.Touch.getDispatcher(<SVGElement> component.content().node());
-    this._touchDispatcher.onTouchStart(this._touchStartCallback);
-    this._touchDispatcher.onTouchEnd(this._touchEndCallback);
-    this._touchDispatcher.onTouchCancel(this._touchCancelCallback);
   }
 
   protected _unanchor() {
     super._unanchor();
-    this._mouseDispatcher.offMouseDown(this._mouseDownCallback);
-    this._mouseDispatcher.offMouseUp(this._mouseUpCallback);
     this._mouseDispatcher.offDblClick(this._dblClickCallback);
     this._mouseDispatcher = null;
-
-    this._touchDispatcher.offTouchStart(this._touchStartCallback);
-    this._touchDispatcher.offTouchEnd(this._touchEndCallback);
-    this._touchDispatcher.offTouchCancel(this._touchCancelCallback);
-    this._touchDispatcher = null;
   }
 
-  private _handleClickDown(p: Point) {
-    let translatedP = this._translateToComponentSpace(p);
-    if (this._isInsideComponent(translatedP)) {
-      if (!(this._clickState === ClickState.SingleClicked) || !DoubleClick._pointsEqual(translatedP, this._clickedPoint)) {
-        this._clickState = ClickState.NotClicked;
-      }
-      this._clickedPoint = translatedP;
-      this._clickedDown = true;
-    }
-  }
-
-  private _handleClickUp(p: Point) {
-    let translatedP = this._translateToComponentSpace(p);
-    if (this._clickedDown && DoubleClick._pointsEqual(translatedP, this._clickedPoint)) {
-      this._clickState = this._clickState === ClickState.NotClicked ? ClickState.SingleClicked : ClickState.DoubleClicked;
-    } else {
-      this._clickState = ClickState.NotClicked;
-    }
-    this._clickedDown = false;
-  }
-
-  private _handleDblClick() {
-    if (this._clickState === ClickState.DoubleClicked) {
-      this._onDoubleClickCallbacks.callCallbacks(this._clickedPoint);
-      this._clickState = ClickState.NotClicked;
-    }
-  }
-
-  private _handleClickCancel() {
-    this._clickState = ClickState.NotClicked;
-    this._clickedDown = false;
-  }
-
-  private static _pointsEqual(p1: Point, p2: Point) {
-    return p1.x === p2.x && p1.y === p2.y;
+  private _handleDblClick(p: Point, event: MouseEvent) {
+    const point = this._translateToComponentSpace(p);
+    this._onDoubleClickCallbacks.callCallbacks(point, event);
   }
 
   /**

--- a/test/interactions/doubleClickInteractionTests.ts
+++ b/test/interactions/doubleClickInteractionTests.ts
@@ -131,38 +131,17 @@ describe("Interactions", () => {
       });
     });
 
-    [TestMethods.InteractionMode.Mouse, TestMethods.InteractionMode.Touch].forEach((mode) => {
-      describe(`invoking callbacks with ${TestMethods.InteractionMode[mode]} events`, () => {
-        let callback: ClickTestCallback;
+    describe(`invoking callbacks with mouse events`, () => {
+      let callback: ClickTestCallback;
 
-        beforeEach(() => {
-          callback = makeClickCallback();
-          doubleClickInteraction.onDoubleClick(callback);
-        });
+      beforeEach(() => {
+        callback = makeClickCallback();
+        doubleClickInteraction.onDoubleClick(callback);
+      });
 
-        it("calls callback and passes correct click position", () => {
-          doubleClickPoint(mode);
-          assert.deepEqual(callback.lastPoint, clickedPoint, "was passed correct point");
-        });
-
-        it("does not call callback if clicked in different locations", () => {
-          doubleClickPointWithMove(clickedPoint, {x: clickedPoint.x + 10, y: clickedPoint.y + 10}, mode);
-          assert.isFalse(callback.called, "callback was not called");
-        });
-
-        if (mode === TestMethods.InteractionMode.Touch) {
-          it("does not trigger callback when touch event is cancelled", () => {
-            doubleClickInteraction.onDoubleClick(callback);
-
-            TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [clickedPoint]);
-            TestMethods.triggerFakeTouchEvent("touchend", component.content(), [clickedPoint]);
-            TestMethods.triggerFakeTouchEvent("touchstart", component.content(), [clickedPoint]);
-            TestMethods.triggerFakeTouchEvent("touchend", component.content(), [clickedPoint]);
-            TestMethods.triggerFakeTouchEvent("touchcancel", component.content(), [clickedPoint]);
-            TestMethods.triggerFakeMouseEvent("dblclick", component.content(), clickedPoint.x, clickedPoint.y);
-            assert.isUndefined(callback.lastPoint, "point never set");
-          });
-        }
+      it("calls callback and passes correct click position", () => {
+        doubleClickPoint(TestMethods.InteractionMode.Mouse);
+        assert.deepEqual(callback.lastPoint, clickedPoint, "was passed correct point");
       });
     });
   });


### PR DESCRIPTION
Fixes #3246 

- The `_handleDblClick` method is only hooked up to the `dblclick` event - the `mouseup` `mousedown` logic is not actually doing anything. Any combinations of `Interactions.Click` and `Interactions.DoubleClick` should be done on the consumer side.
- `dblclick` can only get fired from a mouse - the touchevents logic that we have won't happen in practice.
- also, passing through the events to the callbacks