### PR TITLE
Invalidate bar label text measurer caches

### DIFF
--- a/src/components/legend.ts
+++ b/src/components/legend.ts
@@ -693,6 +693,7 @@ export class Legend extends Component {
   }
 
   public invalidateCache() {
+    super.invalidateCache();
     this._measurer.reset();
   }
 }

--- a/src/plots/barPlot.ts
+++ b/src/plots/barPlot.ts
@@ -914,6 +914,11 @@ export class Bar<X, Y> extends XYPlot<X, Y> {
       0, 0, plotWidth, plotHeight,
     );
   }
+
+  public invalidateCache() {
+    super.invalidateCache();
+    this.datasets().forEach((dataset) => this._labelConfig.get(dataset).measurer.reset());
+  }
 }
 
 /**


### PR DESCRIPTION
A bug exists where bar chart labels render incorrectly
when the chart is first rendered into a invalid element,
such as one with zero size or display: none style.

Since text measurement is cached, these incorrect measurements
would perist and the labels would remain broken even
if the element becomes valid for rendering.

This change correctly invalidates all the bar chart
label measurer caches, and bar labels will then
render correctly when the element becomes valid.