### PR TITLE
Fix stackOverflow in EntityStore with large XYPlots

### DIFF
--- a/src/utils/entityStore.ts
+++ b/src/utils/entityStore.ts
@@ -109,7 +109,7 @@ export class EntityStore<T extends IPositionedEntity> implements IEntityStore<T>
   }
 
   public addAll(entities: T[], entityBoundsFactory: (entity: T) => IEntityBounds, bounds?: Bounds) {
-    this._entities.push(...entities);
+    this._entities = this._entities.concat(entities);
 
     // filter out of bounds entities if bounds is defined
     if (bounds !== undefined) {


### PR DESCRIPTION
When you have a lot of UI elements, this spread (compiled to `.push.apply(this._entities, entities)`) causes a Maximum Call Stack Exceeded error. Also, `.concat` is seemingly faster than the `.push` most of the time: https://jsperf.com/es6-add-element-to-create-new-array-concat-vs-spread-op

Also, when this exception gets throw, the lock is never released somewhere in StackedBar and at that point your chart is hosed.