### PR TITLE
Add new method for manipulating transformable scales

### DIFF
--- a/src/scales/categoryScale.ts
+++ b/src/scales/categoryScale.ts
@@ -234,8 +234,17 @@ export class Category extends Scale<string, number> implements ITransformableSca
     return this._d3TransformationScale.invert(value);
   }
 
+  public getTransformationExtent() {
+    return TRANSFORMATION_SPACE;
+  }
+
   public getTransformationDomain() {
     return this._d3TransformationScale.domain() as [number, number];
+  }
+
+  public setTransformationDomain(domain: [number, number]) {
+    this._d3TransformationScale.domain(domain);
+    this._dispatchUpdate();
   }
 
   protected _getDomain() {

--- a/src/scales/index.ts
+++ b/src/scales/index.ts
@@ -78,11 +78,23 @@ export interface ITransformableScale {
   scaleTransformation(value: number): number;
 
   /**
+   * Gets the full extent of the transformation domain.
+   */
+  getTransformationExtent(): [number, number];
+
+  /**
    * Returns the current transformed domain of the scale. This must be a
    * numerical range in the same coordinate space used for
    * `scaleTransformation`.
    */
   getTransformationDomain(): [number, number];
+
+  /**
+   * Directly set the transformation domain. Instead of calling `.zoom` or
+   * `.pan` perform calculations relative to the current domain, this can but
+   * used to pan/zoom to an exact domain interval (in transformation space).
+   */
+  setTransformationDomain(domain: [number, number]): void;
 
   /**
    * Returns value in *Transformation Space* for the provided *screen space*.

--- a/src/scales/linearScale.ts
+++ b/src/scales/linearScale.ts
@@ -41,8 +41,16 @@ export class Linear extends QuantitativeScale<number> {
     return this.invert(value);
   }
 
+  public getTransformationExtent() {
+    return this._getUnboundedExtent() as [number, number];
+  }
+
   public getTransformationDomain() {
     return this.domain() as [number, number];
+  }
+
+  public setTransformationDomain(domain: [number, number]) {
+    this.domain(domain);
   }
 
   protected _getDomain() {

--- a/src/scales/modifiedLogScale.ts
+++ b/src/scales/modifiedLogScale.ts
@@ -107,8 +107,16 @@ export class ModifiedLog extends QuantitativeScale<number> {
     return this.invert(value);
   }
 
+  public getTransformationExtent() {
+    return this._getUnboundedExtent() as [number, number];
+  }
+
   public getTransformationDomain() {
     return this.domain() as [number, number];
+  }
+
+  public setTransformationDomain(domain: [number, number]) {
+    this.domain(domain);
   }
 
   protected _getDomain() {

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -69,7 +69,7 @@ export class QuantitativeScale<D> extends Scale<D, number> implements ITransform
     super._autoDomainIfAutomaticMode();
   }
 
-  protected _getExtent(): D[] {
+  protected _getUnboundedExtent(): D[] {
     const includedValues = this._getAllIncludedValues();
     let extent = this._defaultExtent();
     if (includedValues.length !== 0) {
@@ -79,7 +79,11 @@ export class QuantitativeScale<D> extends Scale<D, number> implements ITransform
       ];
       extent = this._padDomain(combinedExtent);
     }
+    return extent;
+  }
 
+  protected _getExtent(): D[] {
+    const extent = this._getUnboundedExtent();
     if (this._domainMin != null) {
       extent[0] = this._domainMin;
     }
@@ -288,8 +292,16 @@ export class QuantitativeScale<D> extends Scale<D, number> implements ITransform
     throw new Error("Subclasses should override invertedTransformation");
   }
 
+  public getTransformationExtent(): [number, number] {
+    throw new Error("Subclasses should override getTransformationExtent");
+  }
+
   public getTransformationDomain(): [number, number] {
     throw new Error("Subclasses should override getTransformationDomain");
+  }
+
+  public setTransformationDomain(domain: [number, number])  {
+    throw new Error("Subclasses should override setTransformationDomain");
   }
 
   protected _setDomain(values: D[]) {

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -75,9 +75,18 @@ export class Time extends QuantitativeScale<Date> {
     return this.invert(value).getTime();
   }
 
+  public getTransformationExtent() {
+    const extent = this._getUnboundedExtent();
+    return [extent[0].valueOf(), extent[1].valueOf()] as [number, number];
+  }
+
   public getTransformationDomain() {
     const dates = this.domain();
     return [dates[0].valueOf(), dates[1].valueOf()] as [number, number];
+  }
+
+  public setTransformationDomain([domainMin, domainMax]: [number, number]) {
+    this.domain([new Date(domainMin), new Date(domainMax)]);
   }
 
   protected _getDomain() {


### PR DESCRIPTION
1. setTransformationDomain - allows users to directly set the domain position for pan/zoom.
2. getTransformationExtent - gets the unbounded extent for all values in the scale.