### PR TITLE
MVP canvas renderer for Line Drawer

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -6804,13 +6804,12 @@ var Line = (function (_super) {
      * @private
      */
     Line.prototype._d3LineFactory = function (dataset, xProjector, yProjector) {
+        var _this = this;
         if (xProjector === void 0) { xProjector = plot_1.Plot._scaledAccessor(this.x()); }
         if (yProjector === void 0) { yProjector = plot_1.Plot._scaledAccessor(this.y()); }
-        var xScaledAccessor = plot_1.Plot._scaledAccessor(this.x());
-        var yScaledAccessor = plot_1.Plot._scaledAccessor(this.x());
         var definedProjector = function (d, i, dataset) {
-            var positionX = xScaledAccessor(d, i, dataset);
-            var positionY = yScaledAccessor(d, i, dataset);
+            var positionX = plot_1.Plot._scaledAccessor(_this.x())(d, i, dataset);
+            var positionY = plot_1.Plot._scaledAccessor(_this.y())(d, i, dataset);
             return positionX != null && !Utils.Math.isNaN(positionX) &&
                 positionY != null && !Utils.Math.isNaN(positionY);
         };

--- a/plottable.js
+++ b/plottable.js
@@ -6322,7 +6322,7 @@ var Area = (function (_super) {
         return this;
     };
     Area.prototype._addDataset = function (dataset) {
-        var lineDrawer = new Drawers.Line(dataset, this);
+        var lineDrawer = new Drawers.Line(dataset, this._d3LineFactory);
         if (this._isSetup) {
             lineDrawer.renderArea(this._renderArea.append("g"));
         }
@@ -6505,7 +6505,16 @@ var Line = (function (_super) {
         this._autorangeSmooth = false;
         this._croppedRenderingEnabled = true;
         this._downsamplingEnabled = false;
-        this.d3LineFactory = function (dataset, xProjector, yProjector) {
+        /**
+         * Return a d3.Line whose .x, .y, and .defined accessors are hooked up to the xProjector and yProjector
+         * after they've been fed the dataset, and whose curve is configured to this plot's curve.
+         * @param dataset
+         * @param xProjector
+         * @param yProjector
+         * @returns {Line<[number,number]>}
+         * @private
+         */
+        this._d3LineFactory = function (dataset, xProjector, yProjector) {
             if (xProjector === void 0) { xProjector = plot_1.Plot._scaledAccessor(_this.x()); }
             if (yProjector === void 0) { yProjector = plot_1.Plot._scaledAccessor(_this.y()); }
             var xScaledAccessor = plot_1.Plot._scaledAccessor(_this.x());
@@ -6604,7 +6613,7 @@ var Line = (function (_super) {
         return this;
     };
     Line.prototype._createDrawer = function (dataset) {
-        return new Drawers.Line(dataset, this.d3LineFactory);
+        return new Drawers.Line(dataset, this._d3LineFactory);
     };
     Line.prototype._extentsForProperty = function (property) {
         var extents = _super.prototype._extentsForProperty.call(this, property);
@@ -6807,7 +6816,7 @@ var Line = (function (_super) {
     Line.prototype._constructLineProjector = function (xProjector, yProjector) {
         var _this = this;
         return function (datum, index, dataset) {
-            return _this.d3LineFactory(dataset, xProjector, yProjector)(datum);
+            return _this._d3LineFactory(dataset, xProjector, yProjector)(datum);
         };
     };
     Line.prototype._getCurveFactory = function () {

--- a/quicktests/overlaying/overlaying.js
+++ b/quicktests/overlaying/overlaying.js
@@ -244,8 +244,7 @@ function evalAndRunTest(name, error, text, firstQTBranch, secondQTBranch) {
   var className = "quicktest " + name;
   var div = d3.select("#results").append("div").attr("class", className);
   div.insert("label").text(name);
-  // var firstTarget = div.append("div").attr("class", "first").append("div").styles({"width": targetWidth + "px", "height": targetHeight + "px"});
-  var firstTarget = div.append("div").attr("class", "first").append("svg").styles({"width": targetWidth + "px", "height": targetHeight + "px"});
+  var firstTarget = div.append("div").attr("class", "first").append("div").styles({"width": targetWidth + "px", "height": targetHeight + "px"});
   var secondTarget = div.append("div").attr("class", "second").append("div").styles({"width": targetWidth + "px", "height": targetHeight + "px"});
   var data = result.makeData();
 

--- a/quicktests/overlaying/tests/basic/canvas_line.js
+++ b/quicktests/overlaying/tests/basic/canvas_line.js
@@ -1,0 +1,47 @@
+function makeData() {
+  "use strict";
+
+  // makes 10 datasets of 10000 points
+  return Array.apply(null, Array(10)).map((_, datasetIndex) => {
+    return Array.apply(null, Array(10000)).map((_, i) => {
+      return {
+        // one data point per day, offset by one hour per dataset
+        x: new Date(i * 1000 * 3600 * 24 + datasetIndex * 1000 * 3600),
+        y: datasetIndex + Math.random()
+      };
+    });
+  });
+}
+
+function run(div, data, Plottable) {
+  "use strict";
+  var xScale = new Plottable.Scales.Time();
+  var yScale = new Plottable.Scales.Linear();
+  var xAxis = new Plottable.Axes.Time(xScale, "bottom");
+  var yAxis = new Plottable.Axes.Numeric(yScale, "left");
+  var colorScale = new Plottable.Scales.Color();
+
+  const datasets = data.map((dataArray, index) => {
+    return new Plottable.Dataset(dataArray).metadata(index);
+  });
+  var plot = new Plottable.Plots.Line().datasets(datasets)
+    .renderer("canvas")
+    .x((d) => d.x, xScale)
+    .y((d) => d.y, yScale)
+    .attr("stroke", (d,i,ds) => ds.metadata(), colorScale);
+
+  var table = new Plottable.Components.Table([
+    [yAxis, plot],
+    [null, xAxis]
+  ]);
+
+  new Plottable.Interactions.PanZoom(xScale, null)
+    .attachTo(plot);
+    // .setMinMaxDomainValuesTo(xScale);
+    // .setMinMaxDomainValuesTo(yScale);
+
+  table.renderTo(div);
+  window.addEventListener("resize", () => {
+    table.redraw();
+  });
+}

--- a/src/drawers/drawer.ts
+++ b/src/drawers/drawer.ts
@@ -30,7 +30,7 @@ export class Drawer {
 
   protected _svgElementName: string;
   protected _className: string;
-  private _dataset: Dataset;
+  protected _dataset: Dataset;
 
   private _cachedSelectionValid = false;
   private _cachedSelection: SimpleSelection<any>;
@@ -192,9 +192,6 @@ export class Drawer {
         delay += drawStep.animator.totalTime(data.length);
       });
     } else if (this._canvas != null) {
-      const canvas = this.canvas().node();
-      const context = canvas.getContext("2d");
-      context.clearRect(0, 0, canvas.width, canvas.height);
       // don't support animations for now; just draw the last draw step immediately
       const lastDrawStep = appliedDrawSteps[appliedDrawSteps.length - 1];
       Utils.Window.setTimeout(() => this._drawStepCanvas(data, lastDrawStep), 0);

--- a/src/drawers/lineDrawer.ts
+++ b/src/drawers/lineDrawer.ts
@@ -12,14 +12,14 @@ import { SimpleSelection } from "../core/interfaces";
 import { AppliedDrawStep } from "./index";
 
 export class Line extends Drawer {
-  private _d3LineFactory: (dataset: Dataset) => d3.Line<any>;
+  private _d3LineFactory: () => d3.Line<any>;
 
   /**
    * @param dataset
    * @param _d3LineFactory A callback that gives this Line Drawer a d3.Line object which will be
    * used to draw with.
    */
-  constructor(dataset: Dataset, d3LineFactory: (dataset: Dataset) => d3.Line<any>) {
+  constructor(dataset: Dataset, d3LineFactory: () => d3.Line<any>) {
     super(dataset);
     this._d3LineFactory = d3LineFactory;
     this._className = "line";
@@ -35,10 +35,17 @@ export class Line extends Drawer {
     return d3.select(this.selection().node());
   }
 
+  /**
+   *
+   * @param data Data to draw. The data will be passed through the line factory in order to get applied
+   * onto the canvas.
+   * @param step
+   * @private
+   */
   protected _drawStepCanvas(data: any[][], step: AppliedDrawStep) {
     const context = this.canvas().node().getContext("2d");
 
-    const d3Line = this._d3LineFactory(this._dataset);
+    const d3Line = this._d3LineFactory();
 
     const attrToAppliedProjector = step.attrToAppliedProjector;
     const resolvedAttrs = Object.keys(attrToAppliedProjector).reduce((obj, attrName) => {

--- a/src/drawers/lineDrawer.ts
+++ b/src/drawers/lineDrawer.ts
@@ -9,11 +9,19 @@ import { Dataset } from "../core/dataset";
 
 import { Drawer } from "./drawer";
 import { SimpleSelection } from "../core/interfaces";
+import { AppliedDrawStep } from "./index";
 
 export class Line extends Drawer {
+  private _d3LineFactory: (dataset: Dataset) => d3.Line<any>;
 
-  constructor(dataset: Dataset) {
+  /**
+   * @param dataset
+   * @param _d3LineFactory A callback that gives this Line Drawer a d3.Line object which will be
+   * used to draw with.
+   */
+  constructor(dataset: Dataset, d3LineFactory: (dataset: Dataset) => d3.Line<any>) {
     super(dataset);
+    this._d3LineFactory = d3LineFactory;
     this._className = "line";
     this._svgElementName = "path";
   }
@@ -25,5 +33,39 @@ export class Line extends Drawer {
 
   public selectionForIndex(index: number): SimpleSelection<any> {
     return d3.select(this.selection().node());
+  }
+
+  protected _drawStepCanvas(data: any[][], step: AppliedDrawStep) {
+    const context = this.canvas().node().getContext("2d");
+
+    const d3Line = this._d3LineFactory(this._dataset);
+
+    const attrToAppliedProjector = step.attrToAppliedProjector;
+    const resolvedAttrs = Object.keys(attrToAppliedProjector).reduce((obj, attrName) => {
+      obj[attrName] = attrToAppliedProjector[attrName](data, 0);
+      return obj;
+    }, {} as { [key: string]: any | number | string });
+
+    context.save();
+
+    context.beginPath();
+    d3Line.context(context);
+
+    d3Line(data[0]);
+
+    if (resolvedAttrs["stroke-width"]) {
+      context.lineWidth = parseFloat(resolvedAttrs["stroke-width"]);
+    }
+
+    if (resolvedAttrs["stroke"]) {
+      const strokeColor = d3.color(resolvedAttrs["stroke"]);
+      if (resolvedAttrs["opacity"]) {
+        strokeColor.opacity = resolvedAttrs["opacity"];
+      }
+      context.strokeStyle = strokeColor.rgb().toString();
+      context.stroke();
+    }
+
+    context.restore();
   }
 }

--- a/src/plots/areaPlot.ts
+++ b/src/plots/areaPlot.ts
@@ -100,7 +100,7 @@ export class Area<X> extends Line<X> {
   }
 
   protected _addDataset(dataset: Dataset) {
-    let lineDrawer = new Drawers.Line(dataset, this);
+    let lineDrawer = new Drawers.Line(dataset, this._d3LineFactory);
     if (this._isSetup) {
       lineDrawer.renderArea(this._renderArea.append("g"));
     }

--- a/src/plots/areaPlot.ts
+++ b/src/plots/areaPlot.ts
@@ -100,7 +100,7 @@ export class Area<X> extends Line<X> {
   }
 
   protected _addDataset(dataset: Dataset) {
-    let lineDrawer = new Drawers.Line(dataset, this._d3LineFactory);
+    let lineDrawer = new Drawers.Line(dataset, () => this._d3LineFactory(dataset));
     if (this._isSetup) {
       lineDrawer.renderArea(this._renderArea.append("g"));
     }

--- a/src/plots/areaPlot.ts
+++ b/src/plots/areaPlot.ts
@@ -100,7 +100,7 @@ export class Area<X> extends Line<X> {
   }
 
   protected _addDataset(dataset: Dataset) {
-    let lineDrawer = new Drawers.Line(dataset);
+    let lineDrawer = new Drawers.Line(dataset, this);
     if (this._isSetup) {
       lineDrawer.renderArea(this._renderArea.append("g"));
     }

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -224,7 +224,7 @@ export class Line<X> extends XYPlot<X, number> {
   }
 
   protected _createDrawer(dataset: Dataset): Drawer {
-    return new Drawers.Line(dataset, this._d3LineFactory);
+    return new Drawers.Line(dataset, () => this._d3LineFactory(dataset));
   }
 
   protected _extentsForProperty(property: string) {
@@ -485,10 +485,10 @@ export class Line<X> extends XYPlot<X, number> {
    * @returns {Line<[number,number]>}
    * @private
    */
-  protected _d3LineFactory = (
+  protected _d3LineFactory(
     dataset: Dataset,
     xProjector = Plot._scaledAccessor(this.x()),
-    yProjector = Plot._scaledAccessor(this.y())): d3Shape.Line<any> => {
+    yProjector = Plot._scaledAccessor(this.y())): d3Shape.Line<any> {
     const xScaledAccessor = Plot._scaledAccessor(this.x());
     const yScaledAccessor = Plot._scaledAccessor(this.x());
     const definedProjector = (d: any, i: number, dataset: Dataset) => {

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -4,6 +4,7 @@
  */
 
 import * as d3 from "d3";
+import * as d3Shape from "d3-shape";
 
 import * as Animators from "../animators";
 import { Accessor, AttributeToProjector, Projector, Point, Bounds, Range } from "../core/interfaces";
@@ -223,7 +224,7 @@ export class Line<X> extends XYPlot<X, number> {
   }
 
   protected _createDrawer(dataset: Dataset): Drawer {
-    return new Drawers.Line(dataset, this.d3LineFactory);
+    return new Drawers.Line(dataset, this._d3LineFactory);
   }
 
   protected _extentsForProperty(property: string) {
@@ -471,14 +472,23 @@ export class Line<X> extends XYPlot<X, number> {
 
   protected _constructLineProjector(xProjector: Projector, yProjector: Projector) {
     return (datum: any, index: number, dataset: Dataset) => {
-      return this.d3LineFactory(dataset, xProjector, yProjector)(datum);
+      return this._d3LineFactory(dataset, xProjector, yProjector)(datum);
     };
   }
 
-  private d3LineFactory = (
+  /**
+   * Return a d3.Line whose .x, .y, and .defined accessors are hooked up to the xProjector and yProjector
+   * after they've been fed the dataset, and whose curve is configured to this plot's curve.
+   * @param dataset
+   * @param xProjector
+   * @param yProjector
+   * @returns {Line<[number,number]>}
+   * @private
+   */
+  protected _d3LineFactory = (
     dataset: Dataset,
     xProjector = Plot._scaledAccessor(this.x()),
-    yProjector = Plot._scaledAccessor(this.y())): d3.Line<any> => {
+    yProjector = Plot._scaledAccessor(this.y())): d3Shape.Line<any> => {
     const xScaledAccessor = Plot._scaledAccessor(this.x());
     const yScaledAccessor = Plot._scaledAccessor(this.x());
     const definedProjector = (d: any, i: number, dataset: Dataset) => {

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -223,7 +223,7 @@ export class Line<X> extends XYPlot<X, number> {
   }
 
   protected _createDrawer(dataset: Dataset): Drawer {
-    return new Drawers.Line(dataset);
+    return new Drawers.Line(dataset, this.d3LineFactory);
   }
 
   protected _extentsForProperty(property: string) {
@@ -340,7 +340,6 @@ export class Line<X> extends XYPlot<X, number> {
           });
         }
       }
-      ;
     });
 
     return intersectionPoints;
@@ -471,20 +470,30 @@ export class Line<X> extends XYPlot<X, number> {
   }
 
   protected _constructLineProjector(xProjector: Projector, yProjector: Projector) {
-    let definedProjector = (d: any, i: number, dataset: Dataset) => {
-      let positionX = Plot._scaledAccessor(this.x())(d, i, dataset);
-      let positionY = Plot._scaledAccessor(this.y())(d, i, dataset);
+    return (datum: any, index: number, dataset: Dataset) => {
+      return this.d3LineFactory(dataset, xProjector, yProjector)(datum);
+    };
+  }
+
+  private d3LineFactory = (
+    dataset: Dataset,
+    xProjector = Plot._scaledAccessor(this.x()),
+    yProjector = Plot._scaledAccessor(this.y())): d3.Line<any> => {
+    const xScaledAccessor = Plot._scaledAccessor(this.x());
+    const yScaledAccessor = Plot._scaledAccessor(this.x());
+    const definedProjector = (d: any, i: number, dataset: Dataset) => {
+      let positionX = xScaledAccessor(d, i, dataset);
+      let positionY = yScaledAccessor(d, i, dataset);
       return positionX != null && !Utils.Math.isNaN(positionX) &&
         positionY != null && !Utils.Math.isNaN(positionY);
     };
-    return (datum: any, index: number, dataset: Dataset) => {
-      return d3.line()
-        .x((innerDatum, innerIndex) => xProjector(innerDatum, innerIndex, dataset))
-        .y((innerDatum, innerIndex) => yProjector(innerDatum, innerIndex, dataset))
-        .curve(this._getCurveFactory())
-        .defined((innerDatum, innerIndex) => definedProjector(innerDatum, innerIndex, dataset))(datum);
-    };
-  }
+
+    return d3.line()
+      .x((innerDatum, innerIndex) => xProjector(innerDatum, innerIndex, dataset))
+      .y((innerDatum, innerIndex) => yProjector(innerDatum, innerIndex, dataset))
+      .curve(this._getCurveFactory())
+      .defined((innerDatum, innerIndex) => definedProjector(innerDatum, innerIndex, dataset));
+  };
 
   protected _getCurveFactory(): d3.CurveFactory | d3.CurveFactoryLineOnly {
     const curve = this.curve();

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -489,11 +489,9 @@ export class Line<X> extends XYPlot<X, number> {
     dataset: Dataset,
     xProjector = Plot._scaledAccessor(this.x()),
     yProjector = Plot._scaledAccessor(this.y())): d3Shape.Line<any> {
-    const xScaledAccessor = Plot._scaledAccessor(this.x());
-    const yScaledAccessor = Plot._scaledAccessor(this.x());
     const definedProjector = (d: any, i: number, dataset: Dataset) => {
-      let positionX = xScaledAccessor(d, i, dataset);
-      let positionY = yScaledAccessor(d, i, dataset);
+      let positionX = Plot._scaledAccessor(this.x())(d, i, dataset);
+      let positionY = Plot._scaledAccessor(this.y())(d, i, dataset);
       return positionX != null && !Utils.Math.isNaN(positionX) &&
         positionY != null && !Utils.Math.isNaN(positionY);
     };

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -598,6 +598,11 @@ export class Plot extends Component {
     let dataToDraw = this._getDataToDraw();
     let drawers = this.datasets().map((dataset) => this._datasetToDrawer.get(dataset));
 
+    if (this.renderer() === "canvas") {
+      const canvas = this._canvas.node();
+      const context = canvas.getContext("2d");
+      context.clearRect(0, 0, canvas.width, canvas.height);
+    }
     this.datasets().forEach((ds, i) => drawers[i].draw(dataToDraw.get(ds), drawSteps));
 
     let times = this.datasets().map((ds, i) => drawers[i].totalDrawTime(dataToDraw.get(ds), drawSteps));

--- a/test/drawers/lineDrawerTests.ts
+++ b/test/drawers/lineDrawerTests.ts
@@ -1,9 +1,9 @@
-import { SimpleSelection } from "../../src/core/interfaces";
-import * as d3 from "d3";
-
 import { assert } from "chai";
+import * as d3 from "d3";
+import * as sinon from "sinon";
 
 import * as Plottable from "../../src";
+import { SimpleSelection } from "../../src/core/interfaces";
 
 import * as TestMethods from "../testMethods";
 
@@ -13,18 +13,20 @@ describe("Drawers", () => {
     let svg: SimpleSelection<void>;
     let drawer: Plottable.Drawers.Line;
 
+    const drawSteps: Plottable.Drawers.DrawStep[] = [
+      {
+        attrToProjector: {},
+        animator: new Plottable.Animators.Null(),
+      },
+    ];
+
+    let d3LineFactorySpy: sinon.SinonSpy;
+
     beforeEach(() => {
       svg = TestMethods.generateSVG();
-      drawer = new Plottable.Drawers.Line(null);
+      drawer = new Plottable.Drawers.Line(null, () => d3.line());
+      d3LineFactorySpy = sinon.spy(drawer, "_d3LineFactory");
       drawer.renderArea(svg);
-
-      const drawSteps: Plottable.Drawers.DrawStep[] = [
-        {
-          attrToProjector: {},
-          animator: new Plottable.Animators.Null(),
-        },
-      ];
-      drawer.draw(data, drawSteps);
     });
 
     afterEach(function() {
@@ -34,16 +36,26 @@ describe("Drawers", () => {
     });
 
     it("has a fill of \"none\"", () => {
+      drawer.draw(data, drawSteps);
       assert.strictEqual(drawer.selection().style("fill"), "none");
     });
 
     it("retrieves the same path regardless of requested selection index", () => {
+      drawer.draw(data, drawSteps);
       const expectedSelection = svg.selectAll<Element, any>("path");
       data[0].forEach((datum, index) => {
         const selectionForIndex = drawer.selectionForIndex(index);
         assert.strictEqual(selectionForIndex.size(), 1, `selection for index ${index} contains only one element`);
         assert.strictEqual(selectionForIndex.node(), expectedSelection.node(), `selection for index ${index} contains the correct element`);
       });
+    });
+
+    it("uses the line factory during canvas drawing", () => {
+      const canvas = d3.select(document.createElement("canvas"));
+      drawer.canvas(canvas);
+
+      drawer.draw(data, drawSteps);
+      assert.isTrue(d3LineFactorySpy.called, "got a line factory");
     });
   });
 });


### PR DESCRIPTION
Implementation of canvas rendering for Line Drawer. Supports stroke-width, stroke, and opacity attributes. 

TODO would be nice to deduplicate the d3.line logic between svg and canvas

Perf of drawing lines is much better; when zoomed in, perf is now dominated by croppedRendering doing a linear pass through all datapoints. 

Addresses second point of #3266 