### PR TITLE
publish develop snapshots on every commit to develop

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,11 +24,17 @@ test:
     - yarn test
 
 deployment:
+  publish-npm-next:
+    branch: develop
+    commands:
+      - echo -e "$NPM_USER\n$NPM_PASS\n$NPM_EMAIL" | npm login
+      - ./publishSnapshot.sh
+      - ./demo.js
   demo:
     branch: /.*/
     commands:
       - ./demo.js
-  npm:
+  publish-npm-latest:
     tag: /v[0-9.]+(-beta[0-9.]*)?/
     commands:
       # Confirm we are ready to publish

--- a/publishSnapshot.sh
+++ b/publishSnapshot.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+GIT_DESCRIBE=`git describe --tags`
+
+if [ `git describe --tags --abbrev=0` == $GIT_DESCRIBE ]
+then
+  echo "Cannot snapshot publish concrete version ${GIT_DESCRIBE}"
+  exit 1
+else
+  # set package.json version
+  npm --no-git-tag-version version $GIT_DESCRIBE
+  yarn dist-compile
+  npm publish --tag next
+fi


### PR DESCRIPTION
Fixes #3308 

Note: With our current release process, the following behavior happens:

1. We commit a "bump version release" for e.g. v3.2.0, **which triggers a dev snapshot**
2. That commit will get published as e.g. `3.1.0-6-g123abc` to `next`
3. Then, we create git tag v3.2.0, and publish `3.2.0` to `latest` (which is actually the exact same release as `3.1.0-6g123abc`).

This means every `latest` release will be mirrored as a `next` release with a different version number, which is not ideal. Thoughts? @themadcreator @giladgray @aidanns 

Also, on the next commit to develop, we'd publish `3.2.0-1-g-456def` to `next` -- this means `next` never gets `3.2.0`; they just jump from `3.1.0-6` to `3.2.0`.