### PR TITLE
don't require label padding to draw bar labels; improve perf

### DIFF
--- a/quicktests/overlaying/tests/basic/bar_horizontal_labels.js
+++ b/quicktests/overlaying/tests/basic/bar_horizontal_labels.js
@@ -1,0 +1,42 @@
+function makeData() {
+  "use strict";
+
+  return [
+      { y: "none", x: 550 },
+      { y: "government", x: 500 },
+      { y: "contractor", x: 330 },
+      { y: "developer (inhouse)", x: 300 },
+      { y: "developer (outsourced)", x: 270 },
+      { y: "corporation", x: 210 },
+      { y: "unknown", x: 115 },
+      { y: "retired", x: 55 },
+      { y: "x", x: 25 },
+      { y: "y", x: 15 },
+      { y: "z", x: 10 },
+  ];
+}
+
+function run(div, data, Plottable) {
+  "use strict";
+
+  var xScale = new Plottable.Scales.Linear();
+  var yScale = new Plottable.Scales.Category();
+
+  var dataset = new Plottable.Dataset(data);
+  var horizontalBarPlot = new Plottable.Plots.Bar("horizontal")
+                              .addDataset(dataset)
+                              .x(function(d) { return d.x; }, xScale)
+                              .y(function(d) { return d.y; }, yScale)
+                              .labelsEnabled(true)
+                              .attr("opacity", 0.8);
+
+  var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
+  var yAxis = new Plottable.Axes.Category(yScale, "left");
+
+  var chart = new Plottable.Components.Table([
+    [yAxis, horizontalBarPlot],
+    [null, xAxis]
+  ]);
+
+  chart.renderTo(div);
+}

--- a/quicktests/overlaying/tests/basic/label_bars.js
+++ b/quicktests/overlaying/tests/basic/label_bars.js
@@ -25,7 +25,7 @@ function run(svg, data, Plottable) {
                               .addDataset(dataset)
                               .x(function(d) { return d.x; }, xScale)
                               .y(function(d) { return d.y; }, yScale)
-                              .labelsEnabled(true, "start")
+                              .labelsEnabled(true, "middle")
                               .attr("opacity", 0.75)
 
   var verticalStackedBarPlot = new Plottable.Plots.StackedBar("vertical")
@@ -40,7 +40,7 @@ function run(svg, data, Plottable) {
                               .addDataset(dataset)
                               .x(function(d) { return d.x; }, xScale)
                               .y(function(d) { return d.y; }, yScale)
-                              .labelsEnabled(true, "outside")
+                              .labelsEnabled(true, "middle")
                               .attr("opacity", 0.75)
 
   var horizontalStackedBarPlot = new Plottable.Plots.StackedBar("horizontal")
@@ -48,7 +48,7 @@ function run(svg, data, Plottable) {
                               .addDataset(dataset1)
                               .x(function(d) { return d.x; }, xScale)
                               .y(function(d) { return d.y; }, yScale)
-                              .labelsEnabled(true, "end")
+                              .labelsEnabled(true, "middle")
                               .attr("opacity", 0.75)
 
   var chart = new Plottable.Components.Table([

--- a/quicktests/overlaying/tests/basic/label_bars.js
+++ b/quicktests/overlaying/tests/basic/label_bars.js
@@ -25,7 +25,7 @@ function run(svg, data, Plottable) {
                               .addDataset(dataset)
                               .x(function(d) { return d.x; }, xScale)
                               .y(function(d) { return d.y; }, yScale)
-                              .labelsEnabled(true, "middle")
+                              .labelsEnabled(true)
                               .attr("opacity", 0.75)
 
   var verticalStackedBarPlot = new Plottable.Plots.StackedBar("vertical")
@@ -40,7 +40,7 @@ function run(svg, data, Plottable) {
                               .addDataset(dataset)
                               .x(function(d) { return d.x; }, xScale)
                               .y(function(d) { return d.y; }, yScale)
-                              .labelsEnabled(true, "middle")
+                              .labelsEnabled(true)
                               .attr("opacity", 0.75)
 
   var horizontalStackedBarPlot = new Plottable.Plots.StackedBar("horizontal")

--- a/quicktests/overlaying/tests/realistic/many_bars.js
+++ b/quicktests/overlaying/tests/realistic/many_bars.js
@@ -43,6 +43,9 @@ function run(div, datas, Plottable) {
         .datasets([ds1, ds2, ds3, ds4])
         .x(function (d) { return d.x; }, xScale)
         .y(function (d) { return d.y; }, yScale)
+        .labelsEnabled(true, "middle")
         .attr("fill", function (d, i, ds) { return ds.metadata()}, colorScale);
     plot.renderTo(div);
+
+    new Plottable.Interactions.PanZoom(xScale, null).attachTo(plot).setMinMaxDomainValuesTo(xScale);
 }

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -11,4 +11,4 @@ declare var __VERSION__: string;
  * real version number during the dist phase for for npm module publishing. Modifying this line should
  * be accompanied by modifying the "sed-version" task in package.json accordingly.
  */
-export let version = "test";
+export let version = __VERSION__;

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -11,4 +11,4 @@ declare var __VERSION__: string;
  * real version number during the dist phase for for npm module publishing. Modifying this line should
  * be accompanied by modifying the "sed-version" task in package.json accordingly.
  */
-export let version = __VERSION__;
+export let version = "test";

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -61,7 +61,11 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
   // we re-assign "width" to specifically refer to <rect>'s width attribute
   protected static _BAR_THICKNESS_KEY = "width";
   protected static _LABEL_AREA_CLASS = "bar-label-text-area";
-  protected static _LABEL_PADDING = 10;
+  /**
+   * In the case of "start" or "end" LabelPositions, put the label this many px away
+   * from the bar's length distance edge
+   */
+  protected static _LABEL_MARGIN_INSIDE_BAR = 10;
 
   private _baseline: SimpleSelection<void>;
   private _baselineValue: X|Y;
@@ -670,16 +674,16 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
       switch (position) {
         case "topLeft":
           alignmentDimension = this._isVertical ? "top" : "left";
-          labelContainerOriginCoordinate += Bar._LABEL_PADDING;
-          labelOriginCoordinate += Bar._LABEL_PADDING;
+          labelContainerOriginCoordinate += Bar._LABEL_MARGIN_INSIDE_BAR;
+          labelOriginCoordinate += Bar._LABEL_MARGIN_INSIDE_BAR;
           return;
         case "center":
           labelOriginCoordinate += (barDimension + measurementDimension) / 2;
           return;
         case "bottomRight":
           alignmentDimension = this._isVertical ? "bottom" : "right";
-          labelContainerOriginCoordinate -= Bar._LABEL_PADDING;
-          labelOriginCoordinate += containerDimension - Bar._LABEL_PADDING - measurementDimension;
+          labelContainerOriginCoordinate -= Bar._LABEL_MARGIN_INSIDE_BAR;
+          labelOriginCoordinate += containerDimension - Bar._LABEL_MARGIN_INSIDE_BAR - measurementDimension;
           return;
       }
     };
@@ -699,13 +703,13 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
     } else {
       if (aboveOrLeftOfBaseline) {
         alignmentDimension = this._isVertical ? "top" : "left";
-        containerDimension = barDimension + Bar._LABEL_PADDING + measurementDimension;
-        labelContainerOriginCoordinate -= Bar._LABEL_PADDING + measurementDimension;
-        labelOriginCoordinate -= Bar._LABEL_PADDING + measurementDimension;
+        containerDimension = barDimension + Bar._LABEL_MARGIN_INSIDE_BAR + measurementDimension;
+        labelContainerOriginCoordinate -= Bar._LABEL_MARGIN_INSIDE_BAR + measurementDimension;
+        labelOriginCoordinate -= Bar._LABEL_MARGIN_INSIDE_BAR + measurementDimension;
       } else {
         alignmentDimension = this._isVertical ? "bottom" : "right";
-        containerDimension = barDimension + Bar._LABEL_PADDING + measurementDimension;
-        labelOriginCoordinate += barDimension + Bar._LABEL_PADDING;
+        containerDimension = barDimension + Bar._LABEL_MARGIN_INSIDE_BAR + measurementDimension;
+        labelOriginCoordinate += barDimension + Bar._LABEL_MARGIN_INSIDE_BAR;
       }
     }
 

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -32,7 +32,6 @@ import { IPlotEntity } from "./";
 import { ILightweightPlotEntity } from "./commons";
 import { Plot } from "./plot";
 import { XYPlot } from "./xyPlot";
-import {boundsIntersects} from "../utils/mathUtils";
 
 type LabelConfig = {
   labelArea: SimpleSelection<void>;
@@ -939,7 +938,7 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
     if (!isValid) {
       return false;
     }
-    return boundsIntersects(
+    return Utils.Math.boundsIntersects(
       pixelX, pixelY, pixelWidth, pixelHeight,
       0, 0, plotWidth, plotHeight,
     );

--- a/src/plots/stackedBarPlot.ts
+++ b/src/plots/stackedBarPlot.ts
@@ -16,7 +16,7 @@ import { Bar, BarOrientation } from "./barPlot";
 import { Plot } from "./plot";
 
 export class StackedBar<X, Y> extends Bar<X, Y> {
-  protected static _STACKED_BAR_LABEL_PADDING = 5;
+  protected static _EXTREMA_LABEL_MARGIN_FROM_BAR = 5;
 
   private _extremaFormatter: Formatter = identity();
   private _labelArea: SimpleSelection<void>;
@@ -231,9 +231,9 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
       return {
         x: this._isVertical
             ? stackEdge.x - primaryTextMeasurement / 2
-            : stackEdge.x + StackedBar._STACKED_BAR_LABEL_PADDING,
+            : stackEdge.x + StackedBar._EXTREMA_LABEL_MARGIN_FROM_BAR,
         y: this._isVertical
-            ? stackEdge.y - secondaryTextMeasurement - StackedBar._STACKED_BAR_LABEL_PADDING
+            ? stackEdge.y - secondaryTextMeasurement
             : stackEdge.y - primaryTextMeasurement / 2,
       };
     });
@@ -245,9 +245,9 @@ export class StackedBar<X, Y> extends Bar<X, Y> {
       return {
         x: this._isVertical
             ? stackEdge.x - primaryTextMeasurement / 2
-            : stackEdge.x - secondaryTextMeasurement - StackedBar._STACKED_BAR_LABEL_PADDING,
+            : stackEdge.x - secondaryTextMeasurement,
         y: this._isVertical
-            ? stackEdge.y + StackedBar._STACKED_BAR_LABEL_PADDING
+            ? stackEdge.y + StackedBar._EXTREMA_LABEL_MARGIN_FROM_BAR
             : stackEdge.y - primaryTextMeasurement / 2,
       };
     });

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -143,6 +143,22 @@ export function within(p: Point, bounds: Bounds) {
 }
 
 /**
+ * Returns whether the first bounds intersects the second bounds.
+ * Pass primitive numbers directly for performance.
+ *
+ * Assumes width and heights are positive.
+ */
+export function boundsIntersects(
+  aX: number, aY: number, aWidth: number, aHeight: number,
+  bX: number, bY: number, bWidth: number, bHeight: number,
+) {
+  return aX <= bX + bWidth &&
+         bX <= aX + aWidth &&
+         aY <= bY + bHeight &&
+         bY <= aY + aHeight;
+}
+
+/**
  * Returns a `ICssTransformMatrix` representing the cumulative transformation of
  * the element and all its parents. This transform converts from top-level
  * clientX/clientY coordinates (such as document mouse events) to internal

--- a/test/plots/stackedBarPlotTests.ts
+++ b/test/plots/stackedBarPlotTests.ts
@@ -473,7 +473,7 @@ describe("Plots", () => {
       // HACKHACK #2795: correct off-bar label logic to be implemented
       it("doesn't show any off-bar labels", () => {
         stackedBarPlot.labelsEnabled(true);
-        xScale.domain([0, 50]);
+        xScale.domain([0, 90]);
         const offBarLabels = stackedBarPlot.content().selectAll<Element, any>(".off-bar-label");
         assert.operator(offBarLabels.size(), ">", 0, "some off-bar labels are drawn");
         offBarLabels.each(function(d, i) {


### PR DESCRIPTION
improves data density.

drastically improve bar plot perf by performing viewbox culling on data before
rendering