### PR TITLE
Render canvas line plot with multiple styles

### DIFF
--- a/quicktests/overlaying/tests/basic/canvas_line.js
+++ b/quicktests/overlaying/tests/basic/canvas_line.js
@@ -31,7 +31,7 @@ function run(div, data, Plottable) {
     .collapseDenseLinesEnabled(true)
     .x((d) => d.x, xScale)
     .y((d) => d.y, yScale)
-    .attr("opacity", (d, i) => {
+    .attr("opacity", (d) => {
       return d.index / 10000;
     })
     .attr("stroke", (d,i,ds) => ds.metadata(), colorScale);

--- a/quicktests/overlaying/tests/basic/canvas_line.js
+++ b/quicktests/overlaying/tests/basic/canvas_line.js
@@ -7,7 +7,8 @@ function makeData() {
       return {
         // one data point per day, offset by one hour per dataset
         x: new Date(i * 1000 * 3600 * 24 + datasetIndex * 1000 * 3600),
-        y: datasetIndex + Math.random()
+        y: datasetIndex + Math.random(),
+        index: i,
       };
     });
   });
@@ -30,6 +31,9 @@ function run(div, data, Plottable) {
     .collapseDenseLinesEnabled(true)
     .x((d) => d.x, xScale)
     .y((d) => d.y, yScale)
+    .attr("opacity", (d, i) => {
+      return d.index / 10000;
+    })
     .attr("stroke", (d,i,ds) => ds.metadata(), colorScale);
 
   var table = new Plottable.Components.Table([

--- a/src/drawers/canvasDrawer.ts
+++ b/src/drawers/canvasDrawer.ts
@@ -65,6 +65,27 @@ export const ContextStyleAttrs = [
   "stroke-dasharray",
 ];
 
+/**
+ * attributesEqual performs a shallow equality check on two attributes objects.
+ * @param a
+ * @param b
+ * @returns true if a and b are equavalent false otherwise
+ */
+export function attributesEqual(a: Record<string, any>, b: Record<string, any>): boolean {
+  if (a === b) {
+    // literally the same object
+    return true;
+  }
+
+  for (const attrKey of Object.keys(a)) {
+    if (!b.hasOwnProperty(attrKey) || a[attrKey] !== b[attrKey]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 export function resolveAttributesSubsetWithStyles(projector: AttributeToAppliedProjector, extraKeys: string[], datum: any, index: number) {
   const attrKeys = ContextStyleAttrs.concat(extraKeys);
   return resolveAttributes(projector, attrKeys, datum, index);

--- a/src/drawers/lineDrawer.ts
+++ b/src/drawers/lineDrawer.ts
@@ -5,7 +5,7 @@
 
 import * as d3 from "d3";
 import { AttributeToAppliedProjector, SimpleSelection } from "../core/interfaces";
-import { CanvasDrawStep, renderLine, resolveAttributes } from "./canvasDrawer";
+import { attributesEqual, CanvasDrawStep, renderLine, resolveAttributes } from "./canvasDrawer";
 import { SVGDrawer } from "./svgDrawer";
 
 export class LineSVGDrawer extends SVGDrawer {
@@ -22,7 +22,7 @@ export class LineSVGDrawer extends SVGDrawer {
   }
 }
 
-const LINE_ATTRIBUTES =  [
+const LINE_ATTRIBUTES = [
   "opacity",
   "stroke-opacity",
   "stroke-width",
@@ -38,7 +38,15 @@ const LINE_ATTRIBUTES =  [
  */
 export function makeLineCanvasDrawStep(d3LineFactory: () => d3.Line<any>): CanvasDrawStep {
   return (context: CanvasRenderingContext2D, data: any[][], attrToAppliedProjector: AttributeToAppliedProjector) => {
-    const lineStyle = resolveAttributes(attrToAppliedProjector, LINE_ATTRIBUTES, data[0], 0);
-    renderLine(context, d3LineFactory(), data[0], lineStyle);
+    let start = 0;
+    let lastStyle = resolveAttributes(attrToAppliedProjector, LINE_ATTRIBUTES, data[0], 0);
+    for (let index = 1; index < data[0].length; index++) {
+      const lineStyle = resolveAttributes(attrToAppliedProjector, LINE_ATTRIBUTES, data[0], index);
+      if (!attributesEqual(lineStyle, lastStyle) || index === data[0].length - 1) {
+        renderLine(context, d3LineFactory(), data[0].slice(start, index + 1), lastStyle);
+        start = index;
+        lastStyle = lineStyle;
+      }
+    }
   };
 }

--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -417,7 +417,7 @@ export class Line<X> extends XYPlot<X, number> {
       }
       const projector = attrToProjector[attribute];
       attrToProjector[attribute] = (data: any[], i: number, dataset: Dataset) =>
-        data.length > 0 ? projector(data[0], i, dataset) : null;
+        data.length > 0 ? projector(data[i], i, dataset) : null;
     });
 
     return attrToProjector;


### PR DESCRIPTION
Enables the ability for canvas lineDrawer to utilize different styles in the same plot.
This is especially useful for changing opacity/stroke for segments along a plot.
When drawing between two points that produce different styles, it chooses the first style arbitrarily.