### PR TITLE
Gridlines constructor parameters type definition is missing null

### DIFF
--- a/src/components/gridlines.ts
+++ b/src/components/gridlines.ts
@@ -52,8 +52,8 @@ function gridPositionFactory(
 export class Gridlines extends Component {
   private _betweenX: boolean;
   private _betweenY: boolean;
-  private _xScale: Scale<any, any>;
-  private _yScale: Scale<any, any>;
+  private _xScale: Scale<any, any> | null;
+  private _yScale: Scale<any, any> | null;
   private _xLinesContainer: SimpleSelection<void>;
   private _yLinesContainer: SimpleSelection<void>;
 
@@ -64,7 +64,7 @@ export class Gridlines extends Component {
    * @param {Scale} xScale The scale to base the x gridlines on. Pass null if no gridlines are desired.
    * @param {Scale} yScale The scale to base the y gridlines on. Pass null if no gridlines are desired.
    */
-  constructor(xScale: Scale<any, any>, yScale: Scale<any, any>) {
+  constructor(xScale: Scale<any, any> | null, yScale: Scale<any, any> | null) {
     super();
     this.addClass("gridlines");
     this._xScale = xScale;

--- a/src/components/gridlines.ts
+++ b/src/components/gridlines.ts
@@ -20,7 +20,7 @@ function gridPositionFactory(
   between: boolean,
   orderedTicks?: any[]) {
 
-  const previousTick: { [index: string ]: string } = {};
+  const previousTick: { [index: string]: string } = {};
   if (orderedTicks !== undefined) {
     for(let i = 0; i < orderedTicks.length; i ++) {
       const previous = orderedTicks[i - 1];


### PR DESCRIPTION
Hi, I'm developing with TS 2.4.1 and strict mode turned on.

If I try to create a Gridlines component with a null x or y scale, like this:

`new Components.Gridlines(null, yScale)`

 I get this compilation error:

`error TS2345: Argument of type 'null' is not assignable to parameter of type 'QuantitativeScale<any>'`

so I fixed the gridlines code and added the explicit null type to the parameters.