### PR TITLE
Fix selection mismatch on nearest entity due to hidden elements

### DIFF
--- a/quicktests/overlaying/tests/interactions/select_bars.js
+++ b/quicktests/overlaying/tests/interactions/select_bars.js
@@ -1,0 +1,48 @@
+
+function makeData() {
+    "use strict";
+
+    return [
+        {x: 1, y: 10},
+        {x: 2, y: 20},
+        {x: 3, y: 10},
+        {x: 4, y: 30},
+        {x: 5, y: 10},
+        {x: 6, y: 60},
+        {x: 7, y: 20},
+    ];
+}
+
+function run(svg, data, Plottable) {
+    "use strict";
+
+    var xScale = new Plottable.Scales.Linear();
+    var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
+
+    // exposes selection misalignment issue
+    xScale.domainMin(3);
+
+    var yScale = new Plottable.Scales.Linear();
+    var yAxis = new Plottable.Axes.Numeric(yScale, "left");
+
+    var barPlot = new Plottable.Plots.Bar()
+        .addDataset(new Plottable.Dataset(data))
+        .x(function(d) { return d.x; }, xScale)
+        .y(function(d) { return d.y; }, yScale);
+
+    new Plottable.Components.Table([
+        [yAxis, barPlot],
+        [null,  xAxis],
+    ]).renderTo(svg);
+
+    var clickInteraction = new Plottable.Interactions.Click();
+    clickInteraction.attachTo(barPlot);
+    clickInteraction.onClick(function (p) {
+        barPlot.selections().style("fill", null);
+        var bars = barPlot.entitiesAt(p);
+        if (bars) {
+            bars.forEach(function(bar) { bar.selection.style("fill", "red"); });
+        }
+    });
+
+}

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -841,7 +841,7 @@ export class Plot extends Component {
       datum: entity.datum,
       index: entity.index,
       position: entity.position,
-      selection: d3.select(entity.drawer.getVisualPrimitives()[entity.validDatumIndex]),
+      selection: d3.select(entity.drawer.getVisualPrimitiveAtIndex(entity.validDatumIndex)),
     };
     return plotEntity;
   }

--- a/test/core/symbolFactoriesTests.ts
+++ b/test/core/symbolFactoriesTests.ts
@@ -10,6 +10,7 @@ describe("SymbolFactory", () => {
   describe("Generates correct path", () => {
     let svg: d3.Selection<SVGSVGElement, any, any, any>;
     const symbolSize = 5;
+    const epsilon = 0.1;
 
     beforeEach(() => {
       svg = TestMethods.generateSVG();
@@ -23,10 +24,10 @@ describe("SymbolFactory", () => {
       assert.strictEqual(d, expectedD, "a circle of set size is generated");
       const path = svg.append("path").attr("d", d);
       const bbox = Plottable.Utils.DOM.elementBBox(path);
-      assert.strictEqual(bbox.height, symbolSize, "height is as set");
-      assert.strictEqual(bbox.width, symbolSize, "width is as set");
-      assert.strictEqual(bbox.x, -bbox.width / 2, "x is centered in the middle");
-      assert.strictEqual(bbox.y, -bbox.height / 2, "y is centered in the middle");
+      assert.closeTo(bbox.height, symbolSize, epsilon, "height is as set");
+      assert.closeTo(bbox.width, symbolSize, epsilon, "width is as set");
+      assert.closeTo(bbox.x, -bbox.width / 2, epsilon, "x is centered in the middle");
+      assert.closeTo(bbox.y, -bbox.height / 2, epsilon,"y is centered in the middle");
       svg.remove();
     });
 

--- a/test/plots/barPlotTests.ts
+++ b/test/plots/barPlotTests.ts
@@ -601,14 +601,14 @@ describe("Plots", () => {
           };
         }
 
-        function expectedEntityForIndex(index: number) {
-          const datum = data[index];
+        function expectedEntityForIndex(sourceDataIndex: number, visibleElementIndex: number) {
+          const datum = data[sourceDataIndex];
           const basePosition = baseScale.scale(datum.base);
           const valuePosition = valueScale.scale(datum.value);
-          const element = barPlot.content().selectAll<Element, any>("rect").nodes()[index];
+          const element = barPlot.content().selectAll<Element, any>("rect").nodes()[visibleElementIndex];
           return {
             datum: datum,
-            index: index,
+            index: sourceDataIndex,
             dataset: dataset,
             datasetIndex: 0,
             position: getPointFromBaseAndValuePositions(basePosition, valuePosition),
@@ -621,7 +621,7 @@ describe("Plots", () => {
         describe("retrieving the nearest Entity", () => {
           function testEntityNearest() {
             data.forEach((datum, index) => {
-              const expectedEntity = expectedEntityForIndex(index);
+              const expectedEntity = expectedEntityForIndex(index, index);
 
               const barBasePosition = baseScale.scale(datum.base);
 
@@ -655,7 +655,7 @@ describe("Plots", () => {
             const baselineValuePosition = valueScale.scale(barPlot.baselineValue());
 
             const nearestEntity = barPlot.entityNearest(getPointFromBaseAndValuePositions(bar0BasePosition, baselineValuePosition));
-            const expectedEntity = expectedEntityForIndex(1); // nearest visible bar
+            const expectedEntity = expectedEntityForIndex(1, 0); // nearest visible bar
             TestMethods.assertPlotEntitiesEqual(nearestEntity, expectedEntity, "returned Entity for nearest in-view bar");
           });
 
@@ -686,7 +686,7 @@ describe("Plots", () => {
               if (datum.value === barPlot.baselineValue()) {
                 return; // bar has no height
               }
-              const expectedEntity = expectedEntityForIndex(index);
+              const expectedEntity = expectedEntityForIndex(index, index);
 
               const barBasePosition = baseScale.scale(datum.base);
 
@@ -721,7 +721,7 @@ describe("Plots", () => {
             const entitiesInRange = isVertical ? barPlot.entitiesIn(baseRange, fullSizeValueRange)
                                                : barPlot.entitiesIn(fullSizeValueRange, baseRange);
             assert.lengthOf(entitiesInRange, 1, "retrieved two Entities when range intersects one bar");
-            TestMethods.assertPlotEntitiesEqual(entitiesInRange[0], expectedEntityForIndex(0), "Entity corresponds to bar 0");
+            TestMethods.assertPlotEntitiesEqual(entitiesInRange[0], expectedEntityForIndex(0, 0), "Entity corresponds to bar 0");
           });
 
           it("returns the Entity if the range includes any part of the bar", () => {
@@ -738,7 +738,7 @@ describe("Plots", () => {
             const entitiesInRange = isVertical ? barPlot.entitiesIn(fullSizeBaseRange, valueRange)
                                                : barPlot.entitiesIn(valueRange, fullSizeBaseRange);
             assert.lengthOf(entitiesInRange, 1, "retrieved one entity when range intersects one bar");
-            TestMethods.assertPlotEntitiesEqual(entitiesInRange[0], expectedEntityForIndex(0), "Entity corresponds to bar 0");
+            TestMethods.assertPlotEntitiesEqual(entitiesInRange[0], expectedEntityForIndex(0, 0), "Entity corresponds to bar 0");
           });
         });
       });


### PR DESCRIPTION
Some features would cause a mismatch in the nearest entity `d3.selection`. This occurred because the source dataset indices that generate SVG elements were not properly maintained.

With this change, we store the original source dataset index for each rendered SVG entity.