### PR TITLE
Use entityNearest() rather than entityNearestByXThenY() for LinePlot.entitiesAt()

### DIFF
--- a/src/plots/linePlot.ts
+++ b/src/plots/linePlot.ts
@@ -1,4 +1,4 @@
-/**
+  /**
  * Copyright 2014-present Palantir Technologies
  * @license MIT
  */
@@ -424,44 +424,12 @@ export class Line<X> extends XYPlot<X, number> {
   }
 
   public entitiesAt(point: Point): IPlotEntity[] {
-    const entity = this.entityNearestByXThenY(point);
+    const entity = this.entityNearest(point);
     if (entity != null) {
       return [entity];
     } else {
       return [];
     }
-  }
-
-  /**
-   * Returns the PlotEntity nearest to the query point by X then by Y, or undefined if no PlotEntity can be found.
-   *
-   * @param {Point} queryPoint
-   * @returns {PlotEntity} The nearest PlotEntity, or undefined if no PlotEntity can be found.
-   */
-  public entityNearestByXThenY(queryPoint: Point): IPlotEntity {
-    let minXDist = Infinity;
-    let minYDist = Infinity;
-    let closest: IPlotEntity;
-
-    const chartBounds = this.bounds();
-    const entities = this.entities();
-    const entityLen = entities.length;
-    for (let i = 0; i < entityLen; i++) {
-      const entity = entities[i];
-      if (!Utils.Math.within(entity.position, chartBounds)) {
-        continue;
-      }
-      const xDist = Math.abs(queryPoint.x - entity.position.x);
-      const yDist = Math.abs(queryPoint.y - entity.position.y);
-
-      if (xDist < minXDist || xDist === minXDist && yDist < minYDist) {
-        closest = entity;
-        minXDist = xDist;
-        minYDist = yDist;
-      }
-    }
-
-    return closest;
   }
 
   protected _propertyProjectors(): AttributeToProjector {


### PR DESCRIPTION
Usinig `entityNearestByXThenY` causes some weird behaviour - if the cursor is marginally closer in the x domain to another point than the one the user intended to click on, that point will be the one that gets selected - even if it is hundreds of pixels away in the y domain.

Even worse, the tooltip-on-hover codepath just uses `entityNearest()`, so the intuitive nearest point has a tooltip, but then clicking selects a different point.

I went through the git history and couldn't see any reason why the "by x then y" approach was taken, but may well be missing something.

Hovering showing the nearest point:
![image](https://user-images.githubusercontent.com/1652335/96299530-1a20fc80-0fec-11eb-89dc-fa1ae6cdd242.png)

After clicking at that exact same cursor location:
![image](https://user-images.githubusercontent.com/1652335/96299607-37ee6180-0fec-11eb-9a0c-75208f663f3a.png)

After this PR, the selected point is the expected one.
