### PR TITLE
Use submodule imports for lodash-es

### DIFF
--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -9,7 +9,7 @@ import { Bounds, Point, SimpleSelection, SpaceRequest } from "../core/interfaces
 import * as RenderController from "../core/renderController";
 import * as Utils from "../utils";
 
-import { isElement } from "lodash-es";
+import isElement from "lodash-es/isElement";
 import { coerceExternalD3 } from "../utils/coerceD3";
 import { makeEnum } from "../utils/makeEnum";
 import { ComponentContainer } from "./componentContainer";

--- a/src/memoize/memoizeProjectors.ts
+++ b/src/memoize/memoizeProjectors.ts
@@ -1,5 +1,5 @@
 import type { MapCache } from "lodash";
-import { memoize } from "lodash-es";
+import memoize from "lodash-es/memoize";
 
 import { Dataset } from "../core/dataset";
 import { AttributeToProjector, Projector } from "../core/interfaces";

--- a/src/utils/stackingUtils.ts
+++ b/src/utils/stackingUtils.ts
@@ -9,7 +9,7 @@ import { Dataset } from "../core/dataset";
 import { IAccessor } from "../core/interfaces";
 
 import type { MemoizedFunction } from "lodash";
-import { memoize } from "lodash-es";
+import memoize from "lodash-es/memoize";
 import * as Utils from "./";
 import { makeEnum } from "./makeEnum";
 


### PR DESCRIPTION
Reduces `lodash-es` dependency to about 25kb. Resolves https://github.com/palantir/plottable/issues/3588

Before:
![Screen Shot 2021-11-19 at 5 15 36 PM](https://user-images.githubusercontent.com/3681045/142698412-95b611a7-0af1-4c23-8679-3ac270933970.png)

After:
![Screen Shot 2021-11-19 at 5 10 16 PM](https://user-images.githubusercontent.com/3681045/142698421-a0efa229-6146-490e-a90e-9d717f2dc9bf.png)
