### PR TITLE
Incorrectly excluded entities not considered for nearest entity in interactions #3345 #3268

### DIFF
--- a/test/plots/plotTests.ts
+++ b/test/plots/plotTests.ts
@@ -84,6 +84,39 @@ describe("Plots", () => {
         assert.deepEqual(entities3, entities1);
         assert.strictEqual(lightweightPlotEntitySpy.callCount, 4);
       });
+
+      describe("adding entities", () => {
+        let addAllSpy: sinon.SinonSpy;
+
+        beforeEach(() => {
+          addAllSpy = sinon.spy(Plottable.Utils.EntityStore.prototype, "addAll");
+        });
+
+        afterEach(() => {
+          addAllSpy.restore();
+        });
+
+        it("supplies plot bounds from its own origin when adding entities to the store", () => {
+          const dataset = new Plottable.Dataset();
+          plot.addDataset(dataset);
+          const width = 200;
+          const height = 100;
+          const originX = 50;
+          const originY = 20;
+
+          plot.setBounds(width, height, originX, originY);
+          const parentSpaceBounds = plot.bounds();
+
+          plot.entities();
+          const plotLocalBounds = addAllSpy.args[0][1];
+
+          assert.notDeepEqual(parentSpaceBounds, plotLocalBounds);
+          assert.deepEqual(plotLocalBounds, {
+            topLeft: {x: 0, y: 0},
+            bottomRight: {x: width, y: height},
+          });
+        });
+      });
     });
 
     describe("entityNearest", () => {


### PR DESCRIPTION
Fixes / relates to https://github.com/palantir/plottable/issues/3345 & https://github.com/palantir/plottable/issues/3268

Plot entity store creation passes incorrect bounds to the entity store (plot's parent space rather than from plot's origin itself), which then can exclude visible entities from being considered for nearest calculation. 

The only other call to `addAll` entities does not pass bounds info, so other than performance reasons is not absolutely necessary and precedence is already set here to not always be needed for perf, so originally I removed it, which fixed the use case, however it seems to be desired for certain plot types (eg scatter) as per the tests, so have done a simple mapping of bounds to become relative to plot's own origin for this particular use case, and also applied it to the missing one

This fix is simple and localised - it doesn't address the wider issue, but for us and presumably for others, this is actually a blocker currently as it is very noticeable by users - for example when showing tooltips, or selecting data points

For the disparity between whether the bounds of a plot in general are to be used in plot or parent space I felt before I could do anything more meaningful to help other than this quick fix, I'd need some input first as it...

1) has API design decisions - bounds in various different places now have different pixel space meanings but how you want to convey that to the user is not my decision as could be a breaking change (ie for use in other methods where bounds are passed in signature - like `_entitityIsVisibleOnPlot` - could default it to use the localised version but that may have repercussions)
2) has too wide an impact on parts of the lib I have not enough knowledge of (ie panning/zooming or how interpolation from the different spaces needs to be done to work with scales etc)
