### PR TITLE
Bring back TransformAwareTranslator for MouseDispatcher

### DIFF
--- a/quicktests/overlaying/tests/interactions/css_transforms.js
+++ b/quicktests/overlaying/tests/interactions/css_transforms.js
@@ -1,7 +1,8 @@
 function makeData() {
+  return [{x: "Frodo", y: 3}, {x: "Sam", y: 2}, {x: "Gollum", y: 4}];
 }
 
-function run(container) {
+function run(container, data) {
   "use strict";
 
   container
@@ -26,17 +27,28 @@ function run(container) {
 
   const child3 = container.append("div")
     .style("position", "absolute")
-    .style("top", "100px")
+    .style("top", "50px")
     .style("left", "400px")
     .style("width", "300px")
     .style("height", "200px")
     .style("border", "5px solid #888")
     .style("padding", "10px 10px")
+    .style("transform", "rotate(15deg)");
+
+  const child4 = container.append("div")
+    .style("position", "absolute")
+    .style("top", "300px")
+    .style("left", "300px")
+    .style("width", "300px")
+    .style("height", "200px")
+    .style("border", "1px solid magenta")
+    .style("transform", "rotate(-10deg)");
 
   debugCursor(child0, "red");
   debugCursor(child1, "lime");
   debugCursor(child2, "dodgerblue");
   debugPlot(child3);
+  debugBarPlot(child4, data);
 }
 
 function debugPlot(child) {
@@ -74,8 +86,33 @@ function debugPlot(child) {
     [yAxis, plot],
     [null, xAxis],
   ]).renderTo(child);
+}
 
-  d3.select(".plottable").style("transform", "rotate(15deg)");
+function debugBarPlot(child, data) {
+  const xScale = new Plottable.Scales.Category();
+  const yScale = new Plottable.Scales.Linear();
+  const xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
+  const yAxis = new Plottable.Axes.Numeric(yScale, "left");
+  const title = new Plottable.Components.TitleLabel("Pan Zoom");
+  const plot = new Plottable.Plots.Bar()
+    .renderer("canvas")
+    .addDataset(new Plottable.Dataset(data))
+    .attr("fill", () => "dodgerblue")
+    .x(({ x }) => x, xScale)
+    .y(({ y }) => y, yScale);
+
+  new Plottable.Interactions.PanZoom(xScale, yScale)
+    .attachTo(plot);
+
+  // new Plottable.Interactions.Pointer()
+  //   .onPointerMove((p) => console.log("Bar pointer", p))
+  //   .attachTo(plot);
+
+  new Plottable.Components.Table([
+    [null, title],
+    [yAxis, plot],
+    [null, xAxis],
+  ]).renderTo(child);
 
 }
 

--- a/src/dispatchers/mouseDispatcher.ts
+++ b/src/dispatchers/mouseDispatcher.ts
@@ -22,6 +22,7 @@ export class Mouse extends Dispatcher {
   private static _MOUSEUP_EVENT_NAME = "mouseup";
   private static _WHEEL_EVENT_NAME = "wheel";
   private static _DBLCLICK_EVENT_NAME = "dblclick";
+  private _translator: Utils.Translator;
 
   /**
    * Get a Mouse Dispatcher for the component tree.
@@ -50,6 +51,7 @@ export class Mouse extends Dispatcher {
     super();
 
     this._lastMousePosition = { x: -1, y: -1 };
+    this._translator = Utils.getTranslator(component);
 
     const processMoveCallback = (e: MouseEvent) => this._measureAndDispatch(component, e, Mouse._MOUSEMOVE_EVENT_NAME, "page");
     this._eventToProcessingFunction[Mouse._MOUSEOVER_EVENT_NAME] = processMoveCallback;
@@ -188,9 +190,10 @@ export class Mouse extends Dispatcher {
       throw new Error("Invalid scope '" + scope + "', must be 'element' or 'page'");
     }
     if (scope === "page" || this.eventInside(component, event)) {
+      const position = this._translator.computePosition(event.clientX, event.clientY);
       const origin = component.originToRoot();
-      const x = event.offsetX + origin.x;
-      const y = event.offsetY + origin.y;
+      const x = position.x + origin.x;
+      const y = position.y + origin.y;
       this._lastMousePosition = { x, y };
       this._callCallbacksForEvent(eventName, this.lastMousePosition(), event);
     }


### PR DESCRIPTION
Now that the translator doesn't thrash the DOM, we can
use it once again to handle the clientX/clientY coordinate
conversion for components.

Using offsetX/offsetY was producing incorrect results
when the event target was outside the plot.