### PR TITLE
axis sets its own size

### DIFF
--- a/quicktests/overlaying/tests/basic/non_canvas_scatter.js
+++ b/quicktests/overlaying/tests/basic/non_canvas_scatter.js
@@ -1,8 +1,8 @@
 function makeData() {
   "use strict";
 
-  // makes 10k random points
-  return Array.apply(null, Array(10000)).map(() => ({
+  // makes 1k random points
+  return Array.apply(null, Array(1000)).map(() => ({
     x: Math.random(),
     y: Math.random(),
   }));

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -183,6 +183,23 @@ export class Axis<D> extends Component {
     return this;
   }
 
+  protected _sizeFromOffer(availableWidth: number, availableHeight: number) {
+    const requestedSpace = this.requestedSpace(availableWidth, availableHeight);
+    if (this.isHorizontal()) {
+      return {
+        width: availableWidth,
+        // always keep the height to be what we request; Axes tell the outside what height they are.
+        // this allows blueprint-chart to put the Axis in document flow by removing absolute positioning
+        height: requestedSpace.minHeight,
+      };
+    } else {
+      return {
+        height: availableHeight,
+        width: requestedSpace.minWidth,
+      };
+    }
+  }
+
   protected _setup() {
     super._setup();
     this._tickMarkContainer = this.content().append("g")

--- a/src/axes/categoryAxis.ts
+++ b/src/axes/categoryAxis.ts
@@ -6,11 +6,11 @@
 import * as d3 from "d3";
 import * as Typesetter from "typesettable";
 
+import { Component } from "../components/component";
 import { Point, SimpleSelection, SpaceRequest } from "../core/interfaces";
 import * as Scales from "../scales";
 import * as Utils from "../utils";
 import { Axis, AxisOrientation } from "./axis";
-import { Component } from "../components/component";
 
 export interface IDownsampleInfo {
   domain: string[];

--- a/src/axes/categoryAxis.ts
+++ b/src/axes/categoryAxis.ts
@@ -10,6 +10,7 @@ import { Point, SimpleSelection, SpaceRequest } from "../core/interfaces";
 import * as Scales from "../scales";
 import * as Utils from "../utils";
 import { Axis, AxisOrientation } from "./axis";
+import { Component } from "../components/component";
 
 export interface IDownsampleInfo {
   domain: string[];
@@ -140,6 +141,12 @@ export class Category extends Axis<string> {
 
   protected _getTickValues() {
     return this.getDownsampleInfo().domain;
+  }
+
+  protected _sizeFromOffer(availableWidth: number, availableHeight: number) {
+    // hack: continue using Component._sizeFromOffer to prevent angled axis ticks
+    // from overflowing their container
+    return (Component.prototype as any)._sizeFromOffer.call(this, availableWidth, availableHeight);
   }
 
   /**

--- a/src/drawers/canvasDrawer.ts
+++ b/src/drawers/canvasDrawer.ts
@@ -6,7 +6,7 @@
 import * as d3 from "d3";
 import { AttributeToAppliedProjector } from "../core/interfaces";
 import { IDrawer } from "./drawer";
-import { AppliedDrawStep } from "./index";
+import { AppliedDrawStep } from "./drawStep";
 
 export type CanvasDrawStep = (
   context: CanvasRenderingContext2D,

--- a/src/drawers/drawStep.ts
+++ b/src/drawers/drawStep.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2014-present Palantir Technologies
+ * @license MIT
+ */
+
+import { IAnimator } from "../animators/animator";
+import { AttributeToAppliedProjector, AttributeToProjector } from "../core/interfaces";
+
+/**
+ * A step for the drawer to draw.
+ *
+ * Specifies how AttributeToProjector needs to be animated.
+ */
+export type DrawStep = {
+  attrToProjector: AttributeToProjector;
+  animator: IAnimator;
+};
+
+/**
+ * A DrawStep that carries an AttributeToAppliedProjector map.
+ */
+export type AppliedDrawStep = {
+  attrToAppliedProjector: AttributeToAppliedProjector;
+  animator: IAnimator;
+};

--- a/src/drawers/drawer.ts
+++ b/src/drawers/drawer.ts
@@ -6,7 +6,7 @@
 import * as d3 from "d3";
 
 import { CanvasDrawer, CanvasDrawStep } from "./canvasDrawer";
-import { AppliedDrawStep } from "./index";
+import { AppliedDrawStep } from "./drawStep";
 import { SVGDrawer } from "./svgDrawer";
 
 /**

--- a/src/drawers/index.ts
+++ b/src/drawers/index.ts
@@ -3,34 +3,14 @@
  * @license MIT
  */
 
-import { IAnimator } from "../animators/animator";
-import { AttributeToAppliedProjector, AttributeToProjector } from "../core/interfaces";
-
 export * from "./arcDrawer";
 export * from "./arcOutlineDrawer";
 export * from "./areaDrawer";
 export * from "./canvasDrawer";
 export * from "./drawer";
+export * from "./drawStep";
 export * from "./lineDrawer";
 export * from "./rectangleDrawer";
 export * from "./segmentDrawer";
 export * from "./svgDrawer";
 export * from "./symbolDrawer";
-
-/**
- * A step for the drawer to draw.
- *
- * Specifies how AttributeToProjector needs to be animated.
- */
-export type DrawStep = {
-  attrToProjector: AttributeToProjector;
-  animator: IAnimator;
-};
-
-/**
- * A DrawStep that carries an AttributeToAppliedProjector map.
- */
-export type AppliedDrawStep = {
-  attrToAppliedProjector: AttributeToAppliedProjector;
-  animator: IAnimator;
-};

--- a/src/drawers/svgDrawer.ts
+++ b/src/drawers/svgDrawer.ts
@@ -9,7 +9,7 @@ import * as Utils from "../utils";
 
 import { SimpleSelection } from "../core/interfaces";
 import { IDrawer } from "./drawer";
-import { AppliedDrawStep } from "./index";
+import { AppliedDrawStep } from "./drawStep";
 
 /**
  * An SVGDrawer draws data by creating DOM elements and setting specific attributes on them

--- a/test/axes/numericAxisTests.ts
+++ b/test/axes/numericAxisTests.ts
@@ -86,12 +86,12 @@ describe("Axes", () => {
           const axis = new Plottable.Axes.Numeric(scale, orientation);
           axis.renderTo(div);
 
-          const visibconstickLabels = applyVisibleFilter(axis.content().selectAll<Element, any>(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+          const visibleTickLabels = applyVisibleFilter(axis.content().selectAll<Element, any>(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
 
-          visibconstickLabels.each(function(d, i) {
+          visibleTickLabels.each(function(d, i) {
             const labelRect = this.getBoundingClientRect();
-            visibconstickLabels.nodes().slice(i + 1).forEach(function(otherVisibconstickLabel, i2) {
-              const labelRect2 = (<Element> otherVisibconstickLabel).getBoundingClientRect();
+            visibleTickLabels.nodes().slice(i + 1).forEach(function(othervisibleTickLabel, i2) {
+              const labelRect2 = (<Element> othervisibleTickLabel).getBoundingClientRect();
               const rectOverlap = Plottable.Utils.DOM.clientRectsOverlap(labelRect, labelRect2);
               assert.isFalse(rectOverlap, `tick label ${i} does not overlap with tick label ${i2}`);
             });
@@ -110,16 +110,16 @@ describe("Axes", () => {
           const axis = new Plottable.Axes.Numeric(scale, orientation);
           axis.renderTo(div);
 
-          const visibconstickLabels = applyVisibleFilter(axis.content().selectAll<Element, any>(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+          const visibleTickLabels = applyVisibleFilter(axis.content().selectAll<Element, any>(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
 
-          const visibconstickLabelRects = visibconstickLabels.nodes().map((label: Element) => label.getBoundingClientRect());
+          const visibleTickLabelRects = visibleTickLabels.nodes().map((label: Element) => label.getBoundingClientRect());
 
           function getClientRectCenter(rect: ClientRect) {
             return isHorizontalOrientation(orientation) ? rect.left + rect.width / 2 : rect.top + rect.height / 2;
           }
 
-          const interval = getClientRectCenter(visibconstickLabelRects[1]) - getClientRectCenter(visibconstickLabelRects[0]);
-          d3.pairs(visibconstickLabelRects).forEach((rects, i) => {
+          const interval = getClientRectCenter(visibleTickLabelRects[1]) - getClientRectCenter(visibleTickLabelRects[0]);
+          d3.pairs(visibleTickLabelRects).forEach((rects, i) => {
             assert.closeTo(getClientRectCenter(rects[1]) - getClientRectCenter(rects[0]),
               interval, window.Pixel_CloseTo_Requirement, `tick label pair ${i} is spaced the same as the first pair`);
           });
@@ -258,11 +258,11 @@ describe("Axes", () => {
           const axis = new Plottable.Axes.Numeric(scale, orientation);
           axis.renderTo(div);
 
-          const visibconstickLabels = applyVisibleFilter(axis.content().selectAll<Element, any>(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+          const visibleTickLabels = applyVisibleFilter(axis.content().selectAll<Element, any>(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
           const boundingBox = axis.element().node().getBoundingClientRect();
-          visibconstickLabels.each(function(d, i) {
-            const visibconstickLabelRect = this.getBoundingClientRect();
-            assertBoxInside(visibconstickLabelRect, boundingBox, 0.5, `tick label ${i} is inside the bounding box`);
+          visibleTickLabels.each(function(d, i) {
+            const visibleTickLabelRect = this.getBoundingClientRect();
+            assertBoxInside(visibleTickLabelRect, boundingBox, 0.5, `tick label ${i} is inside the bounding box`);
           });
         });
       });
@@ -275,11 +275,11 @@ describe("Axes", () => {
           const axis = new Plottable.Axes.Numeric(scale, verticalOrientation);
           axis.renderTo(div);
 
-          const visibconstickLabels = applyVisibleFilter(axis.content().selectAll<Element, any>(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
+          const visibleTickLabels = applyVisibleFilter(axis.content().selectAll<Element, any>(`.${Plottable.Axis.TICK_LABEL_CLASS}`));
           const boundingBox = axis.element().node().getBoundingClientRect();
-          visibconstickLabels.each(function(d, i) {
-            const visibconstickLabelRect = this.getBoundingClientRect();
-            assertBoxInside(visibconstickLabelRect, boundingBox, 0, `long tick label ${i} is inside the bounding box`);
+          visibleTickLabels.each(function(d, i) {
+            const visibleTickLabelRect = this.getBoundingClientRect();
+            assertBoxInside(visibleTickLabelRect, boundingBox, 0, `long tick label ${i} is inside the bounding box`);
           });
         });
       });


### PR DESCRIPTION
Modify Axis to always be the width/height that it wants; Axes tell the outside what height they are.
This allows blueprint-chart to put the Axis in document flow by removing absolute positioning.

reduce the non_canvas_scatter number of points for better perf while looking through overlaying.

Fix a bad search/replace of let -> const in the tests

Refactor DrawStep to remove a circular dependency