### PR TITLE
Fast entity bounds queries

### DIFF
--- a/src/interactions/panZoomInteraction.ts
+++ b/src/interactions/panZoomInteraction.ts
@@ -17,6 +17,7 @@ import { Interaction } from "./interaction";
 
 export type PanCallback = () => void;
 export type ZoomCallback = () => void;
+export type PanZoomUpdateCallback = () => void;
 
 export type WheelFilter = (wheelEvent: WheelEvent) => boolean;
 
@@ -57,6 +58,7 @@ export class PanZoom extends Interaction {
 
   private _panEndCallbacks = new Utils.CallbackSet<PanCallback>();
   private _zoomEndCallbacks = new Utils.CallbackSet<ZoomCallback>();
+  private _panZoomUpdateCallbacks = new Utils.CallbackSet<PanZoomUpdateCallback>();
 
   /**
    * A PanZoom Interaction updates the domains of an x-scale and/or a y-scale
@@ -124,6 +126,8 @@ export class PanZoom extends Interaction {
     this.yScales().forEach((yScale) => {
       yScale.pan(this._constrainedTranslation(yScale, translateAmount.y));
     });
+
+    this._panZoomUpdateCallbacks.callCallbacks();
   }
 
   /**
@@ -153,6 +157,8 @@ export class PanZoom extends Interaction {
 
       yScale.zoom(zoomAmount, yCenter);
     });
+
+    this._panZoomUpdateCallbacks.callCallbacks();
   }
 
   protected _anchor(component: Component) {
@@ -804,6 +810,29 @@ export class PanZoom extends Interaction {
    */
   public offZoomEnd(callback: ZoomCallback) {
     this._zoomEndCallbacks.delete(callback);
+    return this;
+  }
+
+  /**
+   * Adds a callback to be called when any pan or zoom update occurs. This is
+   * called on every frame, so be sure your callback is fast.
+   *
+   * @param {PanZoomUpdateCallback} callback
+   * @returns {this} The calling PanZoom Interaction.
+   */
+  public onPanZoomUpdate(callback: PanZoomUpdateCallback) {
+    this._panZoomUpdateCallbacks.add(callback);
+    return this;
+  }
+
+  /**
+   * Removes a callback that would be called when any pan or zoom update occurs.
+   *
+   * @param {PanZoomUpdateCallback} callback
+   * @returns {this} The calling PanZoom Interaction.
+   */
+  public offPanZoomUpdate(callback: PanZoomUpdateCallback) {
+    this._panZoomUpdateCallbacks.delete(callback);
     return this;
   }
 }

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -12,7 +12,6 @@ import * as Formatters from "../core/formatters";
 import { DatumFormatter } from "../core/formatters";
 import {
   AttributeToProjector,
-  Bounds,
   IAccessor,
   IEntityBounds,
   Point,
@@ -483,35 +482,6 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
    */
   public entitiesAt(p: Point) {
     return this._entitiesIntersecting(p.x, p.y);
-  }
-
-  /**
-   * Gets the Entities that intersect the Bounds.
-   *
-   * @param {Bounds} bounds
-   * @returns {PlotEntity[]}
-   */
-  public entitiesIn(bounds: Bounds): IPlotEntity[];
-  /**
-   * Gets the Entities that intersect the area defined by the ranges.
-   *
-   * @param {Range} xRange
-   * @param {Range} yRange
-   * @returns {PlotEntity[]}
-   */
-  public entitiesIn(xRange: Range, yRange: Range): IPlotEntity[];
-  public entitiesIn(xRangeOrBounds: Range | Bounds, yRange?: Range): IPlotEntity[] {
-    let dataXRange: Range;
-    let dataYRange: Range;
-    if (yRange == null) {
-      const bounds = (<Bounds> xRangeOrBounds);
-      dataXRange = { min: bounds.topLeft.x, max: bounds.bottomRight.x };
-      dataYRange = { min: bounds.topLeft.y, max: bounds.bottomRight.y };
-    } else {
-      dataXRange = (<Range> xRangeOrBounds);
-      dataYRange = yRange;
-    }
-    return this._entitiesIntersecting(dataXRange, dataYRange);
   }
 
   private _entitiesIntersecting(xValOrRange: number | Range, yValOrRange: number | Range): IPlotEntity[] {

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -8,7 +8,7 @@ import * as d3Shape from "d3-shape";
 
 import * as Animators from "../animators";
 import { Dataset } from "../core/dataset";
-import { AttributeToProjector, Bounds, IAccessor, IRangeProjector, Point, Projector, Range } from "../core/interfaces";
+import { AttributeToProjector, IAccessor, IRangeProjector, Point, Projector } from "../core/interfaces";
 import * as Drawers from "../drawers";
 import { ProxyDrawer } from "../drawers/drawer";
 import { LineSVGDrawer, makeLineCanvasDrawStep } from "../drawers/lineDrawer";
@@ -430,44 +430,6 @@ export class Line<X> extends XYPlot<X, number> {
     } else {
       return [];
     }
-  }
-
-  /**
-   * Gets the Entities that intersect the Bounds.
-   *
-   * @param {Bounds} bounds
-   * @returns {PlotEntity[]}
-   */
-  public entitiesIn(bounds: Bounds): IPlotEntity[];
-  /**
-   * Gets the Entities that intersect the area defined by the ranges.
-   *
-   * @param {Range} xRange
-   * @param {Range} yRange
-   * @returns {PlotEntity[]}
-   */
-  public entitiesIn(xRange: Range, yRange: Range): IPlotEntity[];
-  public entitiesIn(xRangeOrBounds: Range | Bounds, yRange?: Range): IPlotEntity[] {
-    let dataXRange: Range;
-    let dataYRange: Range;
-    if (yRange == null) {
-      const bounds = (<Bounds> xRangeOrBounds);
-      dataXRange = { min: bounds.topLeft.x, max: bounds.bottomRight.x };
-      dataYRange = { min: bounds.topLeft.y, max: bounds.bottomRight.y };
-    } else {
-      dataXRange = (<Range> xRangeOrBounds);
-      dataYRange = yRange;
-    }
-
-    const xProjector = Plot._scaledAccessor(this.x());
-    const yProjector = Plot._scaledAccessor(this.y());
-    return this.entities().filter((entity) => {
-      const { datum, index, dataset } = entity;
-
-      const x = xProjector(datum, index, dataset);
-      const y = yProjector(datum, index, dataset);
-      return dataXRange.min <= x && x <= dataXRange.max && dataYRange.min <= y && y <= dataYRange.max;
-    });
   }
 
   /**

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -865,6 +865,9 @@ export class Plot extends Component {
     return nearest === undefined ? undefined : this._lightweightPlotEntityToPlotEntity(nearest);
   }
 
+  /**
+   * Returns the entites whose bounding boxes overlap the parameter.
+   */
   public entitiesInBounds(queryBounds: IEntityBounds): Plots.IPlotEntity[] {
     const found = this._getEntityStore().entitiesInBounds(queryBounds);
     if (!found) {
@@ -873,7 +876,11 @@ export class Plot extends Component {
     return found.map((entity) => this._lightweightPlotEntityToPlotEntity(entity));
   }
 
-  public entitiesInBoundsX(queryBounds: IEntityBounds): Plots.IPlotEntity[] {
+  /**
+   * Returns the entites whose bounding boxes overlap the parameter on the
+   * x-axis.
+   */
+  public entitiesInXRange(queryBounds: IEntityBounds): Plots.IPlotEntity[] {
     const found = this._getEntityStore().entitiesInXRange(queryBounds);
     if (!found) {
       return undefined;
@@ -881,7 +888,11 @@ export class Plot extends Component {
     return found.map((entity) => this._lightweightPlotEntityToPlotEntity(entity));
   }
 
-  public entitiesInBoundsY(queryBounds: IEntityBounds): Plots.IPlotEntity[] {
+  /**
+   * Returns the entites whose bounding boxes overlap the parameter on the
+   * y-axis.
+   */
+  public entitiesInYRange(queryBounds: IEntityBounds): Plots.IPlotEntity[] {
     const found = this._getEntityStore().entitiesInYRange(queryBounds);
     if (!found) {
       return undefined;

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -14,6 +14,7 @@ import {
   AttributeToProjector,
   Bounds,
   IAccessor,
+  IEntityBounds,
   IRangeProjector,
   Point,
   SimpleSelection,
@@ -864,8 +865,24 @@ export class Plot extends Component {
     return nearest === undefined ? undefined : this._lightweightPlotEntityToPlotEntity(nearest);
   }
 
-  public entitiesInBounds(queryBounds: Bounds): Plots.IPlotEntity[] {
+  public entitiesInBounds(queryBounds: IEntityBounds): Plots.IPlotEntity[] {
     const found = this._getEntityStore().entitiesInBounds(queryBounds);
+    if (!found) {
+      return undefined;
+    }
+    return found.map((entity) => this._lightweightPlotEntityToPlotEntity(entity));
+  }
+
+  public entitiesInBoundsX(queryBounds: IEntityBounds): Plots.IPlotEntity[] {
+    const found = this._getEntityStore().entitiesInXRange(queryBounds);
+    if (!found) {
+      return undefined;
+    }
+    return found.map((entity) => this._lightweightPlotEntityToPlotEntity(entity));
+  }
+
+  public entitiesInBoundsY(queryBounds: IEntityBounds): Plots.IPlotEntity[] {
+    const found = this._getEntityStore().entitiesInYRange(queryBounds);
     if (!found) {
       return undefined;
     }

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -783,13 +783,22 @@ export class Plot extends Component {
    * are specified all datasets will be used.
    */
   protected _getEntityStore(datasets?: Dataset[]): Utils.IEntityStore<Plots.ILightweightPlotEntity> {
+    const entityBoundsFactory = (entity: Plots.ILightweightPlotEntity) => this._entityBounds(entity);
     if (datasets !== undefined) {
       const entityStore = new Utils.EntityStore<Plots.ILightweightPlotEntity>();
-      entityStore.addAll(this._buildLightweightPlotEntities(datasets), this._localOriginBounds());
+      entityStore.addAll(
+        this._buildLightweightPlotEntities(datasets),
+        entityBoundsFactory,
+        this._localOriginBounds(),
+      );
       return entityStore;
     } else if (this._cachedEntityStore === undefined) {
       const entityStore = new Utils.EntityStore<Plots.ILightweightPlotEntity>();
-      entityStore.addAll(this._buildLightweightPlotEntities(this.datasets()), this._localOriginBounds());
+      entityStore.addAll(
+        this._buildLightweightPlotEntities(this.datasets()),
+        entityBoundsFactory,
+        this._localOriginBounds(),
+      );
       this._cachedEntityStore = entityStore;
     }
 
@@ -853,6 +862,14 @@ export class Plot extends Component {
   public entityNearest(queryPoint: Point): Plots.IPlotEntity {
     const nearest = this._getEntityStore().entityNearest(queryPoint);
     return nearest === undefined ? undefined : this._lightweightPlotEntityToPlotEntity(nearest);
+  }
+
+  public entitiesInBounds(queryBounds: Bounds): Plots.IPlotEntity[] {
+    const found = this._getEntityStore().entitiesInBounds(queryBounds);
+    if (!found) {
+      return undefined;
+    }
+    return found.map((entity) => this._lightweightPlotEntityToPlotEntity(entity));
   }
 
   protected _uninstallScaleForKey(scale: Scale<any, any>, key: string) {

--- a/src/plots/rectanglePlot.ts
+++ b/src/plots/rectanglePlot.ts
@@ -295,6 +295,11 @@ export class Rectangle<X, Y> extends XYPlot<X, Y> {
     return this._entitiesIntersecting(dataXRange, dataYRange);
   }
 
+  protected _entityBounds(entity: Plots.IPlotEntity | Plots.ILightweightPlotEntity) {
+    const { datum, index, dataset } = entity;
+    return this._entityBBox(datum, index, dataset, this._getAttrToProjector());
+  }
+
   private _entityBBox(datum: any, index: number, dataset: Dataset, attrToProjector: AttributeToProjector): SVGRect {
     return {
       x: attrToProjector["x"](datum, index, dataset),

--- a/src/plots/rectanglePlot.ts
+++ b/src/plots/rectanglePlot.ts
@@ -8,7 +8,7 @@ import * as Typesettable from "typesettable";
 
 import * as Animators from "../animators";
 import { Dataset } from "../core/dataset";
-import { AttributeToProjector, Bounds, IAccessor, IRangeProjector, Point, Range } from "../core/interfaces";
+import { AttributeToProjector, IAccessor, IRangeProjector, Point, Range } from "../core/interfaces";
 import * as Drawers from "../drawers";
 import { ProxyDrawer } from "../drawers/drawer";
 import { RectangleSVGDrawer } from "../drawers/rectangleDrawer";
@@ -266,35 +266,6 @@ export class Rectangle<X, Y> extends XYPlot<X, Y> {
     });
   }
 
-  /**
-   * Gets the Entities that intersect the Bounds.
-   *
-   * @param {Bounds} bounds
-   * @returns {PlotEntity[]}
-   */
-  public entitiesIn(bounds: Bounds): IPlotEntity[];
-  /**
-   * Gets the Entities that intersect the area defined by the ranges.
-   *
-   * @param {Range} xRange
-   * @param {Range} yRange
-   * @returns {PlotEntity[]}
-   */
-  public entitiesIn(xRange: Range, yRange: Range): IPlotEntity[];
-  public entitiesIn(xRangeOrBounds: Range | Bounds, yRange?: Range): IPlotEntity[] {
-    let dataXRange: Range;
-    let dataYRange: Range;
-    if (yRange == null) {
-      const bounds = (<Bounds> xRangeOrBounds);
-      dataXRange = { min: bounds.topLeft.x, max: bounds.bottomRight.x };
-      dataYRange = { min: bounds.topLeft.y, max: bounds.bottomRight.y };
-    } else {
-      dataXRange = (<Range> xRangeOrBounds);
-      dataYRange = yRange;
-    }
-    return this._entitiesIntersecting(dataXRange, dataYRange);
-  }
-
   protected _entityBounds(entity: Plots.IPlotEntity | Plots.ILightweightPlotEntity) {
     const { datum, index, dataset } = entity;
     return this._entityBBox(datum, index, dataset, this._getAttrToProjector());
@@ -307,18 +278,6 @@ export class Rectangle<X, Y> extends XYPlot<X, Y> {
       width: attrToProjector["width"](datum, index, dataset),
       height: attrToProjector["height"](datum, index, dataset),
     };
-  }
-
-  private _entitiesIntersecting(xValOrRange: number | Range, yValOrRange: number | Range): IPlotEntity[] {
-    const intersected: IPlotEntity[] = [];
-    const attrToProjector = this._getAttrToProjector();
-    this.entities().forEach((entity) => {
-      if (Utils.DOM.intersectsBBox(xValOrRange, yValOrRange,
-          this._entityBBox(entity.datum, entity.index, entity.dataset, attrToProjector))) {
-        intersected.push(entity);
-      }
-    });
-    return intersected;
   }
 
   /**

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -4,7 +4,7 @@
  */
 
 import { Dataset } from "../core/dataset";
-import { AttributeToProjector, Bounds, IAccessor, Point, Range } from "../core/interfaces";
+import { AttributeToProjector, Bounds, IAccessor, Point } from "../core/interfaces";
 import * as SymbolFactories from "../core/symbolFactories";
 import { SymbolFactory } from "../core/symbolFactories";
 import { ProxyDrawer } from "../drawers/drawer";
@@ -186,50 +186,12 @@ export class Scatter<X, Y> extends XYPlot<X, Y> {
   }
 
   /**
-   * Gets the Entities that intersect the Bounds.
-   *
-   * @param {Bounds} bounds
-   * @returns {PlotEntity[]}
-   */
-  public entitiesIn(bounds: Bounds): IPlotEntity[];
-  /**
-   * Gets the Entities that intersect the area defined by the ranges.
-   *
-   * @param {Range} xRange
-   * @param {Range} yRange
-   * @returns {PlotEntity[]}
-   */
-  public entitiesIn(xRange: Range, yRange: Range): IPlotEntity[];
-  public entitiesIn(xRangeOrBounds: Range | Bounds, yRange?: Range): IPlotEntity[] {
-    let dataXRange: Range;
-    let dataYRange: Range;
-    if (yRange == null) {
-      const bounds = (<Bounds> xRangeOrBounds);
-      dataXRange = { min: bounds.topLeft.x, max: bounds.bottomRight.x };
-      dataYRange = { min: bounds.topLeft.y, max: bounds.bottomRight.y };
-    } else {
-      dataXRange = (<Range> xRangeOrBounds);
-      dataYRange = yRange;
-    }
-    const xProjector = Plot._scaledAccessor(this.x());
-    const yProjector = Plot._scaledAccessor(this.y());
-    return this.entities().filter((entity) => {
-      const datum = entity.datum;
-      const index = entity.index;
-      const dataset = entity.dataset;
-      const x = xProjector(datum, index, dataset);
-      const y = yProjector(datum, index, dataset);
-      return dataXRange.min <= x && x <= dataXRange.max && dataYRange.min <= y && y <= dataYRange.max;
-    });
-  }
-
-  /**
    * Gets the Entities at a particular Point.
    *
    * @param {Point} p
    * @returns {PlotEntity[]}
    */
-  public entitiesAt(p: Point) {
+  public entitiesAt(p: Point): IPlotEntity[] {
     const xProjector = Plot._scaledAccessor(this.x());
     const yProjector = Plot._scaledAccessor(this.y());
     const sizeProjector = Plot._scaledAccessor(this.size());

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -169,17 +169,19 @@ export class Scatter<X, Y> extends XYPlot<X, Y> {
     };
   }
 
-  protected _entityVisibleOnPlot(entity: ILightweightScatterPlotEntity, bounds: Bounds) {
-    const xRange = { min: bounds.topLeft.x, max: bounds.bottomRight.x };
-    const yRange = { min: bounds.topLeft.y, max: bounds.bottomRight.y };
-
-    const translatedBbox = {
-      x: entity.position.x - entity.diameter,
-      y: entity.position.y - entity.diameter,
+  protected _entityBounds(entity: ILightweightScatterPlotEntity) {
+    return {
+      x: entity.position.x - entity.diameter / 2,
+      y: entity.position.y - entity.diameter / 2,
       width: entity.diameter,
       height: entity.diameter,
     };
+  }
 
+  protected _entityVisibleOnPlot(entity: ILightweightScatterPlotEntity, bounds: Bounds) {
+    const xRange = { min: bounds.topLeft.x, max: bounds.bottomRight.x };
+    const yRange = { min: bounds.topLeft.y, max: bounds.bottomRight.y };
+    const translatedBbox = this._entityBounds(entity);
     return Utils.DOM.intersectsBBox(xRange, yRange, translatedBbox);
   }
 

--- a/src/utils/entityStore.ts
+++ b/src/utils/entityStore.ts
@@ -25,6 +25,8 @@ export interface IEntityStore<T extends IPositionedEntity> {
    *
    * @param {T[]} [entities] Entity array to add to the store. Entities must be
    * positionable
+   * @param [entityBoundsFactory] A factory method for producing {IEntityBounds}
+   * for each entity.
    * @param {Bounds} [bounds] Optionally add bounds filter for entityNearest
    * queries
    */
@@ -41,8 +43,27 @@ export interface IEntityStore<T extends IPositionedEntity> {
    */
   entityNearest(point: Point): T;
 
+  /**
+   * Returns the entites whose bounding boxes overlap the parameter.
+   *
+   * @param {IEntityBounds} [bounds] The query bounding box.
+   */
   entitiesInBounds(bounds: IEntityBounds): T[];
+
+  /**
+   * Returns the entites whose bounding boxes overlap the parameter on the
+   * x-axis.
+   *
+   * @param {IEntityBounds} [bounds] The query bounding box.
+   */
   entitiesInXRange(bounds: IEntityBounds): T[];
+
+  /**
+   * Returns the entites whose bounding boxes overlap the parameter on the
+   * y-axis.
+   *
+   * @param {IEntityBounds} [bounds] The query bounding box.
+   */
   entitiesInYRange(bounds: IEntityBounds): T[];
 
   /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,6 +8,7 @@ import * as Color from "./colorUtils";
 import * as DOM from "./domUtils";
 import * as Math from "./mathUtils";
 import * as Object from "./objectUtils";
+import * as RTree from "./rTree";
 import * as Stacking from "./stackingUtils";
 import * as Window from "./windowUtils";
 
@@ -17,6 +18,7 @@ export {
   DOM,
   Object,
   Math,
+  RTree,
   Stacking,
   Window
 };

--- a/src/utils/rTree.ts
+++ b/src/utils/rTree.ts
@@ -28,8 +28,13 @@ const DEFAULT_SPLIT_STRATEGY: IRTreeSplitStrategy = new SplitStrategyLinear();
  * arbitrarily overlapping bounding boxes and supports efficient point and
  * bounding box overlap queries.
  *
+ * Average search time complexity is O(log_M(N)) where M = max children per node
+ * and N is number of values stored in tree.
+ *
  * It is similar in purpose to a quadtree except quadtrees can only store a
- * single point per entry.
+ * single point per entry. Also, the space-partitioning structure of quadtrees
+ * provides guarantees that any given value has no neighbors closer than its
+ * node's bounds, whereas r-trees provide no such guarantees.
  */
 export class RTree<T> {
     private root: RTreeNode<T>;

--- a/src/utils/rTree.ts
+++ b/src/utils/rTree.ts
@@ -1,0 +1,276 @@
+/**
+ * Copyright 2017-present Palantir Technologies
+ * @license MIT
+ */
+import { Bounds, IEntityBounds, Point } from "../core/interfaces";
+import {
+    IRTreeSplitStrategy,
+    NodePair,
+    SplitStrategyLinear,
+} from "./rTreeSplitStrategies";
+
+const DEFAULT_NODE_SIZE = 3;
+const DEFAULT_SPLIT_STRATEGY = new SplitStrategyLinear();
+
+/**
+ * R-Tree is a multidimensional spatial region tree. It stores entries that have
+ * arbitrarily overlapping bounding boxes and supports efficient point and
+ * bounding box queries.
+ *
+ * Similar in purpose to a quadtree except quadtrees can only store a single
+ * point per entry.
+ */
+export class RTree<T> {
+    private root: RTreeNode<T>;
+    private size: number;
+
+    constructor(
+        private maxNodeChildren = DEFAULT_NODE_SIZE,
+        private splitStrategy = DEFAULT_SPLIT_STRATEGY,
+    ) {
+        this.root = new RTreeNode<T>(true);
+        this.size = 0;
+    }
+
+    public getRoot() {
+        return this.root;
+    }
+
+    public clear() {
+        this.root = new RTreeNode<T>(true);
+        this.size = 0;
+    }
+
+    public insert(bounds: RTreeBounds, value: T) {
+        let node = this.root;
+
+        // Choose subtree until we find a leaf
+        while (!node.leaf) {
+            node = node.subtree(bounds);
+        }
+
+        // Insert new value node into leaf node
+        const valueNode = RTreeNode.valueNode<T>(bounds, value);
+        node.insert(valueNode);
+        this.size += 1;
+
+        // While node overflows, split and walk up
+        while (node.overflow(this.maxNodeChildren)) {
+            node = node.split(this.splitStrategy);
+            if (node.parent == null) {
+                this.root = node;
+            }
+        }
+        return valueNode;
+    }
+
+    public locate(xy: Point) {
+        return this.query((mbr) => mbr.contains(xy));
+    }
+
+    public intersect(bounds: RTreeBounds) {
+        return this.query((mbr) => mbr.intersects(bounds));
+    }
+
+    public query(predicate: (mbr: RTreeBounds) => boolean) {
+        const results: T[] = [];
+        if (this.root.bounds != null && !predicate(this.root.bounds)) {
+            return results;
+        }
+
+        const candidates = [this.root];
+        while (candidates.length > 0) {
+            const candidate = candidates.shift();
+            for (let i = 0; i < candidate.entries.length; i++) {
+                const entry = candidate.entries[i];
+                if (predicate(entry.bounds)) {
+                    if (candidate.leaf) {
+                        results.push(entry.value);
+                    } else {
+                        candidates.push(entry);
+                    }
+                }
+            }
+        }
+        return results;
+    }
+}
+
+export class RTreeNode<T> {
+    public static valueNode<T>(bounds: RTreeBounds, value: T) {
+        const node = new RTreeNode<T>(true);
+        node.bounds = bounds;
+        node.value = value;
+        return node;
+    }
+
+    public bounds: RTreeBounds = null;
+    public entries: RTreeNode<T>[] = [];
+    public parent: RTreeNode<T> = null;
+    public value: T = null;
+
+    constructor(
+        public leaf: boolean,
+    ) {}
+
+    public overflow(maxNodeChildren: number) {
+        return this.entries.length > maxNodeChildren;
+    }
+
+    public insert(node: RTreeNode<T>) {
+        this.entries.push(node);
+        node.parent = this;
+
+        // Update ancestor bounds
+        let ancestor: RTreeNode<T> = this;
+        while (ancestor != null) {
+            ancestor.bounds = RTreeBounds.unionAll([ancestor.bounds, node.bounds]);
+            ancestor = ancestor.parent;
+        }
+        return this;
+    }
+
+    public remove(node: RTreeNode<T>) {
+        const i = this.entries.indexOf(node);
+        if (i >= 0) {
+            this.entries.splice(i, 1);
+
+            // Update ancestor bounds
+            let ancestor: RTreeNode<T> = this;
+            while (ancestor != null) {
+                ancestor.bounds = RTreeBounds.unionAll(ancestor.entries.map((e) => e.bounds));
+                ancestor = ancestor.parent;
+            }
+        }
+        return this;
+    }
+
+    public subtree(bounds: RTreeBounds) {
+        const minDiff = Infinity;
+        let minEntry = null;
+
+        // choose entry for which the addition least increases the entry"s area
+        for (let i = 0; i < this.entries.length; i++) {
+            const entry = this.entries[i];
+            const diffArea = RTreeBounds.union(entry.bounds, bounds).area() - entry.bounds.area();
+            if (diffArea < minDiff) {
+                minEntry = entry;
+            }
+        }
+        return minEntry;
+    }
+
+    public split(strategy: IRTreeSplitStrategy): RTreeNode<T> {
+        // Remove self from parent.
+        if (this.parent != null) {
+            this.parent.remove(this);
+        }
+
+        // Create children from split
+        const children: NodePair<T> = [
+            new RTreeNode<T>(this.leaf),
+            new RTreeNode<T>(this.leaf),
+        ];
+        strategy.split(this.entries, children);
+
+        // Add new nodes to parent
+        // If root, create new non-leaf node as parent.
+        const parent = this.parent != null ? this.parent : new RTreeNode<T>(false);
+        parent.insert(children[0]);
+        parent.insert(children[1]);
+        return parent;
+    }
+}
+
+export class RTreeBounds {
+    public static xywh(x: number, y: number, w: number, h: number) {
+        return new RTreeBounds(x, y, x + w, y + h);
+    }
+
+    public static entityBounds(bounds: IEntityBounds) {
+        return new RTreeBounds(
+            bounds.x,
+            bounds.y,
+            bounds.x + bounds.width,
+            bounds.y + bounds.height,
+        );
+    }
+
+    public static bounds(bounds: Bounds) {
+        return RTreeBounds.pointPair(
+            bounds.topLeft,
+            bounds.bottomRight,
+        );
+    }
+
+    public static pointPair(p0: Point, p1: Point) {
+        return new RTreeBounds(
+            Math.min(p0.x, p1.x),
+            Math.min(p0.y, p1.y),
+            Math.max(p0.x, p1.x),
+            Math.max(p0.y, p1.y),
+        );
+    }
+
+    public static points(points: Point[]) {
+        if (points.length < 2) {
+            throw new Error("need at least 2 points to create bounds");
+        }
+        const xs: number[] = points.map((p) => p.x);
+        const ys: number[] = points.map((p) => p.y);
+        return new RTreeBounds(
+            xs.reduce((a, b) => Math.min(a, b)),
+            ys.reduce((a, b) => Math.min(a, b)),
+            xs.reduce((a, b) => Math.max(a, b)),
+            ys.reduce((a, b) => Math.max(a, b)),
+        );
+    }
+
+    public static union(b0: RTreeBounds, b1: RTreeBounds) {
+        return new RTreeBounds(
+            Math.min(b0.xl, b1.xl),
+            Math.min(b0.yl, b1.yl),
+            Math.max(b0.xh, b1.xh),
+            Math.max(b0.yh, b1.yh),
+        );
+    }
+
+    public static unionAll(bounds: RTreeBounds[]) {
+        bounds = bounds.filter((b) => b != null);
+        if (bounds.length === 0) {
+            return null;
+        }
+        return bounds.reduce((b0, b1) => RTreeBounds.union(b0, b1));
+    }
+
+    public width: number;
+    public height: number;
+    private areaCached: number;
+
+    constructor(
+        public xl: number,
+        public yl: number,
+        public xh: number,
+        public yh: number,
+    ) {
+        this.width = this.xh - this.xl;
+        this.height = this.yh - this.yl;
+    }
+
+    public area() {
+        if (this.areaCached == null) {
+            this.areaCached = (this.xh - this.xl) * (this.yh - this.yl);
+        }
+        return this.areaCached;
+    }
+
+    public contains(xy: Point) {
+        return this.xl <= xy.x && this.xh >= xy.x && this.yl <= xy.y && this.yh >= xy.y;
+    }
+
+    // http://gamedev.stackexchange.com/questions/586/what-is-the-fastest-way-to-work-out-2d-bounding-box-intersection
+    public intersects(bounds: RTreeBounds) {
+        return Math.abs(this.xl - bounds.xl) * 2 < (this.width + bounds.width) &&
+               Math.abs(this.yl - bounds.yl) * 2 < (this.height + bounds.height);
+    }
+}

--- a/src/utils/rTreeSplitStrategies.ts
+++ b/src/utils/rTreeSplitStrategies.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2017-present Palantir Technologies
+ * @license MIT
+ */
+
+import { RTreeBounds, RTreeNode } from "./rTree";
+
+export type NodePair<T> = [RTreeNode<T>, RTreeNode<T>];
+
+export interface IRTreeSplitStrategy {
+    split: <T>(entries: RTreeNode<T>[], nodes: NodePair<T>) => void;
+}
+
+export class SplitStrategyTrival implements IRTreeSplitStrategy {
+    public split<T>(entries: RTreeNode<T>[], nodes: NodePair<T>) {
+        // Create simple middle split
+        const mid = Math.floor(entries.length / 2);
+
+        const leftEntries = entries.slice(0, mid);
+        for (let i = 0; i < leftEntries.length; i++) {
+            nodes[0].insert(leftEntries[i]);
+        }
+
+        const rightEntries = entries.slice(0, mid);
+        for (let i = 0; i < rightEntries.length; i++) {
+            nodes[1].insert(rightEntries[i]);
+        }
+    }
+}
+
+// Linear split method adapted from https://github.com/imbcmdth/RTree/blob/master/src/rtree.js
+export class SplitStrategyLinear implements IRTreeSplitStrategy {
+    public split<T>(entries: RTreeNode<T>[], nodes: NodePair<T>) {
+        entries = entries.slice();
+        this.chooseFirstSplit(entries, nodes);
+        while (entries.length > 0) {
+            this.addNext(entries, nodes);
+        }
+    }
+
+    private chooseFirstSplit<T>(entries: RTreeNode<T>[], nodes: NodePair<T>) {
+        let minXH = entries.length - 1;
+        let minYH = entries.length - 1;
+        let maxXL = 0;
+        let maxYL = 0;
+
+        for (let i = entries.length - 2; i >= 0; i--) {
+            const entry = entries[i];
+
+            if (entry.bounds.xl > entries[maxXL].bounds.xl) {
+                maxXL = i;
+            } else if (entry.bounds.xh < entries[minXH].bounds.xh) {
+                minXH = i;
+            }
+
+            if (entry.bounds.yl > entries[maxYL].bounds.yl) {
+                maxYL = i;
+            } else if (entry.bounds.yh < entries[minYH].bounds.yh) {
+                minYH = i;
+            }
+        }
+
+        // Choose to split x or y
+        const dx = Math.abs(entries[minXH].bounds.xh - entries[maxXL].bounds.xl);
+        const dy = Math.abs(entries[minYH].bounds.yh - entries[maxYL].bounds.yl);
+        const [ i0, i1 ] = dx > dy ? [ minXH, maxXL ] : [ minYH, maxYL ];
+
+        // Split off nodes
+        nodes[0].insert(entries.splice(Math.max(i0, i1), 1)[0]);
+        nodes[1].insert(entries.splice(Math.min(i0, i1), 1)[0]);
+    }
+
+    private addNext<T>(entries: RTreeNode<T>[], nodes: NodePair<T>) {
+        let index: number = null;
+        let areaDiff: number = null;
+        let minDiffNode: RTreeNode<T> = null;
+
+        for (let i = 0; i < entries.length; i++) {
+            const entry = entries[i];
+            const areaDiffs = nodes.map(function (node) {
+                return RTreeBounds.union(entry.bounds, node.bounds).area() - node.bounds.area();
+            });
+
+            const diff = Math.abs(areaDiffs[1] - areaDiffs[0]);
+            if (!index || diff < areaDiff) {
+                index = i;
+                areaDiff = diff;
+                minDiffNode = areaDiffs[1] < areaDiffs[0] ? nodes[0] : nodes[1];
+            }
+        }
+
+        minDiffNode.insert(entries.splice(index, 1)[0]);
+    }
+}

--- a/test/plots/plotTests.ts
+++ b/test/plots/plotTests.ts
@@ -108,7 +108,7 @@ describe("Plots", () => {
           const parentSpaceBounds = plot.bounds();
 
           plot.entities();
-          const plotLocalBounds = addAllSpy.args[0][1];
+          const plotLocalBounds = addAllSpy.args[0][2];
 
           assert.notDeepEqual(parentSpaceBounds, plotLocalBounds);
           assert.deepEqual(plotLocalBounds, {

--- a/test/plots/scatterPlotTests.ts
+++ b/test/plots/scatterPlotTests.ts
@@ -342,11 +342,11 @@ describe("Plots", () => {
         plot.renderTo(div);
 
         const entities = plot.entitiesIn({
-          min: xScale.scale(1.001),
-          max: xScale.scale(1.001),
+          min: xScale.scale(1) + 10,
+          max: xScale.scale(1) + 10,
         }, {
-          min: yScale.scale(1.001),
-          max: yScale.scale(1.001),
+          min: yScale.scale(1) + 10,
+          max: yScale.scale(1) + 10,
         });
 
         assert.lengthOf(entities, 0, "no Entities retrieved");

--- a/test/utils/rTreeTests.ts
+++ b/test/utils/rTreeTests.ts
@@ -1,0 +1,126 @@
+import { assert } from "chai";
+import * as Plottable from "../../src";
+
+const RTree = Plottable.Utils.RTree;
+
+// convert tuple to point
+const P = ([x, y]: [number, number]) => {
+  return {x, y};
+};
+
+describe("RTreeBounds", () => {
+  it("creates bounds from corner points", () => {
+    const b0 = RTree.RTreeBounds.pointPair(P([0, 0]), P([100, 100]));
+    const b1 = RTree.RTreeBounds.pointPair(P([0, 100]), P([100, 0]));
+    assert.deepEqual(b0, b1);
+  });
+
+  it("creates bounds from points array", () => {
+    const points = [
+      P([-100, 0]),
+      P([10, 100]),
+      P([20, -100]),
+      P([100, 0]),
+      P([-40, 30]),
+    ];
+    const b0 = RTree.RTreeBounds.points(points);
+    const b1 = RTree.RTreeBounds.pointPair(P([-100, -100]), P([100, 100]));
+    assert.deepEqual(b0, b1);
+  });
+});
+
+describe("RTree", () => {
+  it("inserts a couple entries",()  => {
+    const rtree = new RTree.RTree(5);
+    rtree.insert(RTree.RTreeBounds.pointPair(P([0, 10]), P([100, 100])), "A");
+    rtree.insert(RTree.RTreeBounds.pointPair(P([0, 0]), P([200, 10])), "B");
+
+    const b0 = RTree.RTreeBounds.pointPair(P([0, 0]), P([200, 100]));
+    assert.deepEqual(b0, rtree.getRoot().bounds);
+    assert.equal(2, rtree.getRoot().entries.length);
+  });
+
+  it("splits when necessary ",()  => {
+    // create tree with max entries per node == 2
+    const rtree = new RTree.RTree(2);
+    rtree.insert(RTree.RTreeBounds.pointPair(P([0, 10]), P([100, 100])), "A");
+    rtree.insert(RTree.RTreeBounds.pointPair(P([0, 0]), P([200, 10])), "B");
+    assert.equal(2, rtree.getRoot().entries.length);
+    assert.equal(true, rtree.getRoot().leaf);
+
+    // add 3rd entry
+    rtree.insert(RTree.RTreeBounds.pointPair(P([10, 0]), P([100, 10])), "C");
+    assert.equal(2, rtree.getRoot().entries.length);
+    assert.equal(false, rtree.getRoot().leaf);
+  });
+
+  it("updates bounds on removal", () => {
+    const rtree = new RTree.RTree(2);
+    const nodeA = rtree.insert(RTree.RTreeBounds.pointPair(P([0, 10]), P([100, 100])), "A");
+    rtree.insert(RTree.RTreeBounds.pointPair(P([0, 0]), P([200, 10])), "B");
+    rtree.insert(RTree.RTreeBounds.pointPair(P([10, 0]), P([100, 10])), "C");
+    assert.deepEqual(RTree.RTreeBounds.pointPair(P([0, 0]), P([200, 100])), rtree.getRoot().bounds);
+    assert.equal(2, rtree.getRoot().entries.length);
+
+    nodeA.parent.remove(nodeA);
+    assert.equal(2, rtree.getRoot().entries.length);
+    assert.deepEqual(RTree.RTreeBounds.pointPair(P([0, 0]), P([200, 10])), rtree.getRoot().bounds);
+  });
+
+  it("locates a point", () => {
+    const xy = P([100, 100]);
+    const rtree = new RTree.RTree(3);
+    rtree.insert(RTree.RTreeBounds.pointPair(P([90, 90]), P([110, 110])), "MATCH");
+    assert.deepEqual(["MATCH"], rtree.locate(xy));
+  });
+
+  it("locates on the edge of a region", () => {
+    const xy = P([100, 100]);
+    let rtree = new RTree.RTree(3);
+    rtree.insert(RTree.RTreeBounds.pointPair(P([100, 100]), P([110, 110])), "MATCH");
+    assert.deepEqual(["MATCH"], rtree.locate(xy));
+
+    rtree = new RTree.RTree(3);
+    rtree.insert(RTree.RTreeBounds.pointPair(P([90, 90]), P([100, 100])), "MATCH");
+    assert.deepEqual(["MATCH"], rtree.locate(xy));
+  });
+
+  it("builds a big tree and locates", () => {
+    const xy = P([100, 100]);
+    const randoms = 1000;
+    const rtree = new RTree.RTree(3);
+
+    // single matching value
+    rtree.insert(RTree.RTreeBounds.pointPair(P([90, 90]), P([110, 110])), "MATCH");
+
+    // add a bunch of bounds that WILL NOT match
+    for (let i = 0; i < randoms; i++) {
+      const offset = [10, 110][Math.floor(Math.random() * 2)];
+      rtree.insert(RTree.RTreeBounds.pointPair(
+          P([offset + Math.random() * 80, offset + Math.random() * 80]),
+          P([offset + Math.random() * 80, offset + Math.random() * 80]),
+        ),
+        `RANDOM-${i}`,
+      );
+    }
+    assert.deepEqual(["MATCH"], rtree.locate(xy));
+
+    // add a bunch of bounds that WILL match
+    for (let i = 0; i < randoms; i++) {
+      rtree.insert(RTree.RTreeBounds.pointPair(
+          P([99 - Math.random() * 100, 99 - Math.random() * 100]),
+          P([101 + Math.random() * 100, 101 + Math.random() * 100]),
+        ),
+        `RANDOM-MATCH-${i}`,
+      );
+    }
+    assert.equal(randoms + 1, rtree.locate(xy).length);
+  });
+
+  it("intersects an aabb", () => {
+    const bounds = RTree.RTreeBounds.pointPair(P([100, 100]), P([120, 120]));
+    const rtree = new RTree.RTree(3);
+    rtree.insert(RTree.RTreeBounds.pointPair(P([90, 90]), P([110, 110])), "MATCH");
+    assert.deepEqual(["MATCH"], rtree.intersect(bounds));
+  });
+});

--- a/test/utils/rTreeTests.ts
+++ b/test/utils/rTreeTests.ts
@@ -1,5 +1,10 @@
 import { assert } from "chai";
 import * as Plottable from "../../src";
+import {
+  IRTreeSplitStrategy,
+  SplitStrategyLinear,
+  SplitStrategyTrivial,
+} from "../../src/utils/rTreeSplitStrategies";
 
 const RTree = Plottable.Utils.RTree;
 
@@ -7,27 +12,6 @@ const RTree = Plottable.Utils.RTree;
 const P = ([x, y]: [number, number]) => {
   return {x, y};
 };
-
-describe("RTreeBounds", () => {
-  it("creates bounds from corner points", () => {
-    const b0 = RTree.RTreeBounds.pointPair(P([0, 0]), P([100, 100]));
-    const b1 = RTree.RTreeBounds.pointPair(P([0, 100]), P([100, 0]));
-    assert.deepEqual(b0, b1);
-  });
-
-  it("creates bounds from points array", () => {
-    const points = [
-      P([-100, 0]),
-      P([10, 100]),
-      P([20, -100]),
-      P([100, 0]),
-      P([-40, 30]),
-    ];
-    const b0 = RTree.RTreeBounds.points(points);
-    const b1 = RTree.RTreeBounds.pointPair(P([-100, -100]), P([100, 100]));
-    assert.deepEqual(b0, b1);
-  });
-});
 
 describe("RTree", () => {
   it("inserts a couple entries",()  => {
@@ -92,6 +76,7 @@ describe("RTree", () => {
 
     // single matching value
     rtree.insert(RTree.RTreeBounds.pointPair(P([90, 90]), P([110, 110])), "MATCH");
+    assert.equal(1, rtree.query(() => true).length);
 
     // add a bunch of bounds that WILL NOT match
     for (let i = 0; i < randoms; i++) {
@@ -103,6 +88,7 @@ describe("RTree", () => {
         `RANDOM-${i}`,
       );
     }
+    assert.equal(randoms + 1, rtree.query(() => true).length);
     assert.deepEqual(["MATCH"], rtree.locate(xy));
 
     // add a bunch of bounds that WILL match
@@ -114,6 +100,7 @@ describe("RTree", () => {
         `RANDOM-MATCH-${i}`,
       );
     }
+    assert.equal(randoms * 2 + 1, rtree.query(() => true).length);
     assert.equal(randoms + 1, rtree.locate(xy).length);
   });
 
@@ -122,5 +109,65 @@ describe("RTree", () => {
     const rtree = new RTree.RTree(3);
     rtree.insert(RTree.RTreeBounds.pointPair(P([90, 90]), P([110, 110])), "MATCH");
     assert.deepEqual(["MATCH"], rtree.intersect(bounds));
+  });
+});
+
+describe("RTreeSplitStrategies", () => {
+  const strategyTests = (strategy: IRTreeSplitStrategy, name: string) => {
+    describe(name, () => {
+      it("splits a node", () => {
+        const rtree = new RTree.RTree(2, strategy);
+        rtree.insert(RTree.RTreeBounds.pointPair(P([0, 0]), P([100, 100])), "A");
+        rtree.insert(RTree.RTreeBounds.pointPair(P([100, 0]), P([200, 100])), "B");
+
+        assert.equal(2, rtree.getRoot().entries.length);
+        assert.equal(true, rtree.getRoot().leaf);
+
+        rtree.insert(RTree.RTreeBounds.pointPair(P([200, 0]), P([300, 100])), "C");
+        assert.equal(2, rtree.getRoot().entries.length);
+        assert.equal(false, rtree.getRoot().leaf);
+        assert.equal(2, rtree.getRoot().maxDepth());
+      });
+
+      it("splits exactly matching bounds", () => {
+        const rtree = new RTree.RTree(2, strategy);
+        for (let i = 0; i < 4; i++) {
+          rtree.insert(RTree.RTreeBounds.pointPair(P([0, 0]), P([100, 100])), `${i}`);
+        }
+        assert.equal(false, rtree.getRoot().leaf);
+        assert.isTrue(rtree.getRoot().maxDepth() <= 3, "no split");
+      });
+
+      it("splits exactly matching bounds balanced", () => {
+        const rtree = new RTree.RTree(2, strategy);
+        for (let i = 0; i < 16; i++) {
+          rtree.insert(RTree.RTreeBounds.pointPair(P([0, 0]), P([100, 100])), `${i}`);
+        }
+        assert.isTrue(rtree.getRoot().maxDepth() <= 5, "imbalanced split");
+      });
+    });
+  };
+  strategyTests(new SplitStrategyTrivial(), "trivial");
+  strategyTests(new SplitStrategyLinear(), "linear");
+});
+
+describe("RTreeBounds", () => {
+  it("creates bounds from corner points", () => {
+    const b0 = RTree.RTreeBounds.pointPair(P([0, 0]), P([100, 100]));
+    const b1 = RTree.RTreeBounds.pointPair(P([0, 100]), P([100, 0]));
+    assert.deepEqual(b0, b1);
+  });
+
+  it("creates bounds from points array", () => {
+    const points = [
+      P([-100, 0]),
+      P([10, 100]),
+      P([20, -100]),
+      P([100, 0]),
+      P([-40, 30]),
+    ];
+    const b0 = RTree.RTreeBounds.points(points);
+    const b1 = RTree.RTreeBounds.pointPair(P([-100, -100]), P([100, 100]));
+    assert.deepEqual(b0, b1);
   });
 });


### PR DESCRIPTION
- Add R-Tree and supporting unit tests.
- Use rtree to efficiently test bounds for entity overlap.
- Add API methods for `entitiesInBounds` and as well as x- and y- only versions.
- Switch to using more standard `IEntityBounds`.
- Add more tests.
- Add proper bounds for scatter plot and rect plot entities.
- Fix r-tree split strategy balancing and verify with test.
- Comments.