### PR TITLE
Deferred Rendering Fixes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -101,6 +101,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask("dev-compile", [
     "exec:yarn:build:tsc",
+    "exec:yarn:build:webpack",
     "update-quicktests"
   ]);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,14 +100,14 @@ module.exports = function(grunt) {
   require("load-grunt-tasks")(grunt);
 
   grunt.registerTask("dev-compile", [
-    "exec:yarn:build",
+    "exec:yarn:build:tsc",
     "update-quicktests"
   ]);
 
   grunt.registerTask("default", ["exec:yarn:start"]);
 
   grunt.registerTask("test", ["dev-compile", "test-local"]);
-  grunt.registerTask("test-local", ["blanket_mocha", "lint"]);
+  grunt.registerTask("test-local", ["blanket_mocha"]);
   grunt.registerTask("test-sauce", ["connect", "saucelabs-mocha"]);
 
   grunt.registerTask("watch-quicktests", function() {
@@ -116,13 +116,13 @@ module.exports = function(grunt) {
     grunt.task.run(["watch"]);
   });
 
-  grunt.registerTask("lint", ["jscs", "eslint"]);
+  grunt.registerTask("lint", ["exec:yarn:lint", "jscs", "eslint"]);
 
   // Disable saucelabs on dev environments by checking if SAUCE_USERNAME is an environment variable
   if (process.env.SAUCE_USERNAME) {
-    grunt.registerTask("test-travis", ["dev-compile", "test-local", "test-sauce"]);
+    grunt.registerTask("test-ci", ["dev-compile", "lint", "test-local", "test-sauce"]);
   } else {
-    grunt.registerTask("test-travis", ["dev-compile", "test-local"]);
+    grunt.registerTask("test-ci", ["dev-compile", "lint", "test-local"]);
   }
 
   grunt.registerTask("update-quicktests", function() {

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ dependencies:
 
 test:
   override:
-    - yarn test
+    - yarn test:ci
 
 deployment:
   publish-npm-next:

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "start:watch-quicktests": "grunt watch-quicktests",
     "start:watch-tsc": "tsc -w -p .",
     "start:webpack-dev-server": "webpack-dev-server",
-    "test": "grunt test-travis"
+    "test": "grunt test-local",
+    "test:ci": "grunt test-ci"
   },
   "devDependencies": {
     "@types/chai": "^3.4.34",

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -19,6 +19,17 @@ export interface IAccessor<T> {
 }
 
 /**
+ * Converts one range-like value to another. This is useful to, for example,
+ * floor or ceiling a pixel coordinate after the scale has been applied.
+ * Performing the a `Math.floor` inside the accessor is not advised since it
+ * prevents the storage of the scale object for other features like nearest
+ * entity location, computing extents, or deferred rendering.
+ */
+export interface IRangeProjector<T> {
+  (value: T, datum: any, index: number, dataset: Dataset): T;
+}
+
+/**
  * Retrieves a scaled datum property.
  * Essentially passes the result of an Accessor through a Scale.
  * Projectors are exclusively built from Plot._scaledAccessor.

--- a/src/plots/commons.ts
+++ b/src/plots/commons.ts
@@ -4,7 +4,7 @@
  */
 
 import { Dataset } from "../core/dataset";
-import { IAccessor, IEntity, Point } from "../core/interfaces";
+import { IAccessor, IEntity, IRangeProjector, Point } from "../core/interfaces";
 import { IDrawer } from "../drawers/drawer";
 import { Plot } from "../plots/plot";
 import { Scale, TransformableScale } from "../scales/scale";
@@ -39,12 +39,27 @@ export interface IAccessorScaleBinding<D, R> {
    * The first argument in `plot.x((d) => d.x, scale)`.
    */
   accessor: IAccessor<any>;
+
   /**
    * The Scale that the accessor's result gets passed through.
    *
    * The second argument in `plot.x((d) => d.x, scale)`.
    */
   scale?: Scale<D, R>;
+
+  /**
+   * Transforms the scaled result of the accessor.
+   *
+   * Normally, the accessors ,`(d) => d.x`, will be wrapped like
+   * `scale.scale((d) => d.x)`. But, this is not sufficient if you want to
+   * modify the scaled value.
+   *
+   * However, moving the scale inside the accessor prevents several useful
+   * features from working properly (including `computeExtents`, `entityNearest`
+   * and `deferredRendering`). So, you may optionally provide this projector
+   * which, if present, will be applied to the scaled accessor result.
+   * */
+  postScale?: IRangeProjector<R>;
 }
 
 /**
@@ -55,6 +70,7 @@ export interface IAccessorScaleBinding<D, R> {
 export interface ITransformableAccessorScaleBinding<D, R> {
   accessor: IAccessor<any>;
   scale?: TransformableScale<D, R>;
+  postScale?: IRangeProjector<R>;
 }
 
 export namespace Animator {

--- a/src/plots/deferredRenderer.ts
+++ b/src/plots/deferredRenderer.ts
@@ -65,7 +65,6 @@ export class DeferredRenderer<X, Y> {
     if (scaleY) {
       this.domainTransformY.setDomain(scaleY.domain());
     }
-    this.resetTransforms();
     this.renderDeferred();
   }
 

--- a/src/plots/deferredRenderer.ts
+++ b/src/plots/deferredRenderer.ts
@@ -1,0 +1,85 @@
+
+import { Scale } from "../scales/scale";
+
+class DomainTransform<T> {
+  public translate = 0;
+  public scale = 0;
+  private cachedDomain: T[] = [null, null];
+  private lastSeenDomain: T[] = [null, null];
+  private renderCallback: () => void;
+
+  public reset() {
+    this.translate = 0;
+    this.scale = 1;
+    this.cachedDomain = this.lastSeenDomain;
+  }
+
+  public setDomain(domain: T[]) {
+    this.cachedDomain = domain;
+  }
+
+  public updateDomain = (scale: Scale<T, any>) => {
+    this.lastSeenDomain = scale.domain();
+    const cachedLength = scale.scale(this.cachedDomain[1]) - scale.scale(this.cachedDomain[0]);
+    const lastSeenLength = scale.scale(this.lastSeenDomain[1]) - scale.scale(this.lastSeenDomain[0]);
+    this.scale = (cachedLength / lastSeenLength) || 1;
+    this.translate = scale.scale(this.cachedDomain[0]) - scale.scale(this.lastSeenDomain[0]) * this.scale || 0;
+  };
+}
+
+export class DeferredRenderer<X, Y> {
+  private static DEFERRED_RENDERING_DELAY = 200;
+
+  private domainTransformX = new DomainTransform<X>();
+  private domainTransformY = new DomainTransform<Y>();
+  private timeoutToken: number;
+
+  constructor(
+    private renderCallback: () => void,
+    private applyTransformCallback: (tx: number, ty: number, sx: number, sy: number) => void,
+  ) {}
+
+  public reset() {
+      this.domainTransformX.reset();
+      this.domainTransformY.reset();
+  }
+
+  public setDomains(scaleX?: Scale<X, any>, scaleY?: Scale<Y, any>) {
+    if (scaleX) {
+      this.domainTransformX.setDomain(scaleX);
+    }
+    if (scaleY) {
+      this.domainTransformY.setDomain(scaleY);
+    }
+    this.renderCallback();
+  }
+
+  public updateDomains(scaleX?: Scale<X, any>, scaleY?: Scale<Y, any>) {
+    if (scaleX) {
+      this.domainTransformX.updateDomain(scaleX);
+    }
+    if (scaleY) {
+      this.domainTransformY.updateDomain(scaleY);
+    }
+    this.renderCallback();
+  }
+
+  public renderDeferred = () => {
+    this.applyTransform();
+    clearTimeout(this.timeoutToken);
+    this.timeoutToken = setTimeout(() => {
+      this.reset();
+      this.applyTransform();
+      this.renderCallback();
+    }, DeferredRenderer.DEFERRED_RENDERING_DELAY);
+  };
+
+  private applyTransform() {
+    this.applyTransformCallback(
+      this.domainTransformX.translate,
+      this.domainTransformY.translate,
+      this.domainTransformX.scale,
+      this.domainTransformY.scale,
+    );
+  }
+}

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -8,7 +8,7 @@ import * as d3Shape from "d3-shape";
 
 import * as Animators from "../animators";
 import { Dataset } from "../core/dataset";
-import { AttributeToProjector, Bounds, IAccessor, Point, Projector, Range } from "../core/interfaces";
+import { AttributeToProjector, Bounds, IAccessor, IRangeProjector, Point, Projector, Range } from "../core/interfaces";
 import * as Drawers from "../drawers";
 import { ProxyDrawer } from "../drawers/drawer";
 import { LineSVGDrawer, makeLineCanvasDrawStep } from "../drawers/lineDrawer";
@@ -101,16 +101,12 @@ export class Line<X> extends XYPlot<X, number> {
 
   public x(): Plots.ITransformableAccessorScaleBinding<X, number>;
   public x(x: number | IAccessor<number>): this;
-  public x(x: X | IAccessor<X>, xScale: Scale<X, number>): this;
-  public x(x?: number | IAccessor<number> | X | IAccessor<X>, xScale?: Scale<X, number>): any {
+  public x(x: X | IAccessor<X>, xScale: Scale<X, number>, postScale?: IRangeProjector<number>): this;
+  public x(x?: number | IAccessor<number> | X | IAccessor<X>, xScale?: Scale<X, number>, postScale?: IRangeProjector<number>): any {
     if (x == null) {
       return super.x();
     } else {
-      if (xScale == null) {
-        super.x(<number | IAccessor<number>>x);
-      } else {
-        super.x(<X | IAccessor<X>>x, xScale);
-      }
+      super.x(x as X | IAccessor<X>, xScale, postScale);
       this._setScaleSnapping();
       return this;
     }
@@ -118,12 +114,12 @@ export class Line<X> extends XYPlot<X, number> {
 
   public y(): Plots.ITransformableAccessorScaleBinding<number, number>;
   public y(y: number | IAccessor<number>): this;
-  public y(y: number | IAccessor<number>, yScale: Scale<number, number>): this;
-  public y(y?: number | IAccessor<number>, yScale?: Scale<number, number>): any {
+  public y(y: number | IAccessor<number>, yScale: Scale<number, number>, postScale?: IRangeProjector<number>): this;
+  public y(y?: number | IAccessor<number>, yScale?: Scale<number, number>, postScale?: IRangeProjector<number>): any {
     if (y == null) {
       return super.y();
     } else {
-      super.y(y, yScale);
+      super.y(y, yScale, postScale);
       this._setScaleSnapping();
       return this;
     }

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -13,6 +13,7 @@ import {
   AttributeToAppliedProjector,
   AttributeToProjector,
   IAccessor,
+  IRangeProjector,
   Point,
   SimpleSelection,
 } from "../core/interfaces";
@@ -21,11 +22,12 @@ import { ProxyDrawer } from "../drawers/drawer";
 import { AppliedDrawStep, DrawStep } from "../drawers/index";
 import { SVGDrawer } from "../drawers/svgDrawer";
 import * as Scales from "../scales";
-import { IScaleCallback, Scale } from "../scales/scale";
+import { Scale } from "../scales/scale";
 import * as Utils from "../utils";
 import { coerceExternalD3 } from "../utils/coerceD3";
 import { makeEnum } from "../utils/makeEnum";
 import * as Plots from "./commons";
+import { DeferredRenderer } from "./deferredRenderer";
 
 export const Renderer = makeEnum(["svg", "canvas"]);
 export type Renderer = keyof typeof Renderer;
@@ -53,11 +55,6 @@ export class Plot extends Component {
   }
 
   protected static _ANIMATION_MAX_DURATION = 600;
-
-  /**
-   * Debounces rendering and entityStore resets
-   */
-  protected static _DEFERRED_RENDERING_DELAY = 200;
 
   /**
    * _cachedEntityStore is a cache of all the entities in the plot. It, at times
@@ -111,10 +108,11 @@ export class Plot extends Component {
 
   /**
    * Callback that triggers when any scale that's bound to this plot Updates.
+   * This is used by extending classes to defer the actual rendering.
    *
    * TODO make this an arrow method instead of re-defining it in constructor()
    */
-  protected _renderCallback: IScaleCallback<Scale<any, any>>;
+  protected _renderCallback: () => void;
 
   /**
    * Callback that triggers when any Dataset that's bound to this plot Updates.
@@ -124,26 +122,32 @@ export class Plot extends Component {
   private _onDatasetUpdateCallback: DatasetCallback;
 
   /**
-   * Mapping from property names to the AccessorScale that defines that property.
+   * Mapping from property names to the AccessorScale that defines that
+   * property.
    *
-   * e.g. Line may register an "x" -> binding and a "y" -> binding;
-   * Rectangle would register "x", "y", "x2", and "y2"
+   * e.g. Line may register an "x" -> binding and a "y" -> binding; Rectangle
+   * would register "x", "y", "x2", and "y2"
    *
-   * Only subclasses control how they register properties, while attrs can be registered by the user.
-   * By default, only attrs are passed to the _generateDrawStep's attrToProjector; properties are not.
+   * Only subclasses control how they register properties, while attrs can be
+   * registered by the user. By default, only attrs are passed to the
+   * _generateDrawStep's attrToProjector; properties are not.
    */
   protected _propertyBindings: d3.Map<Plots.IAccessorScaleBinding<any, any>>;
   /**
-   * Mapping from property names to the extents ([min, max]) values that that property takes on.
+   * Mapping from property names to the extents ([min, max]) values that that
+   * property takes on.
    */
   protected _propertyExtents: d3.Map<any[]>;
 
   /**
-   * The canvas element that this Plot will render to if using the canvas renderer, or null if not using the SVG
-   * renderer. The node may be parent-less (which means that the plot isn't setup yet but is still using the canvas
-   * renderer).
+   * The canvas element that this Plot will render to if using the canvas
+   * renderer, or null if not using the SVG renderer. The node may be
+   * parent-less (which means that the plot isn't setup yet but is still using
+   * the canvas renderer).
    */
   protected _canvas: d3.Selection<HTMLCanvasElement, any, any, any>;
+  protected _bufferCanvas: d3.Selection<HTMLCanvasElement, any, any, any>;
+  protected _bufferCanvasValid: boolean;
 
   /**
    * A Plot draws some visualization of the inputted Datasets.
@@ -158,14 +162,14 @@ export class Plot extends Component {
     this._attrBindings = d3.map<Plots.IAccessorScaleBinding<any, any>>();
     this._attrExtents = d3.map<any[]>();
     this._includedValuesProvider = (scale: Scale<any, any>) => this._includedValuesForScale(scale);
-    this._renderCallback = (scale) => this.render();
+    this._renderCallback = () => this.render();
     this._onDatasetUpdateCallback = () => this._onDatasetUpdate();
     this._propertyBindings = d3.map<Plots.IAccessorScaleBinding<any, any>>();
     this._propertyExtents = d3.map<any[]>();
     const mainAnimator = new Animators.Easing().maxTotalDuration(Plot._ANIMATION_MAX_DURATION);
     this.animator(Plots.Animator.MAIN, mainAnimator);
     this.animator(Plots.Animator.RESET, new Animators.Null());
-    this._deferredResetEntityStore = Utils.Window.debounce(Plot._DEFERRED_RENDERING_DELAY, this._resetEntityStore);
+    this._deferredResetEntityStore = Utils.Window.debounce(DeferredRenderer.DEFERRED_RENDERING_DELAY, this._resetEntityStore);
   }
 
   public anchor(selection: d3.Selection<HTMLElement, any, any, any>) {
@@ -200,6 +204,16 @@ export class Plot extends Component {
   public setBounds(width: number, height: number, originX?: number, originY?: number) {
     super.setBounds(width, height, originX, originY);
     if (this._canvas != null) {
+      if (this._bufferCanvas && !this._bufferCanvasValid) {
+        // copy current canvas to buffer 1:1
+        this._bufferCanvas.attr("width", this._canvas.attr("width"));
+        this._bufferCanvas.attr("height", this._canvas.attr("height"));
+        const btx = this._bufferCanvas.node().getContext("2d");
+        btx.drawImage(this._canvas.node(), 0, 0);
+        this._bufferCanvasValid = true;
+      }
+
+      // update canvas size
       const ratio = (window.devicePixelRatio != null) ? window.devicePixelRatio : 1;
       // update canvas width/height taking into account retina displays.
       // This will also clear the canvas of any drawn elements so we should
@@ -210,6 +224,11 @@ export class Plot extends Component {
       // reset the transform then set the scale factor
       const ctx = this._canvas.node().getContext("2d");
       ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+
+      if (this._bufferCanvas) {
+        // draw buffer to current canvas at new size
+        ctx.drawImage(this._bufferCanvas.node(), 0, 0, width, height);
+      }
     }
     return this;
   }
@@ -257,7 +276,7 @@ export class Plot extends Component {
     this._updateExtents();
     this._dataChanged = true;
     this._resetEntityStore();
-    this._renderCallback(null);
+    this.renderLowPriority();
   }
 
   /**
@@ -294,12 +313,17 @@ export class Plot extends Component {
     return this;
   }
 
-  protected _bindProperty(property: string, valueOrFn: any | Function, scale: Scale<any, any>) {
+  protected _bindProperty(
+      property: string,
+      valueOrFn: any | Function,
+      scale: Scale<any, any>,
+      postScale?: IRangeProjector<any>,
+    ) {
     const binding = this._propertyBindings.get(property);
     const oldScale = binding != null ? binding.scale : null;
 
     const accessor = typeof valueOrFn === "function" ? valueOrFn : () => valueOrFn;
-    this._propertyBindings.set(property, { accessor, scale });
+    this._propertyBindings.set(property, { accessor, scale, postScale });
     this._updateExtentsForProperty(property);
 
     if (oldScale != null) {
@@ -329,10 +353,7 @@ export class Plot extends Component {
   protected _generateAttrToProjector(): AttributeToProjector {
     const h: AttributeToProjector = {};
     this._attrBindings.each((binding, attr) => {
-      const accessor = binding.accessor;
-      const scale = binding.scale;
-      const fn = scale ? (d: any, i: number, dataset: Dataset) => scale.scale(accessor(d, i, dataset)) : accessor;
-      h[attr] = fn;
+      h[attr] = Plot._scaledAccessor(binding);
     });
     const propertyProjectors = this._propertyProjectors();
     Object.keys(propertyProjectors).forEach((key) => {
@@ -350,6 +371,10 @@ export class Plot extends Component {
       this._dataChanged = false;
     }
     return this;
+  }
+
+  public renderLowPriority() {
+    this._renderCallback();
   }
 
   /**
@@ -518,6 +543,7 @@ export class Plot extends Component {
       if (this._canvas == null && renderer === "canvas") {
         // construct the canvas, remove drawer's renderAreas, set drawer's canvas
         this._canvas = d3.select(document.createElement("canvas")).classed("plot-canvas", true);
+        this._bufferCanvas = d3.select(document.createElement("canvas"));
         if (this.element() != null) {
           this._appendCanvasNode();
         }
@@ -528,6 +554,7 @@ export class Plot extends Component {
       } else if (this._canvas != null && renderer == "svg") {
         this._canvas.remove();
         this._canvas = null;
+        this._bufferCanvas = null;
         this._datasetToDrawer.forEach((drawer) => {
           drawer.useSVG(this._renderArea);
         });
@@ -666,6 +693,7 @@ export class Plot extends Component {
       const canvas = this._canvas.node();
       const context = canvas.getContext("2d");
       context.clearRect(0, 0, canvas.width, canvas.height);
+      this._bufferCanvasValid = false;
     }
 
     this.datasets().forEach((ds, i) => {
@@ -799,9 +827,17 @@ export class Plot extends Component {
   }
 
   protected static _scaledAccessor<D, R>(binding: Plots.IAccessorScaleBinding<D, R>) {
-    return binding.scale == null ?
-      binding.accessor :
-      (d: any, i: number, ds: Dataset) => binding.scale.scale(binding.accessor(d, i, ds));
+    const { scale, accessor, postScale } = binding;
+
+    // if provided, apply scale
+    const scaledAccesor = scale == null ? accessor :
+      (d: any, i: number, ds: Dataset) => scale.scale(accessor(d, i, ds));
+
+    // if provided, apply post scale
+    const postScaledAccesor = postScale == null ? scaledAccesor :
+      (d: any, i: number, ds: Dataset) => postScale(scaledAccesor(d, i, ds), d, i, ds);
+
+    return postScaledAccesor;
   }
 
   protected _pixelPoint(datum: any, index: number, dataset: Dataset): Point {

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -206,6 +206,17 @@ export class Plot extends Component {
     if (this._canvas != null) {
       if (this._bufferCanvas && !this._bufferCanvasValid) {
         // copy current canvas to buffer 1:1
+        //
+        // Why use a buffer canvas?
+        // As soon as we change the size of a canvas with css or attributes, it
+        // clears the contents. Without a buffer canvas, this requires
+        // drag-resizable charts to immediately do a full redraw while you
+        // drag-resize, which can cause jank. To avoid that, this buffer canvas
+        // stores the current canvas contents when the resize starts and redraws
+        // it into the resized canvas. Eventually, the deferred rendering
+        // callback will trigger and do a full-rez redraw. If deferred rendering
+        // is disabled, the buffer copy will be overwritten immediately by a
+        // full redraw.
         this._bufferCanvas.attr("width", this._canvas.attr("width"));
         this._bufferCanvas.attr("height", this._canvas.attr("height"));
         const btx = this._bufferCanvas.node().getContext("2d");

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -115,6 +115,7 @@ export class Plot extends Component {
    * TODO make this an arrow method instead of re-defining it in constructor()
    */
   protected _renderCallback: IScaleCallback<Scale<any, any>>;
+
   /**
    * Callback that triggers when any Dataset that's bound to this plot Updates.
    *
@@ -256,7 +257,7 @@ export class Plot extends Component {
     this._updateExtents();
     this._dataChanged = true;
     this._resetEntityStore();
-    this.render();
+    this._renderCallback(null);
   }
 
   /**

--- a/src/plots/rectanglePlot.ts
+++ b/src/plots/rectanglePlot.ts
@@ -8,7 +8,7 @@ import * as Typesettable from "typesettable";
 
 import * as Animators from "../animators";
 import { Dataset } from "../core/dataset";
-import { AttributeToProjector, Bounds, IAccessor, Point, Range } from "../core/interfaces";
+import { AttributeToProjector, Bounds, IAccessor, IRangeProjector, Point, Range } from "../core/interfaces";
 import * as Drawers from "../drawers";
 import { ProxyDrawer } from "../drawers/drawer";
 import { RectangleCanvasDrawStep, RectangleSVGDrawer } from "../drawers/rectangleDrawer";
@@ -127,8 +127,8 @@ export class Rectangle<X, Y> extends XYPlot<X, Y> {
    * @param {Scale<X, number>} xScale
    * @returns {Plots.Rectangle} The calling Rectangle Plot.
    */
-  public x(x: X | IAccessor<X>, xScale: Scale<X, number>): this;
-  public x(x?: number | IAccessor<number> | X | IAccessor<X>, xScale?: Scale<X, number>): any {
+  public x(x: X | IAccessor<X>, xScale: Scale<X, number>, postScale?: IRangeProjector<number>): this;
+  public x(x?: number | IAccessor<number> | X | IAccessor<X>, xScale?: Scale<X, number>, postScale?: IRangeProjector<number>): any {
     if (x == null) {
       return super.x();
     }
@@ -136,14 +136,14 @@ export class Rectangle<X, Y> extends XYPlot<X, Y> {
     if (xScale == null) {
       super.x(<number | IAccessor<number>>x);
     } else {
-      super.x(<X | IAccessor<X>>x, xScale);
+      super.x(<X | IAccessor<X>>x, xScale, postScale);
     }
 
     if (xScale != null) {
       const x2Binding = this.x2();
       const x2 = x2Binding && x2Binding.accessor;
       if (x2 != null) {
-        this._bindProperty(Rectangle._X2_KEY, x2, xScale);
+        this._bindProperty(Rectangle._X2_KEY, x2, xScale, x2Binding.postScale);
       }
     }
 
@@ -166,15 +166,15 @@ export class Rectangle<X, Y> extends XYPlot<X, Y> {
    * @param {number|Accessor<number>|X|Accessor<X>} x2
    * @returns {Plots.Rectangle} The calling Rectangle Plot.
    */
-  public x2(x2: number | IAccessor<number> | X | IAccessor<X>): this;
-  public x2(x2?: number | IAccessor<number> | X | IAccessor<X>): any {
+  public x2(x2: number | IAccessor<number> | X | IAccessor<X>, postScale?: IRangeProjector<number>): this;
+  public x2(x2?: number | IAccessor<number> | X | IAccessor<X>, postScale?: IRangeProjector<number>): any {
     if (x2 == null) {
       return this._propertyBindings.get(Rectangle._X2_KEY);
     }
 
     const xBinding = this.x();
     const xScale = xBinding && xBinding.scale;
-    this._bindProperty(Rectangle._X2_KEY, x2, xScale);
+    this._bindProperty(Rectangle._X2_KEY, x2, xScale, postScale);
 
     this.render();
     return this;
@@ -199,8 +199,8 @@ export class Rectangle<X, Y> extends XYPlot<X, Y> {
    * @param {Scale<Y, number>} yScale
    * @returns {Plots.Rectangle} The calling Rectangle Plot.
    */
-  public y(y: Y | IAccessor<Y>, yScale: Scale<Y, number>): this;
-  public y(y?: number | IAccessor<number> | Y | IAccessor<Y>, yScale?: Scale<Y, number>): any {
+  public y(y: Y | IAccessor<Y>, yScale: Scale<Y, number>, postScale?: IRangeProjector<number>): this;
+  public y(y?: number | IAccessor<number> | Y | IAccessor<Y>, yScale?: Scale<Y, number>, postScale?: IRangeProjector<number>): any {
     if (y == null) {
       return super.y();
     }
@@ -208,14 +208,14 @@ export class Rectangle<X, Y> extends XYPlot<X, Y> {
     if (yScale == null) {
       super.y(<number | IAccessor<number>>y);
     } else {
-      super.y(<Y | IAccessor<Y>>y, yScale);
+      super.y(<Y | IAccessor<Y>>y, yScale, postScale);
     }
 
     if (yScale != null) {
       const y2Binding = this.y2();
       const y2 = y2Binding && y2Binding.accessor;
       if (y2 != null) {
-        this._bindProperty(Rectangle._Y2_KEY, y2, yScale);
+        this._bindProperty(Rectangle._Y2_KEY, y2, yScale, y2Binding.postScale);
       }
     }
 
@@ -238,15 +238,15 @@ export class Rectangle<X, Y> extends XYPlot<X, Y> {
    * @param {number|Accessor<number>|Y|Accessor<Y>} y2
    * @returns {Plots.Rectangle} The calling Rectangle Plot.
    */
-  public y2(y2: number | IAccessor<number> | Y | IAccessor<Y>): this;
-  public y2(y2?: number | IAccessor<number> | Y | IAccessor<Y>): any {
+  public y2(y2: number | IAccessor<number> | Y | IAccessor<Y>, postScale?: IRangeProjector<number>): this;
+  public y2(y2?: number | IAccessor<number> | Y | IAccessor<Y>, postScale?: IRangeProjector<number>): any {
     if (y2 == null) {
       return this._propertyBindings.get(Rectangle._Y2_KEY);
     }
 
     const yBinding = this.y();
     const yScale = yBinding && yBinding.scale;
-    this._bindProperty(Rectangle._Y2_KEY, y2, yScale);
+    this._bindProperty(Rectangle._Y2_KEY, y2, yScale, postScale);
 
     this.render();
     return this;

--- a/test/plots/xyPlotTests.ts
+++ b/test/plots/xyPlotTests.ts
@@ -178,7 +178,7 @@ describe("Plots", () => {
         const magnifyAmount = 2;
         xScale.domain(xScale.domain().map((d) => d * magnifyAmount));
         const renderAreaScale = getScaleValues(plot.content().select(".render-area"));
-        assert.deepEqual(renderAreaScale[0], 1 / magnifyAmount, "translates with the same amount as domain shift");
+        assert.deepEqual(renderAreaScale[0], 1 / magnifyAmount, "scales with the same amount as domain change");
 
         div.remove();
       });


### PR DESCRIPTION
Refactored deferred rendering in xyplot mostly into new `DeferredRenderer` class.

Added `postScale` projector to `.x()` and `.y()` setters to allow transformation in pixel coordinates while still storing the scale on the accessor binding.

Buffer canvas content while resizing to prevent janky redraws while resizing.

Make dataset changes use deferred rendering callback.

Exposed deferred render callback as `renderLowPriority`.