### PR TITLE
Perf: Make scatter point color computation faster

### DIFF
--- a/quicktests/overlaying/tests/basic/canvas_bar.js
+++ b/quicktests/overlaying/tests/basic/canvas_bar.js
@@ -1,0 +1,69 @@
+function makeData() {
+  "use strict";
+
+  // makes 10 datasets of 10000 points
+  return Array.apply(null, Array(1)).map((_, datasetIndex) => {
+    return Array.apply(null, Array(5*10000)).map((_, i) => {
+      return {
+        // one data point per day, offset by one hour per dataset
+        x: new Date(i * 1000 * 3600 * 24 + datasetIndex * 1000 * 3600),
+        y: datasetIndex + Math.random()
+      };
+    });
+  });
+}
+
+function run(div, data, Plottable) {
+  "use strict";
+  var xScale = new Plottable.Scales.Time()
+    .padProportion(0);
+  var yScale = new Plottable.Scales.Linear();
+  var xAxis = new Plottable.Axes.Time(xScale, "bottom");
+  var yAxis = new Plottable.Axes.Numeric(yScale, "left");
+  var colorScale = new Plottable.Scales.Color();
+
+  const datasets = data.map((dataArray, index) => {
+    return new Plottable.Dataset(dataArray).metadata(index);
+  });
+  var plot = new Plottable.Plots.Bar()
+    .datasets(datasets)
+    .renderer("canvas")
+    .deferredRendering(true)
+    .x((d) => d.x, xScale)
+    .y((d) => d.y, yScale)
+    .attr("gap", () => 0)
+    .attr("fill", (d,i,ds) => ds.metadata(), colorScale);
+
+  var table = new Plottable.Components.Table([
+    [yAxis, plot],
+    [null, xAxis]
+  ]);
+
+  const defaultEntityLabel = "Hover for nearest entity";
+  const nearestEntityLabel = div.append("div").style("text-align", "center").text(defaultEntityLabel);
+  new Plottable.Interactions.Pointer()
+    .onPointerMove((p) => {
+      const nearestEntity = plot.entityNearest(p);
+      let text = defaultEntityLabel;
+      if (nearestEntity != null) {
+        const datum = nearestEntity.datum;
+        if (datum != null) {
+          text = `Nearest Entity: ${datum.x.toString()} ${datum.y.toFixed(2)}`;
+        }
+      }
+      nearestEntityLabel.text(text);
+    })
+    .onPointerExit(() => {
+      nearestEntityLabel.text(defaultEntityLabel);
+    })
+    .attachTo(plot);
+
+  new Plottable.Interactions.PanZoom(xScale, null)
+    .attachTo(plot);
+
+  table.renderTo(div);
+
+  window.addEventListener("resize", () => {
+    table.redraw();
+  });
+}

--- a/quicktests/overlaying/tests/basic/canvas_scatter.js
+++ b/quicktests/overlaying/tests/basic/canvas_scatter.js
@@ -1,3 +1,7 @@
+
+const POINT_COUNT = 100*1000;
+const BUFFER_INVALIDATE_PERIOD = 100;
+
 function makeData() {
   "use strict";
 
@@ -10,7 +14,7 @@ function makeData() {
   };
 
   var data = [];
-  for (var i = 0; i < 100*1000; i++) {
+  for (var i = 0; i < POINT_COUNT; i++) {
     data.push(boxMuller({
       x: Math.random(),
       y: Math.random(),
@@ -24,6 +28,7 @@ function run(div, data, Plottable) {
 
   var xScale = new Plottable.Scales.Linear();
   var yScale = new Plottable.Scales.Linear();
+  var colorScale = new Plottable.Scales.Color();
   var xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
   var yAxis = new Plottable.Axes.Numeric(yScale, "left");
 
@@ -39,10 +44,11 @@ function run(div, data, Plottable) {
     .renderer("canvas")
     .deferredRendering(true)
     .addDataset(new Plottable.Dataset(data))
+    .attr("fill", (d, i) => colorScale.scale(Math.floor(i / BUFFER_INVALIDATE_PERIOD) % 50))
     .x((d) => d.x, xScale)
     .y((d) => d.y, yScale)
-    .size((d, i) => 6 + (Math.floor(i / 100) % 6) * 4)
-    .symbol((d, i) => symbols[Math.floor(i / 100) % 3]);
+    .size((d, i) => 6 + (Math.floor(i / BUFFER_INVALIDATE_PERIOD) % 6) * 4)
+    .symbol((d, i) => symbols[Math.floor(i / BUFFER_INVALIDATE_PERIOD) % 3]);
 
   var table = new Plottable.Components.Table([
     [yAxis, plot],


### PR DESCRIPTION
- Update scatter plot example with varies colors
- Add high-scale canvas bar plot example
- Previously, color computations in the inner render loop
were making many calls to .domain() and .range(). These
have negative impact on performance, so instead we carefully
cache the relevant information instead of constantly
recomputing it.