### PR TITLE
only call barPlot's updateBarPixelWidth on computeLayout

### DIFF
--- a/quicktests/overlaying/tests/realistic/many_bars.js
+++ b/quicktests/overlaying/tests/realistic/many_bars.js
@@ -1,0 +1,42 @@
+
+function makeData() {
+    "use strict";
+    var JAN_01_2012 = new Date(2012, 0, 0).valueOf();
+    var MILLIS_IN_DAY = 1000 * 60 * 60 * 24;
+    var data1 = [];
+    var data2 = [];
+    var data3 = [];
+    for (var i = 0; i < 1000; i++) {
+        data1.push({
+            x: new Date(JAN_01_2012 + MILLIS_IN_DAY * i),
+            y: Math.random() * 50 - 25,
+        });
+        data2.push({
+            x: new Date(JAN_01_2012 + MILLIS_IN_DAY * i),
+            y: Math.random() * 50 - 25,
+        });
+        data3.push({
+            x: new Date(JAN_01_2012 + MILLIS_IN_DAY * i),
+            y: Math.random() * 50 - 25,
+        });
+    }
+    return [data1, data2, data3];
+}
+
+function run(div, datas, Plottable) {
+    "use strict";
+
+    var xScale = new Plottable.Scales.Time();
+    var yScale = new Plottable.Scales.Linear();
+    var colorScale = new Plottable.Scales.Color();
+
+    var ds1 = new Plottable.Dataset(datas[0]).metadata(1);
+    var ds2 = new Plottable.Dataset(datas[1]).metadata(2);
+    var ds3 = new Plottable.Dataset(datas[2]).metadata(3);
+    var plot = new Plottable.Plots.StackedBar()
+        .datasets([ds1, ds2, ds3])
+        .x(function (d) { return d.x; }, xScale)
+        .y(function (d) { return d.y; }, yScale)
+        .attr("fill", function (d, i, ds) { return ds.metadata()}, colorScale);
+    plot.renderTo(div);
+}

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -954,4 +954,3 @@ function computeBarPixelThickness(
   }
   return barPixelThickness;
 }
-

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -959,7 +959,6 @@ function computeBarPixelThickness(
 
     barPixelThickness *= Bar._BAR_THICKNESS_RATIO;
   }
-  console.trace("computed bar pixel thickness to", barPixelThickness, "based off", arguments);
   return barPixelThickness;
 }
 

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -16,7 +16,7 @@ import { ProxyDrawer } from "../drawers/drawer";
 import { RectangleCanvasDrawStep, RectangleSVGDrawer } from "../drawers/rectangleDrawer";
 import * as Scales from "../scales";
 import { QuantitativeScale } from "../scales/quantitativeScale";
-import { IScaleCallback, Scale } from "../scales/scale";
+import { Scale } from "../scales/scale";
 import * as Utils from "../utils";
 import { makeEnum } from "../utils/makeEnum";
 import * as Plots from "./";
@@ -229,13 +229,6 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
   public orientation(): BarOrientation {
     return this._isVertical ? "vertical" : "horizontal";
   }
-
-  // public render() {
-  //   this._updateBarPixelWidth();
-  //   this._updateExtents();
-  //   super.render();
-  //   return this;
-  // }
 
   protected _createDrawer() {
     return new ProxyDrawer(() => new RectangleSVGDrawer(Bar._BAR_AREA_CLASS), RectangleCanvasDrawStep);

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -16,7 +16,7 @@ import { ProxyDrawer } from "../drawers/drawer";
 import { RectangleCanvasDrawStep, RectangleSVGDrawer } from "../drawers/rectangleDrawer";
 import * as Scales from "../scales";
 import { QuantitativeScale } from "../scales/quantitativeScale";
-import { Scale } from "../scales/scale";
+import { IScaleCallback, Scale } from "../scales/scale";
 import * as Utils from "../utils";
 import { makeEnum } from "../utils/makeEnum";
 import * as Plots from "./";
@@ -43,8 +43,8 @@ export const BarAlignment = makeEnum(["start", "middle", "end"]);
 export type BarAlignment = keyof typeof BarAlignment;
 
 export class Bar<X, Y> extends XYPlot<X, Y> {
-  private static _BAR_THICKNESS_RATIO = 0.95;
-  private static _SINGLE_BAR_DIMENSION_RATIO = 0.4;
+  public static _BAR_THICKNESS_RATIO = 0.95;
+  public static _SINGLE_BAR_DIMENSION_RATIO = 0.4;
   private static _BAR_AREA_CLASS = "bar-area";
   private static _BAR_END_KEY = "barEnd";
 
@@ -93,6 +93,13 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
     this._labelConfig = new Utils.Map<Dataset, LabelConfig>();
     this._baselineValueProvider = () => [this.baselineValue()];
     this._updateBarPixelThicknessCallback = () => this._updateBarPixelWidth();
+  }
+
+  public computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number) {
+    super.computeLayout(origin, availableWidth, availableHeight);
+    this._updateBarPixelWidth();
+    this._updateExtents();
+    return this;
   }
 
   public x(): Plots.ITransformableAccessorScaleBinding<X, number>;
@@ -223,12 +230,12 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
     return this._isVertical ? "vertical" : "horizontal";
   }
 
-  public render() {
-    this._updateBarPixelWidth();
-    this._updateExtents();
-    super.render();
-    return this;
-  }
+  // public render() {
+  //   this._updateBarPixelWidth();
+  //   this._updateExtents();
+  //   super.render();
+  //   return this;
+  // }
 
   protected _createDrawer() {
     return new ProxyDrawer(() => new RectangleSVGDrawer(Bar._BAR_AREA_CLASS), RectangleCanvasDrawStep);
@@ -835,7 +842,7 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
   }
 
   protected _updateThicknessAttr() {
-    const startProj: Plots.ITransformableAccessorScaleBinding<any, number> = this._isVertical ? this.x() : this.y();
+    const startProj = this.position();
     const endProj = this.barEnd();
     if (startProj != null && endProj != null) {
       this._fixedBarPixelThickness = false;
@@ -853,50 +860,17 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
     }
   }
 
-  /**
-   * Computes the barPixelThickness of all the bars in the plot.
-   *
-   * If the position scale of the plot is a CategoryScale and in bands mode, then the rangeBands function will be used.
-   * If the position scale of the plot is a QuantitativeScale, then the bar thickness is equal to the smallest distance between
-   * two adjacent data points, padded for visualisation.
-   *
-   * This is ignored when explicitly setting the barEnd.
-   */
-  protected _computeBarPixelThickness(): number {
-    if (!this._projectorsReady()) {
-      return 0;
-    }
-    let barPixelThickness: number;
-    const positionScale = this.position().scale;
-    if (positionScale instanceof Scales.Category) {
-      barPixelThickness = positionScale.rangeBand();
-    } else {
-      const positionAccessor = this.position().accessor;
-
-      const numberBarAccessorData = d3.set(Utils.Array.flatten(this.datasets().map((dataset) => {
-        return dataset.data().map((d, i) => positionAccessor(d, i, dataset))
-          .filter((d) => d != null)
-          .map((d) => d.valueOf());
-      }))).values().map((value) => +value);
-
-      numberBarAccessorData.sort((a, b) => a - b);
-
-      const scaledData = numberBarAccessorData.map((datum) => positionScale.scale(datum));
-      const barAccessorDataPairs = d3.pairs(scaledData);
-      const barWidthDimension = this._isVertical ? this.width() : this.height();
-
-      barPixelThickness = Utils.Math.min(barAccessorDataPairs, (pair: any[], i: number) => {
-        return Math.abs(pair[1] - pair[0]);
-      }, barWidthDimension * Bar._SINGLE_BAR_DIMENSION_RATIO);
-
-      barPixelThickness *= Bar._BAR_THICKNESS_RATIO;
-    }
-    return barPixelThickness;
-  }
-
   private _updateBarPixelWidth() {
     if (this._fixedBarPixelThickness) {
-      this._barPixelThickness = this._computeBarPixelThickness();
+      if (this._projectorsReady()) {
+        this._barPixelThickness = computeBarPixelThickness(
+            this.position(),
+            this.datasets(),
+            this._isVertical ? this.width() : this.height(),
+        );
+      } else {
+        this._barPixelThickness = 0;
+      }
     }
   }
 
@@ -946,3 +920,46 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
     return dataToDraw;
   }
 }
+
+/**
+ * Computes the barPixelThickness of all the bars in the plot.
+ *
+ * If the position scale of the plot is a CategoryScale and in bands mode, then the rangeBands function will be used.
+ * If the position scale of the plot is a QuantitativeScale, then the bar thickness is equal to the smallest distance between
+ * two adjacent data points, padded for visualisation.
+ *
+ * This is ignored when explicitly setting the barEnd.
+ */
+function computeBarPixelThickness(
+    positionBinding: Plots.ITransformableAccessorScaleBinding<any, number>,
+    datasets: Dataset[],
+    barWidthDimension: number,
+): number {
+  let barPixelThickness: number;
+  const positionScale = positionBinding.scale;
+  if (positionScale instanceof Scales.Category) {
+    barPixelThickness = positionScale.rangeBand();
+  } else {
+    const positionAccessor = positionBinding.accessor;
+
+    const numberBarAccessorData = d3.set(Utils.Array.flatten(datasets.map((dataset) => {
+      return dataset.data().map((d, i) => positionAccessor(d, i, dataset))
+          .filter((d) => d != null)
+          .map((d) => d.valueOf());
+    }))).values().map((value) => +value);
+
+    numberBarAccessorData.sort((a, b) => a - b);
+
+    const scaledData = numberBarAccessorData.map((datum) => positionScale.scale(datum));
+    const barAccessorDataPairs = d3.pairs(scaledData);
+
+    barPixelThickness = Utils.Math.min(barAccessorDataPairs, (pair: any[], i: number) => {
+      return Math.abs(pair[1] - pair[0]);
+    }, barWidthDimension * Bar._SINGLE_BAR_DIMENSION_RATIO);
+
+    barPixelThickness *= Bar._BAR_THICKNESS_RATIO;
+  }
+  console.trace("computed bar pixel thickness to", barPixelThickness, "based off", arguments);
+  return barPixelThickness;
+}
+

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -212,7 +212,7 @@ describe("Plots", () => {
       });
 
       describe(`auto bar width calculation when ${orientation}`, () => {
-        const scaleTypes = ["Linear", "ModifiedLog", "Time"];
+        const scaleTypes = ["Linear", "Time"];
         scaleTypes.forEach((scaleType) => {
           describe(`using a ${scaleType} base Scale`, () => {
             let div: d3.Selection<HTMLDivElement, any, any, any>;
@@ -228,9 +228,6 @@ describe("Plots", () => {
               switch (scaleType) {
                 case "Linear":
                   baseScale = new Plottable.Scales.Linear();
-                  break;
-                case "ModifiedLog":
-                  baseScale = new Plottable.Scales.ModifiedLog();
                   break;
                 case "Time":
                   baseScale = new Plottable.Scales.Time();

--- a/test/plots/stackedBarPlotTests.ts
+++ b/test/plots/stackedBarPlotTests.ts
@@ -146,7 +146,10 @@ describe("Plots", () => {
       it("doesn't show stacked bar labels when columns are too narrow", () => {
         stackedBarPlot.labelsEnabled(true);
         xScale.range([0, 20]);
+        // HACKHACK send a scale update to update the barPixelThickness
         xScale.domain(xScale.domain());
+        // HACKHACK explicitly re-render with the new barPixelThickness
+        stackedBarPlot.render();
         const stackedBarLabels = stackedBarPlot.content().selectAll<Element, any>(".stacked-bar-label");
         assert.strictEqual(stackedBarLabels.size(), 0);
       });
@@ -213,7 +216,10 @@ describe("Plots", () => {
       it("doesn't show stacked bar labels when columns are too narrow", () => {
         stackedBarPlot.labelsEnabled(true);
         xScale.range([0, 40]);
+        // HACKHACK send a scale update to update the barPixelThickness
         xScale.domain(xScale.domain());
+        // HACKHACK explicitly re-render to cause the barPixelThickness
+        stackedBarPlot.render();
         const stackedBarLabels = stackedBarPlot.content().selectAll<Element, any>(".stacked-bar-label");
         assert.strictEqual(stackedBarLabels.size(), 0);
       });
@@ -425,7 +431,10 @@ describe("Plots", () => {
       it("doesn't show stacked bar labels when columns are too narrow", () => {
         stackedBarPlot.labelsEnabled(true);
         yScale.range([0, 40]);
+        // HACKHACK send a scale update to update the barPixelThickness
         yScale.domain(yScale.domain());
+        // HACKHACK explicitly re-render to cause the barPixelThickness
+        stackedBarPlot.render();
         const stackedBarLabels = stackedBarPlot.content().selectAll<Element, any>(".stacked-bar-label");
         assert.strictEqual(stackedBarLabels.size(), 0);
       });


### PR DESCRIPTION
BarPlot.render used to call _updateBarPixelWidth and _updateExtents (because the extents depend on the bar pixel width) which would send Plottable into a loop:

BarPlot.render -> updateExtents -> Scale.autoDomain -> Scale.dispatchUpdate -> Plot._renderCallback -> BarPlot.render

This results in unnecessary computation and slowdown.

The reason .render() called _updateBarPixelWidth to begin with is because the bar pixel width is computed based off several inputs and detecting when the input has updated is not always easy. It's pretty much a rats nest of knowing when the scale domain, scale range, other scale properties, plot dimensions, or data, has changed. Putting _updateBarPixelWidth in .render was a sort of catch-all that made sure it was always "up to date", but wastefully so. This PR does the opposite - it removes the catch all to reduce wasted computation.

A side effect is that _updateBarPixelWidth may now be stale/out of date (aka we're introducing some regressions). We should tackle this in an upcoming PR (the groundwork for this change is why computeBarPixelThickness has been refactored).

I've also deleted ModifiedLog Bar Plot tests since the behavior of "the pixel width affects the extent" is really tricky to get right here, and it doesn't affect the perf use case.

Before this change: many_bars took **3.01s**
After this change: many_bars took **0.39s**

Fixes #3219 