### PR TITLE
Add labels to scatterplots

### DIFF
--- a/plottable.css
+++ b/plottable.css
@@ -113,7 +113,8 @@
   fill: #32313F;
 }
 
-.plottable .bar-label-text-area text {
+.plottable .bar-label-text-area text,
+.plottable .scatter-label-text-area text {
   font-family: "Helvetica Neue", sans-serif;
   font-size: 12px;
 }

--- a/quicktests/overlaying/tests/basic/scatter_labels.js
+++ b/quicktests/overlaying/tests/basic/scatter_labels.js
@@ -1,0 +1,87 @@
+function makeData() {
+    "use strict";
+
+    var data = [
+        {
+            x: 10,
+            y: 10,
+            label: "these",
+            size: 100
+        },
+        {
+            x: 15,
+            y: 30,
+            label: "Label on bubble",
+            size: 30
+        },
+        {
+            x: 20,
+            y: 40,
+            label: "Label off bubble",
+            size: 10
+        },
+        {
+            x: 20,
+            y: 20,
+            label: "are",
+            size: 150
+        },
+        {
+            x: 30,
+            y: 30,
+            label: "scatter",
+            size: 200
+        },
+        {
+            x: 40,
+            y: 40,
+            label: "plot",
+            size: 300
+        },
+        {
+            x: 50,
+            y: 50,
+            label: "labels",
+            size: 150   
+        }
+    ];
+
+    return data;
+}
+
+function run(div, data, Plottable) {
+    "use strict";
+
+    var xScale = new Plottable.Scales.Linear();
+    var yScale = new Plottable.Scales.Linear();
+    var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
+    var yAxis = new Plottable.Axes.Numeric(yScale, "left");
+
+    // using the same symbol factories instead of new instances from each
+    // projector allows us to compare the instances and save a lot of re-rendering
+    var symbols = [
+        new Plottable.SymbolFactories.cross(),
+        new Plottable.SymbolFactories.square(),
+        new Plottable.SymbolFactories.star(),
+    ];
+
+    var plot = new Plottable.Plots.Scatter()
+        .renderer("svg")
+        .deferredRendering(true)
+        .addDataset(new Plottable.Dataset(data))
+        .x((d) => d.x, xScale)
+        .y((d) => d.y, yScale)
+        .size((d) => d.size);
+
+    var table = new Plottable.Components.Table([
+        [yAxis, plot],
+        [null, xAxis]
+    ]);
+
+    var panZoom = new Plottable.Interactions.PanZoom(xScale, yScale).attachTo(plot);
+
+    table.renderTo(div);
+
+    panZoom.setMinMaxDomainValuesTo(xScale);
+    panZoom.setMinMaxDomainValuesTo(yScale);
+}

--- a/quicktests/overlaying/tests/basic/scatter_labels.js
+++ b/quicktests/overlaying/tests/basic/scatter_labels.js
@@ -57,14 +57,6 @@ function run(div, data, Plottable) {
     var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
     var yAxis = new Plottable.Axes.Numeric(yScale, "left");
 
-    // using the same symbol factories instead of new instances from each
-    // projector allows us to compare the instances and save a lot of re-rendering
-    var symbols = [
-        new Plottable.SymbolFactories.cross(),
-        new Plottable.SymbolFactories.square(),
-        new Plottable.SymbolFactories.star(),
-    ];
-
     var plot = new Plottable.Plots.Scatter()
         .renderer("svg")
         .deferredRendering(true)

--- a/quicktests/overlaying/tests/basic/scatter_labels.js
+++ b/quicktests/overlaying/tests/basic/scatter_labels.js
@@ -61,6 +61,7 @@ function run(div, data, Plottable) {
         .renderer("svg")
         .deferredRendering(true)
         .addDataset(new Plottable.Dataset(data))
+        .labelsEnabled(true)
         .x((d) => d.x, xScale)
         .y((d) => d.y, yScale)
         .size((d) => d.size);

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -1,3 +1,9 @@
+import { DatumFormatter } from './../core/formatters';
+import { SimpleSelection } from './../core/interfaces';
+import * as Typesettable from "typesettable";
+import * as Formatters from "../core/formatters";
+
+
 /**
  * Copyright 2014-present Palantir Technologies
  * @license MIT
@@ -15,6 +21,7 @@ import * as Animators from "../animators";
 import * as Drawers from "../drawers";
 import * as Scales from "../scales";
 import * as Utils from "../utils";
+import { makeEnum } from "../utils/makeEnum";
 import * as Plots from "./";
 import { IAccessorScaleBinding, ILightweightPlotEntity, IPlotEntity, ITransformableAccessorScaleBinding } from "./";
 import { Plot } from "./plot";
@@ -23,11 +30,27 @@ import { XYPlot } from "./xyPlot";
 export interface ILightweightScatterPlotEntity extends ILightweightPlotEntity {
   // size of the entity in pixel space
   diameter: number;
+  label?: string;
 }
+
+type LabelConfig = {
+  labelArea: SimpleSelection<void>;
+  measurer: Typesettable.CacheMeasurer;
+  writer: Typesettable.Writer;
+};
+export const LabelsPosition = makeEnum(["start", "middle", "end", "outside"]);
+
 
 export class Scatter<X, Y> extends XYPlot<X, Y> {
   private static _SIZE_KEY = "size";
   private static _SYMBOL_KEY = "symbol";
+  
+  // label stuff
+  protected static _LABEL_AREA_CLASS = "bar-label-text-area";
+  private _labelConfig: Utils.Map<Dataset, LabelConfig>;
+  private _labelFormatter: DatumFormatter = Formatters.identity();
+  private _labelsEnabled = true;
+  private _labelsPosition = LabelsPosition.end;
 
   /**
    * A Scatter Plot draws a symbol at each data point.
@@ -47,6 +70,7 @@ export class Scatter<X, Y> extends XYPlot<X, Y> {
     this.size(6);
     const circleSymbolFactory = SymbolFactories.circle();
     this.symbol(() => circleSymbolFactory);
+    this._labelConfig = new Utils.Map<Dataset, LabelConfig>();
   }
 
   protected _buildLightweightPlotEntities(datasets: Dataset[]) {
@@ -59,6 +83,9 @@ export class Scatter<X, Y> extends XYPlot<X, Y> {
         lightweightPlotEntity.dataset);
 
       lightweightPlotEntity.diameter = diameter;
+
+      lightweightPlotEntity.label = "NO_LABEL";
+
       return lightweightPlotEntity;
     });
   }
@@ -205,4 +232,96 @@ export class Scatter<X, Y> extends XYPlot<X, Y> {
       return x - size / 2 <= p.x && p.x <= x + size / 2 && y - size / 2 <= p.y && p.y <= y + size / 2;
     });
   }
+
+  // labels
+
+  protected _createNodesForDataset(dataset: Dataset): ProxyDrawer {
+    const drawer = super._createNodesForDataset(dataset);
+    const labelArea = this._renderArea.append("g").classed(Scatter._LABEL_AREA_CLASS, true);
+    const context = new Typesettable.SvgContext(labelArea.node() as SVGElement);
+    const measurer = new Typesettable.CacheMeasurer(context);
+    const writer = new Typesettable.Writer(measurer, context);
+    this._labelConfig.set(dataset, { labelArea: labelArea, measurer: measurer, writer: writer });
+    return drawer;
+  }
+
+  protected _removeDatasetNodes(dataset: Dataset) {
+    super._removeDatasetNodes(dataset);
+    const labelConfig = this._labelConfig.get(dataset);
+    if (labelConfig != null) {
+      labelConfig.labelArea.remove();
+      this._labelConfig.delete(dataset);
+    }
+  }
+
+  protected _additionalPaint(time: number) {
+    console.log("SCATTER ADDITIONAL PAINT CALLED!");
+    this.datasets().forEach((dataset) => this._labelConfig.get(dataset).labelArea.selectAll("g").remove());
+    if (this._labelsEnabled) {
+      Utils.Window.setTimeout(() => this._drawLabels(), time);
+    }
+  }
+
+  protected _drawLabels() {
+    const dataToDraw = this._getDataToDraw();
+    const attrToProjector = this._getAttrToProjector();
+    this.datasets().forEach((dataset) => {
+      dataToDraw.get(dataset).forEach((datum, index) => {
+        if (datum == null) {
+          return;
+        }
+        this._drawLabel(datum, index, dataset, attrToProjector);
+      });
+    });
+  }
+
+  private _drawLabel(datum: any, index: number, dataset: Dataset, attrToProjector: AttributeToProjector) {
+    const { labelArea, measurer, writer } = this._labelConfig.get(dataset);
+
+    const scatterCoordinates = { x: attrToProjector["x"](datum, index, dataset), y: attrToProjector["y"](datum, index, dataset) };
+    const text = this._labelFormatter("TEST", datum, index, dataset);
+    const measurement = measurer.measure(text);
+
+    const { containerDimensions, labelContainerOrigin, labelOrigin, alignment } = this._calculateLabelProperties(scatterCoordinates, measurement);
+
+    const labelContainer = this._createLabelContainer(labelArea, labelContainerOrigin, labelOrigin, measurement);
+
+    const writeOptions = { xAlign: alignment.x as Typesettable.IXAlign, yAlign: alignment.y as Typesettable.IYAlign };
+    writer.write(text, containerDimensions.width, containerDimensions.height, writeOptions, labelContainer.node());
+  }
+
+  // Todo: do something smart with the text size vs. symbol diameter
+  private _calculateLabelProperties(
+    pointCoordinates: Point, measurement: Typesettable.IDimensions) {
+
+    return {
+      containerDimensions: {
+        width: measurement.width,
+        height: measurement.height
+      },
+      labelContainerOrigin: {
+        x: pointCoordinates.x - measurement.width / 2,
+        y: pointCoordinates.y - measurement.height / 2,
+      },
+      labelOrigin: {
+        x: pointCoordinates.x,
+        y: pointCoordinates.y,
+      },
+      alignment: {
+        x: "center",
+        y: "center",
+      },
+    };
+  }
+
+  private _createLabelContainer(
+    labelArea: SimpleSelection<void>, labelContainerOrigin: Point, labelOrigin: Point, measurement: Typesettable.IDimensions) {
+
+    const labelContainer = labelArea.append("g").attr("transform", `translate(${labelContainerOrigin.x}, ${labelContainerOrigin.y})`);
+    labelContainer.classed("on-bar-label", true);
+    labelContainer.classed("dark-label");
+
+    return labelContainer;
+  }
+
 }

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -44,7 +44,7 @@ export class Scatter<X, Y> extends XYPlot<X, Y> {
   private _labelFormatter: Formatters.DatumFormatter = Formatters.identity();
 
   protected static _LABEL_MARGIN_FROM_BUBBLE = 15;
-  private _labelsEnabled = true;
+  private _labelsEnabled = false;
   /**
    * A Scatter Plot draws a symbol at each data point.
    *
@@ -223,7 +223,29 @@ export class Scatter<X, Y> extends XYPlot<X, Y> {
     });
   }
 
-  // labels
+ /**
+   * Get whether bar labels are enabled.
+   *
+   * @returns {boolean} Whether bars should display labels or not.
+   */
+  public labelsEnabled(): boolean;
+  /**
+   * Sets whether labels are enabled.
+   *
+   * @param {boolean} labelsEnabled
+   * @returns {Scatter} The calling SCATTER Plot.
+   */
+  public labelsEnabled(enabled: boolean): this;
+  public labelsEnabled(enabled?: boolean): any {
+    if (enabled == null) {
+      return this._labelsEnabled;
+    } else {
+      this._labelsEnabled = enabled;
+      this._clearAttrToProjectorCache();
+      this.render();
+      return this;
+    }
+  }
 
   protected _createNodesForDataset(dataset: Dataset): ProxyDrawer {
     const drawer = super._createNodesForDataset(dataset);

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -1,9 +1,3 @@
-import { DatumFormatter } from './../core/formatters';
-import { SimpleSelection } from './../core/interfaces';
-import * as Typesettable from "typesettable";
-import * as Formatters from "../core/formatters";
-
-
 /**
  * Copyright 2014-present Palantir Technologies
  * @license MIT
@@ -16,12 +10,15 @@ import { SymbolFactory } from "../core/symbolFactories";
 import { ProxyDrawer } from "../drawers/drawer";
 import { makeSymbolCanvasDrawStep, SymbolSVGDrawer } from "../drawers/symbolDrawer";
 import { Scale } from "../scales/scale";
+import { DatumFormatter } from './../core/formatters';
+import { SimpleSelection } from './../core/interfaces';
+import * as Typesettable from "typesettable";
+import * as Formatters from "../core/formatters";
 
 import * as Animators from "../animators";
 import * as Drawers from "../drawers";
 import * as Scales from "../scales";
 import * as Utils from "../utils";
-import { makeEnum } from "../utils/makeEnum";
 import * as Plots from "./";
 import { IAccessorScaleBinding, ILightweightPlotEntity, IPlotEntity, ITransformableAccessorScaleBinding } from "./";
 import { Plot } from "./plot";
@@ -30,7 +27,6 @@ import { XYPlot } from "./xyPlot";
 export interface ILightweightScatterPlotEntity extends ILightweightPlotEntity {
   // size of the entity in pixel space
   diameter: number;
-  label?: string;
 }
 
 type LabelConfig = {
@@ -38,8 +34,6 @@ type LabelConfig = {
   measurer: Typesettable.CacheMeasurer;
   writer: Typesettable.Writer;
 };
-export const LabelsPosition = makeEnum(["start", "middle", "end", "outside"]);
-
 
 export class Scatter<X, Y> extends XYPlot<X, Y> {
   private static _SIZE_KEY = "size";
@@ -293,11 +287,10 @@ export class Scatter<X, Y> extends XYPlot<X, Y> {
     writer.write(label, containerDimensions.width, containerDimensions.height, writeOptions, labelContainer.node());
   }
 
-  // Todo: do something smart with the text size vs. symbol diameter
   private _calculateLabelProperties(
     pointCoordinates: Point, diameter: number, measurement: Typesettable.IDimensions) {
 
-    // if diameter is smaller than font size, put label above 
+    // If diameter is smaller than font size, put label above 
 
     const labelShift = diameter < measurement.height ? diameter / 2 + Scatter._LABEL_MARGIN_FROM_BUBBLE : 0;
 

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -312,7 +312,6 @@ export class Scatter<X, Y> extends XYPlot<X, Y> {
     pointCoordinates: Point, diameter: number, measurement: Typesettable.IDimensions) {
 
     // If diameter is smaller than font size, put label above
-
     const labelShift = diameter < measurement.height ? diameter / 2 + Scatter._LABEL_MARGIN_FROM_BUBBLE : 0;
 
     return {
@@ -336,11 +335,14 @@ export class Scatter<X, Y> extends XYPlot<X, Y> {
   }
 
   private _createLabelContainer(
-    labelArea: SimpleSelection<void>, labelContainerOrigin: Point, labelOrigin: Point, measurement: Typesettable.IDimensions) {
+    labelArea: SimpleSelection<void>,
+    labelContainerOrigin: Point,
+    labelOrigin: Point,
+    measurement: Typesettable.IDimensions) {
 
-    const labelContainer = labelArea.append("g").attr("transform", `translate(${labelContainerOrigin.x}, ${labelContainerOrigin.y})`);
+    const labelContainer = labelArea.append("g")
+                                    .attr("transform", `translate(${labelContainerOrigin.x}, ${labelContainerOrigin.y})`);
     labelContainer.classed("on-bar-label", true);
-    labelContainer.classed("dark-label");
 
     return labelContainer;
   }

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -39,7 +39,7 @@ export class Scatter<X, Y> extends XYPlot<X, Y> {
   private static _SYMBOL_KEY = "symbol";
 
   // label stuff
-  protected static _LABEL_AREA_CLASS = "bar-label-text-area";
+  protected static _LABEL_AREA_CLASS = "scatter-label-text-area";
   private _labelConfig: Utils.Map<Dataset, LabelConfig>;
   private _labelFormatter: Formatters.DatumFormatter = Formatters.identity();
 

--- a/src/plots/scatterPlot.ts
+++ b/src/plots/scatterPlot.ts
@@ -3,17 +3,16 @@
  * @license MIT
  */
 
+import * as Typesettable from "typesettable";
+
 import { Dataset } from "../core/dataset";
-import { AttributeToProjector, Bounds, IAccessor, Point } from "../core/interfaces";
+import * as Formatters from "../core/formatters";
+import { AttributeToProjector, Bounds, IAccessor, Point, SimpleSelection } from "../core/interfaces";
 import * as SymbolFactories from "../core/symbolFactories";
 import { SymbolFactory } from "../core/symbolFactories";
 import { ProxyDrawer } from "../drawers/drawer";
 import { makeSymbolCanvasDrawStep, SymbolSVGDrawer } from "../drawers/symbolDrawer";
 import { Scale } from "../scales/scale";
-import { DatumFormatter } from './../core/formatters';
-import { SimpleSelection } from './../core/interfaces';
-import * as Typesettable from "typesettable";
-import * as Formatters from "../core/formatters";
 
 import * as Animators from "../animators";
 import * as Drawers from "../drawers";
@@ -42,7 +41,7 @@ export class Scatter<X, Y> extends XYPlot<X, Y> {
   // label stuff
   protected static _LABEL_AREA_CLASS = "bar-label-text-area";
   private _labelConfig: Utils.Map<Dataset, LabelConfig>;
-  private _labelFormatter: DatumFormatter = Formatters.identity();
+  private _labelFormatter: Formatters.DatumFormatter = Formatters.identity();
 
   protected static _LABEL_MARGIN_FROM_BUBBLE = 15;
   private _labelsEnabled = true;
@@ -290,14 +289,14 @@ export class Scatter<X, Y> extends XYPlot<X, Y> {
   private _calculateLabelProperties(
     pointCoordinates: Point, diameter: number, measurement: Typesettable.IDimensions) {
 
-    // If diameter is smaller than font size, put label above 
+    // If diameter is smaller than font size, put label above
 
     const labelShift = diameter < measurement.height ? diameter / 2 + Scatter._LABEL_MARGIN_FROM_BUBBLE : 0;
 
     return {
       containerDimensions: {
         width: measurement.width,
-        height: measurement.height
+        height: measurement.height,
       },
       labelContainerOrigin: {
         x: pointCoordinates.x - measurement.width / 2,


### PR DESCRIPTION
If a data point includes a "label" field it will be rendered centered at that points (x,y) coordinates on top of the symbol. In the event the symbol's diameter is smaller than the rendered text, the text will be rendered below the point.