### PR TITLE
Expose autoDomainIfAutomaticMode in public API

### DIFF
--- a/src/scales/interpolatedColorScale.ts
+++ b/src/scales/interpolatedColorScale.ts
@@ -128,7 +128,7 @@ export class InterpolatedColor extends Scale<number, string> {
 
   private _resetScale(): any {
     this._d3Scale = this._d3InterpolatedScale();
-    this._autoDomainIfAutomaticMode();
+    this.autoDomainIfAutomaticMode();
     this._dispatchUpdate();
   }
 

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -66,7 +66,7 @@ export class QuantitativeScale<D> extends Scale<D, number> implements ITransform
       return;
     }
 
-    super._autoDomainIfAutomaticMode();
+    super.autoDomainIfAutomaticMode();
   }
 
   protected _getUnboundedExtent(ignoreAttachState = false): D[] {

--- a/src/scales/quantitativeScale.ts
+++ b/src/scales/quantitativeScale.ts
@@ -40,7 +40,7 @@ export class QuantitativeScale<D> extends Scale<D, number> implements ITransform
     return this;
   }
 
-  protected _autoDomainIfAutomaticMode() {
+  public autoDomainIfAutomaticMode() {
     if (this._domainMin != null && this._domainMax != null) {
       this._setDomain([this._domainMin, this._domainMax]);
       return;
@@ -103,7 +103,7 @@ export class QuantitativeScale<D> extends Scale<D, number> implements ITransform
    */
   public addPaddingExceptionsProvider(provider: Scales.IPaddingExceptionsProvider<D>) {
     this._paddingExceptionsProviders.add(provider);
-    this._autoDomainIfAutomaticMode();
+    this.autoDomainIfAutomaticMode();
     return this;
   }
 
@@ -115,7 +115,7 @@ export class QuantitativeScale<D> extends Scale<D, number> implements ITransform
    */
   public removePaddingExceptionsProvider(provider: Scales.IPaddingExceptionsProvider<D>) {
     this._paddingExceptionsProviders.delete(provider);
-    this._autoDomainIfAutomaticMode();
+    this.autoDomainIfAutomaticMode();
     return this;
   }
 
@@ -140,7 +140,7 @@ export class QuantitativeScale<D> extends Scale<D, number> implements ITransform
       throw new Error("padProportion must be non-negative");
     }
     this._padProportion = padProportion;
-    this._autoDomainIfAutomaticMode();
+    this.autoDomainIfAutomaticMode();
     return this;
   }
 
@@ -194,7 +194,7 @@ export class QuantitativeScale<D> extends Scale<D, number> implements ITransform
     }
 
     this._snappingDomainEnabled = snappingDomainEnabled;
-    this._autoDomainIfAutomaticMode();
+    this.autoDomainIfAutomaticMode();
     return this;
   }
 
@@ -239,7 +239,7 @@ export class QuantitativeScale<D> extends Scale<D, number> implements ITransform
       return this.domain()[0];
     }
     this._domainMin = domainMin;
-    this._autoDomainIfAutomaticMode();
+    this.autoDomainIfAutomaticMode();
     return this;
   }
 
@@ -260,7 +260,7 @@ export class QuantitativeScale<D> extends Scale<D, number> implements ITransform
       return this.domain()[1];
     }
     this._domainMax = domainMax;
-    this._autoDomainIfAutomaticMode();
+    this.autoDomainIfAutomaticMode();
     return this;
   }
 

--- a/src/scales/scale.ts
+++ b/src/scales/scale.ts
@@ -90,7 +90,10 @@ export class Scale<D, R> {
     return this;
   }
 
-  protected _autoDomainIfAutomaticMode() {
+  /**
+   * Triggers `.autoDomain()` if the domain is not explicitly set.
+   */
+  public autoDomainIfAutomaticMode() {
     if (this._autoDomainAutomatically) {
       this.autoDomain();
     }
@@ -195,7 +198,7 @@ export class Scale<D, R> {
    */
   public addIncludedValuesProvider(provider: Scales.IIncludedValuesProvider<D>) {
     this._includedValuesProviders.add(provider);
-    this._autoDomainIfAutomaticMode();
+    this.autoDomainIfAutomaticMode();
     return this;
   }
 
@@ -207,7 +210,7 @@ export class Scale<D, R> {
    */
   public removeIncludedValuesProvider(provider: Scales.IIncludedValuesProvider<D>) {
     this._includedValuesProviders.delete(provider);
-    this._autoDomainIfAutomaticMode();
+    this.autoDomainIfAutomaticMode();
     return this;
   }
 


### PR DESCRIPTION
Simply adds the already existing `Scale.autoDomainIfAutomaticMode` method to the public API