### PR TITLE
Fix 'passive' event listener

### DIFF
--- a/src/dispatchers/dispatcher.ts
+++ b/src/dispatchers/dispatcher.ts
@@ -42,7 +42,8 @@ export class Dispatcher {
     }
     Object.keys(this._eventToProcessingFunction).forEach((event: string) => {
       const processingFunction = this._eventToProcessingFunction[event];
-      this._eventTarget.addEventListener(event, processingFunction);
+      // Add `{ passive: false }` option because Chrome 73 broke this.
+      this._eventTarget.addEventListener(event, processingFunction, { passive: false });
     });
     this._connected = true;
   }

--- a/src/dispatchers/dispatcher.ts
+++ b/src/dispatchers/dispatcher.ts
@@ -43,7 +43,8 @@ export class Dispatcher {
     Object.keys(this._eventToProcessingFunction).forEach((event: string) => {
       const processingFunction = this._eventToProcessingFunction[event];
       // Add `{ passive: false }` option because Chrome 73 broke this.
-      this._eventTarget.addEventListener(event, processingFunction, { passive: false });
+      const options = event === "wheel" ?  { passive: false } : undefined;
+      this._eventTarget.addEventListener(event, processingFunction, options);
     });
     this._connected = true;
   }


### PR DESCRIPTION
Chrome 73 broke wheel listeners with its new "passive" listener settings. This overrides them explicitly to avoid the errors.