### PR TITLE
Filter for y0 in scale domain

### DIFF
--- a/src/plots/xyPlot.ts
+++ b/src/plots/xyPlot.ts
@@ -175,7 +175,7 @@ export class XYPlot<X, Y> extends Plot {
   protected _filterForProperty(property: string): IAccessor<boolean> {
     if (property === "x" && this._autoAdjustXScaleDomain) {
       return this._makeFilterByProperty("y");
-    } else if (property === "y" && this._autoAdjustYScaleDomain) {
+    } else if ((property === "y" || property === "y0") && this._autoAdjustYScaleDomain) {
       return this._makeFilterByProperty("x");
     }
     return null;


### PR DESCRIPTION
Fixes #3476.
`getExtentsForProperty` currently does not observe scale domain for y0 and will break `autorangeMode` as a consequence. This change allows getExtentsForProperty to be filtered properly for y0.