### PR TITLE
remove font-family declarations from plottable.css

### DIFF
--- a/plottable.css
+++ b/plottable.css
@@ -109,19 +109,16 @@
 }
 
 .plottable .label text {
-  font-family: "Helvetica Neue", sans-serif;
   fill: #32313F;
 }
 
 .plottable .bar-label-text-area text,
 .plottable .scatter-label-text-area text {
-  font-family: "Helvetica Neue", sans-serif;
   font-size: 12px;
 }
 
 .plottable .label-area text {
   fill: #32313F;
-  font-family: "Helvetica Neue", sans-serif;
   font-size: 14px;
 }
 
@@ -172,7 +169,6 @@
 
 .plottable .axis text {
   fill: #32313F;
-  font-family: "Helvetica Neue", sans-serif;
   font-size: 12px;
   font-weight: 200;
   line-height: normal;
@@ -260,7 +256,6 @@
 
 .plottable .legend text {
   fill: #32313F;
-  font-family: "Helvetica Neue", sans-serif;
   font-size: 12px;
   font-weight: bold;
   line-height: normal;


### PR DESCRIPTION
these `font-family` declarations cause problems in downstream libraries that use custom fonts.
removing them allows charts to instantly inherit surrounding fonts.

🔥 this is a slight breaking style change as it affects chart appearance.