### PR TITLE
Use separate lodash modules per function

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "@types/chai": "^3.4.34",
     "@types/d3-selection-multi": "1.0.4",
     "@types/lodash": "^4.14.109",
-    "@types/lodash-es": "^4.17.3",
+    "@types/lodash.memoize": "^4.1.6",
+    "@types/lodash.iselement": "^4.1.6",
     "@types/mocha": "^2.2.27",
     "@types/sinon": "^1.16.36",
     "awesome-typescript-loader": "^3.4.1",
@@ -69,7 +70,8 @@
     "d3-ease": "^1.0.0",
     "d3-shape": "^1.0.0",
     "is-plain-object": "^2.0.4",
-    "lodash-es": "^4.17.15",
+    "lodash.memoize": "^4.1.2",
+    "lodash.iselement": "^4.1.1",
     "tslib": "~2.3.1",
     "typesettable": "4.1.0"
   }

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -4,12 +4,12 @@
  */
 
 import * as d3 from "d3";
+import isElement from "lodash.iselement";
 
 import { Bounds, Point, SimpleSelection, SpaceRequest } from "../core/interfaces";
 import * as RenderController from "../core/renderController";
 import * as Utils from "../utils";
 
-import { isElement } from "lodash-es";
 import { coerceExternalD3 } from "../utils/coerceD3";
 import { makeEnum } from "../utils/makeEnum";
 import { ComponentContainer } from "./componentContainer";

--- a/src/memoize/memoizeProjectors.ts
+++ b/src/memoize/memoizeProjectors.ts
@@ -1,5 +1,5 @@
 import type { MapCache } from "lodash";
-import { memoize } from "lodash-es";
+import memoize from "lodash.memoize";
 
 import { Dataset } from "../core/dataset";
 import { AttributeToProjector, Projector } from "../core/interfaces";

--- a/src/memoize/signature.ts
+++ b/src/memoize/signature.ts
@@ -13,7 +13,7 @@
  * We must hand-write a signature for each custom class we wish to support.
  */
 
-import * as isPlainObject from "is-plain-object";
+import isPlainObject from "is-plain-object";
 
 import { Dataset } from "../core/dataset";
 import { Scale } from "../scales/scale";

--- a/src/utils/stackingUtils.ts
+++ b/src/utils/stackingUtils.ts
@@ -9,7 +9,7 @@ import { Dataset } from "../core/dataset";
 import { IAccessor } from "../core/interfaces";
 
 import type { MemoizedFunction } from "lodash";
-import { memoize } from "lodash-es";
+import memoize from "lodash.memoize";
 import * as Utils from "./";
 import { makeEnum } from "./makeEnum";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
+      "allowSyntheticDefaultImports": true,
       "declaration": true,
-      "esModuleInterop": true,
       "forceConsistentCasingInFileNames": true,
       "importHelpers": true,
       "module": "commonjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
       "declaration": true,
+      "esModuleInterop": true,
       "forceConsistentCasingInFileNames": true,
       "importHelpers": true,
       "module": "commonjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -248,10 +248,17 @@
   resolved "https://registry.npmjs.org/@types/is-plain-object/-/is-plain-object-0.0.2.tgz#25bca7b656ba23fb03799a060dba201a7952103d"
   integrity sha1-Jbyntla6I/sDeZoGDbogGnlSED0=
 
-"@types/lodash-es@^4.17.3":
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.5.tgz#1c3fdd16849d84aea43890b1c60da379fb501353"
-  integrity sha512-SHBoI8/0aoMQWAgUHMQ599VM6ZiSKg8sh/0cFqqlQQMyY9uEplc0ULU5yQNzcvdR4ZKa0ey8+vFmahuRbOCT1A==
+"@types/lodash.iselement@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.iselement/-/lodash.iselement-4.1.6.tgz#27bf3766d6bfd74228df4a785bed8f812a6857c7"
+  integrity sha512-wFAnFWyw3q+NTilLymkfMYWm5qI0tVec7ImR+eydg2Cb/Ua34CLp7tZEU+rc8OUj74MpZiFZ7h1LbLD4gMw+mw==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.memoize@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.memoize/-/lodash.memoize-4.1.6.tgz#3221f981790a415cab1a239f25c17efd8b604c23"
+  integrity sha512-mYxjKiKzRadRJVClLKxS4wb3Iy9kzwJ1CkbyKiadVxejnswnRByyofmPMscFKscmYpl36BEEhCMPuWhA1R/1ZQ==
   dependencies:
     "@types/lodash" "*"
 
@@ -4477,11 +4484,6 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
-  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
-
 lodash._arraycopy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz#76e7b7c1f1fb92547374878a562ed06a3e50f6e1"
@@ -4630,6 +4632,11 @@ lodash.isarray@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
   integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
 
+lodash.iselement@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.iselement/-/lodash.iselement-4.1.1.tgz#f678d4f6f3a964f9ec7f115f2546f3e4a0ba82ca"
+  integrity sha1-9njU9vOpZPnsfxFfJUbz5KC6gso=
+
 lodash.isplainobject@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz#9a8238ae16b200432960cd7346512d0123fbf4c5"
@@ -4660,6 +4667,11 @@ lodash.keysin@^3.0.0:
   dependencies:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
+
+lodash.memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
 lodash.merge@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
Treeshaking in downstream libs not possible because we are targeting
commonjs. Not changing to esnext since it might be a breaking change.