### PR TITLE
Only run deployment scripts if owner is in palantir org

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,18 +27,21 @@ test:
     - yarn test:ci
 
 deployment:
+  demo:
+    branch: /.*/
+    owner: palantir
+    commands:
+      - ./demo.js
   publish-npm-next:
     branch: develop
+    owner: palantir
     commands:
       - echo -e "$NPM_USER\n$NPM_PASS\n$NPM_EMAIL" | npm login
       - ./publishSnapshot.sh
       - ./demo.js
-  demo:
-    branch: /.*/
-    commands:
-      - ./demo.js
   publish-npm-latest:
     tag: /v[0-9.]+(-(beta|rc)[0-9.]*)?$/
+    owner: palantir
     commands:
       # Confirm we are ready to publish
       - yarn dist


### PR DESCRIPTION
Previously, community submissions did not trigger circle builds. Once enabled, those builds failed because the deployment scripts don't have access to env var secrets. So, this commit disables deployment scripts on PRs that are not part of the palantir org. Tests will still run and artifacts are still collected, but blueprint-bot won't post a comment