### PR TITLE
Fix drawLabels with barAlignment

### DIFF
--- a/quicktests/overlaying/tests/basic/histogram.js
+++ b/quicktests/overlaying/tests/basic/histogram.js
@@ -37,7 +37,8 @@ function run(svg, data, Plottable) {
         .attr("gap", 1)
         .x((d) => d.start, vert.x)
         .y((d) => d.val, vert.y)
-        .barEnd((d) => d.end, vert.x);
+        .barEnd((d) => d.end, vert.x)
+        .labelsEnabled(true);
     vert.table.add(vbarPlot, 0, 1);
 
     // horizontal bar plot
@@ -48,7 +49,8 @@ function run(svg, data, Plottable) {
         .attr("gap", 1)
         .x((d) => d.val, horiz.x)
         .y((d) => d.start, horiz.y)
-        .barEnd((d) => d.end, horiz.y);
+        .barEnd((d) => d.end, horiz.y)
+        .labelsEnabled(true);
     horiz.table.add(hbarPlot, 0, 1);
 
     // stacked bar plot
@@ -63,7 +65,8 @@ function run(svg, data, Plottable) {
         .attr("fill", (d, i, dataset) => colors[dataset.metadata().series])
         .x((d) => d.start, stack.x)
         .y((d) => d.val, stack.y)
-        .barEnd((d) => d.end, stack.x);
+        .barEnd((d) => d.end, stack.x)
+        .labelsEnabled(true);
     stack.table.add(stackPlot, 0, 1);
 
     const layout = new Plottable.Components.Table([

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -63,8 +63,8 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
   private _barAlignment: BarAlignment = "middle";
   private _fixedWidth = true;
 
-  private _barPixelWidth = 0;
-  private _updateBarPixelWidthCallback: () => void;
+  private _barPixelThickness = 0;
+  private _updateBarPixelThicknessCallback: () => void;
 
   /**
    * A Bar Plot draws bars growing out from a baseline to some value
@@ -81,10 +81,14 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
     this._isVertical = orientation === "vertical";
     this.animator("baseline", new Animators.Null());
     this.attr("fill", new Scales.Color().range()[0]);
-    this.attr("width", () => this._barPixelWidth);
+    // we special case the "width" property to actually represent the bar
+    // thickness (aka the distance between adjacent bar positions); in
+    // _generateAttrToProjector we re-assign "width" to specifically refer
+    // to <rect>'s width attribute
+    this.attr("width", () => this._barPixelThickness);
     this._labelConfig = new Utils.Map<Dataset, LabelConfig>();
     this._baselineValueProvider = () => [this.baselineValue()];
-    this._updateBarPixelWidthCallback = () => this._updateBarPixelWidth();
+    this._updateBarPixelThicknessCallback = () => this._updateBarPixelWidth();
   }
 
   public x(): Plots.ITransformableAccessorScaleBinding<X, number>;
@@ -99,11 +103,11 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
       super.x(<number | IAccessor<number>>x);
     } else {
       super.x(< X | IAccessor<X>>x, xScale);
-      xScale.onUpdate(this._updateBarPixelWidthCallback);
+      xScale.onUpdate(this._updateBarPixelThicknessCallback);
     }
 
     this._updateWidthAccesor();
-    this._updateValueScale();
+    this._updateLengthScale();
     return this;
   }
 
@@ -119,11 +123,27 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
       super.y(<number | IAccessor<number>>y);
     } else {
       super.y(<Y | IAccessor<Y>>y, yScale);
-      yScale.onUpdate(this._updateBarPixelWidthCallback);
+      yScale.onUpdate(this._updateBarPixelThicknessCallback);
     }
 
-    this._updateValueScale();
+    this._updateLengthScale();
     return this;
+  }
+
+  /**
+   * The binding associated with bar length. Length is the count or value the bar is trying to show.
+   * This is the .y() for a vertical plot and .x() for a horizontal plot.
+   */
+  protected length(): Plots.ITransformableAccessorScaleBinding<any, number> {
+    return this._isVertical ? this.y() : this.x();
+  }
+
+  /**
+   * The binding associated with bar position. Position separates the different bar categories.
+   * This is the .x() for a vertical plot and .y() for a horizontal plot.
+   */
+  protected position(): Plots.ITransformableAccessorScaleBinding<any, number> {
+    return this._isVertical ? this.x() : this.y();
   }
 
   /**
@@ -156,11 +176,11 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
       return this._propertyBindings.get(Bar._BAR_END_KEY);
     }
 
-    const binding = (this._isVertical) ? this.x() : this.y();
+    const binding = this.position();
     const scale = binding && binding.scale;
     this._bindProperty(Bar._BAR_END_KEY, end, scale);
     this._updateWidthAccesor();
-    this._updateValueScale();
+    this._updateLengthScale();
     this.render();
     return this;
   }
@@ -238,19 +258,19 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
       if (!this._projectorsReady()) {
         return 0;
       }
-      const valueScale = this._isVertical ? this.y().scale : this.x().scale;
-      if (!valueScale) {
+      const lengthScale = this.length().scale;
+      if (!lengthScale) {
         return 0;
       }
 
-      if (valueScale instanceof Scales.Time) {
+      if (lengthScale instanceof Scales.Time) {
         return new Date(0);
       }
 
       return 0;
     }
     this._baselineValue = value;
-    this._updateValueScale();
+    this._updateLengthScale();
     this.render();
     return this;
   }
@@ -262,20 +282,20 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
   }
 
   protected _addDataset(dataset: Dataset) {
-    dataset.onUpdate(this._updateBarPixelWidthCallback);
+    dataset.onUpdate(this._updateBarPixelThicknessCallback);
     super._addDataset(dataset);
     return this;
   }
 
   public removeDataset(dataset: Dataset) {
-    dataset.offUpdate(this._updateBarPixelWidthCallback);
+    dataset.offUpdate(this._updateBarPixelThicknessCallback);
     super.removeDataset(dataset);
     this._updateBarPixelWidth();
     return this;
   }
 
   protected _removeDataset(dataset: Dataset) {
-    dataset.offUpdate(this._updateBarPixelWidthCallback);
+    dataset.offUpdate(this._updateBarPixelThicknessCallback);
     super._removeDataset(dataset);
     return this;
   }
@@ -499,21 +519,20 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
     return intersected;
   }
 
-  private _updateValueScale() {
+  private _updateLengthScale() {
     if (!this._projectorsReady()) {
       return;
     }
-    const valueScale = this._isVertical ? this.y().scale : this.x().scale;
-    if (valueScale instanceof QuantitativeScale) {
-      const qscale = <QuantitativeScale<any>> valueScale;
-      qscale.addPaddingExceptionsProvider(this._baselineValueProvider);
-      qscale.addIncludedValuesProvider(this._baselineValueProvider);
+    const lengthScale = this.length().scale;
+    if (lengthScale instanceof QuantitativeScale) {
+      lengthScale.addPaddingExceptionsProvider(this._baselineValueProvider);
+      lengthScale.addIncludedValuesProvider(this._baselineValueProvider);
     }
   }
 
   protected _additionalPaint(time: number) {
-    const primaryScale: Scale<any, number> = this._isVertical ? this.y().scale : this.x().scale;
-    const scaledBaseline = primaryScale.scale(this.baselineValue());
+    const lengthScale: Scale<any, number> = this.length().scale;
+    const scaledBaseline = lengthScale.scale(this.baselineValue());
 
     const baselineAttr: any = {
       "x1": this._isVertical ? 0 : scaledBaseline,
@@ -550,36 +569,40 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
     }
 
     const scale = <QuantitativeScale<any>>accScaleBinding.scale;
-    const width = this._barPixelWidth;
+    const width = this._barPixelThickness;
 
     // To account for inverted domains
     extents = extents.map((extent) => d3.extent([
-      scale.invert(this._getAlignedX(scale.scale(extent[0]), width)),
-      scale.invert(this._getAlignedX(scale.scale(extent[0]), width) + width),
-      scale.invert(this._getAlignedX(scale.scale(extent[1]), width)),
-      scale.invert(this._getAlignedX(scale.scale(extent[1]), width) + width),
+      scale.invert(this._getPositionAttr(scale.scale(extent[0]), width)),
+      scale.invert(this._getPositionAttr(scale.scale(extent[0]), width) + width),
+      scale.invert(this._getPositionAttr(scale.scale(extent[1]), width)),
+      scale.invert(this._getPositionAttr(scale.scale(extent[1]), width) + width),
     ]));
 
     return extents;
   }
 
-  protected _getAlignedX(x: number, width: number): number {
+  /**
+   * Return the <rect>'s x or y attr value given the position and thickness of
+   * that bar. This method is responsible for account for barAlignment, in particular.
+   */
+  protected _getPositionAttr(position: number, thickness: number): number {
     // account for flipped vertical axis
     if (!this._isVertical) {
-      x -= width;
-      width *= -1;
+      position -= thickness;
+      thickness *= -1;
     }
 
     switch(this._barAlignment) {
       case "start":
-        return x;
+        return position;
 
       case "end":
-        return x - width;
+        return position - thickness;
 
       case "middle":
       default:
-        return x - width / 2;
+        return position - thickness / 2;
     }
   }
 
@@ -600,21 +623,21 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
   private _drawLabel(datum: any, index: number, dataset: Dataset, attrToProjector: AttributeToProjector) {
     const { labelArea, measurer, writer } = this._labelConfig.get(dataset);
 
-    const valueAccessor = this._isVertical ? this.y().accessor : this.x().accessor;
-    const value = valueAccessor(datum, index, dataset);
-    const valueScale: Scale<any, number> = this._isVertical ? this.y().scale : this.x().scale;
-    const scaledValue = valueScale != null ? valueScale.scale(value) : value;
-    const scaledBaseline = valueScale != null ? valueScale.scale(this.baselineValue()) : this.baselineValue();
+    const lengthAccessor = this.length().accessor;
+    const length = lengthAccessor(datum, index, dataset);
+    const lengthScale: Scale<any, number> = this.length().scale;
+    const scaledLength = lengthScale != null ? lengthScale.scale(length) : length;
+    const scaledBaseline = lengthScale != null ? lengthScale.scale(this.baselineValue()) : this.baselineValue();
 
     const barCoordinates = { x: attrToProjector["x"](datum, index, dataset), y: attrToProjector["y"](datum, index, dataset) };
     const barDimensions = { width: attrToProjector["width"](datum, index, dataset), height: attrToProjector["height"](datum, index, dataset) };
-    const text = this._labelFormatter(value, datum, index, dataset);
+    const text = this._labelFormatter(length, datum, index, dataset);
     const measurement = measurer.measure(text);
 
     const showLabelOnBar = this._getShowLabelOnBar(barCoordinates, barDimensions, measurement);
 
     // show label on right when value === baseline for horizontal plots
-    const aboveOrLeftOfBaseline = this._isVertical ? scaledValue <= scaledBaseline : scaledValue < scaledBaseline;
+    const aboveOrLeftOfBaseline = this._isVertical ? scaledLength <= scaledBaseline : scaledLength < scaledBaseline;
     const { containerDimensions, labelContainerOrigin, labelOrigin, alignment } = this._calculateLabelProperties(
       barCoordinates, barDimensions, measurement, showLabelOnBar, aboveOrLeftOfBaseline,
     );
@@ -751,8 +774,8 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
     const drawSteps: Drawers.DrawStep[] = [];
     if (this._animateOnNextRender()) {
       const resetAttrToProjector = this._generateAttrToProjector();
-      const primaryScale: Scale<any, number> = this._isVertical ? this.y().scale : this.x().scale;
-      const scaledBaseline = primaryScale.scale(this.baselineValue());
+      const lengthScale: Scale<any, number> = this.length().scale;
+      const scaledBaseline = lengthScale.scale(this.baselineValue());
       const positionAttr = this._isVertical ? "y" : "x";
       const dimensionAttr = this._isVertical ? "height" : "width";
       resetAttrToProjector[positionAttr] = () => scaledBaseline;
@@ -767,38 +790,41 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
   }
 
   protected _generateAttrToProjector() {
-    // Primary scale/direction: the "length" of the bars
-    // Secondary scale/direction: the "width" of the bars
     const attrToProjector = super._generateAttrToProjector();
-    const primaryScale: Scale<any, number> = this._isVertical ? this.y().scale : this.x().scale;
-    const primaryAttr = this._isVertical ? "y" : "x";
-    const secondaryAttr = this._isVertical ? "x" : "y";
-    const scaledBaseline = primaryScale.scale(this.baselineValue());
 
-    const positionF = this._isVertical ? Plot._scaledAccessor(this.x()) : Plot._scaledAccessor(this.y());
-    const widthF = attrToProjector["width"];
-    const originalPositionFn = this._isVertical ? Plot._scaledAccessor(this.y()) : Plot._scaledAccessor(this.x());
-    const heightF = (d: any, i: number, dataset: Dataset) => {
-      return Math.abs(scaledBaseline - originalPositionFn(d, i, dataset));
+    const lengthScale = this.length().scale;
+    const scaledBaseline = lengthScale.scale(this.baselineValue());
+
+    const lengthAttr = this._isVertical ? "y" : "x";
+    const positionAttr = this._isVertical ? "x" : "y";
+
+    const positionF = Plot._scaledAccessor(this.position());
+    const originalLengthFn = Plot._scaledAccessor(this.length());
+    const lengthFn = (d: any, i: number, dataset: Dataset) => {
+      return Math.abs(scaledBaseline - originalLengthFn(d, i, dataset));
     };
 
+    const thicknessF = attrToProjector["width"];
     const gapF = attrToProjector["gap"];
-    const widthMinusGap = gapF == null ? widthF : (d: any, i: number, dataset: Dataset) => {
-      return widthF(d, i, dataset) - gapF(d, i, dataset);
-    };
-    attrToProjector["width"] = this._isVertical ? widthMinusGap : heightF;
-    attrToProjector["height"] = this._isVertical ? heightF : widthMinusGap;
-
-    attrToProjector[secondaryAttr] = (d: any, i: number, dataset: Dataset) => {
-      return this._getAlignedX(positionF(d, i, dataset), widthF(d, i, dataset));
+    const thicknessMinusGap = gapF == null ? thicknessF : (d: any, i: number, dataset: Dataset) => {
+      return thicknessF(d, i, dataset) - gapF(d, i, dataset);
     };
 
-    attrToProjector[primaryAttr] = (d: any, i: number, dataset: Dataset) => {
-      const originalPos = originalPositionFn(d, i, dataset);
-      // If it is past the baseline, it should start at the baselin then width/height
+    // re-interpret "width" attr from representing "thickness" to actually meaning
+    // width (that is, x-direction specific) again
+    attrToProjector["width"] = this._isVertical ? thicknessMinusGap : lengthFn;
+    attrToProjector["height"] = this._isVertical ? lengthFn : thicknessMinusGap;
+
+    attrToProjector[lengthAttr] = (d: any, i: number, dataset: Dataset) => {
+      const originalLength = originalLengthFn(d, i, dataset);
+      // If it is past the baseline, it should start at the baseline then width/height
       // carries it over. If it's not past the baseline, leave it at original position and
       // then width/height carries it to baseline
-      return (originalPos > scaledBaseline) ? scaledBaseline : originalPos;
+      return (originalLength > scaledBaseline) ? scaledBaseline : originalLength;
+    };
+
+    attrToProjector[positionAttr] = (d: any, i: number, dataset: Dataset) => {
+      return this._getPositionAttr(positionF(d, i, dataset), thicknessF(d, i, dataset));
     };
 
     return attrToProjector;
@@ -819,7 +845,7 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
     } else {
       this._fixedWidth = true;
       this._updateBarPixelWidth();
-      this.attr("width", () => this._barPixelWidth);
+      this.attr("width", () => this._barPixelThickness);
     }
   }
 
@@ -829,6 +855,8 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
    * If the position scale of the plot is a CategoryScale and in bands mode, then the rangeBands function will be used.
    * If the position scale of the plot is a QuantitativeScale, then the bar width is equal to the smallest distance between
    * two adjacent data points, padded for visualisation.
+   *
+   * This doesn't account for explicitly setting the barEnd.
    */
   protected _getBarPixelWidth(): number {
     if (!this._projectorsReady()) {
@@ -864,7 +892,7 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
 
   private _updateBarPixelWidth() {
     if (this._fixedWidth) {
-      this._barPixelWidth = this._getBarPixelWidth();
+      this._barPixelThickness = this._getBarPixelWidth();
     }
   }
 
@@ -897,7 +925,7 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
   }
 
   protected _uninstallScaleForKey(scale: Scale<any, number>, key: string) {
-    scale.offUpdate(this._updateBarPixelWidthCallback);
+    scale.offUpdate(this._updateBarPixelThicknessCallback);
     super._uninstallScaleForKey(scale, key);
   }
 

--- a/src/plots/clusteredBarPlot.ts
+++ b/src/plots/clusteredBarPlot.ts
@@ -55,7 +55,7 @@ export class ClusteredBar<X, Y> extends Bar<X, Y> {
   private _makeInnerScale() {
     const innerScale = new Scales.Category();
     innerScale.domain(this.datasets().map((d, i) => String(i)));
-    const widthProjector = Plot._scaledAccessor(this.attr("width"));
+    const widthProjector = Plot._scaledAccessor(this.attr(Bar._BAR_THICKNESS_KEY));
     innerScale.range([0, widthProjector(null, 0, null)]);
     return innerScale;
   }

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -328,10 +328,7 @@ export class Plot extends Component {
   protected _generateAttrToProjector(): AttributeToProjector {
     const h: AttributeToProjector = {};
     this._attrBindings.each((binding, attr) => {
-      const accessor = binding.accessor;
-      const scale = binding.scale;
-      const fn = scale ? (d: any, i: number, dataset: Dataset) => scale.scale(accessor(d, i, dataset)) : accessor;
-      h[attr] = fn;
+        h[attr] = Plot._scaledAccessor(binding);
     });
     const propertyProjectors = this._propertyProjectors();
     Object.keys(propertyProjectors).forEach((key) => {

--- a/src/plots/stackedBarPlot.ts
+++ b/src/plots/stackedBarPlot.ts
@@ -156,7 +156,7 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
      * @param bounds
      * @returns {boolean}
      */
-    const tryDrawLabel = (text: string, bounds: Bounds, barThickness: number) => {
+    const maybeDrawLabel = (text: string, bounds: Bounds, barThickness: number) => {
       const { x, y } = bounds.topLeft;
       const width = bounds.bottomRight.x - bounds.topLeft.x;
       const height = bounds.bottomRight.y - bounds.topLeft.y;
@@ -217,7 +217,7 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
 
           const topLeft = computeLabelTopLeft(stackEdge, textDimensions, barThickness);
 
-          const isTooWide = tryDrawLabel(
+          const isTooWide = maybeDrawLabel(
               text,
               {
                 topLeft,

--- a/src/plots/stackedBarPlot.ts
+++ b/src/plots/stackedBarPlot.ts
@@ -10,11 +10,11 @@ import { Formatter, identity } from "../core/formatters";
 import { Bounds, IAccessor, Point, SimpleSelection } from "../core/interfaces";
 import { Scale } from "../scales/scale";
 import * as Utils from "../utils";
+import { StackExtent } from "../utils/stackingUtils";
 
 import * as Plots from "./";
 import { Bar, BarOrientation } from "./barPlot";
 import { Plot } from "./plot";
-import { StackExtent } from "../utils/stackingUtils";
 
 export class StackedBar<X, Y> extends Bar<X, Y> {
   protected static _STACKED_BAR_LABEL_PADDING = 5;

--- a/src/plots/stackedBarPlot.ts
+++ b/src/plots/stackedBarPlot.ts
@@ -164,13 +164,7 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
         ? ( width > barThickness - (2 * StackedBar._LABEL_PADDING) )
         : ( height > barThickness - (2 * StackedBar._LABEL_PADDING) );
 
-      const hideLabel = x < 0
-        || y < 0
-        || x + width > this.width()
-        || y + height > this.height()
-        || textTooLong;
-
-      if (!hideLabel) {
+      if (!textTooLong) {
         const labelContainer = this._labelArea.append("g").attr("transform", `translate(${x}, ${y})`);
         labelContainer.classed("stacked-bar-label", true);
 

--- a/src/plots/stackedBarPlot.ts
+++ b/src/plots/stackedBarPlot.ts
@@ -13,6 +13,7 @@ import * as Utils from "../utils";
 
 import * as Plots from "./";
 import { Bar, BarOrientation } from "./barPlot";
+import { Plot } from "./plot";
 
 export class StackedBar<X, Y> extends Bar<X, Y> {
   protected static _STACKED_BAR_LABEL_PADDING = 5;
@@ -154,19 +155,19 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
      * @param bounds
      * @returns {boolean}
      */
-    const tryDrawLabel = (text: string, bounds: Bounds, barWidth: number) => {
+    const tryDrawLabel = (text: string, bounds: Bounds, barThickness: number) => {
       const { x, y } = bounds.topLeft;
       const width = bounds.bottomRight.x - bounds.topLeft.x;
       const height = bounds.bottomRight.y - bounds.topLeft.y;
-      const tooWide = this._isVertical
-        ? ( width > barWidth - (2 * StackedBar._LABEL_PADDING) )
-        : ( height > barWidth - (2 * StackedBar._LABEL_PADDING) );
+      const textTooLong = this._isVertical
+        ? ( width > barThickness - (2 * StackedBar._LABEL_PADDING) )
+        : ( height > barThickness - (2 * StackedBar._LABEL_PADDING) );
 
       const hideLabel = x < 0
         || y < 0
         || x + width > this.width()
         || y + height > this.height()
-        || tooWide;
+        || textTooLong;
 
       if (!hideLabel) {
         const labelContainer = this._labelArea.append("g").attr("transform", `translate(${x}, ${y})`);
@@ -179,7 +180,7 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
         this._writer.write(text, width, height, writeOptions, labelContainer.node());
       }
 
-      return tooWide;
+      return textTooLong;
     };
 
     maximumExtents.forEach((maximum) => {
@@ -201,7 +202,8 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
 
         const { stackedDatum } = maximum;
         const { originalDatum, originalIndex, originalDataset } = stackedDatum;
-        const barWidth = this.attr("width").accessor(originalDatum, originalIndex, originalDataset);
+
+        const barThickness = Plot._scaledAccessor(this.attr(Bar._BAR_THICKNESS_KEY))(originalDatum, originalIndex, originalDataset);
 
         const isTooWide = tryDrawLabel(
             text,
@@ -212,7 +214,7 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
                 y: y + measurement.height,
               },
             },
-            barWidth,
+            barThickness,
         );
         anyTooWide.push(isTooWide);
       }
@@ -233,6 +235,11 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
           ? secondaryScale.scale(minimum.extent) + StackedBar._STACKED_BAR_LABEL_PADDING
           : primaryScale.scale(minimum.axisValue) - primaryTextMeasurement / 2;
 
+        const { stackedDatum } = minimum;
+        const { originalDatum, originalIndex, originalDataset } = stackedDatum;
+
+        const barThickness = Plot._scaledAccessor(this.attr(Bar._BAR_THICKNESS_KEY))(originalDatum, originalIndex, originalDataset);
+
         const isTooWide = tryDrawLabel(
             text,
             {
@@ -242,7 +249,7 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
                 y: y + measurement.height,
               },
             },
-            barWidth,
+            barThickness,
         );
         anyTooWide.push(isTooWide);
       }

--- a/test/plots/stackedBarPlotTests.ts
+++ b/test/plots/stackedBarPlotTests.ts
@@ -143,13 +143,6 @@ describe("Plots", () => {
         stackedBar.destroy();
       });
 
-      it("doesn't show stacked bar labels when columns are too tall", () => {
-        stackedBarPlot.labelsEnabled(true);
-        yScale.domain([0, 3]);
-        const stackedBarLabels = stackedBarPlot.content().selectAll<Element, any>(".stacked-bar-label");
-        assert.strictEqual(stackedBarLabels.size(), 0);
-      });
-
       it("doesn't show stacked bar labels when columns are too narrow", () => {
         stackedBarPlot.labelsEnabled(true);
         xScale.range([0, 20]);
@@ -215,13 +208,6 @@ describe("Plots", () => {
           text.push(d3.select(this).text());
         });
         assert.deepEqual(["-3", "-3"], text);
-      });
-
-      it("doesn't show stacked bar labels when columns are too tall", () => {
-        stackedBarPlot.labelsEnabled(true);
-        yScale.domain([-3, 0]);
-        const stackedBarLabels = stackedBarPlot.content().selectAll<Element, any>(".stacked-bar-label");
-        assert.strictEqual(stackedBarLabels.size(), 0);
       });
 
       it("doesn't show stacked bar labels when columns are too narrow", () => {
@@ -434,13 +420,6 @@ describe("Plots", () => {
           text.push(d3.select(this).text());
         });
         assert.deepEqual(["3", "3"], text);
-      });
-
-      it("doesn't show stacked bar labels when columns are too tall", () => {
-        xScale.domain([0, 3]);
-        stackedBarPlot.labelsEnabled(true);
-        const stackedBarLabels = stackedBarPlot.content().selectAll<Element, any>(".stacked-bar-label");
-        assert.strictEqual(stackedBarLabels.size(), 0);
       });
 
       it("doesn't show stacked bar labels when columns are too narrow", () => {


### PR DESCRIPTION
Previously stackedBar's drawLabels didn't take into account barAlignment. It now does. Refactored/cleaned code to more accurately reflect what's going on.

Use the term bar "thickness" instead of bar "width" where appropriate. width is specifically associated with the x direction but it was being used to represent the thickness (which is meaningful in both x and y).

Also consolidate the terms "primary" and "secondary" into bar "length" and bar "position". Add methods to get the "length" binding and "position" bindings.