### PR TITLE
disable flaky safari tests

### DIFF
--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -160,7 +160,8 @@ describe("Legend", () => {
       svg.remove();
     });
 
-    it("can set maximum number of lines per entry", () => {
+    // Disable this test for now since it flakes all the time on Saucelabs Safari 10
+    xit("can set maximum number of lines per entry", () => {
       color.domain(["this is a very very very very very very very long"]);
       legend.renderTo(svg);
       legend.maxWidth(100);
@@ -179,7 +180,8 @@ describe("Legend", () => {
       svg.remove();
     });
 
-    it("can set maximum number of entries per row", () => {
+    // Disable this test for now since it flakes all the time on Saucelabs Safari 10
+    xit("can set maximum number of entries per row", () => {
       color.domain(["AA", "BB", "CC", "DD", "EE", "FF"]);
       legend.renderTo(svg);
 


### PR DESCRIPTION
These two tests cause the large majority of flakes so just disable them for now (legend will be rewritten with HTML anyways)