### PR TITLE
remove box api

### DIFF
--- a/plottable.css
+++ b/plottable.css
@@ -68,8 +68,7 @@
 
 .plottable .background-container,
 .plottable .content,
-.plottable .foreground-container,
-.plottable .box-container {
+.plottable .foreground-container {
   position: absolute;
   width: 100%;
   height: 100%;
@@ -78,19 +77,8 @@
 /**
  * Don't allow svg elements above the content to steal events
  */
-.plottable .foreground-container,
-.plottable .box-container {
+.plottable .foreground-container {
   pointer-events: none;
-}
-
-.plottable .background-fill {
-  fill: none;
-}
-
-.plottable .bounding-box {
-  /* Invisible pink bounding-box to allow for collision testing */
-  fill: pink;
-  visibility: hidden;
 }
 
 .plottable .component-overflow-hidden {

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -794,7 +794,7 @@ export class Axis<D> extends Component {
    * container.
    */
   protected _hideOverflowingTickLabels() {
-    const boundingBox = (<Element> this._boundingBox.node()).getBoundingClientRect();
+    const boundingBox = this.element().node().getBoundingClientRect();
     const tickLabels = this._tickLabelContainer.selectAll<SVGGElement, any>("." + Axis.TICK_LABEL_CLASS);
     if (tickLabels.empty()) {
       return;

--- a/src/axes/numericAxis.ts
+++ b/src/axes/numericAxis.ts
@@ -277,7 +277,7 @@ export class Numeric extends Axis<number> {
   }
 
   private _hideEndTickLabels() {
-    const boundingBox = (<Element> this._boundingBox.node()).getBoundingClientRect();
+    const boundingBox = this.element().node().getBoundingClientRect();
     const tickLabels = this._tickLabelContainer.selectAll("." + Axis.TICK_LABEL_CLASS);
     if (tickLabels.size() === 0) {
       return;

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -616,7 +616,7 @@ export class Time extends Axis<Date> {
   }
 
   private _hideOverlappingAndCutOffLabels(index: number) {
-    const boundingBox = (<Element> this._boundingBox.node()).getBoundingClientRect();
+    const boundingBox = this.element().node().getBoundingClientRect();
 
     const isInsideBBox = (tickBox: ClientRect) => {
       return (

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -34,10 +34,6 @@ export class Component {
    */
   private _content: SimpleSelection<void>;
   /**
-   * Used by axes to hide cut off axis labels.
-   */
-  protected _boundingBox: SimpleSelection<void>;
-  /**
    * Place more objects just behind this Component's Content by appending them to the _backgroundContainer.
    */
   private _backgroundContainer: SimpleSelection<void>;
@@ -75,26 +71,6 @@ export class Component {
   protected _isSetup = false;
   protected _isAnchored = false;
 
-  /**
-   * List of "boxes"; SVGComponent has a "box" API that lets subclasses add boxes
-   * with "addBox". Two boxes are added:
-   *
-   * .background-fill - for the background container (unclear what it's use is)
-   * .bounding-box - this._boundingBox
-   *
-   * boxes get their width/height attributes updated in computeLayout.
-   *
-   * I think this API is to make an idea of a "100% width/height" box that could be
-   * useful in a variety of situations. But enumerating the three usages of it, it
-   * doesn't look like it's being used very much.
-   *
-   * TODO possily remove in HTML world
-   */
-  private _boxes: SimpleSelection<void>[] = [];
-  /**
-   * Element containing all the boxes.
-   */
-  private _boxContainer: SimpleSelection<void>;
   /**
    * If we're the root Component (top-level), this is the HTMLElement we've anchored to (user-supplied).
    */
@@ -192,18 +168,14 @@ export class Component {
     this._cssClasses = new Utils.Set<string>();
 
     this._backgroundContainer = this._element.append("svg").classed("background-container", true);
-    this._addBox("background-fill", this._backgroundContainer);
     this._content = this._element.append("svg").classed("content", true);
     this._foregroundContainer = this._element.append("svg").classed("foreground-container", true);
-    this._boxContainer = this._element.append("svg").classed("box-container", true);
 
     if (this._overflowHidden) {
       this._content.classed("component-overflow-hidden", true);
     } else {
       this._content.classed("component-overflow-visible", true);
     }
-
-    this._boundingBox = this._addBox("bounding-box");
 
     this._isSetup = true;
   }
@@ -263,7 +235,6 @@ export class Component {
       top: `${this._origin.y}px`,
       width: `${this.width()}px`,
     });
-    this._boxes.forEach((b: SimpleSelection<void>) => b.attr("width", this.width()).attr("height", this.height()));
 
     if (this._resizeHandler != null) {
       this._resizeHandler(size);
@@ -427,24 +398,6 @@ export class Component {
     this._yAlignment = yAlignment;
     this.redraw();
     return this;
-  }
-
-  private _addBox(className?: string, parentElement?: SimpleSelection<void>) {
-    if (this._element == null) {
-      throw new Error("Adding boxes before anchoring is currently disallowed");
-    }
-    parentElement = parentElement == null ? this._boxContainer : parentElement;
-    const box = parentElement.append("rect");
-    if (className != null) {
-      box.classed(className, true);
-    }
-    box.attr("stroke-width", "0");
-
-    this._boxes.push(box);
-    if (this.width() != null && this.height() != null) {
-      box.attr("width", this.width()).attr("height", this.height());
-    }
-    return box;
   }
 
   /**

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -258,7 +258,7 @@ describe("Axes", () => {
           axis.renderTo(div);
 
           const visibconstickLabels = applyVisibleFilter(axis.content().selectAll<Element, any>(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
-          const boundingBox = div.select(".axis").select<Element>(".bounding-box").node().getBoundingClientRect();
+          const boundingBox = axis.element().node().getBoundingClientRect();
           visibconstickLabels.each(function(d, i) {
             const visibconstickLabelRect = this.getBoundingClientRect();
             assertBoxInside(visibconstickLabelRect, boundingBox, 0.5, `tick label ${i} is inside the bounding box`);
@@ -275,7 +275,7 @@ describe("Axes", () => {
           axis.renderTo(div);
 
           const visibconstickLabels = applyVisibleFilter(axis.content().selectAll<Element, any>(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
-          const boundingBox = div.select(".axis").select<Element>(".bounding-box").node().getBoundingClientRect();
+          const boundingBox = axis.element().node().getBoundingClientRect();
           visibconstickLabels.each(function(d, i) {
             const visibconstickLabelRect = this.getBoundingClientRect();
             assertBoxInside(visibconstickLabelRect, boundingBox, 0, `long tick label ${i} is inside the bounding box`);

--- a/test/axes/timeAxisTests.ts
+++ b/test/axes/timeAxisTests.ts
@@ -329,7 +329,7 @@ describe("TimeAxis", () => {
 
       axis.renderTo(div);
 
-      let axisBoundingRect = (<Element> div.select(".axis").select(".bounding-box").node()).getBoundingClientRect();
+      let axisBoundingRect = axis.element().node().getBoundingClientRect();
 
       let isInsideAxisBoundingRect = function(innerRect: ClientRect) {
         return Math.floor(innerRect.bottom) <= Math.ceil(axisBoundingRect.bottom) + window.Pixel_CloseTo_Requirement &&

--- a/test/components/componentTests.ts
+++ b/test/components/componentTests.ts
@@ -36,26 +36,21 @@ describe("Component", () => {
       assert.isFalse(c.foreground().empty(), "foreground exists in the DOM");
       assert.isFalse(c.background().empty(), "background exists in the DOM");
       assert.isFalse(c.content().empty(), "content exists in the DOM");
-      assert.isFalse(c.background().select(".background-fill").empty(), "background fill container exists in the DOM");
 
       let componentElement = div.select(".component");
       let containerNodes = componentElement.selectAll<Element, any>("svg").nodes();
       assert.strictEqual(containerNodes[0], c.background().node(), "background at the back");
       assert.strictEqual(containerNodes[1], c.content().node(), "content at the middle");
       assert.strictEqual(containerNodes[2], c.foreground().node(), "foreground at the front");
-      assert.strictEqual(containerNodes[3], componentElement.select(".box-container").node(), "boxes at front of foreground");
       c.destroy();
       div.remove();
     });
 
-    it("sets the foreground-container and box-container pointer-events to none", () => {
+    it("sets the foreground-container pointer-events to none", () => {
       c.anchor(div);
       const foreground = c.foreground().node();
-      const boxContainer = c.element().select(".box-container").node();
       let pointerEventForeground = window.getComputedStyle(<Element>foreground).pointerEvents;
-      let pointerEventBox = window.getComputedStyle(<Element>boxContainer).pointerEvents;
       assert.strictEqual(pointerEventForeground, "none", "foreground-container's pointer-event is set to none");
-      assert.strictEqual(pointerEventBox, "none", "box-container's pointer-event is set to none");
       c.destroy();
       div.remove();
     });
@@ -450,14 +445,9 @@ describe("Component", () => {
       assert.strictEqual(c.width() , width, "width set");
       assert.strictEqual(c.height(), height, "height set");
 
-      let componentElement = div.select(".component");
+      let componentElement = c.element();
       let translate = [parseFloat(componentElement.style("left")), parseFloat(componentElement.style("top"))];
       assert.deepEqual(translate, [origin.x, origin.y], "the element translated appropriately");
-      let backgroundFillBox = div.select(".background-fill");
-      assert.closeTo(TestMethods.numAttr(backgroundFillBox, "width"),
-        width, window.Pixel_CloseTo_Requirement, "box width set to computed width");
-      assert.closeTo(TestMethods.numAttr(backgroundFillBox, "height"),
-        height, window.Pixel_CloseTo_Requirement, "box height set to computed height");
       c.destroy();
       div.remove();
     });

--- a/test/components/interpolatedColorLegendTests.ts
+++ b/test/components/interpolatedColorLegendTests.ts
@@ -11,7 +11,6 @@ describe("InterpolatedColorLegend", () => {
   const SWATCH_SELECTOR = ".swatch";
   const SWATCH_CONTAINER_SELECTOR = ".swatch-container";
   const SWATCH_BBOX_SELECTOR = ".swatch-bounding-box";
-  const BACKGROUND_SELECTOR = ".background-fill";
   const ORIENTATIONS = ["horizontal", "left", "right"];
 
   describe("Basic Usage", () => {
@@ -325,7 +324,7 @@ describe("InterpolatedColorLegend", () => {
       legend.orientation("left");
       legend.renderTo(div);
       let swatchBoundingRect = (<Element> legend.content().select(SWATCH_CONTAINER_SELECTOR).node()).getBoundingClientRect();
-      let legendBoundingRect = (<Element> legend.background().select(BACKGROUND_SELECTOR).node()).getBoundingClientRect();
+      let legendBoundingRect = legend.element().node().getBoundingClientRect();
       let swatchWidth = swatchBoundingRect.width;
       let swatchEdge = swatchBoundingRect.right;
       let legendEdge = legendBoundingRect.right;
@@ -334,7 +333,7 @@ describe("InterpolatedColorLegend", () => {
         "padding is approximately equal to swatch width");
       legend.expands(true);
       swatchBoundingRect = (<Element> legend.content().select(SWATCH_CONTAINER_SELECTOR).node()).getBoundingClientRect();
-      legendBoundingRect = (<Element> legend.background().select(BACKGROUND_SELECTOR).node()).getBoundingClientRect();
+      legendBoundingRect = legend.element().node().getBoundingClientRect();
       swatchWidth = swatchBoundingRect.width;
       swatchEdge = swatchBoundingRect.right;
       legendEdge = legendBoundingRect.right;
@@ -348,7 +347,7 @@ describe("InterpolatedColorLegend", () => {
       legend.orientation("right");
       legend.renderTo(div);
       let swatchBoundingRect = (<Element> legend.content().select(SWATCH_CONTAINER_SELECTOR).node()).getBoundingClientRect();
-      let legendBoundingRect = (<Element> legend.background().select(BACKGROUND_SELECTOR).node()).getBoundingClientRect();
+      let legendBoundingRect = legend.element().node().getBoundingClientRect();
       let swatchWidth = swatchBoundingRect.width;
       let swatchEdge = swatchBoundingRect.left;
       let legendEdge = legendBoundingRect.left;
@@ -358,7 +357,7 @@ describe("InterpolatedColorLegend", () => {
         "padding is approximately equal to swatch width");
       legend.expands(true);
       swatchBoundingRect = (<Element> legend.content().select(SWATCH_CONTAINER_SELECTOR).node()).getBoundingClientRect();
-      legendBoundingRect = (<Element> legend.background().select(BACKGROUND_SELECTOR).node()).getBoundingClientRect();
+      legendBoundingRect = legend.element().node().getBoundingClientRect();
       swatchWidth = swatchBoundingRect.width;
       swatchEdge = swatchBoundingRect.left;
       legendEdge = legendBoundingRect.left;
@@ -373,7 +372,7 @@ describe("InterpolatedColorLegend", () => {
       legend.orientation("horizontal");
       legend.renderTo(div);
       let swatchBoundingRect = (<Element> legend.content().select(SWATCH_CONTAINER_SELECTOR).node()).getBoundingClientRect();
-      let legendBoundingRect = (<Element> legend.background().select(BACKGROUND_SELECTOR).node()).getBoundingClientRect();
+      let legendBoundingRect = legend.element().node().getBoundingClientRect();
       let swatchHeight = swatchBoundingRect.height;
       let swatchEdge = swatchBoundingRect.bottom;
       let legendEdge = legendBoundingRect.bottom;
@@ -382,7 +381,7 @@ describe("InterpolatedColorLegend", () => {
         "padding is approximately equal to swatch height");
       legend.expands(true);
       swatchBoundingRect = (<Element> legend.content().select(SWATCH_CONTAINER_SELECTOR).node()).getBoundingClientRect();
-      legendBoundingRect = (<Element> legend.background().select(BACKGROUND_SELECTOR).node()).getBoundingClientRect();
+      legendBoundingRect = legend.element().node().getBoundingClientRect();
       swatchHeight = swatchBoundingRect.height;
       swatchEdge = swatchBoundingRect.bottom;
       legendEdge = legendBoundingRect.bottom;
@@ -413,7 +412,7 @@ describe("InterpolatedColorLegend", () => {
       const constrainedHeight = textHeight;
       div.style("height", constrainedHeight + "px");
       legend.redraw();
-      const legendBoundingRect = (<Element> legend.background().select(BACKGROUND_SELECTOR).node()).getBoundingClientRect();
+      const legendBoundingRect = legend.element().node().getBoundingClientRect();
       swatchBoundingRect = (<Element> legend.content().select(SWATCH_CONTAINER_SELECTOR).node()).getBoundingClientRect();
       const topPadding = swatchBoundingRect.top - legendBoundingRect.top;
       const bottomPadding = legendBoundingRect.bottom - swatchBoundingRect.bottom;
@@ -431,7 +430,7 @@ describe("InterpolatedColorLegend", () => {
       const constrainedWidth = textHeight * 2;
       div.style("width", constrainedWidth + "px");
       legend.redraw();
-      const legendBoundingRect = (<Element> legend.background().select(BACKGROUND_SELECTOR).node()).getBoundingClientRect();
+      const legendBoundingRect = legend.element().node().getBoundingClientRect();
       swatchBoundingRect = (<Element> legend.content().select(SWATCH_CONTAINER_SELECTOR).node()).getBoundingClientRect();
       const leftPadding = legendBoundingRect.right - swatchBoundingRect.right;
       assert.operator(leftPadding, "<", textHeight, "right-side padding degrades to be smaller than textHeight");
@@ -447,7 +446,7 @@ describe("InterpolatedColorLegend", () => {
       const constrainedWidth = textHeight * 2;
       div.style("width", constrainedWidth + "px");
       legend.redraw();
-      const legendBoundingRect = (<Element> legend.background().select(BACKGROUND_SELECTOR).node()).getBoundingClientRect();
+      const legendBoundingRect = legend.element().node().getBoundingClientRect();
       swatchBoundingRect = (<Element> legend.content().select(SWATCH_CONTAINER_SELECTOR).node()).getBoundingClientRect();
       const leftPadding = swatchBoundingRect.left - legendBoundingRect.left;
       assert.operator(leftPadding, "<", textHeight, "left-side padding degrades to be smaller than textHeight");

--- a/test/components/labelTests.ts
+++ b/test/components/labelTests.ts
@@ -23,7 +23,6 @@ describe("Labels", () => {
 
   describe("Label", () => {
     describe("Basic Usage", () => {
-      const BBOX_SELECTOR = ".bounding-box";
       let div: d3.Selection<HTMLDivElement, any, any, any>;
 
       beforeEach(() => {
@@ -54,7 +53,7 @@ describe("Labels", () => {
         label.angle(90);
         text = content.select("text");
         bbox = Plottable.Utils.DOM.elementBBox(text);
-        TestMethods.assertBBoxInclusion((<any> label)._element.select(BBOX_SELECTOR), text);
+        TestMethods.assertBBoxInclusion(label.element(), text);
         assert.closeTo(bbox.height, label.width(), window.Pixel_CloseTo_Requirement, "label is in vertical position");
 
         div.remove();
@@ -107,7 +106,7 @@ describe("Labels", () => {
         const content = label.content();
         const text = content.select("text");
         const textBBox = Plottable.Utils.DOM.elementBBox(text);
-        TestMethods.assertBBoxInclusion((<any> label)._element.select(BBOX_SELECTOR), text);
+        TestMethods.assertBBoxInclusion(label.element(), text);
         assert.closeTo(textBBox.height, label.width(), window.Pixel_CloseTo_Requirement, "text height");
         // OS/Browser specific kerning messes with typesetter's per-character measurement
         const widthFudge = str.length;
@@ -122,7 +121,7 @@ describe("Labels", () => {
         const content = label.content();
         const text = content.select("text");
         const textBBox = Plottable.Utils.DOM.elementBBox(text);
-        TestMethods.assertBBoxInclusion((<any> label)._element.select(BBOX_SELECTOR), text);
+        TestMethods.assertBBoxInclusion(label.element(), text);
         assert.closeTo(textBBox.height, label.width(), window.Pixel_CloseTo_Requirement, "text height");
         // OS/Browser specific kerning messes with typesetter's per-character measurement
         const widthFudge = str.length;
@@ -179,7 +178,7 @@ describe("Labels", () => {
       it("adds padding for label accordingly under left alignment", () => {
         label.xAlignment("left").renderTo(div);
         const testTextRect = (<Element> label.content().select("text").node()).getBoundingClientRect();
-        const elementRect = (<any> label)._element.node().getBoundingClientRect();
+        const elementRect = label.element().node().getBoundingClientRect();
         assert.closeTo(testTextRect.left, elementRect.left + PADDING, window.Pixel_CloseTo_Requirement,
           "left difference by padding amount");
 
@@ -189,7 +188,7 @@ describe("Labels", () => {
       it("adds padding for label accordingly under right alignment", () => {
         label.xAlignment("right").renderTo(div);
         const testTextRect = (<Element> label.content().select("text").node()).getBoundingClientRect();
-        const elementRect = (<any> label)._element.node().getBoundingClientRect();
+        const elementRect = label.element().node().getBoundingClientRect();
         assert.closeTo(testTextRect.right, elementRect.right - PADDING, window.Pixel_CloseTo_Requirement,
           "right difference by padding amount");
 
@@ -199,7 +198,7 @@ describe("Labels", () => {
       it("adds padding for label accordingly under top alignment", () => {
         label.yAlignment("top").renderTo(div);
         const testTextRect = (<Element> label.content().select("text").node()).getBoundingClientRect();
-        const elementRect = (<any> label)._element.node().getBoundingClientRect();
+        const elementRect = label.element().node().getBoundingClientRect();
         assert.closeTo(testTextRect.top, elementRect.top + PADDING, window.Pixel_CloseTo_Requirement,
           "top difference by padding amount");
 
@@ -209,7 +208,7 @@ describe("Labels", () => {
       it("adds padding for label accordingly under bottom alignment", () => {
         label.yAlignment("bottom").renderTo(div);
         const testTextRect = (<Element> label.content().select("text").node()).getBoundingClientRect();
-        const elementRect = (<any> label)._element.node().getBoundingClientRect();
+        const elementRect = label.element().node().getBoundingClientRect();
         assert.closeTo(testTextRect.bottom, elementRect.bottom - PADDING, window.Pixel_CloseTo_Requirement,
           "bottom difference by padding amount");
 

--- a/test/components/legendTests.ts
+++ b/test/components/legendTests.ts
@@ -70,8 +70,8 @@ describe("Legend", () => {
 
       const contentBBox = Plottable.Utils.DOM.elementBBox(legend.content());
       const contentBottomEdge = contentBBox.y + contentBBox.height;
-      const bboxBBox = Plottable.Utils.DOM.elementBBox((<any> legend)._element.select(".bounding-box"));
-      const bboxBottomEdge = bboxBBox.y + bboxBBox.height;
+      const bboxBBox = legend.element().node().getBoundingClientRect();
+      const bboxBottomEdge = bboxBBox.top + bboxBBox.height;
 
       assert.operator(contentBottomEdge, "<=", bboxBottomEdge, "content does not extend past bounding box");
       div.remove();
@@ -84,8 +84,7 @@ describe("Legend", () => {
       let text = legend.content().select("text").text();
       assert.notEqual(text, "foooboooloonoogoorooboopoo", "the text was truncated");
       let rightEdge = (<Element> legend.content().select("text").node()).getBoundingClientRect().right;
-      let bbox = (<any> legend)._element.select(".bounding-box");
-      let rightEdgeBBox = (<Element> bbox.node()).getBoundingClientRect().right;
+      let rightEdgeBBox = legend.element().node().getBoundingClientRect().right;
       assert.operator(rightEdge, "<=", rightEdgeBBox, "the long text did not overflow the legend");
       div.remove();
     });

--- a/test/globalInitialization.ts
+++ b/test/globalInitialization.ts
@@ -20,8 +20,7 @@ before(() => {
     // HACKHACK #2122
     window.Pixel_CloseTo_Requirement = 2;
   } else if (TestMethods.isIE()) {
-    const FP_EPSILON = 1e-5;
-    window.Pixel_CloseTo_Requirement = 1.5 + FP_EPSILON;
+    window.Pixel_CloseTo_Requirement = 2;
   } else {
     window.Pixel_CloseTo_Requirement = 0.5;
   }


### PR DESCRIPTION
Fixes #3261 

# Breaking changes

.bounding-box removed - use .width() and .height() instead, or use .element() to get the DOM element that bounds the component

.background-fill removed - was put in so CSS users could add a background color to the chart. Instead, style the .component
