### PR TITLE
scale canvas by devicePixelRatio

### DIFF
--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -152,10 +152,12 @@ export class Plot extends Component {
   public computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number) {
     super.computeLayout(origin, availableWidth, availableHeight);
     if (this._canvas != null) {
-      // update canvas width/height; this will also clear the canvas of any drawn elements so we should
+      // update canvas width/height taking into account retina displays.
+      // This will also clear the canvas of any drawn elements so we should
       // be sure not to computeLayout() without a render() in the future.
-      this._canvas.attr("width", this.width());
-      this._canvas.attr("height", this.height());
+      this._canvas.attr("width", this.width() * window.devicePixelRatio);
+      this._canvas.attr("height", this.height() * window.devicePixelRatio);
+      this._canvas.node().getContext("2d").scale(window.devicePixelRatio, window.devicePixelRatio);
     }
     return this;
   }


### PR DESCRIPTION
Fixes #3273 

FYI this decreases perf by devicePixelRatio^2 times (so e.g. rendering all of canvas_line is a little painful on the macbook)