### PR TITLE
Update extents after setBounds

### DIFF
--- a/src/plots/plot.ts
+++ b/src/plots/plot.ts
@@ -211,7 +211,7 @@ export class Plot extends Component {
 
   public setBounds(width: number, height: number, originX?: number, originY?: number) {
     super.setBounds(width, height, originX, originY);
-    this._resetEntityStore();
+    this._updateExtents();
     if (this._canvas != null) {
       if (this._bufferCanvas && !this._bufferCanvasValid) {
         // copy current canvas to buffer 1:1


### PR DESCRIPTION
This change will trigger the 'updateExtents' method of a plot after
its bounds are set.

This is necessary because some scales, such as quantitative, will
use the scale to add add padding to a domain in a proportional manner
requiring the scale to have a valid domain and range.

When the plots are anchored to an element with zero size or hidden
with `display: none` the collapsed range causes invalid padding values
to set the domain.

This change will ensure that when the component finally has a valid
size, the domains are updated correctly.