### PR TITLE
Don't short-circuit `_includedValuesProvider` for unanchored components

### DIFF
--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -165,7 +165,9 @@ export class Plot extends Component {
     this.addClass("plot");
     this._datasetToDrawer = new Utils.Map<Dataset, ProxyDrawer>();
     this._attrBindings = d3.map<Plots.IAccessorScaleBinding<any, any>>();
-    this._includedValuesProvider = (scale: Scale<any, any>) => this._includedValuesForScale(scale);
+    this._includedValuesProvider = (scale: Scale<any, any>, ignoreAnchorState: boolean) => {
+      return this._includedValuesForScale(scale, ignoreAnchorState);
+    };
     this._renderCallback = () => this.render();
     this._onDatasetUpdateCallback = () => this._onDatasetUpdate();
     this._propertyBindings = d3.map<Plots.IAccessorScaleBinding<any, any>>();
@@ -512,7 +514,11 @@ export class Plot extends Component {
     return this._propertyExtents[property]();
   }
 
-  private _includedValuesForScale<D>(scale: Scale<D, any>): D[] {
+  private _includedValuesForScale<D>(scale: Scale<D, any>, ignoreAttachState?: boolean): D[] {
+    if (!this._isAnchored && !ignoreAttachState) {
+      return [];
+    }
+
     let includedValues: D[] = [];
     this._attrBindings.each((binding, attr) => {
       if (binding.scale === scale) {

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -513,9 +513,6 @@ export class Plot extends Component {
   }
 
   private _includedValuesForScale<D>(scale: Scale<D, any>): D[] {
-    if (!this._isAnchored) {
-      return [];
-    }
     let includedValues: D[] = [];
     this._attrBindings.each((binding, attr) => {
       if (binding.scale === scale) {

--- a/src/scales/index.ts
+++ b/src/scales/index.ts
@@ -26,10 +26,14 @@ import { Scale } from "./scale";
  * A function that supplies domain values to be included into a Scale.
  *
  * @param {Scale} scale
+ * @param {boolean} ignoreAnchorState - by default the provider will produce no
+ *  results if it is not "attached" to the DOM. Setting this flag to `true` will
+ *  force this provider to compute its values even before it is attached to the
+ *  DOM.
  * @returns {D[]} An array of values that should be included in the Scale.
  */
 export interface IIncludedValuesProvider<D> {
-  (scale: Scale<D, any>): D[];
+  (scale: Scale<D, any>, ignoreAnchorState?: boolean): D[];
 }
 
 /**

--- a/src/scales/linearScale.ts
+++ b/src/scales/linearScale.ts
@@ -42,7 +42,7 @@ export class Linear extends QuantitativeScale<number> {
   }
 
   public getTransformationExtent() {
-    return this._getUnboundedExtent() as [number, number];
+    return this._getUnboundedExtent(true) as [number, number];
   }
 
   public getTransformationDomain() {

--- a/src/scales/modifiedLogScale.ts
+++ b/src/scales/modifiedLogScale.ts
@@ -108,7 +108,7 @@ export class ModifiedLog extends QuantitativeScale<number> {
   }
 
   public getTransformationExtent() {
-    return this._getUnboundedExtent() as [number, number];
+    return this._getUnboundedExtent(true) as [number, number];
   }
 
   public getTransformationDomain() {

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -69,8 +69,8 @@ export class QuantitativeScale<D> extends Scale<D, number> implements ITransform
     super._autoDomainIfAutomaticMode();
   }
 
-  protected _getUnboundedExtent(): D[] {
-    const includedValues = this._getAllIncludedValues();
+  protected _getUnboundedExtent(ignoreAttachState = false): D[] {
+    const includedValues = this._getAllIncludedValues(ignoreAttachState);
     let extent = this._defaultExtent();
     if (includedValues.length !== 0) {
       const combinedExtent = [

--- a/src/scales/scale.ts
+++ b/src/scales/scale.ts
@@ -39,10 +39,10 @@ export class Scale<D, R> {
     return []; // this should be overwritten
   }
 
-  protected _getAllIncludedValues(): D[] {
+  protected _getAllIncludedValues(ignoreAttachState = false): D[] {
     let providerArray: D[] = [];
     this._includedValuesProviders.forEach((provider: Scales.IIncludedValuesProvider<D>) => {
-      const extents = provider(this);
+      const extents = provider(this, ignoreAttachState);
       providerArray = providerArray.concat(extents);
     });
     return providerArray;

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -76,7 +76,7 @@ export class Time extends QuantitativeScale<Date> {
   }
 
   public getTransformationExtent() {
-    const extent = this._getUnboundedExtent();
+    const extent = this._getUnboundedExtent(true);
     return [extent[0].valueOf(), extent[1].valueOf()] as [number, number];
   }
 


### PR DESCRIPTION
The lines that were removed prevented `_includedValuesProvider` from working when a component was not yet anchored. This may be a minor performance optimization but it is not necessary.

It prevents extents calculations from working. Furthermore, the calculations in this method depend only on data space, not pixel space, so anchoring is irrelevant.