### PR TITLE
Expose y offset for stacked area plots

### DIFF
--- a/quicktests/overlaying/tests/basic/stacked_area_with_scatterplot.js
+++ b/quicktests/overlaying/tests/basic/stacked_area_with_scatterplot.js
@@ -1,0 +1,46 @@
+function makeData() {
+  "use strict";
+
+  var data1 = [{x: 1, y: 5, type: "q1"}, {x: 2, y: 2, type: "q1"}, {x: 3, y: 4, type: "q1"}, {x: 4, y: 2, type: "q1"}];
+  var data2 = [{x: 1, y: 4, type: "q2"}, {x: 2, y: 3, type: "q2"}, {x: 3, y: 3, type: "q2"}, {x: 4, y: 1, type: "q2"}];
+  return [data1, data2];
+}
+  
+function run(svg, data, Plottable) {
+  "use strict";
+
+  var xScale = new Plottable.Scales.Category();
+  var yScale = new Plottable.Scales.Linear();
+  var colorScale = new Plottable.Scales.Color("10");
+
+  var xAxis = new Plottable.Axes.Category(xScale, "bottom");
+  var yAxis = new Plottable.Axes.Numeric(yScale, "left");
+
+  var dataset1 = new Plottable.Dataset(data[0]);
+  var dataset2 = new Plottable.Dataset(data[1])
+
+  var stackedAreaPlot = new Plottable.Plots.StackedArea()
+                                          .renderer("canvas")
+                                          .x(function(d) { return d.x; }, xScale)
+                                          .y(function(d) { return d.y; }, yScale)
+                                          .attr("fill", function(d) { return d.type; }, colorScale)
+                                          .attr("stroke", function(d) { return d.type; }, colorScale)
+                                          .addDataset(dataset1)
+                                          .addDataset(dataset2);
+  var scatterPlot = new Plottable.Plots.Scatter()
+                                          .renderer("canvas")
+                                          .size(10)
+                                          .x(function(d) { return d.x; }, xScale)
+                                          .y(function(d, index, dataset) {
+                                            return stackedAreaPlot.yOffset(dataset, d.x) + d.y;
+                                          }, yScale)
+                                          .attr("fill", function(d) { return d.type; }, colorScale)
+                                          .addDataset(dataset1)
+                                          .addDataset(dataset2); 
+
+  var center = new Plottable.Components.Group([stackedAreaPlot, scatterPlot, new Plottable.Components.Legend(colorScale)]);
+
+  new Plottable.Components.Table([
+    [yAxis, center], [null, xAxis]
+  ]).renderTo(svg);
+}

--- a/src/plots/stackedAreaPlot.ts
+++ b/src/plots/stackedAreaPlot.ts
@@ -129,7 +129,7 @@ export class StackedArea<X> extends Area<X> {
     if (datasetStackingResult == null) {
       return undefined;
     }
-    const result = datasetStackingResult.get(`${x}`);
+    const result = datasetStackingResult.get(String(x));
     if (result == null) {
       return undefined;
     }

--- a/src/plots/stackedAreaPlot.ts
+++ b/src/plots/stackedAreaPlot.ts
@@ -115,6 +115,28 @@ export class StackedArea<X> extends Area<X> {
   }
 
   /**
+   * Gets the offset of the y value corresponding to an x value of a given dataset. This allows other plots to plot
+   * points corresponding to their stacked value in the graph.
+   * @param dataset The dataset from which to retrieve the y value offset
+   * @param x The x value corresponding to the y-value of interest.
+   */
+  public yOffset(dataset: Dataset, x: any): number {
+    const stackingResult = this._stackingResult();
+    if (stackingResult == null) {
+      return undefined;
+    }
+    const datasetStackingResult = stackingResult.get(dataset);
+    if (datasetStackingResult == null) {
+      return undefined;
+    }
+    const result = datasetStackingResult.get(`${x}`);
+    if (result == null) {
+      return undefined;
+    }
+    return result.offset;
+  }
+
+  /**
    * Gets the stacking order of the plot.
    */
   public stackingOrder(): Utils.Stacking.IStackingOrder;


### PR DESCRIPTION
This exposes a `yOffset` method (happy to change name) on the `StackedArea` plot which allows users to retrieve the offset of a given data point on a specific dataset for the purpose of coordinating the display of data across plots that share datasets but some of which are not stacked.

![screen shot 2018-04-30 at 3 24 03 pm](https://user-images.githubusercontent.com/993321/39445900-92015a42-4c8a-11e8-81b1-595122cd1c29.png)
