### PR TITLE
Add gridlines between ticks

### DIFF
--- a/quicktests/overlaying/tests/basic/gridlines.js
+++ b/quicktests/overlaying/tests/basic/gridlines.js
@@ -59,26 +59,6 @@ function run(svg, data, Plottable) {
         [plotGroup2, plotGroup3]
     ]);
 
-    /*
-    var xScale = new Plottable.Scales.Category().domain(data.map(d => d.x));
-    var xAxis = new Plottable.Axes.Category(xScale, "bottom");
-    xAxis.tickLabelMaxLines(1);
-    var yScale = new Plottable.Scales.Linear().domain([0, 20]);
-    var yAxis = new Plottable.Axes.Numeric(yScale, "left");
-    var gridlines = new Plottable.Components.Gridlines(xScale, yScale).betweenX(true);
-
-    var plot = new Plottable.Plots.Bar();
-    plot.x(function(d) { return d.x }, xScale);
-    plot.y(function(d) { return d.y }, yScale);
-    plot.addDataset(new Plottable.Dataset(data));
-
-    var plotGroup = new Plottable.Components.Group([plot, gridlines]);
-    var table = new Plottable.Components.Table([
-        [yAxis, plotGroup],
-        [null,  xAxis]
-    ]);
-
-    */
     table.renderTo(svg);
     window.addEventListener("resize", () => table.redraw());
 }

--- a/quicktests/overlaying/tests/basic/gridlines.js
+++ b/quicktests/overlaying/tests/basic/gridlines.js
@@ -1,0 +1,84 @@
+function makeData() {
+    "use strict";
+    const rockTypes = [
+            "pegmatite",
+            "dolomite",
+            "quartzite",
+            "limestone",
+            "diorite",
+            "serpentite",
+            "travertine",
+            "lapis lazuli",
+            "marble",
+            "coquina",
+            "syenite",
+            "dunite",
+            "coal",
+            "flint",
+            "chalk",
+            "hornfels",
+            "skarn",
+            "greenschist"
+        ];
+    return rockTypes.map(function(rockType, index) { return { x: rockType, y: index + 3 } });
+}
+
+function run(svg, data, Plottable) {
+    "use strict";
+
+    var xScale = new Plottable.Scales.Category().domain(data.map(d => d.x));
+    var yScale = new Plottable.Scales.Linear().domain([0, 100]);
+    var xAxis = new Plottable.Axes.Category(xScale, "bottom");
+    var yAxis = new Plottable.Axes.Numeric(yScale, "left");
+    var gridlines = new Plottable.Components.Gridlines(xScale, yScale).betweenX(true).betweenY(true);
+    var plotGroup = new Plottable.Components.Table([[yAxis, gridlines], [null, xAxis]]);
+
+    var xScale1 = new Plottable.Scales.Linear().domain([0, 100]);
+    var yScale1 = new Plottable.Scales.Category().domain(data.map(d => d.x));
+    var xAxis1 = new Plottable.Axes.Numeric(xScale1, "bottom");
+    var yAxis1 = new Plottable.Axes.Category(yScale1, "left");
+    var gridlines1 = new Plottable.Components.Gridlines(xScale1, yScale1).betweenX(true).betweenY(true);
+    var plotGroup1 = new Plottable.Components.Table([[yAxis1, gridlines1], [null, xAxis1]]);
+
+    var xScale2 = new Plottable.Scales.Time().domain([new Date("1/1/1"), new Date("2/2/2")]);
+    var yScale2 = new Plottable.Scales.Category().domain(data.map(d => d.x));
+    var xAxis2 = new Plottable.Axes.Time(xScale2, "bottom");
+    var yAxis2 = new Plottable.Axes.Category(yScale2, "left");
+    var gridlines2 = new Plottable.Components.Gridlines(xScale2, yScale2).betweenX(true).betweenY(false);
+    var plotGroup2 = new Plottable.Components.Table([[yAxis2, gridlines2], [null, xAxis2]]);
+
+    var xScale3 = new Plottable.Scales.ModifiedLog().domain([0, 100000]);
+    var yScale3 = new Plottable.Scales.Category().domain(data.map(d => d.x));
+    var xAxis3 = new Plottable.Axes.Numeric(xScale3, "bottom");
+    var yAxis3 = new Plottable.Axes.Category(yScale3, "left");
+    var gridlines3 = new Plottable.Components.Gridlines(xScale3, yScale3).betweenX(true);
+    var plotGroup3 = new Plottable.Components.Table([[yAxis3, gridlines3], [null, xAxis3]]);
+
+    var table = new Plottable.Components.Table([
+        [plotGroup1, plotGroup],
+        [plotGroup2, plotGroup3]
+    ]);
+
+    /*
+    var xScale = new Plottable.Scales.Category().domain(data.map(d => d.x));
+    var xAxis = new Plottable.Axes.Category(xScale, "bottom");
+    xAxis.tickLabelMaxLines(1);
+    var yScale = new Plottable.Scales.Linear().domain([0, 20]);
+    var yAxis = new Plottable.Axes.Numeric(yScale, "left");
+    var gridlines = new Plottable.Components.Gridlines(xScale, yScale).betweenX(true);
+
+    var plot = new Plottable.Plots.Bar();
+    plot.x(function(d) { return d.x }, xScale);
+    plot.y(function(d) { return d.y }, yScale);
+    plot.addDataset(new Plottable.Dataset(data));
+
+    var plotGroup = new Plottable.Components.Group([plot, gridlines]);
+    var table = new Plottable.Components.Table([
+        [yAxis, plotGroup],
+        [null,  xAxis]
+    ]);
+
+    */
+    table.renderTo(svg);
+    window.addEventListener("resize", () => table.redraw());
+}

--- a/src/components/gridlines.ts
+++ b/src/components/gridlines.ts
@@ -4,31 +4,53 @@
  */
 
 import { Point, SimpleSelection } from "../core/interfaces";
-import { QuantitativeScale } from "../scales/quantitativeScale";
-import { IScaleCallback } from "../scales/scale";
+import { IScaleCallback, Scale } from "../scales/scale";
 
 import { Component } from "./component";
 
+function getScaledValue(
+  scale: Scale<any, any>,
+  between: boolean,
+  initialValue?: string) {
+
+  let previousPosition = initialValue === undefined
+    ? undefined
+    : scale.scale(initialValue);
+
+  return (tickVal: any) => {
+    const position = scale.scale(tickVal);
+
+    if (!between) {
+      return position;
+    }
+
+    let gridPosition: number;
+
+    if (previousPosition !== undefined) {
+      gridPosition = previousPosition + (position - previousPosition) / 2;
+    }
+
+    previousPosition = position;
+    return gridPosition;
+  };
+}
+
 export class Gridlines extends Component {
-  private _xScale: QuantitativeScale<any>;
-  private _yScale: QuantitativeScale<any>;
+  private _betweenX: boolean;
+  private _betweenY: boolean;
+  private _xScale: Scale<any, any>;
+  private _yScale: Scale<any, any>;
   private _xLinesContainer: SimpleSelection<void>;
   private _yLinesContainer: SimpleSelection<void>;
 
-  private _renderCallback: IScaleCallback<QuantitativeScale<any>>;
+  private _renderCallback: IScaleCallback<Scale<any, any>>;
 
   /**
    * @constructor
-   * @param {QuantitativeScale} xScale The scale to base the x gridlines on. Pass null if no gridlines are desired.
-   * @param {QuantitativeScale} yScale The scale to base the y gridlines on. Pass null if no gridlines are desired.
+   * @param {Scale} xScale The scale to base the x gridlines on. Pass null if no gridlines are desired.
+   * @param {Scale} yScale The scale to base the y gridlines on. Pass null if no gridlines are desired.
    */
-  constructor(xScale: QuantitativeScale<any>, yScale: QuantitativeScale<any>) {
-    if (xScale != null && !(QuantitativeScale.prototype.isPrototypeOf(xScale))) {
-      throw new Error("xScale needs to inherit from Scale.QuantitativeScale");
-    }
-    if (yScale != null && !(QuantitativeScale.prototype.isPrototypeOf(yScale))) {
-      throw new Error("yScale needs to inherit from Scale.QuantitativeScale");
-    }
+  constructor(xScale: Scale<any, any>, yScale: Scale<any, any>) {
     super();
     this.addClass("gridlines");
     this._xScale = xScale;
@@ -40,6 +62,36 @@ export class Gridlines extends Component {
     if (this._yScale) {
       this._yScale.onUpdate(this._renderCallback);
     }
+  }
+
+  public betweenX(_betweenX: boolean): this;
+  public betweenX(): boolean;
+  public betweenX(_betweenX?: boolean): this | boolean {
+    if (_betweenX === undefined) {
+      return this._betweenX;
+    }
+
+    if (_betweenX !== this._betweenX) {
+      this._betweenX = _betweenX;
+      this.render();
+    }
+
+    return this;
+  }
+
+  public betweenY(_betweenY: boolean): this;
+  public betweenY(): boolean;
+  public betweenY(_betweenY?: boolean): this | boolean {
+    if (_betweenY === undefined) {
+      return this._betweenY;
+    }
+
+    if (_betweenY !== this._betweenY) {
+      this._betweenY = _betweenY;
+      this.render();
+    }
+
+    return this;
   }
 
   public destroy() {
@@ -79,13 +131,19 @@ export class Gridlines extends Component {
 
   private _redrawXLines() {
     if (this._xScale) {
-      const xTicks = this._xScale.ticks();
-      const getScaledXValue = (tickVal: number) => this._xScale.scale(tickVal);
+      const xTicks = this._xScale.ticks().slice();
+      let initialXValue;
+      const between = this.betweenX();
+      if (between) {
+        // don't render the first value, just pass to the gridline positioning
+        initialXValue = xTicks.shift();
+      }
+
       const xLinesUpdate = this._xLinesContainer.selectAll("line").data(xTicks);
       const xLines = xLinesUpdate.enter().append("line").merge(xLinesUpdate);
-      xLines.attr("x1", getScaledXValue)
+      xLines.attr("x1", getScaledValue(this._xScale, between, initialXValue))
         .attr("y1", 0)
-        .attr("x2", getScaledXValue)
+        .attr("x2", getScaledValue(this._xScale, between, initialXValue))
         .attr("y2", this.height())
         .classed("zeroline", (t: number) => t === 0);
       xLinesUpdate.exit().remove();
@@ -94,16 +152,24 @@ export class Gridlines extends Component {
 
   private _redrawYLines() {
     if (this._yScale) {
-      const yTicks = this._yScale.ticks();
-      const getScaledYValue = (tickVal: number) => this._yScale.scale(tickVal);
+      const yTicks = this._yScale.ticks().slice();
+
+      let initialYValue;
+      const between = this.betweenY();
+      if (between) {
+        // don't render the first value, just pass to the gridline positioning
+        initialYValue = yTicks.shift();
+      }
+
       const yLinesUpdate = this._yLinesContainer.selectAll("line").data(yTicks);
       const yLines = yLinesUpdate.enter().append("line").merge(yLinesUpdate);
       yLines.attr("x1", 0)
-        .attr("y1", getScaledYValue)
+        .attr("y1", getScaledValue(this._yScale, between, initialYValue))
         .attr("x2", this.width())
-        .attr("y2", getScaledYValue)
+        .attr("y2", getScaledValue(this._yScale, between, initialYValue))
         .classed("zeroline", (t: number) => t === 0);
       yLinesUpdate.exit().remove();
     }
   }
-}
+
+ }

--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -143,6 +143,10 @@ export class Category extends Scale<string, number> implements ITransformableSca
     return this._rescaleBand(this._d3Scale.bandwidth() * (1 + this.innerPadding()));
   }
 
+  public ticks(): string[] {
+    return this.domain();
+  }
+
   /**
    * Gets the inner padding.
    *

--- a/src/scales/scale.ts
+++ b/src/scales/scale.ts
@@ -105,6 +105,15 @@ export class Scale<D, R> {
   }
 
   /**
+   * Gets an array of tick values spanning the domain.
+   *
+   * @returns {D[]}
+   */
+  public ticks(): D[] {
+    return this.domain();
+  }
+
+  /**
    * Gets the domain.
    *
    * @returns {D[]} The current domain.

--- a/test/components/gridlinesTests.ts
+++ b/test/components/gridlinesTests.ts
@@ -69,19 +69,29 @@ describe("Gridlines", () => {
     div.remove();
   });
 
-  it("throws error on non-Quantitative Scales", () => {
-    const categoryScale = new Plottable.Scales.Category();
-    // HACKHACK #2661: Cannot assert errors being thrown with description
-    (<any> assert).throw(() => new Plottable.Components.Gridlines(<any> categoryScale, null), Error,
-      "xScale needs to inherit from Scale.QuantitativeScale", "can't set xScale to category scale");
-    (<any> assert).throw(() => new Plottable.Components.Gridlines(null, <any> categoryScale), Error,
-      "yScale needs to inherit from Scale.QuantitativeScale", "can't set yScale to category scale");
+  it("draws gridlines between ticks of its scales and updates when scale update", () => {
+    gridlines.betweenX(true);
+    gridlines.betweenY(true);
 
-    const colorScale = new Plottable.Scales.Color();
-    (<any> assert).throw(() => new Plottable.Components.Gridlines(<any> colorScale, null), Error,
-      "xScale needs to inherit from Scale.QuantitativeScale", "can't set xScale to color scale");
-    (<any> assert).throw(() => new Plottable.Components.Gridlines(null, <any> colorScale), Error,
-      "yScale needs to inherit from Scale.QuantitativeScale", "can't set yScale to color scale");
+    gridlines.renderTo(div);
+
+    const xGridlines = gridlines.content().select(".x-gridlines").selectAll<Element, any>("line");
+    const xTicks = xScale.ticks();
+    assert.strictEqual(xGridlines.size(), xTicks.length - 1, "There is an x gridline for each x tick minus one");
+    xGridlines.each(function(gridline, i) {
+      const x = TestMethods.numAttr(d3.select(this), "x1");
+      const expectedLocation = xScale.scale(xTicks[i]) + (xScale.scale(xTicks[i + 1]) - xScale.scale(xTicks[i])) / 2;
+      assert.closeTo(x, expectedLocation, window.Pixel_CloseTo_Requirement, "x gridline drawn between ticks");
+    });
+
+    const yGridlines = gridlines.content().select(".y-gridlines").selectAll<Element, any>("line");
+    const yTicks = yScale.ticks();
+    assert.strictEqual(yGridlines.size(), yTicks.length - 1, "There is a y gridline for each y tick minus one");
+    yGridlines.each(function(gridline, i) {
+      const y = TestMethods.numAttr(d3.select(this), "y1");
+      const expectedLocation = yScale.scale(yTicks[i]) + (yScale.scale(yTicks[i + 1]) - yScale.scale(yTicks[i])) / 2;
+      assert.closeTo(y, expectedLocation, window.Pixel_CloseTo_Requirement, "y gridline drawn on ticks");
+    });
 
     div.remove();
   });

--- a/test/components/gridlinesTests.ts
+++ b/test/components/gridlinesTests.ts
@@ -75,7 +75,7 @@ describe("Gridlines", () => {
 
     gridlines.renderTo(div);
 
-    const xGridlines = gridlines.content().select(".x-gridlines").selectAll<Element, any>("line");
+    const xGridlines = gridlines.content().select(".x-gridlines").selectAll<Element, any>(".betweenline");
     const xTicks = xScale.ticks();
     assert.strictEqual(xGridlines.size(), xTicks.length - 1, "There is an x gridline for each x tick minus one");
     xGridlines.each(function(gridline, i) {
@@ -84,7 +84,7 @@ describe("Gridlines", () => {
       assert.closeTo(x, expectedLocation, window.Pixel_CloseTo_Requirement, "x gridline drawn between ticks");
     });
 
-    const yGridlines = gridlines.content().select(".y-gridlines").selectAll<Element, any>("line");
+    const yGridlines = gridlines.content().select(".y-gridlines").selectAll<Element, any>(".betweenline");
     const yTicks = yScale.ticks();
     assert.strictEqual(yGridlines.size(), yTicks.length - 1, "There is a y gridline for each y tick minus one");
     yGridlines.each(function(gridline, i) {


### PR DESCRIPTION
Change adds `betweenX` and `betweenY` methods to the gridlines api
which each toggle rendering of x and y gridlines between ticks,
respectively. Additionally, gridlines can now be displayed for
oridinal scales.