### PR TITLE
Prepare release 3.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plottable",
   "description": "A modular charting library built on D3",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -88,7 +88,7 @@ export type Bounds = {
 };
 
 /**
- * Client bounds
+ * Client bounds in pixel-space.
  */
 export interface IEntityBounds {
   x: number;

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -869,6 +869,8 @@ export class Plot extends Component {
   }
 
   /**
+   * @deprecated Use `entitiesInBounds` instead
+   *
    * Gets the Entities that intersect the Bounds.
    *
    * @param {Bounds} bounds
@@ -876,6 +878,8 @@ export class Plot extends Component {
    */
   public entitiesIn(bounds: Bounds): Plots.IPlotEntity[];
   /**
+   * @deprecated Use `entitiesInBounds` instead
+   *
    * Gets the Entities that intersect the area defined by the ranges.
    *
    * @param {Range} xRange
@@ -907,6 +911,8 @@ export class Plot extends Component {
 
   /**
    * Returns the entites whose bounding boxes overlap the parameter.
+   *
+   * `queryBounds` are in pixel space, measured from the origin of this plot.
    */
   public entitiesInBounds(queryBounds: IEntityBounds): Plots.IPlotEntity[] {
     const found = this._getEntityStore().entitiesInBounds(queryBounds);
@@ -917,11 +923,13 @@ export class Plot extends Component {
   }
 
   /**
-   * Returns the entites whose bounding boxes overlap the parameter on the
-   * x-axis.
+   * Returns the entites whose bounding boxes overlap the `queryBounds`
+   * parameter on the x-axis.
+   *
+   * `queryBounds` are in pixel space, measured from the origin of this plot.
    */
-  public entitiesInXRange(queryBounds: IEntityBounds): Plots.IPlotEntity[] {
-    const found = this._getEntityStore().entitiesInXRange(queryBounds);
+  public entitiesInXBounds(queryBounds: IEntityBounds): Plots.IPlotEntity[] {
+    const found = this._getEntityStore().entitiesInXBounds(queryBounds);
     if (!found) {
       return undefined;
     }
@@ -929,11 +937,13 @@ export class Plot extends Component {
   }
 
   /**
-   * Returns the entites whose bounding boxes overlap the parameter on the
-   * y-axis.
+   * Returns the entites whose bounding boxes overlap the `queryBounds`
+   * parameter on the y-axis.
+   *
+   * `queryBounds` are in pixel space, measured from the origin of this plot.
    */
-  public entitiesInYRange(queryBounds: IEntityBounds): Plots.IPlotEntity[] {
-    const found = this._getEntityStore().entitiesInYRange(queryBounds);
+  public entitiesInYBounds(queryBounds: IEntityBounds): Plots.IPlotEntity[] {
+    const found = this._getEntityStore().entitiesInYBounds(queryBounds);
     if (!found) {
       return undefined;
     }

--- a/src/utils/entityStore.ts
+++ b/src/utils/entityStore.ts
@@ -56,7 +56,7 @@ export interface IEntityStore<T extends IPositionedEntity> {
    *
    * @param {IEntityBounds} [bounds] The query bounding box.
    */
-  entitiesInXRange(bounds: IEntityBounds): T[];
+  entitiesInXBounds(bounds: IEntityBounds): T[];
 
   /**
    * Returns the entites whose bounding boxes overlap the parameter on the
@@ -64,7 +64,7 @@ export interface IEntityStore<T extends IPositionedEntity> {
    *
    * @param {IEntityBounds} [bounds] The query bounding box.
    */
-  entitiesInYRange(bounds: IEntityBounds): T[];
+  entitiesInYBounds(bounds: IEntityBounds): T[];
 
   /**
    * Returns the current internal array of all entities.
@@ -129,11 +129,11 @@ export class EntityStore<T extends IPositionedEntity> implements IEntityStore<T>
     return this._rtree.intersect(RTreeBounds.entityBounds(bounds));
   }
 
-  public entitiesInXRange(bounds: IEntityBounds) {
+  public entitiesInXBounds(bounds: IEntityBounds) {
     return this._rtree.intersectX(RTreeBounds.entityBounds(bounds));
   }
 
-  public entitiesInYRange(bounds: IEntityBounds) {
+  public entitiesInYBounds(bounds: IEntityBounds) {
     return this._rtree.intersectY(RTreeBounds.entityBounds(bounds));
   }
 


### PR DESCRIPTION
Notes:
# v3.5.4

### Performance Enhancements

- (#3403) Fast entity bounds queries. Added new methods on all plots for efficient bounds-overlap queries for plot entities.
  - `entitiesInBounds`
  - `entitiesInXRange`
  - `entitiesInYRange`
  - Use these methods directly or use the existing `entitiesIn` method that takes either a single `Bounds` object or two `Range` objects. In both of these cases, they are converted to `IEntityBounds` and then applied to `entitiesInBounds`.

- (#3404) Fix perf regression of `entityNearest` in bar plots.