### PR TITLE
reuse passed x/yProjectors into the line defined accessor

### DIFF
--- a/plottable.js
+++ b/plottable.js
@@ -6811,12 +6811,11 @@ var Line = (function (_super) {
      * @private
      */
     Line.prototype._d3LineFactory = function (dataset, xProjector, yProjector) {
-        var _this = this;
         if (xProjector === void 0) { xProjector = plot_1.Plot._scaledAccessor(this.x()); }
         if (yProjector === void 0) { yProjector = plot_1.Plot._scaledAccessor(this.y()); }
         var definedProjector = function (d, i, dataset) {
-            var positionX = plot_1.Plot._scaledAccessor(_this.x())(d, i, dataset);
-            var positionY = plot_1.Plot._scaledAccessor(_this.y())(d, i, dataset);
+            var positionX = xProjector(d, i, dataset);
+            var positionY = yProjector(d, i, dataset);
             return positionX != null && !Utils.Math.isNaN(positionX) &&
                 positionY != null && !Utils.Math.isNaN(positionY);
         };

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -493,8 +493,8 @@ export class Line<X> extends XYPlot<X, number> {
     xProjector = Plot._scaledAccessor(this.x()),
     yProjector = Plot._scaledAccessor(this.y())): d3Shape.Line<any> {
     const definedProjector = (d: any, i: number, dataset: Dataset) => {
-      const positionX = Plot._scaledAccessor(this.x())(d, i, dataset);
-      const positionY = Plot._scaledAccessor(this.y())(d, i, dataset);
+      const positionX = xProjector(d, i, dataset);
+      const positionY = yProjector(d, i, dataset);
       return positionX != null && !Utils.Math.isNaN(positionX) &&
         positionY != null && !Utils.Math.isNaN(positionY);
     };


### PR DESCRIPTION
avoids re-constructing a function on every invocation which improves perf