### PR TITLE
Configurable UTC/local-time

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",
   "scripts": {
+    "prepare": "npm run dist",
     "build": "npm-run-all -p lint:tslint build:tsc -s build:webpack",
     "build:tsc": "tsc -p .",
     "build:webpack": "webpack",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",
   "scripts": {
-    "prepare": "npm run dist",
     "build": "npm-run-all -p lint:tslint build:tsc -s build:webpack",
     "build:tsc": "tsc -p .",
     "build:webpack": "webpack",

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -80,115 +80,118 @@ export class Time extends Axis<Date> {
     [TimeInterval.year]: 6,
   };
 
-  private static _DEFAULT_TIME_AXIS_CONFIGURATIONS: TimeAxisConfiguration[] = [
-    [
-      { interval: TimeInterval.second, step: 1, formatter: Formatters.time("%I:%M:%S %p") },
-      { interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y") },
-    ],
-    [
-      { interval: TimeInterval.second, step: 5, formatter: Formatters.time("%I:%M:%S %p") },
-      { interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y") },
-    ],
-    [
-      { interval: TimeInterval.second, step: 10, formatter: Formatters.time("%I:%M:%S %p") },
-      { interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y") },
-    ],
-    [
-      { interval: TimeInterval.second, step: 15, formatter: Formatters.time("%I:%M:%S %p") },
-      { interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y") },
-    ],
-    [
-      { interval: TimeInterval.second, step: 30, formatter: Formatters.time("%I:%M:%S %p") },
-      { interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y") },
-    ],
-    [
-      { interval: TimeInterval.minute, step: 1, formatter: Formatters.time("%I:%M %p") },
-      { interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y") },
-    ],
-    [
-      { interval: TimeInterval.minute, step: 5, formatter: Formatters.time("%I:%M %p") },
-      { interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y") },
-    ],
-    [
-      { interval: TimeInterval.minute, step: 10, formatter: Formatters.time("%I:%M %p") },
-      { interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y") },
-    ],
-    [
-      { interval: TimeInterval.minute, step: 15, formatter: Formatters.time("%I:%M %p") },
-      { interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y") },
-    ],
-    [
-      { interval: TimeInterval.minute, step: 30, formatter: Formatters.time("%I:%M %p") },
-      { interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y") },
-    ],
-    [
-      { interval: TimeInterval.hour, step: 1, formatter: Formatters.time("%I %p") },
-      { interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y") },
-    ],
-    [
-      { interval: TimeInterval.hour, step: 3, formatter: Formatters.time("%I %p") },
-      { interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y") },
-    ],
-    [
-      { interval: TimeInterval.hour, step: 6, formatter: Formatters.time("%I %p") },
-      { interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y") },
-    ],
-    [
-      { interval: TimeInterval.hour, step: 12, formatter: Formatters.time("%I %p") },
-      { interval: TimeInterval.day, step: 1, formatter: Formatters.time("%B %e, %Y") },
-    ],
-    [
-      { interval: TimeInterval.day, step: 1, formatter: Formatters.time("%a %e") },
-      { interval: TimeInterval.month, step: 1, formatter: Formatters.time("%B %Y") },
-    ],
-    [
-      { interval: TimeInterval.day, step: 1, formatter: Formatters.time("%e") },
-      { interval: TimeInterval.month, step: 1, formatter: Formatters.time("%B %Y") },
-    ],
-    [
-      { interval: TimeInterval.month, step: 1, formatter: Formatters.time("%B") },
-      { interval: TimeInterval.year, step: 1, formatter: Formatters.time("%Y") },
-    ],
-    [
-      { interval: TimeInterval.month, step: 1, formatter: Formatters.time("%b") },
-      { interval: TimeInterval.year, step: 1, formatter: Formatters.time("%Y") },
-    ],
-    [
-      { interval: TimeInterval.month, step: 3, formatter: Formatters.time("%b") },
-      { interval: TimeInterval.year, step: 1, formatter: Formatters.time("%Y") },
-    ],
-    [
-      { interval: TimeInterval.month, step: 6, formatter: Formatters.time("%b") },
-      { interval: TimeInterval.year, step: 1, formatter: Formatters.time("%Y") },
-    ],
-    [
-      { interval: TimeInterval.year, step: 1, formatter: Formatters.time("%Y") },
-    ],
-    [
-      { interval: TimeInterval.year, step: 1, formatter: Formatters.time("%y") },
-    ],
-    [
-      { interval: TimeInterval.year, step: 5, formatter: Formatters.time("%Y") },
-    ],
-    [
-      { interval: TimeInterval.year, step: 25, formatter: Formatters.time("%Y") },
-    ],
-    [
-      { interval: TimeInterval.year, step: 50, formatter: Formatters.time("%Y") },
-    ],
-    [
-      { interval: TimeInterval.year, step: 100, formatter: Formatters.time("%Y") },
-    ],
-    [
-      { interval: TimeInterval.year, step: 200, formatter: Formatters.time("%Y") },
-    ],
-    [
-      { interval: TimeInterval.year, step: 500, formatter: Formatters.time("%Y") },
-    ],
-    [
-      { interval: TimeInterval.year, step: 1000, formatter: Formatters.time("%Y") },
-    ],
-  ];
+  private static _DEFAULT_TIME_AXIS_CONFIGURATIONS = (useUTC: boolean) => {
+    const formatter = (specifier: string) => Formatters.time(specifier, useUTC);
+    return [
+      [
+        { interval: TimeInterval.second, step: 1, formatter: formatter("%I:%M:%S %p") },
+        { interval: TimeInterval.day, step: 1, formatter: formatter("%B %e, %Y") },
+      ],
+      [
+        { interval: TimeInterval.second, step: 5, formatter: formatter("%I:%M:%S %p") },
+        { interval: TimeInterval.day, step: 1, formatter: formatter("%B %e, %Y") },
+      ],
+      [
+        { interval: TimeInterval.second, step: 10, formatter: formatter("%I:%M:%S %p") },
+        { interval: TimeInterval.day, step: 1, formatter: formatter("%B %e, %Y") },
+      ],
+      [
+        { interval: TimeInterval.second, step: 15, formatter: formatter("%I:%M:%S %p") },
+        { interval: TimeInterval.day, step: 1, formatter: formatter("%B %e, %Y") },
+      ],
+      [
+        { interval: TimeInterval.second, step: 30, formatter: formatter("%I:%M:%S %p") },
+        { interval: TimeInterval.day, step: 1, formatter: formatter("%B %e, %Y") },
+      ],
+      [
+        { interval: TimeInterval.minute, step: 1, formatter: formatter("%I:%M %p") },
+        { interval: TimeInterval.day, step: 1, formatter: formatter("%B %e, %Y") },
+      ],
+      [
+        { interval: TimeInterval.minute, step: 5, formatter: formatter("%I:%M %p") },
+        { interval: TimeInterval.day, step: 1, formatter: formatter("%B %e, %Y") },
+      ],
+      [
+        { interval: TimeInterval.minute, step: 10, formatter: formatter("%I:%M %p") },
+        { interval: TimeInterval.day, step: 1, formatter: formatter("%B %e, %Y") },
+      ],
+      [
+        { interval: TimeInterval.minute, step: 15, formatter: formatter("%I:%M %p") },
+        { interval: TimeInterval.day, step: 1, formatter: formatter("%B %e, %Y") },
+      ],
+      [
+        { interval: TimeInterval.minute, step: 30, formatter: formatter("%I:%M %p") },
+        { interval: TimeInterval.day, step: 1, formatter: formatter("%B %e, %Y") },
+      ],
+      [
+        { interval: TimeInterval.hour, step: 1, formatter: formatter("%I %p") },
+        { interval: TimeInterval.day, step: 1, formatter: formatter("%B %e, %Y") },
+      ],
+      [
+        { interval: TimeInterval.hour, step: 3, formatter: formatter("%I %p") },
+        { interval: TimeInterval.day, step: 1, formatter: formatter("%B %e, %Y") },
+      ],
+      [
+        { interval: TimeInterval.hour, step: 6, formatter: formatter("%I %p") },
+        { interval: TimeInterval.day, step: 1, formatter: formatter("%B %e, %Y") },
+      ],
+      [
+        { interval: TimeInterval.hour, step: 12, formatter: formatter("%I %p") },
+        { interval: TimeInterval.day, step: 1, formatter: formatter("%B %e, %Y") },
+      ],
+      [
+        { interval: TimeInterval.day, step: 1, formatter: formatter("%a %e") },
+        { interval: TimeInterval.month, step: 1, formatter: formatter("%B %Y") },
+      ],
+      [
+        { interval: TimeInterval.day, step: 1, formatter: formatter("%e") },
+        { interval: TimeInterval.month, step: 1, formatter: formatter("%B %Y") },
+      ],
+      [
+        { interval: TimeInterval.month, step: 1, formatter: formatter("%B") },
+        { interval: TimeInterval.year, step: 1, formatter: formatter("%Y") },
+      ],
+      [
+        { interval: TimeInterval.month, step: 1, formatter: formatter("%b") },
+        { interval: TimeInterval.year, step: 1, formatter: formatter("%Y") },
+      ],
+      [
+        { interval: TimeInterval.month, step: 3, formatter: formatter("%b") },
+        { interval: TimeInterval.year, step: 1, formatter: formatter("%Y") },
+      ],
+      [
+        { interval: TimeInterval.month, step: 6, formatter: formatter("%b") },
+        { interval: TimeInterval.year, step: 1, formatter: formatter("%Y") },
+      ],
+      [
+        { interval: TimeInterval.year, step: 1, formatter: formatter("%Y") },
+      ],
+      [
+        { interval: TimeInterval.year, step: 1, formatter: formatter("%y") },
+      ],
+      [
+        { interval: TimeInterval.year, step: 5, formatter: formatter("%Y") },
+      ],
+      [
+        { interval: TimeInterval.year, step: 25, formatter: formatter("%Y") },
+      ],
+      [
+        { interval: TimeInterval.year, step: 50, formatter: formatter("%Y") },
+      ],
+      [
+        { interval: TimeInterval.year, step: 100, formatter: formatter("%Y") },
+      ],
+      [
+        { interval: TimeInterval.year, step: 200, formatter: formatter("%Y") },
+      ],
+      [
+        { interval: TimeInterval.year, step: 500, formatter: formatter("%Y") },
+      ],
+      [
+        { interval: TimeInterval.year, step: 1000, formatter: formatter("%Y") },
+      ],
+    ];
+  }
 
   private _tierLabelContainers: SimpleSelection<void>[];
   private _tierMarkContainers: SimpleSelection<void>[];
@@ -213,14 +216,15 @@ export class Time extends Axis<Date> {
    * @constructor
    * @param {Scales.Time} scale
    * @param {AxisOrientation} orientation Orientation of this Time Axis. Time Axes can only have "top" or "bottom"
+   * @param {boolean} useUTC Displays date object in UTC if true, local time if false. Defaults to false.
    * orientations.
    */
-  constructor(scale: Scales.Time, orientation: TimeAxisOrientation) {
+  constructor(scale: Scales.Time, orientation: TimeAxisOrientation, useUTC?: boolean) {
     super(scale, orientation);
     this.addClass("time-axis");
     this.tickLabelPadding(5);
-    this.axisConfigurations(Time._DEFAULT_TIME_AXIS_CONFIGURATIONS);
-    this.annotationFormatter(Formatters.time("%a %b %d, %Y"));
+    this.axisConfigurations(Time._DEFAULT_TIME_AXIS_CONFIGURATIONS(useUTC));
+    this.annotationFormatter(Formatters.time("%a %b %d, %Y", false));
   }
 
   /**

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -193,7 +193,7 @@ export class Time extends Axis<Date> {
     ];
   }
 
-  private _useUTC: boolean = false;
+  private _useUTC: boolean;
 
   private _tierLabelContainers: SimpleSelection<void>[];
   private _tierMarkContainers: SimpleSelection<void>[];

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -224,7 +224,7 @@ export class Time extends Axis<Date> {
     this.addClass("time-axis");
     this.tickLabelPadding(5);
     this.axisConfigurations(Time._DEFAULT_TIME_AXIS_CONFIGURATIONS(useUTC));
-    this.annotationFormatter(Formatters.time("%a %b %d, %Y", false));
+    this.annotationFormatter(Formatters.time("%a %b %d, %Y", useUTC));
   }
 
   /**

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -193,6 +193,8 @@ export class Time extends Axis<Date> {
     ];
   }
 
+  private _useUTC: boolean = false;
+
   private _tierLabelContainers: SimpleSelection<void>[];
   private _tierMarkContainers: SimpleSelection<void>[];
   private _tierBaselines: SimpleSelection<void>[];
@@ -221,10 +223,11 @@ export class Time extends Axis<Date> {
    */
   constructor(scale: Scales.Time, orientation: TimeAxisOrientation, useUTC?: boolean) {
     super(scale, orientation);
+    this._useUTC = useUTC;
     this.addClass("time-axis");
     this.tickLabelPadding(5);
-    this.axisConfigurations(Time._DEFAULT_TIME_AXIS_CONFIGURATIONS(useUTC));
-    this.annotationFormatter(Formatters.time("%a %b %d, %Y", useUTC));
+    this.axisConfigurations(Time._DEFAULT_TIME_AXIS_CONFIGURATIONS(this._useUTC));
+    this.annotationFormatter(Formatters.time("%a %b %d, %Y", this._useUTC));
   }
 
   /**
@@ -439,7 +442,7 @@ export class Time extends Axis<Date> {
   }
 
   private _getTickIntervalValues(config: TimeAxisTierConfiguration): any[] {
-    return (<Scales.Time> this._scale).tickInterval(config.interval, config.step);
+    return (<Scales.Time> this._scale).tickInterval(config.interval, config.step, this._useUTC);
   }
 
   protected _getTickValues() {
@@ -458,7 +461,7 @@ export class Time extends Axis<Date> {
   }
 
   private _getTickValuesForConfiguration(config: TimeAxisTierConfiguration) {
-    const tickPos = (<Scales.Time> this._scale).tickInterval(config.interval, config.step);
+    const tickPos = (<Scales.Time> this._scale).tickInterval(config.interval, config.step, this._useUTC);
     const domain = this._scale.domain();
     const tickPosValues = tickPos.map((d: Date) => d.valueOf()); // can't indexOf with objects
     if (tickPosValues.indexOf(domain[0].valueOf()) === -1) {

--- a/src/axes/timeAxis.ts
+++ b/src/axes/timeAxis.ts
@@ -368,7 +368,7 @@ export class Time extends Axis<Date> {
 
   private _getIntervalLength(config: TimeAxisTierConfiguration) {
     const startDate = this._scale.domain()[0];
-    const d3Interval = Scales.Time.timeIntervalToD3Time(config.interval);
+    const d3Interval = Scales.Time.timeIntervalToD3Time(config.interval, this._useUTC);
     const endDate = d3Interval.offset(startDate, config.step);
     if (endDate > this._scale.domain()[1]) {
       // this offset is too large, so just return available width

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -244,6 +244,7 @@ export function multiTime() {
  * List of directives can be found on: https://github.com/mbostock/d3/wiki/Time-Formatting#format
  *
  * @param {string} [specifier] The specifier for the formatter.
+ * @param {boolean} [useUTC] Displays time in UTC if true, local time if false.
  *
  * @returns {Formatter} A formatter for time/date values.
  */

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -234,7 +234,7 @@ export function multiTime() {
       ? acceptableFormats[0].specifier
       : "%Y";
 
-    return d3.utcFormat(specifier)(d);
+    return d3.timeFormat(specifier)(d);
   };
 }
 
@@ -247,8 +247,11 @@ export function multiTime() {
  *
  * @returns {Formatter} A formatter for time/date values.
  */
-export function time(specifier: string): Formatter {
-  return d3.utcFormat(specifier);
+export function time(specifier: string, useUTC?: boolean): Formatter {
+  if (useUTC) {
+    return d3.utcFormat(specifier);
+  }
+  return d3.timeFormat(specifier);
 }
 
 function verifyPrecision(precision: number) {

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -6,6 +6,9 @@
 import * as d3 from "d3";
 import { Dataset } from "./dataset";
 
+// Do not use utc by default
+const DEFAULT_USE_UTC = false;
+
 /**
  * A basic formatter function that will be passed a value to format (e.g. the tick value for axes).
  * A Formatter should return the formatted string representation of the input value.
@@ -244,11 +247,11 @@ export function multiTime() {
  * List of directives can be found on: https://github.com/mbostock/d3/wiki/Time-Formatting#format
  *
  * @param {string} [specifier] The specifier for the formatter.
- * @param {boolean} [useUTC] Displays time in UTC if true, local time if false.
+ * @param {boolean} [useUTC] Displays time in UTC if true, local time if false. Defaults to false.
  *
  * @returns {Formatter} A formatter for time/date values.
  */
-export function time(specifier: string, useUTC?: boolean): Formatter {
+export function time(specifier: string, useUTC: boolean = DEFAULT_USE_UTC): Formatter {
   if (useUTC) {
     return d3.utcFormat(specifier);
   }

--- a/src/core/formatters.ts
+++ b/src/core/formatters.ts
@@ -234,7 +234,7 @@ export function multiTime() {
       ? acceptableFormats[0].specifier
       : "%Y";
 
-    return d3.timeFormat(specifier)(d);
+    return d3.utcFormat(specifier)(d);
   };
 }
 
@@ -248,7 +248,7 @@ export function multiTime() {
  * @returns {Formatter} A formatter for time/date values.
  */
 export function time(specifier: string): Formatter {
-  return d3.timeFormat(specifier);
+  return d3.utcFormat(specifier);
 }
 
 function verifyPrecision(precision: number) {

--- a/src/scales/timeScale.ts
+++ b/src/scales/timeScale.ts
@@ -30,10 +30,10 @@ export class Time extends QuantitativeScale<Date> {
    * @param {number?} [step] The number of multiples of the interval between consecutive ticks.
    * @return {Date[]}
    */
-  public tickInterval(interval: string, step: number = 1): Date[] {
+  public tickInterval(interval: string, step: number = 1, useUTC: boolean = false): Date[] {
     // temporarily creats a time scale from our linear scale into a time scale so we can get access to its api
     const tempScale = d3.scaleTime();
-    const d3Interval = Time.timeIntervalToD3Time(interval).every(step);
+    const d3Interval = Time.timeIntervalToD3Time(interval, useUTC).every(step);
     tempScale.domain(this.domain());
     tempScale.range(this.range());
     return tempScale.ticks(d3Interval);
@@ -128,22 +128,22 @@ export class Time extends QuantitativeScale<Date> {
    * Transforms the Plottable TimeInterval string into a d3 time interval equivalent.
    * If the provided TimeInterval is incorrect, the default is d3.timeYear
    */
-  public static timeIntervalToD3Time(timeInterval: string): d3.CountableTimeInterval {
+  public static timeIntervalToD3Time(timeInterval: string, useUTC: boolean): d3.CountableTimeInterval {
     switch (timeInterval) {
       case TimeInterval.second:
-        return d3.timeSecond;
+        return useUTC ? d3.utcSecond : d3.timeSecond;
       case TimeInterval.minute:
-        return d3.timeMinute;
+        return useUTC ? d3.utcMinute : d3.timeMinute;
       case TimeInterval.hour:
-        return d3.timeHour;
+        return useUTC ? d3.utcHour : d3.timeHour;
       case TimeInterval.day:
-        return d3.timeDay;
+        return useUTC ? d3.utcDay : d3.timeDay;
       case TimeInterval.week:
-        return d3.timeWeek;
+        return useUTC ? d3.utcWeek : d3.timeWeek;
       case TimeInterval.month:
-        return d3.timeMonth;
+        return useUTC ? d3.utcMonth : d3.timeMonth;
       case TimeInterval.year:
-        return d3.timeYear;
+        return useUTC ? d3.utcYear : d3.timeYear;
       default:
         throw Error("TimeInterval specified does not exist: " + timeInterval);
     }

--- a/test/core/formattersTests.ts
+++ b/test/core/formattersTests.ts
@@ -181,6 +181,18 @@ describe("Formatters", () => {
     });
   });
 
+  describe("time()", () => {
+    it("defaults to local time", () => {
+      const formatter = Plottable.Formatters.time("%I %p");
+      assert.strictEqual(formatter(new Date(2000, 0, 1, 0, 0, 0, 0)), "12 AM");
+    });
+
+    it("formats to UTC accordingly", () => {
+      const formatter = Plottable.Formatters.time("%I %p", true);
+      assert.strictEqual(formatter(new Date(Date.UTC(2000, 0, 1, 0, 0, 0, 0))), "12 AM");
+    });
+  });
+
   describe("percentage()", () => {
     it("formats number to percetage with correct precision", () => {
       const percentFormatter = Plottable.Formatters.percentage();


### PR DESCRIPTION
This PR allows for `Plottable.Formatters.time` to display dates in UTC in addition to local time with the addition of an optional boolean `useUTC`.

This flag is also passed down from the `TimeAxis` constructor which also contains the additional `useUTC` flag.

For us, this solves a business requirement of displaying time in UTC without having to modify the underlying Date objects, which has a number of drawbacks.