### PR TITLE
Add 0x0 size check to canvas

### DIFF
--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -230,7 +230,7 @@ export class Plot extends Component {
         if (btx) {
           const originalCanvas = this._canvas.node();
           if (originalCanvas.width > 0 && originalCanvas.height > 0 && btx.canvas.width > 0 && btx.canvas.height > 0) {
-            btx.drawImage(this._canvas.node(), 0, 0);
+            btx.drawImage(originalCanvas, 0, 0);
           }
         }
         this._bufferCanvasValid = true;

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -229,8 +229,12 @@ export class Plot extends Component {
         // for headless test compat (jest)
         if (btx) {
           const originalCanvas = this._canvas.node();
-          if (originalCanvas.width > 0 && originalCanvas.height > 0 && btx.canvas.width > 0 && btx.canvas.height > 0) {
-            btx.drawImage(originalCanvas, 0, 0);
+          if (originalCanvas.width > 0 && originalCanvas.height > 0) {
+            if (btx.canvas.width > 0 && btx.canvas.height > 0) {
+              btx.drawImage(originalCanvas, 0, 0);
+            }
+          } else {
+            console.warn("Failed to fill buffer canvas with with 0x0 canvas");
           }
         }
         this._bufferCanvasValid = true;
@@ -253,9 +257,13 @@ export class Plot extends Component {
 
         if (this._bufferCanvas) {
           const bufferCanvas = this._bufferCanvas.node();
-          if (bufferCanvas.width > 0 && bufferCanvas.height > 0 && ctx.canvas.width > 0 && ctx.canvas.height > 0) {
-            // draw buffer to current canvas at new size
-            ctx.drawImage(bufferCanvas, 0, 0, width, height);
+          if (bufferCanvas.width > 0 && bufferCanvas.height > 0) {
+            if (ctx.canvas.width > 0 && ctx.canvas.height > 0) {
+              // draw buffer to current canvas at new size
+              ctx.drawImage(bufferCanvas, 0, 0, width, height);
+            }
+          } else {
+            console.warn("Failed to fill canvas with 0x0 buffer canvas");
           }
         }
       }

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -251,9 +251,12 @@ export class Plot extends Component {
       if (ctx) {
         ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
 
-        if (this._bufferCanvas && ctx.canvas.width > 0 && ctx.canvas.height > 0) {
-          // draw buffer to current canvas at new size
-          ctx.drawImage(this._bufferCanvas.node(), 0, 0, width, height);
+        if (this._bufferCanvas) {
+          const bufferCanvas = this._bufferCanvas.node();
+          if (bufferCanvas.width > 0 && bufferCanvas.height > 0 && ctx.canvas.width > 0 && ctx.canvas.height > 0) {
+            // draw buffer to current canvas at new size
+            ctx.drawImage(bufferCanvas, 0, 0, width, height);
+          }
         }
       }
     }

--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -228,7 +228,10 @@ export class Plot extends Component {
         const btx = this._bufferCanvas.node().getContext("2d");
         // for headless test compat (jest)
         if (btx) {
-          btx.drawImage(this._canvas.node(), 0, 0);
+          const originalCanvas = this._canvas.node();
+          if (originalCanvas.width > 0 && originalCanvas.height > 0 && btx.canvas.width > 0 && btx.canvas.height > 0) {
+            btx.drawImage(this._canvas.node(), 0, 0);
+          }
         }
         this._bufferCanvasValid = true;
       }
@@ -248,7 +251,7 @@ export class Plot extends Component {
       if (ctx) {
         ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
 
-        if (this._bufferCanvas) {
+        if (this._bufferCanvas && ctx.canvas.width > 0 && ctx.canvas.height > 0) {
           // draw buffer to current canvas at new size
           ctx.drawImage(this._bufferCanvas.node(), 0, 0, width, height);
         }


### PR DESCRIPTION
Prevents error from being thrown when we try to
invoke context.drawImage with an argument
that is a 0x0 canvas.

Instead we just skip the drawImage.