### PR TITLE
preparing release 3.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plottable",
   "description": "A modular charting library built on D3",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Breaking Changes
- PanZoomInteraction.zoom() API point now respects the zoom extent and minmax constraints by default. You may disable this behavior by passing `false` to the third argument:

```ts
// old
panZoomInteraction.zoom(amount, center); // unconstrained zoom

// new
panZoomInteraction.zoom(amount, center); // respects constraints
panZoomInteraction.zoom(amount, center, false); // unconstrained again 
```

# Bug Fixes
- Fixed deferred rendering bugs associated with calling immediate redraws while still waiting for a deferred redraw.
- Canvas rendering now respects the inherit opacity in `fill` and `stroke` attrs.
- Fix a PanZoom bug where slightly zooming out would sometimes zoom out completely.