### PR TITLE
Pass datum, index, and dataset to labelFormatter

### DIFF
--- a/quicktests/overlaying/tests/basic/negative_stacked_bar.js
+++ b/quicktests/overlaying/tests/basic/negative_stacked_bar.js
@@ -32,6 +32,7 @@ function run(svg, data, Plottable) {
     .attr("fill", function(d) { return d.team; }, colorScale)
     .datasets([dataset1, dataset2, dataset3])
     .labelsEnabled(true)
+    .extremaFormatter((d) => "Total: " + d)
     .animated(true);
 
   if (typeof verticalPlot.labelsFormatter === "function") {
@@ -46,6 +47,7 @@ function run(svg, data, Plottable) {
     .attr("fill", function(d) { return d.team; }, colorScale)
     .datasets([dataset1, dataset2, dataset3])
     .labelsEnabled(true)
+    .extremaFormatter((d) => "Total: " + d)
     .animated(true);
 
   if (typeof verticalPlot.labelsFormatter === "function") {

--- a/quicktests/overlaying/tests/basic/pies.js
+++ b/quicktests/overlaying/tests/basic/pies.js
@@ -39,7 +39,7 @@ function run(svg, data, Plottable){
           .innerRadius(100)
           .outerRadius(200)
           .labelsEnabled(true)
-          .labelFormatter(function(d){return "Value: " + d; })
+          .labelFormatter(function(v, datum){return datum.key + ": " + v; })
           .attr("fill", function(d){ return d.key; }, cs);
 
   var pies = new Plottable.Components.Group([innerPie, outerPie]);

--- a/src/axes/axis.ts
+++ b/src/axes/axis.ts
@@ -275,11 +275,13 @@ export class Axis<D> extends Component {
   }
 
   /**
-   * Gets the Formatter for the annotations.
+   * Gets the Formatter for the annotations. The annotationFormatter will be passed
+   * each value in annotatedTicks.
    */
   public annotationFormatter(): Formatter;
   /**
-   * Sets the Formatter for the annotations.
+   * Sets the Formatter for the annotations. The annotationFormatter will be passed
+   * each value in annotatedTicks.
    *
    * @returns {Axis} The calling Axis.
    */

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -29,13 +29,22 @@ export type TimeInterval = keyof typeof TimeInterval;
 /**
  * Defines a configuration for a Time Axis tier.
  * For details on how ticks are generated see: https://github.com/mbostock/d3/wiki/Time-Scales#ticks
- * interval - A time unit associated with this configuration (seconds, minutes, hours, etc).
- * step - number of intervals between each tick.
- * formatter - formatter used to format tick labels.
  */
 export type TimeAxisTierConfiguration = {
+  /**
+   * The time unit associated with this configuration (seconds, minutes, hours, etc).
+   */
   interval: string;
+
+  /**
+   * Number of intervals between each tick.
+   */
   step: number;
+
+  /**
+   * Formatter used to format tick labels. Tick values will be passed through the formatter
+   * before being displayed.
+   */
   formatter: Formatter;
 };
 

--- a/src/components/interpolatedColorLegend.ts
+++ b/src/components/interpolatedColorLegend.ts
@@ -70,11 +70,13 @@ export class InterpolatedColorLegend extends Component {
   }
 
   /**
-   * Gets the Formatter for the labels.
+   * Gets the Formatter for the labels. The domain ticks will be passed through the formatter
+   * before being displayed.
    */
   public formatter(): Formatter;
   /**
-   * Sets the Formatter for the labels.
+   * Sets the Formatter for the labels. The domain ticks will be passed through the formatter
+   * before being displayed.
    *
    * @param {Formatter} formatter
    * @returns {InterpolatedColorLegend} The calling InterpolatedColorLegend.

--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -286,7 +286,8 @@ export class Legend extends Component {
    */
   public formatter(): Formatter;
   /**
-   * Sets the Formatter for the entry texts.
+   * Sets the Formatter for the entry texts. The name of each entry (as defined by the domain of this legend's
+   * Color Scale) will be passed through this formatter before being displayed.
    *
    * @param {Formatter} formatter
    * @returns {Legend} The calling Legend.

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -4,8 +4,20 @@
  */
 
 import * as d3 from "d3";
+import { Dataset } from "./dataset";
 
-export type Formatter = (d: any) => string;
+/**
+ * A basic formatter function that will be passed a value to format (e.g. the tick value for axes).
+ * A Formatter should return the formatted string representation of the input value.
+ */
+export type Formatter = (value: any) => string;
+
+/**
+ * A formatter function that will be passed the value to format as well as the underlying datum, index, and
+ * dataset that the value came from. Datum-backed visual elements that display labels, such as Bar Plot bars
+ * or Pie Plot sectors, will use this formatter.
+ */
+export type DatumFormatter = (value: any, datum: any, index: number, dataset: Dataset) => string;
 
 interface IPredicatedFormat {
   specifier: string;

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -9,6 +9,9 @@ import { Dataset } from "./dataset";
 /**
  * A basic formatter function that will be passed a value to format (e.g. the tick value for axes).
  * A Formatter should return the formatted string representation of the input value.
+ *
+ * The value will be different for each use of the formatter - check the documentation of individual
+ * methods to see what will be passed into the formatter.
  */
 export type Formatter = (value: any) => string;
 
@@ -16,6 +19,9 @@ export type Formatter = (value: any) => string;
  * A formatter function that will be passed the value to format as well as the underlying datum, index, and
  * dataset that the value came from. Datum-backed visual elements that display labels, such as Bar Plot bars
  * or Pie Plot sectors, will use this formatter.
+ *
+ * The value will be different for each use of the formatter - check the documentation of individual
+ * methods to see what will be passed into the formatter.
  */
 export type DatumFormatter = (value: any, datum: any, index: number, dataset: Dataset) => string;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export { DragBoxCallback } from "./components/dragBoxLayer";
 export { IDragLineCallback } from "./components/dragLineLayer";
 
 export * from "./core/dataset";
-export { Formatter } from "./core/formatters";
+export { Formatter, DatumFormatter } from "./core/formatters";
 export * from "./core/interfaces";
 export { SymbolFactory } from "./core/symbolFactories";
 export { version } from "./core/version";

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -325,7 +325,10 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
    */
   public labelFormatter(): DatumFormatter;
   /**
-   * Sets the Formatter for the labels.
+   * Sets the Formatter for the labels. The labelFormatter will be fed each bar's
+   * computed height as defined by the `.y()` accessor for vertical bars, or the
+   * width as defined by the `.x()` accessor for horizontal bars, as well as the
+   * datum, datum index, and dataset associated with that bar.
    *
    * @param {Formatter} formatter
    * @returns {Bar} The calling Bar Plot.

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -9,7 +9,7 @@ import * as Typesetter from "typesettable";
 import * as Animators from "../animators";
 import { Dataset } from "../core/dataset";
 import * as Formatters from "../core/formatters";
-import { Formatter } from "../core/formatters";
+import { DatumFormatter } from "../core/formatters";
 import { AttributeToProjector, Bounds, IAccessor, Point, Range, SimpleSelection } from "../core/interfaces";
 import * as Drawers from "../drawers";
 import { ProxyDrawer } from "../drawers/drawer";
@@ -54,7 +54,7 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
   private _baseline: SimpleSelection<void>;
   private _baselineValue: X|Y;
   protected _isVertical: boolean;
-  private _labelFormatter: Formatter = Formatters.identity();
+  private _labelFormatter: DatumFormatter = Formatters.identity();
   private _labelsEnabled = false;
   private _labelsPosition = LabelsPosition.end;
   private _hideBarsIfAnyAreTooWide = true;
@@ -323,15 +323,15 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
   /**
    * Gets the Formatter for the labels.
    */
-  public labelFormatter(): Formatter;
+  public labelFormatter(): DatumFormatter;
   /**
    * Sets the Formatter for the labels.
    *
    * @param {Formatter} formatter
    * @returns {Bar} The calling Bar Plot.
    */
-  public labelFormatter(formatter: Formatter): this;
-  public labelFormatter(formatter?: Formatter): any {
+  public labelFormatter(formatter: DatumFormatter): this;
+  public labelFormatter(formatter?: DatumFormatter): any {
     if (formatter == null) {
       return this._labelFormatter;
     } else {
@@ -605,7 +605,7 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
 
     const barCoordinates = { x: attrToProjector["x"](datum, index, dataset), y: attrToProjector["y"](datum, index, dataset) };
     const barDimensions = { width: attrToProjector["width"](datum, index, dataset), height: attrToProjector["height"](datum, index, dataset) };
-    const text = this._labelFormatter(valueAccessor(datum, index, dataset));
+    const text = this._labelFormatter(value, datum, index, dataset);
     const measurement = measurer.measure(text);
 
     const showLabelOnBar = this._getShowLabelOnBar(barCoordinates, barDimensions, measurement);

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -9,7 +9,7 @@ import * as Typesetter from "typesettable";
 import * as Animators from "../animators";
 import { Dataset } from "../core/dataset";
 import * as Formatters from "../core/formatters";
-import { DatumFormatter, Formatter } from "../core/formatters";
+import { DatumFormatter } from "../core/formatters";
 import { AttributeToProjector, IAccessor, Point, SimpleSelection } from "../core/interfaces";
 import * as Scales from "../scales";
 import { Scale } from "../scales/scale";
@@ -314,7 +314,9 @@ export class Pie extends Plot {
    */
   public labelFormatter(): DatumFormatter;
   /**
-   * Sets the Formatter for the labels.
+   * Sets the Formatter for the labels. The labelFormatter will be fed each pie
+   * slice's value as computed by the `.sectorValue()` accessor, as well as the
+   * datum, datum index, and dataset associated with that bar.
    *
    * @param {Formatter} formatter
    * @returns {Pie} The calling Pie Plot.

--- a/src/plots/piePlot.ts
+++ b/src/plots/piePlot.ts
@@ -9,7 +9,7 @@ import * as Typesetter from "typesettable";
 import * as Animators from "../animators";
 import { Dataset } from "../core/dataset";
 import * as Formatters from "../core/formatters";
-import { Formatter } from "../core/formatters";
+import { DatumFormatter, Formatter } from "../core/formatters";
 import { AttributeToProjector, IAccessor, Point, SimpleSelection } from "../core/interfaces";
 import * as Scales from "../scales";
 import { Scale } from "../scales/scale";
@@ -35,7 +35,7 @@ export class Pie extends Plot {
   private _endAngle: number = 2 * Math.PI;
   private _startAngles: number[];
   private _endAngles: number[];
-  private _labelFormatter: Formatter = Formatters.identity();
+  private _labelFormatter: DatumFormatter = Formatters.identity();
   private _labelsEnabled = false;
   private _strokeDrawers: Utils.Map<Dataset, ArcOutlineSVGDrawer>;
 
@@ -312,15 +312,15 @@ export class Pie extends Plot {
   /**
    * Gets the Formatter for the labels.
    */
-  public labelFormatter(): Formatter;
+  public labelFormatter(): DatumFormatter;
   /**
    * Sets the Formatter for the labels.
    *
    * @param {Formatter} formatter
    * @returns {Pie} The calling Pie Plot.
    */
-  public labelFormatter(formatter: Formatter): this;
-  public labelFormatter(formatter?: Formatter): any {
+  public labelFormatter(formatter: DatumFormatter): this;
+  public labelFormatter(formatter?: DatumFormatter): any {
     if (formatter == null) {
       return this._labelFormatter;
     } else {
@@ -598,7 +598,7 @@ export class Pie extends Plot {
       if (!Utils.Math.isValidNumber(value)) {
         return;
       }
-      value = this._labelFormatter(value);
+      value = this._labelFormatter(value, datum, datumIndex, dataset);
       const measurement = measurer.measure(value);
 
       const theta = (this._endAngles[datumIndex] + this._startAngles[datumIndex]) / 2;

--- a/src/plots/stackedBarPlot.ts
+++ b/src/plots/stackedBarPlot.ts
@@ -108,7 +108,8 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
   /**
    * Sets the Formatter for the stacked bar extrema labels. Extrema labels are the
    * numbers at the very top and bottom of the stack that aren't associated
-   * with a single datum.
+   * with a single datum. Their value will be passed through this formatter
+   * before being displayed.
    *
    * @param {Formatter} formatter
    * @returns {this}

--- a/src/plots/stackedBarPlot.ts
+++ b/src/plots/stackedBarPlot.ts
@@ -6,13 +6,13 @@
 import * as Typesetter from "typesettable";
 
 import { Dataset } from "../core/dataset";
+import { Formatter, identity } from "../core/formatters";
 import { IAccessor, Point, SimpleSelection } from "../core/interfaces";
 import { Scale } from "../scales/scale";
 import * as Utils from "../utils";
 
 import * as Plots from "./";
 import { Bar, BarOrientation } from "./barPlot";
-import { Formatter, identity } from "../core/formatters";
 
 export class StackedBar<X, Y> extends Bar<X, Y> {
   protected static _STACKED_BAR_LABEL_PADDING = 5;

--- a/src/plots/stackedBarPlot.ts
+++ b/src/plots/stackedBarPlot.ts
@@ -151,7 +151,7 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
       if (maximum.extent !== baselineValue) {
         // only draw sums for values not at the baseline
 
-        const text = this.labelFormatter()(maximum.extent);
+        const text = this.labelFormatter()(maximum.extent, undefined, undefined, undefined);
         const measurement = this._measurer.measure(text);
 
         const primaryTextMeasurement = this._isVertical ? measurement.width : measurement.height;
@@ -170,7 +170,7 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
 
     minimumExtents.forEach((minimum) => {
       if (minimum.extent !== baselineValue) {
-        const text = this.labelFormatter()(minimum.extent);
+        const text = this.labelFormatter()(minimum.extent, undefined, undefined, undefined);
         const measurement = this._measurer.measure(text);
 
         const primaryTextMeasurement = this._isVertical ? measurement.width : measurement.height;

--- a/src/plots/stackedBarPlot.ts
+++ b/src/plots/stackedBarPlot.ts
@@ -12,10 +12,12 @@ import * as Utils from "../utils";
 
 import * as Plots from "./";
 import { Bar, BarOrientation } from "./barPlot";
+import { Formatter, identity } from "../core/formatters";
 
 export class StackedBar<X, Y> extends Bar<X, Y> {
   protected static _STACKED_BAR_LABEL_PADDING = 5;
 
+  private _extremaFormatter: Formatter = identity();
   private _labelArea: SimpleSelection<void>;
   private _measurer: Typesetter.CacheMeasurer;
   private _writer: Typesetter.Writer;
@@ -99,6 +101,30 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
     return this;
   }
 
+  /**
+   * Gets the Formatter for the stacked bar extrema labels.
+   */
+  public extremaFormatter(): Formatter;
+  /**
+   * Sets the Formatter for the stacked bar extrema labels. Extrema labels are the
+   * numbers at the very top and bottom of the stack that aren't associated
+   * with a single datum.
+   *
+   * @param {Formatter} formatter
+   * @returns {this}
+   */
+  public extremaFormatter(formatter: Formatter): this;
+
+  public extremaFormatter(formatter?: Formatter): any {
+    if (arguments.length === 0) {
+      return this._extremaFormatter;
+    } else {
+      this._extremaFormatter = formatter;
+      this.render();
+      return this;
+    }
+  }
+
   protected _setup() {
     super._setup();
     this._labelArea = this._renderArea.append("g").classed(Bar._LABEL_AREA_CLASS, true);
@@ -151,7 +177,7 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
       if (maximum.extent !== baselineValue) {
         // only draw sums for values not at the baseline
 
-        const text = this.labelFormatter()(maximum.extent, undefined, undefined, undefined);
+        const text = this.extremaFormatter()(maximum.extent);
         const measurement = this._measurer.measure(text);
 
         const primaryTextMeasurement = this._isVertical ? measurement.width : measurement.height;
@@ -170,7 +196,7 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
 
     minimumExtents.forEach((minimum) => {
       if (minimum.extent !== baselineValue) {
-        const text = this.labelFormatter()(minimum.extent, undefined, undefined, undefined);
+        const text = this.extremaFormatter()(minimum.extent);
         const measurement = this._measurer.measure(text);
 
         const primaryTextMeasurement = this._isVertical ? measurement.width : measurement.height;

--- a/test/namespacingTests.ts
+++ b/test/namespacingTests.ts
@@ -1,6 +1,10 @@
-import * as Plottable from "./src";
+/**
+ * @fileoverview Tests the namespace structure to ensure all the exports we want to be available, are.
+ */
 
-var test = [
+import * as Plottable from "../src";
+
+const test = [
   // namespaces and nested namespaces
   Plottable.Animators.Easing,
   Plottable.Animators.Null,
@@ -11,7 +15,7 @@ var test = [
   Plottable.Components.Table,
   Plottable.Configs.SHOW_WARNINGS,
   Plottable.Dispatchers.Key,
-  Plottable.Drawers.Line,
+  Plottable.Drawers.LineSVGDrawer,
   Plottable.Formatters.identity,
   Plottable.Plots.Pie,
   Plottable.Plots.Animator.MAIN,
@@ -30,7 +34,7 @@ var test = [
   Plottable.ComponentContainer,
   Plottable.Dataset,
   Plottable.Dispatcher,
-  Plottable.Drawer,
+  Plottable.ProxyDrawer,
   Plottable.Interaction,
   Plottable.Plot,
   Plottable.QuantitativeScale,
@@ -38,30 +42,29 @@ var test = [
   Plottable.XYPlot,
 ];
 
-type TestInterfaces = Plottable.Axes.DownsampleInfo
-  | Plottable.Axes.TimeAxisConfiguration
-  | Plottable.Plots.AccessorScaleBinding<any, any>
-  | Plottable.Scales.TickGenerators.TickGenerator<any>
-  | Plottable.Scales.PaddingExceptionsProvider<any>
-  | Plottable.Accessor<any>
-  | Plottable.Animator
-  | Plottable.DragLineCallback<any>
-  | Plottable.DragBoxCallback
-  | Plottable.Entity<any>
-  | Plottable.ScaleCallback<any>;
-
+type TestInterfaces = Plottable.Axes.IDownsampleInfo
+    | Plottable.Axes.TimeAxisConfiguration
+    | Plottable.Plots.IAccessorScaleBinding<any, any>
+    | Plottable.Scales.TickGenerators.ITickGenerator<any>
+    | Plottable.Scales.IPaddingExceptionsProvider<any>
+    | Plottable.IAccessor<any>
+    | Plottable.IAnimator
+    | Plottable.IDragLineCallback<any>
+    | Plottable.DragBoxCallback
+    | Plottable.IEntity<any>
+    | Plottable.IScaleCallback<any>;
 
 type TestTypeAliases = Plottable.Bounds
-  | Plottable.ClickCallback
-  | Plottable.DatasetCallback
-  | Plottable.Formatter
-  | Plottable.Point
-  | Plottable.PointerCallback
-  | Plottable.Projector
-  | Plottable.Range
-  | Plottable.SpaceRequest
-  | Plottable.SymbolFactory
-  | Plottable.TransformableScale<any, any>
-  | Plottable.AxisOrientation;
+    | Plottable.ClickCallback
+    | Plottable.DatasetCallback
+    | Plottable.Formatter
+    | Plottable.Point
+    | Plottable.PointerCallback
+    | Plottable.Projector
+    | Plottable.Range
+    | Plottable.SpaceRequest
+    | Plottable.SymbolFactory
+    | Plottable.TransformableScale<any, any>
+    | Plottable.AxisOrientation;
 
 const version = Plottable.version;

--- a/test/namespacingTests.ts
+++ b/test/namespacingTests.ts
@@ -4,6 +4,7 @@
 
 import * as Plottable from "../src";
 
+// tslint:disable-next-line:no-unused-variable
 const test = [
   // namespaces and nested namespaces
   Plottable.Animators.Easing,
@@ -67,4 +68,5 @@ type TestTypeAliases = Plottable.Bounds
     | Plottable.TransformableScale<any, any>
     | Plottable.AxisOrientation;
 
+// tslint:disable-next-line:no-unused-variable
 const version = Plottable.version;

--- a/test/plots/piePlotTests.ts
+++ b/test/plots/piePlotTests.ts
@@ -351,17 +351,17 @@ describe("Plots", () => {
 
       it("uses its formatter to format labels", () => {
         const data = [
-          { value: 5 },
-          { value: 15 },
+          { value: 5, name: "a" },
+          { value: 15, name: "b" },
         ];
-        const dataset = new Plottable.Dataset(data);
+        const dataset = new Plottable.Dataset(data).metadata("foo");
         piePlot.addDataset(dataset);
-        piePlot.labelFormatter((n: number) => n + " m");
+        piePlot.labelFormatter((n: number, datum, index, dataset) => `${n}, ${datum.name}, ${index}, ${dataset.metadata()}`);
         piePlot.renderTo(div);
         const texts = div.selectAll<Element, any>("text").nodes().map((n: any) => d3.select(n).text());
         assert.lengthOf(texts, 2, "both labels are drawn");
-        assert.strictEqual(texts[0], "5 m", "The formatter was used to format the label for slice index 0");
-        assert.strictEqual(texts[1], "15 m", "The formatter was used to format the label for slice index 1");
+        assert.strictEqual(texts[0], "5, a, 0, foo", "The formatter was used to format the label for slice index 0");
+        assert.strictEqual(texts[1], "15, b, 1, foo", "The formatter was used to format the label for slice index 1");
         div.remove();
       });
 


### PR DESCRIPTION
Fixes #3088 

Introduce a `DatumFormatter`, separate from normal `Formatter`. DatumFormatter is passed the value (like Formatter), as well as the `datum`, `index`, and `dataset` of the datum being labelled. Use this for bar and pie plots.

Loosely based on #3226, thanks @dallinregehr for the existing work!