### PR TITLE
memoize bar pixel thickness, POC memoizing and Signature API

### DIFF
--- a/quicktests/overlaying/tests/realistic/many_bars.js
+++ b/quicktests/overlaying/tests/realistic/many_bars.js
@@ -6,7 +6,8 @@ function makeData() {
     var data1 = [];
     var data2 = [];
     var data3 = [];
-    for (var i = 0; i < 3000; i++) {
+    var data4 = [];
+    for (var i = 0; i < 1000; i++) {
         data1.push({
             x: new Date(JAN_01_2012 + MILLIS_IN_DAY * i),
             y: Math.random() * 50 - 25,
@@ -19,8 +20,12 @@ function makeData() {
             x: new Date(JAN_01_2012 + MILLIS_IN_DAY * i),
             y: Math.random() * 50 - 25,
         });
+        data4.push({
+            x: new Date(JAN_01_2012 + MILLIS_IN_DAY * i),
+            y: Math.random() * 50 - 25,
+        });
     }
-    return [data1, data2, data3];
+    return [data1, data2, data3, data4];
 }
 
 function run(div, datas, Plottable) {
@@ -33,8 +38,9 @@ function run(div, datas, Plottable) {
     var ds1 = new Plottable.Dataset(datas[0]).metadata(1);
     var ds2 = new Plottable.Dataset(datas[1]).metadata(2);
     var ds3 = new Plottable.Dataset(datas[2]).metadata(3);
+    var ds4 = new Plottable.Dataset(datas[3]).metadata(4);
     var plot = new Plottable.Plots.StackedBar()
-        .datasets([ds1, ds2, ds3])
+        .datasets([ds1, ds2, ds3, ds4])
         .x(function (d) { return d.x; }, xScale)
         .y(function (d) { return d.y; }, yScale)
         .attr("fill", function (d, i, ds) { return ds.metadata()}, colorScale);

--- a/quicktests/overlaying/tests/realistic/many_bars.js
+++ b/quicktests/overlaying/tests/realistic/many_bars.js
@@ -6,7 +6,7 @@ function makeData() {
     var data1 = [];
     var data2 = [];
     var data3 = [];
-    for (var i = 0; i < 1000; i++) {
+    for (var i = 0; i < 3000; i++) {
         data1.push({
             x: new Date(JAN_01_2012 + MILLIS_IN_DAY * i),
             y: Math.random() * 50 - 25,

--- a/src/core/dataset.ts
+++ b/src/core/dataset.ts
@@ -11,6 +11,7 @@ export class Dataset {
   private _data: any[];
   private _metadata: any;
   private _callbacks: Utils.CallbackSet<DatasetCallback>;
+  private _updateId = 0;
 
   /**
    * A Dataset contains an array of data and some metadata.
@@ -66,7 +67,7 @@ export class Dataset {
       return this._data;
     } else {
       this._data = data;
-      this._callbacks.callCallbacks(this);
+      this._dispatchUpdate();
       return this;
     }
   }
@@ -89,8 +90,17 @@ export class Dataset {
       return this._metadata;
     } else {
       this._metadata = metadata;
-      this._callbacks.callCallbacks(this);
+      this._dispatchUpdate();
       return this;
     }
+  }
+
+  public updateId() {
+    return this._updateId;
+  }
+
+  private _dispatchUpdate() {
+    this._updateId++;
+    this._callbacks.callCallbacks(this);
   }
 }

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -525,6 +525,8 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
   }
 
   public renderImmediately() {
+    // HACK update bar pixel thickness
+    this._barPixelThickness();
     return this._computeBarPixelThickness.doLocked(() => super.renderImmediately());
   }
 
@@ -858,7 +860,8 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
         return 0;
       }
     } else {
-      throw new Error("called _barPixelThickness when thickness isn't fixed!");
+      // throw new Error("called _barPixelThickness when thickness isn't fixed!");
+      return 0;
     }
   }
 
@@ -1084,6 +1087,10 @@ type LockedMemoize<F extends Function> = F & {
    * property during the duration of fn. This lets you
    * bypass the performance hit of signing when you
    * know the fn will not mutate the inputs.
+   *
+   * Be sure to force the memoization to the value
+   * you want before calling this!
+   *
    * @param fn
    */
   doLocked<T>(fn: () => T): T;

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -92,12 +92,12 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
     this.attr(Bar._BAR_THICKNESS_KEY, () => this._barPixelThickness);
     this._labelConfig = new Utils.Map<Dataset, LabelConfig>();
     this._baselineValueProvider = () => [this.baselineValue()];
-    this._updateBarPixelThicknessCallback = () => this._updateBarPixelWidth();
+    this._updateBarPixelThicknessCallback = () => this._updateBarPixelThickness();
   }
 
   public computeLayout(origin?: Point, availableWidth?: number, availableHeight?: number) {
     super.computeLayout(origin, availableWidth, availableHeight);
-    this._updateBarPixelWidth();
+    this._updateBarPixelThickness();
     this._updateExtents();
     return this;
   }
@@ -281,7 +281,7 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
 
   public addDataset(dataset: Dataset) {
     super.addDataset(dataset);
-    this._updateBarPixelWidth();
+    this._updateBarPixelThickness();
     return this;
   }
 
@@ -294,7 +294,7 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
   public removeDataset(dataset: Dataset) {
     dataset.offUpdate(this._updateBarPixelThicknessCallback);
     super.removeDataset(dataset);
-    this._updateBarPixelWidth();
+    this._updateBarPixelThickness();
     return this;
   }
 
@@ -312,7 +312,7 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
     }
 
     super.datasets(datasets);
-    this._updateBarPixelWidth();
+    this._updateBarPixelThickness();
     return this;
   }
 
@@ -848,12 +848,12 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
       });
     } else {
       this._fixedBarPixelThickness = true;
-      this._updateBarPixelWidth();
+      this._updateBarPixelThickness();
       this.attr(Bar._BAR_THICKNESS_KEY, () => this._barPixelThickness);
     }
   }
 
-  private _updateBarPixelWidth() {
+  private _updateBarPixelThickness() {
     if (this._fixedBarPixelThickness) {
       if (this._projectorsReady()) {
         this._barPixelThickness = computeBarPixelThickness(
@@ -926,7 +926,7 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
 function computeBarPixelThickness(
     positionBinding: Plots.ITransformableAccessorScaleBinding<any, number>,
     datasets: Dataset[],
-    barWidthDimension: number,
+    plotPositionDimensionLength: number,
 ): number {
   let barPixelThickness: number;
   const positionScale = positionBinding.scale;
@@ -948,7 +948,7 @@ function computeBarPixelThickness(
 
     barPixelThickness = Utils.Math.min(barAccessorDataPairs, (pair: any[], i: number) => {
       return Math.abs(pair[1] - pair[0]);
-    }, barWidthDimension * Bar._SINGLE_BAR_DIMENSION_RATIO);
+    }, plotPositionDimensionLength * Bar._SINGLE_BAR_DIMENSION_RATIO);
 
     barPixelThickness *= Bar._BAR_THICKNESS_RATIO;
   }

--- a/src/scales/scale.ts
+++ b/src/scales/scale.ts
@@ -17,6 +17,7 @@ export class Scale<D, R> {
   private _autoDomainAutomatically = true;
   private _domainModificationInProgress = false;
   private _includedValuesProviders: Utils.Set<Scales.IIncludedValuesProvider<D>>;
+  private _updateId = 0;
 
   /**
    * A Scale is a function (in the mathematical sense) that maps values from a domain to a range.
@@ -74,6 +75,7 @@ export class Scale<D, R> {
   }
 
   protected _dispatchUpdate() {
+    this._updateId++;
     this._callbacks.callCallbacks(this);
   }
 
@@ -207,5 +209,9 @@ export class Scale<D, R> {
     this._includedValuesProviders.delete(provider);
     this._autoDomainIfAutomaticMode();
     return this;
+  }
+
+  public updateId() {
+    return this._updateId;
   }
 }

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -212,7 +212,7 @@ describe("Plots", () => {
       });
 
       describe(`auto bar width calculation when ${orientation}`, () => {
-        const scaleTypes = ["Linear", "Time"];
+        const scaleTypes = ["Linear", "ModifiedLog", "Time"];
         scaleTypes.forEach((scaleType) => {
           describe(`using a ${scaleType} base Scale`, () => {
             let div: d3.Selection<HTMLDivElement, any, any, any>;
@@ -228,6 +228,9 @@ describe("Plots", () => {
               switch (scaleType) {
                 case "Linear":
                   baseScale = new Plottable.Scales.Linear();
+                  break;
+                case "ModifiedLog":
+                  baseScale = new Plottable.Scales.ModifiedLog();
                   break;
                 case "Time":
                   baseScale = new Plottable.Scales.Time();


### PR DESCRIPTION
Improve perf of _computeBarPixelThickness by memoizing gets to it, reducing intermediate wasted computes (intermediate computes are computations that are called before renderImmediately).

Implementing memoization in Plottable is complicated by mutable scales and datasets. To resolve this we write a recursive Signature interface that holds an immutable snapshot of whatever state the scale/data was in at the time. Then on memoized function invocation we sign the new inputs and compare the signatures to decide if we should recompute.

Unfortunately signing and comparison is itself a performance hit; in tests they took ~0.3ms per get (which, for 3k bars, is 900ms of overhead), which is unacceptable. To get around this, we notice that almost all of these gets happen inside Plot.renderImmediately (aka getting the thickness of the bar to actually render the bar). Thus we introduce the "doLocked" method that momentarily bypasses sign/comparison logic and simply returns the cached value.

This paves the way for more perf improvements as we refactor other code to using the sign and memoize API - e.g. #2495, #3117, #2949

Starts tackling #3302 