### PR TITLE
Remove gap from bar thickness if width of bar is below threshold

### DIFF
--- a/quicktests/overlaying/tests/basic/canvas_bar.js
+++ b/quicktests/overlaying/tests/basic/canvas_bar.js
@@ -1,13 +1,12 @@
 function makeData() {
   "use strict";
 
-  // makes 10 datasets of 10000 points
   return Array.apply(null, Array(1)).map((_, datasetIndex) => {
-    return Array.apply(null, Array(5*10000)).map((_, i) => {
+    return Array.apply(null, Array(1000)).map((_, i) => {
       return {
         // one data point per day, offset by one hour per dataset
         x: new Date(i * 1000 * 3600 * 24 + datasetIndex * 1000 * 3600),
-        y: datasetIndex + Math.random()
+        y: datasetIndex + 10 + Math.random()
       };
     });
   });
@@ -30,8 +29,9 @@ function run(div, data, Plottable) {
     .renderer("canvas")
     .deferredRendering(true)
     .x((d) => d.x, xScale)
+    .barEnd((d) => new Date(1000 * 3600 * 24 + d.x.valueOf()))
     .y((d) => d.y, yScale)
-    .attr("gap", () => 0)
+    .attr("gap", () => 1)
     .attr("fill", (d,i,ds) => ds.metadata(), colorScale);
 
   var table = new Plottable.Components.Table([

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -51,6 +51,7 @@ export type BarAlignment = keyof typeof BarAlignment;
 
 export class Bar<X, Y> extends XYPlot<X, Y> {
   public static _BAR_THICKNESS_RATIO = 0.95;
+  public static _BAR_GAPLESS_THRESHOLD_PX = 3;
   public static _SINGLE_BAR_DIMENSION_RATIO = 0.4;
   private static _BAR_AREA_CLASS = "bar-area";
   private static _BAR_END_KEY = "barEnd";
@@ -751,7 +752,11 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
     const thicknessF = attrToProjector[Bar._BAR_THICKNESS_KEY];
     const gapF = attrToProjector["gap"];
     const thicknessMinusGap = gapF == null ? thicknessF : (d: any, i: number, dataset: Dataset) => {
-      return thicknessF(d, i, dataset) - gapF(d, i, dataset);
+      const thick = thicknessF(d, i, dataset);
+      // only subtract gap if bars are at least 2 pixels wide, otherwise canvas
+      // interpolation can cause bars to become invisible due to subpixel
+      // sampling
+      return thick < Bar._BAR_GAPLESS_THRESHOLD_PX ? thick : thick - gapF(d, i, dataset);
     };
 
     // re-interpret "width" attr from representing "thickness" to actually meaning


### PR DESCRIPTION
This prevents bars from dissappearing at just the right
resolution and zoom level due to pixel sampling moire