### PR TITLE
Fix deferred rendering

### DIFF
--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -296,6 +296,10 @@ export class Component {
     return this;
   }
 
+  public renderLowPriority() {
+    return this.render();
+  }
+
   private _scheduleComputeLayout() {
     if (this._isAnchored && this._isSetup) {
       RenderController.registerToComputeLayoutAndRender(this);

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -418,6 +418,7 @@ export class Plot extends Component {
 
   public renderLowPriority() {
     this._renderCallback();
+    return this;
   }
 
   /**

--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -49,19 +49,14 @@ export class XYPlot<X, Y> extends Plot {
       }
     };
 
-    const _applyTransform = (tx: number, ty: number, sx: number, sy: number) => {
-      if (!this._isAnchored) {
-        return;
-      }
-      if (this._renderArea != null) {
-        this._renderArea.attr("transform", `translate(${tx}, ${ty}) scale(${sx}, ${sy})`);
-      }
-      if (this._canvas != null) {
-        this._canvas.style("transform", `translate(${tx}px, ${ty}px) scale(${sx}, ${sy})`);
-      }
-    };
+    this._deferredRenderer = new DeferredRenderer<X, Y>(() => this.render(), this._applyDeferredRenderingTransform);
+  }
 
-    this._deferredRenderer = new DeferredRenderer<X, Y>(() => this.render(), _applyTransform);
+  public render() {
+    if (this.deferredRendering()) {
+      this._deferredRenderer.resetTransforms();
+    }
+    return super.render();
   }
 
   /**
@@ -199,6 +194,18 @@ export class XYPlot<X, Y> extends Plot {
       }
     }
     return null;
+  }
+
+  private _applyDeferredRenderingTransform = (tx: number, ty: number, sx: number, sy: number) => {
+    if (!this._isAnchored) {
+      return;
+    }
+    if (this._renderArea != null) {
+      this._renderArea.attr("transform", `translate(${tx}, ${ty}) scale(${sx}, ${sy})`);
+    }
+    if (this._canvas != null) {
+      this._canvas.style("transform", `translate(${tx}px, ${ty}px) scale(${sx}, ${sy})`);
+    }
   }
 
   protected _uninstallScaleForKey(scale: Scale<any, any>, key: string) {


### PR DESCRIPTION
The primary cause of incorrect deferred rendering results was that
the deferred renderer did not know when a component was rendered
except when it triggered the render. Occassionally, direct calls
to render would occur and the deferred renderer did not update
the css transform. This PR refactors the code so that the
component's own render method will reset the deferred renderer to
guarantee that it resets the css transform.

- Add `renderLowPriority` method to all components to make typing easier
- Extract transform method from constructor for legibility
- Switch to transformable scales to support category axis deferred render